### PR TITLE
temporary request and response should be released in server & client mode

### DIFF
--- a/ecal/core/include/ecal/msg/protobuf/server.h
+++ b/ecal/core/include/ecal/msg/protobuf/server.h
@@ -148,6 +148,9 @@ namespace eCAL
         m_service->CallMethod(method_descriptor, nullptr, request, response, nullptr);
         response_ = response->SerializeAsString();
 
+        delete request;
+        delete response;
+
         return 0;
       };
 


### PR DESCRIPTION
When using the server and client pattern in eCal, there's a significant memory leak problem especially when big data chunks are present in the request sent by a client.

This pull request aims to fix this issue by deleting the request and response variables at the end of the "call" method.