### PR TITLE
minimal fix in global log instance

### DIFF
--- a/ecal/core/src/ecal_log_impl.cpp
+++ b/ecal/core/src/ecal_log_impl.cpp
@@ -182,6 +182,8 @@ namespace eCAL
   {
     if(!m_created) return;
 
+    std::lock_guard<std::mutex> lock(m_log_sync);
+
     m_udp_sender->Destroy();
 
     if(m_logfile) fclose(m_logfile);

--- a/ecal/core/src/ecal_log_impl.h
+++ b/ecal/core/src/ecal_log_impl.h
@@ -32,6 +32,7 @@
 
 #include "ecal_global_accessors.h"
 
+#include <atomic>
 #include <mutex>
 #include <memory>
 #include <chrono>
@@ -122,7 +123,7 @@ namespace eCAL
 
     std::mutex                   m_log_sync;
 
-    bool                         m_created;
+    std::atomic<bool>            m_created;
     std::unique_ptr<CUDPSender>  m_udp_sender;
 
     std::string                  m_hname;


### PR DESCRIPTION
Please check the type of change your PR introduces:
- [X] Bugfix

**What is the current behavior?**
Data race while concurrent logging in shutdown process.

**What is the new behavior?**
No more data race.