### PR TITLE
cut dependency of CSyncMemoryFile from CDataWriterBase and CConfig

### DIFF
--- a/ecal/core/src/io/ecal_memfile_sync.h
+++ b/ecal/core/src/io/ecal_memfile_sync.h
@@ -23,10 +23,9 @@
 
 #pragma once
 
-#include "readwrite/ecal_writer_base.h"
-#include "io/ecal_memfile.h"
-
 #include <ecal/ecal_eventhandle.h>
+
+#include "ecal_memfile.h"
 
 #include <mutex>
 #include <string>
@@ -37,14 +36,14 @@ namespace eCAL
   class CSyncMemoryFile
   {
   public:
-    CSyncMemoryFile(const std::string& base_name_, size_t size_, int timeout_open_ms_, int timeout_ack_ms_);
+    CSyncMemoryFile(const std::string& base_name_, size_t size_, size_t min_size_, size_t reserve_, int timeout_open_ms_, int timeout_ack_ms_);
     ~CSyncMemoryFile();
 
     bool Connect(const std::string& process_id_);
     bool Disconnect(const std::string& process_id_);
 
     bool CheckSize(size_t size_);
-    bool Write(const CDataWriterBase::SWriterData& data_);
+    bool Write(const void* buf_, size_t len_, long long id_, long long clock_, size_t hash_, long long time_, bool zero_copy_);
 
     std::string GetName();
 
@@ -61,6 +60,8 @@ namespace eCAL
     std::string      m_base_name;
     std::string      m_memfile_name;
     CMemoryFile      m_memfile;
+    size_t           m_min_size;
+    size_t           m_reserve;
     int              m_timeout_open;
     int              m_timeout_ack;
     bool             m_created;

--- a/ecal/core/src/readwrite/ecal_writer_shm.cpp
+++ b/ecal/core/src/readwrite/ecal_writer_shm.cpp
@@ -77,7 +77,7 @@ namespace eCAL
     m_write_idx = 0;
     for (size_t num(0); num < m_buffer_count; ++num)
     {
-      auto sync_memfile = std::make_shared<CSyncMemoryFile>(topic_name_, Config::GetMemfileMinsizeBytes(), PUB_MEMFILE_OPEN_TO, Config::GetMemfileAckTimeoutMs());
+      auto sync_memfile = std::make_shared<CSyncMemoryFile>(topic_name_, 0, Config::GetMemfileMinsizeBytes(), Config::GetMemfileOverprovisioningPercentage(), PUB_MEMFILE_OPEN_TO, Config::GetMemfileAckTimeoutMs());
       m_memory_file_vec.push_back(sync_memfile);
     }
 
@@ -138,7 +138,7 @@ namespace eCAL
       // increase buffer count
       while (m_memory_file_vec.size() < m_buffer_count)
       {
-        auto sync_memfile = std::make_shared<CSyncMemoryFile>(m_topic_name, data_.len, PUB_MEMFILE_OPEN_TO, Config::GetMemfileAckTimeoutMs());
+        auto sync_memfile = std::make_shared<CSyncMemoryFile>(m_topic_name, data_.len, Config::GetMemfileMinsizeBytes(), Config::GetMemfileOverprovisioningPercentage(), PUB_MEMFILE_OPEN_TO, Config::GetMemfileAckTimeoutMs());
         m_memory_file_vec.push_back(sync_memfile);
       }
       // decrease buffer count
@@ -162,7 +162,7 @@ namespace eCAL
     if (!m_created) return 0;
 
     // write content
-    bool sent = m_memory_file_vec[m_write_idx]->Write(data_);
+    bool sent = m_memory_file_vec[m_write_idx]->Write(data_.buf, data_.len, data_.id, data_.clock, data_.hash, data_.time, data_.zero_copy);
 
     // and increment file index
     m_write_idx++;


### PR DESCRIPTION
Please check the type of change your PR introduces:
- [X] Refactoring (no functional changes, no api changes)

**What is the current behavior?**
CSyncMemoryFile depends on CDataWriterBase and CConfig this needs to be refactored to get all SHM functionality separated finally.

**What is the new behavior?**
Both dependencies removed
