### PR TITLE
FIX: Multiply Defined Symbols

### DIFF
--- a/contrib/ecalhdf5/include/ecal/measurement/imeasurement.h
+++ b/contrib/ecalhdf5/include/ecal/measurement/imeasurement.h
@@ -228,12 +228,12 @@ namespace eCAL
       std::shared_ptr<eh5::HDF5Meas> meas;
     };
 
-    IMeasurement::IMeasurement(const std::string& path)
+    inline IMeasurement::IMeasurement(const std::string& path)
       : meas{ std::make_shared<eh5::HDF5Meas>(path, eh5::RDONLY) }
     {
     }
 
-    ChannelSet IMeasurement::ChannelNames() const
+    inline ChannelSet IMeasurement::ChannelNames() const
     {
       return meas->GetChannelNames();
     }
@@ -243,7 +243,7 @@ namespace eCAL
     // a) channel does not exist in the IMeasurement
     // b) the registered type does not match with the descriptor in the chanenel
     template<typename T>
-    IChannel<T> IMeasurement::Get(const std::string& channel) const
+    inline IChannel<T> IMeasurement::Get(const std::string& channel) const
     {
       // Assert that the channel is in the IMeasurement
       auto channels = ChannelNames();

--- a/contrib/ecalhdf5/include/ecal/measurement/omeasurement.h
+++ b/contrib/ecalhdf5/include/ecal/measurement/omeasurement.h
@@ -118,7 +118,7 @@ namespace eCAL
 
 
 
-    OMeasurement::OMeasurement(const std::string& base_path_, const std::string& measurement_name_)
+    inline OMeasurement::OMeasurement(const std::string& base_path_, const std::string& measurement_name_)
       : meas{ std::make_shared<eh5::HDF5Meas>(base_path_, eh5::CREATE) }
     {
       meas->SetFileBaseName(measurement_name_);
@@ -129,7 +129,7 @@ namespace eCAL
     // a) channel does not exist in the OMeasurement
     // b) the registered type does not match with the descriptor in the chanenel
     template<typename T>
-    OChannel<T> OMeasurement::Create(const std::string& channel) const
+    inline OChannel<T> OMeasurement::Create(const std::string& channel) const
     {
       static T msg;
       meas->SetChannelType(channel, eCAL::message::GetTypeName(msg));


### PR DESCRIPTION
Fix multiply defined symbols linker error that occurs when IMeasurement or OMeasurement is used in two different translation units as the present method definition in the two header files violates the One Definition Rule.

**Pull request type**

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


**What is the current behavior?**
As method implementations for IMeasurement and OMeasurement are contained in the header file, multiply defined symbols errors will be thrown by the linker if the classes are used in two different translation units.

Issue Number: N/A

**What is the new behavior?**
Using the inline keyword, this error is fixed.

**Does this introduce a breaking change?**

- [ ] Yes
- [x] No

**Other information**

Alternative solutions would be implementing the method in the header definition directly or move them to cpp files instead.