### PR TITLE
Steady clock thread sleep implementation for windows

### DIFF
--- a/ecal/core/include/ecal/ecal_process.h
+++ b/ecal/core/include/ecal/ecal_process.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <string>
 
 #include <ecal/ecal_os.h>
@@ -79,11 +80,42 @@ namespace eCAL
     ECAL_API std::string GetTaskParameter(const char* sep_);
 
     /**
-     * @brief  Sleep current thread. 
+     * @brief  Sleep current thread.
      *
-     * @param  time_ms_  Time to sleep in ms. 
+     * Because of the fact that std::this_thread::sleep_for is vulnerable to system clock changes
+     * on Windows, Sleep function from synchapi.h had to be used for Windows. This insures time
+     * robustness on all platforms from a thread sleep perspective.
+     *
+     * @param  time_ms_  Time to sleep in ms.
     **/
     ECAL_API void SleepMS(long time_ms_);
+
+    /**
+     * @brief  Sleep current thread.
+     *
+     * Because of the fact that std::this_thread::sleep_for is vulnerable to system clock changes
+     * on Windows, Sleep function from synchapi.h had to be used for Windows. This insures time
+     * robustness on all platforms from a thread sleep perspective. Used with ns unit to obtain bigger precision.
+     *
+     * @param  time_ms_  Time to sleep in ns.
+    **/
+    ECAL_API void SleepNS(const long long time_ns_);
+
+    /**
+     * @brief  Sleep current thread.
+     *
+     * Templated implementation which takes as argument a std::chrono::duration and calls underlying SleepNS function.
+     * By using a std::chrono::duration argument we ensure that conversion to ms would be more precise for Windows Sleep method.
+     *
+     * @param  time  Time to sleep expressed in std::chrono::duration.
+    **/
+
+    template <typename Rep, typename Period>
+    void SleepFor( std::chrono::duration<Rep, Period> time )
+    {
+        auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(time).count();
+        SleepNS(ns);
+    }
 
     /**
      * @brief  Get current process id. 

--- a/ecal/core/include/ecal/ecal_timed_cb.h
+++ b/ecal/core/include/ecal/ecal_timed_cb.h
@@ -30,6 +30,8 @@
 #include <thread>
 #include <assert.h>
 
+#include "ecal_process.h"
+
 namespace eCAL
 {
   class CTimedCB;
@@ -109,12 +111,18 @@ namespace eCAL
     {
       assert(callback_ != nullptr);
       if (callback_ == nullptr) return;
-      if (delay_ > 0) std::this_thread::sleep_for(std::chrono::milliseconds(delay_));
+      if (delay_ > 0) eCAL::Process::SleepFor(std::chrono::milliseconds(delay_));
       while (!m_stop)
       {
         auto start = std::chrono::steady_clock::now();
         (callback_)();
-        if (timeout_ > 0) std::this_thread::sleep_until(start + std::chrono::milliseconds(timeout_));
+        if (timeout_ > 0)
+        {
+          auto now = std::chrono::steady_clock::now();
+          auto elapsed_time = std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count();
+          auto sleep_duration = timeout_ - elapsed_time;
+          eCAL::Process::SleepFor(std::chrono::milliseconds(sleep_duration));
+        }
       }
       m_stop = false;
     }

--- a/ecal/core/src/ecal_process.cpp
+++ b/ecal/core/src/ecal_process.cpp
@@ -366,7 +366,25 @@ namespace eCAL
 
     void SleepMS(const long time_ms_)
     {
-      std::this_thread::sleep_for(std::chrono::milliseconds(time_ms_));
+      #ifdef ECAL_OS_WINDOWS
+      {
+        Sleep(time_ms_);
+      }
+      #else
+        std::this_thread::sleep_for(std::chrono::milliseconds(time_ms_));
+      #endif
+    }
+
+    void SleepNS(const long long time_ns_)
+    {
+      #ifdef ECAL_OS_WINDOWS
+      {
+        auto milliseconds = time_ns_ / 1000000 + ((time_ns_ / 1000000) != 0);
+        Sleep(milliseconds);
+      }
+      #else
+        std::this_thread::sleep_for(std::chrono::nanoseconds(time_ns_));
+      #endif
     }
 
     float GetProcessCpuUsage()

--- a/ecal/core/src/ecal_process.cpp
+++ b/ecal/core/src/ecal_process.cpp
@@ -379,7 +379,7 @@ namespace eCAL
     {
       #ifdef ECAL_OS_WINDOWS
       {
-        auto milliseconds = time_ns_ / 1000000 + ((time_ns_ / 1000000) != 0);
+        auto milliseconds = time_ns_ / 1000000 + ((time_ns_ % 1000000) != 0);
         Sleep(milliseconds);
       }
       #else

--- a/ecal/core/src/ecal_time.cpp
+++ b/ecal/core/src/ecal_time.cpp
@@ -27,6 +27,7 @@
 #include <thread>
 
 #include "ecal_timegate.h"
+#include "ecal_process.h"
 
 namespace eCAL
 {
@@ -80,7 +81,7 @@ namespace eCAL
     {
       if (!g_timegate() || !g_timegate()->IsValid())
       {
-        std::this_thread::sleep_for(std::chrono::nanoseconds(duration_nsecs_));
+        eCAL::Process::SleepFor(std::chrono::nanoseconds(duration_nsecs_));
       }
       else
       {

--- a/ecal/core/src/ecal_timegate.cpp
+++ b/ecal/core/src/ecal_timegate.cpp
@@ -26,8 +26,9 @@
 
 #include <ecal/ecal_config.h>
 
-#include "ecal_def.h"
 #include "ecal_config_reader_hlp.h"
+#include "ecal_def.h"
+#include "ecal_process.h"
 #include "ecal_timegate.h"
 #include "getenvvar.h"
 
@@ -245,14 +246,14 @@ namespace eCAL
     switch (m_sync_mode)
     {
     case eTimeSyncMode::none:
-      std::this_thread::sleep_for(std::chrono::nanoseconds(duration_nsecs_));
+      eCAL::Process::SleepFor(std::chrono::nanoseconds(duration_nsecs_));
       break;
     case eTimeSyncMode::realtime:
       if (m_is_initialized_rt) {
         m_time_sync_rt.etime_sleep_for_nanoseconds_ptr(duration_nsecs_);
       }
       else {
-        std::this_thread::sleep_for(std::chrono::nanoseconds(duration_nsecs_));
+      eCAL::Process::SleepFor(std::chrono::nanoseconds(duration_nsecs_));
       }
       break;
     case eTimeSyncMode::replay:
@@ -260,11 +261,11 @@ namespace eCAL
         m_time_sync_replay.etime_sleep_for_nanoseconds_ptr(duration_nsecs_);
       }
       else {
-        std::this_thread::sleep_for(std::chrono::nanoseconds(duration_nsecs_));
+      eCAL::Process::SleepFor(std::chrono::nanoseconds(duration_nsecs_));
       }
       break;
     default:
-      std::this_thread::sleep_for(std::chrono::nanoseconds(duration_nsecs_));
+      eCAL::Process::SleepFor(std::chrono::nanoseconds(duration_nsecs_));
     }
   }
 

--- a/ecal/core/src/io/snd_raw_buffer.cpp
+++ b/ecal/core/src/io/snd_raw_buffer.cpp
@@ -23,6 +23,8 @@
 
 #include <thread>
 
+#include "ecal_process.h"
+
 #include "snd_raw_buffer.h"
 #include "io/msg_type.h"
 
@@ -167,7 +169,7 @@ namespace eCAL
           sent = transmit_cb_(buf_ + static_cast<size_t>(current_packet_num)*MSG_PAYLOAD_SIZE, sizeof(struct SUDPMessageHead) + current_snd_len);
           if (sent == 0) return(sent);
           if (send_sleep_us)
-            std::this_thread::sleep_for(std::chrono::microseconds(send_sleep_us));
+            eCAL::Process::SleepFor(std::chrono::microseconds(send_sleep_us));
 
 #ifndef NDEBUG
           // log it

--- a/ecal/core/src/service/ecal_tcpclient.cpp
+++ b/ecal/core/src/service/ecal_tcpclient.cpp
@@ -21,6 +21,7 @@
  * @brief  eCAL tcp server based on asio c++
 **/
 
+#include "ecal_process.h"
 #include "ecal_tcpclient.h"
 #include "ecal_tcpheader.h"
 
@@ -229,7 +230,7 @@ namespace eCAL
         // idle operations
         while (!read_done && !read_failed && !time_expired)
         {
-          std::this_thread::sleep_for(std::chrono::milliseconds(1));
+          eCAL::Process::SleepFor(std::chrono::milliseconds(1));
         }
 
         // stop timer


### PR DESCRIPTION
**Pull request type**

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


**What is the current behavior?**
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
For windows, std::this_thread::sleep_for does not use a steady clock and is affected by system clock changes.

Issue Number: N/A

**What is the new behavior?**
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Added a new templated function which can be used similarly to the classic sleep_for, which takes a std::chrono::duration argument
- Using Sleep method from synchapi.h header, thread sleep works as supposed and is not affected by system clock changes


**Does this introduce a breaking change?**

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

**Other information**

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
