### PR TITLE
Actions: Removed clang-tidy-review LGTM comment

### DIFF
--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -33,6 +33,7 @@ jobs:
           apt_packages: "cmake,ninja-build,build-essential,zlib1g-dev,qtbase5-dev,libhdf5-dev,libprotobuf-dev,libprotoc-dev,protobuf-compiler,libcurl4-openssl-dev,libqwt-qt5-dev"
           config_file: ".clang-tidy"
           exclude: "/thirdparty/*,/_build/*,convert_utf.cpp,convert_utf.h"
+          lgtm_comment_body: ""
           cmake_command: |
             cmake . -B _build \
                     -G Ninja \


### PR DESCRIPTION
This comment doesn't provide any helpful information and would cause the review action to fail from forks, even when no issues were found.
