### PR TITLE
eCAL::pb link targets depending on global CMake configuration

### DIFF
--- a/ecal/pb/CMakeLists.txt
+++ b/ecal/pb/CMakeLists.txt
@@ -57,9 +57,21 @@ add_library(eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 target_link_libraries(${PROJECT_NAME}
   PUBLIC
     eCAL::core_pb
+)
+
+if(BUILD_APPS)
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
     eCAL::app_pb
+)
+endif()
+
+if(BUILD_TIME)
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
     eCAL::ecaltime_pb
 )
+endif()
 
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>


### PR DESCRIPTION
Please check the type of change your PR introduces:
- [X] Bugfix

**What is the current behavior?**
Compatibility target eCAL::pb may depend on other targets based on CMake configuration switches.

Issue Number: #611
