### PR TITLE
renaming global eCAL instances of the registration layer

### DIFF
--- a/ecal/core/CMakeLists.txt
+++ b/ecal/core/CMakeLists.txt
@@ -140,8 +140,8 @@ set(ecal_cmn_cpp_src
     src/ecal_log.cpp
     src/ecal_log_impl.cpp
     src/ecal_process.cpp
-    src/ecal_reggate.cpp
     src/ecal_registration_provider.cpp
+    src/ecal_registration_receiver.cpp
     src/ecal_thread.cpp
     src/ecal_time.cpp
     src/ecal_timegate.cpp
@@ -262,8 +262,8 @@ set(ecal_cmn_header_src
     src/ecal_global_accessors.h
     src/ecal_globals.h
     src/ecal_log_impl.h
-    src/ecal_reggate.h
     src/ecal_registration_provider.h
+    src/ecal_registration_receiver.h
     src/ecal_thread.h
     src/ecal_timegate.h
     $<$<BOOL:${WIN32}>:src/ecal_win_main.h>

--- a/ecal/core/CMakeLists.txt
+++ b/ecal/core/CMakeLists.txt
@@ -141,7 +141,7 @@ set(ecal_cmn_cpp_src
     src/ecal_log_impl.cpp
     src/ecal_process.cpp
     src/ecal_reggate.cpp
-    src/ecal_register.cpp
+    src/ecal_registration_provider.cpp
     src/ecal_thread.cpp
     src/ecal_time.cpp
     src/ecal_timegate.cpp
@@ -263,7 +263,7 @@ set(ecal_cmn_header_src
     src/ecal_globals.h
     src/ecal_log_impl.h
     src/ecal_reggate.h
-    src/ecal_register.h
+    src/ecal_registration_provider.h
     src/ecal_thread.h
     src/ecal_timegate.h
     $<$<BOOL:${WIN32}>:src/ecal_win_main.h>

--- a/ecal/core/src/ecal_global_accessors.cpp
+++ b/ecal/core/src/ecal_global_accessors.cpp
@@ -120,10 +120,10 @@ namespace eCAL
     return(g_globals()->clientgate().get());
   }
 
-  CRegGate* g_reggate()
+  CRegistrationReceiver* g_registration_receiver()
   {
     if (!g_globals()) return(nullptr);
-    return(g_globals()->reggate().get());
+    return(g_globals()->registration_receiver().get());
   }
 
 #ifndef ECAL_LAYER_ICEORYX

--- a/ecal/core/src/ecal_global_accessors.cpp
+++ b/ecal/core/src/ecal_global_accessors.cpp
@@ -84,10 +84,10 @@ namespace eCAL
     return(g_globals()->timegate().get());
   }
 
-  CEntityRegister* g_entity_register()
+  CRegistrationProvider* g_registration_provider()
   {
     if (!g_globals()) return(nullptr);
-    return(g_globals()->entity_register().get());
+    return(g_globals()->registration_provider().get());
   }
 
   CDescGate* g_descgate()

--- a/ecal/core/src/ecal_global_accessors.h
+++ b/ecal/core/src/ecal_global_accessors.h
@@ -42,7 +42,7 @@ namespace eCAL
   class  CPubGate;
   class  CServiceGate;
   class  CClientGate;
-  class  CRegGate;
+  class  CRegistrationReceiver;
 
 #ifndef ECAL_LAYER_ICEORYX
   class  CMemFileThreadPool;
@@ -50,22 +50,22 @@ namespace eCAL
 #endif /* !ECAL_LAYER_ICEORYX */
 
   // Declaration of getter functions for globally accessible variable instances
-  CGlobals*              g_globals();
-  CConfig*               g_config();
-  CLog*                  g_log();
-  CMonitoring*           g_monitoring();
-  CTimeGate*             g_timegate();
-  CRegistrationProvider* g_registration_provider();
-  CDescGate*             g_descgate();
-  CSubGate*              g_subgate();
-  CPubGate*              g_pubgate();
-  CServiceGate*          g_servicegate();
-  CClientGate*           g_clientgate();
-  CRegGate*              g_reggate();
+  CGlobals*               g_globals();
+  CConfig*                g_config();
+  CLog*                   g_log();
+  CMonitoring*            g_monitoring();
+  CTimeGate*              g_timegate();
+  CRegistrationProvider*  g_registration_provider();
+  CDescGate*              g_descgate();
+  CSubGate*               g_subgate();
+  CPubGate*               g_pubgate();
+  CServiceGate*           g_servicegate();
+  CClientGate*            g_clientgate();
+  CRegistrationReceiver*  g_registration_receiver();
 
 #ifndef ECAL_LAYER_ICEORYX
-  CMemFileThreadPool*    g_memfile_pool();
-  CMemFileMap*           g_memfile_map();
+  CMemFileThreadPool*     g_memfile_pool();
+  CMemFileMap*            g_memfile_map();
 #endif /* !ECAL_LAYER_ICEORYX */
 
   // declaration of globally accessible variables

--- a/ecal/core/src/ecal_global_accessors.h
+++ b/ecal/core/src/ecal_global_accessors.h
@@ -36,7 +36,7 @@ namespace eCAL
   class  CLog;
   class  CMonitoring;
   class  CTimeGate;
-  class  CEntityRegister;
+  class  CRegistrationProvider;
   class  CDescGate;
   class  CSubGate;
   class  CPubGate;
@@ -55,7 +55,7 @@ namespace eCAL
   CLog*                  g_log();
   CMonitoring*           g_monitoring();
   CTimeGate*             g_timegate();
-  CEntityRegister*       g_entity_register();
+  CRegistrationProvider* g_registration_provider();
   CDescGate*             g_descgate();
   CSubGate*              g_subgate();
   CPubGate*              g_pubgate();

--- a/ecal/core/src/ecal_globals.cpp
+++ b/ecal/core/src/ecal_globals.cpp
@@ -76,11 +76,11 @@ namespace eCAL
     }
 
     /////////////////////
-    // ENTITY REGISTER
+    // REGISTRATION PROVIDER
     /////////////////////
-    if (entity_register_instance == nullptr)
+    if (registration_provider_instance == nullptr)
     {
-      entity_register_instance = std::make_unique<CEntityRegister>();
+      registration_provider_instance = std::make_unique<CRegistrationProvider>();
       new_initialization = true;
     }
 
@@ -208,7 +208,7 @@ namespace eCAL
     /////////////////////
     //if (config_instance)                                          config_instance->Create();
     if (log_instance && (components_ & Init::Logging))            log_instance->Create();
-    if (entity_register_instance)                                 entity_register_instance->Create(true, true, (components_ & Init::ProcessReg) != 0x0);
+    if (registration_provider_instance)                           registration_provider_instance->Create(true, true, (components_ & Init::ProcessReg) != 0x0);
     if (descgate_instance)                                        descgate_instance->Create();
     if (reggate_instance)                                         reggate_instance->Create();
 #ifndef ECAL_LAYER_ICEORYX
@@ -261,36 +261,36 @@ namespace eCAL
     if (!initialized) return(1);
 
     // start destruction
-    if (monitoring_instance)       monitoring_instance->Destroy();
-    if (timegate_instance)         timegate_instance->Destroy();
-    if (clientgate_instance)       clientgate_instance->Destroy();
-    if (servicegate_instance)      servicegate_instance->Destroy();
-    if (pubgate_instance)          pubgate_instance->Destroy();
-    if (subgate_instance)          subgate_instance->Destroy();
-    if (reggate_instance)          reggate_instance->Destroy();
-    if (descgate_instance)         descgate_instance->Destroy();
-    if (entity_register_instance)  entity_register_instance->Destroy();
+    if (monitoring_instance)             monitoring_instance->Destroy();
+    if (timegate_instance)               timegate_instance->Destroy();
+    if (clientgate_instance)             clientgate_instance->Destroy();
+    if (servicegate_instance)            servicegate_instance->Destroy();
+    if (pubgate_instance)                pubgate_instance->Destroy();
+    if (subgate_instance)                subgate_instance->Destroy();
+    if (reggate_instance)                reggate_instance->Destroy();
+    if (descgate_instance)               descgate_instance->Destroy();
+    if (registration_provider_instance)  registration_provider_instance->Destroy();
 #ifndef ECAL_LAYER_ICEORYX
-    if (memfile_pool_instance)     memfile_pool_instance->Destroy();
-    if (memfile_map_instance)      memfile_map_instance->Destroy();
+    if (memfile_pool_instance)           memfile_pool_instance->Destroy();
+    if (memfile_map_instance)            memfile_map_instance->Destroy();
 #endif /* !ECAL_LAYER_ICEORYX */
-    if (log_instance)              log_instance->Destroy();
-    //if (config_instance)           config_instance->Destroy();
+    if (log_instance)                    log_instance->Destroy();
+    //if (config_instance)                 config_instance->Destroy();
 
-    monitoring_instance       = nullptr;
-    timegate_instance         = nullptr;
-    servicegate_instance      = nullptr;
-    pubgate_instance          = nullptr;
-    subgate_instance          = nullptr;
-    reggate_instance          = nullptr;
-    descgate_instance         = nullptr;
-    entity_register_instance  = nullptr;
+    monitoring_instance             = nullptr;
+    timegate_instance               = nullptr;
+    servicegate_instance            = nullptr;
+    pubgate_instance                = nullptr;
+    subgate_instance                = nullptr;
+    reggate_instance                = nullptr;
+    descgate_instance               = nullptr;
+    registration_provider_instance  = nullptr;
 #ifndef ECAL_LAYER_ICEORYX
-    memfile_pool_instance     = nullptr;
-    memfile_map_instance      = nullptr;
+    memfile_pool_instance           = nullptr;
+    memfile_map_instance            = nullptr;
 #endif /* !ECAL_LAYER_ICEORYX */
-    log_instance              = nullptr;
-    config_instance           = nullptr;
+    log_instance                    = nullptr;
+    config_instance                 = nullptr;
 
     // last not least we close all
     Net::Finalize();

--- a/ecal/core/src/ecal_globals.cpp
+++ b/ecal/core/src/ecal_globals.cpp
@@ -94,11 +94,11 @@ namespace eCAL
     }
 
     /////////////////////
-    // REGISTRATION GATE
+    // REGISTRATION RECEIVER
     /////////////////////
-    if(reggate_instance == nullptr) 
+    if(registration_receiver_instance == nullptr) 
     {
-      reggate_instance = std::make_unique<CRegGate>();
+      registration_receiver_instance = std::make_unique<CRegistrationReceiver>();
       new_initialization = true;
     }
 
@@ -210,7 +210,7 @@ namespace eCAL
     if (log_instance && (components_ & Init::Logging))            log_instance->Create();
     if (registration_provider_instance)                           registration_provider_instance->Create(true, true, (components_ & Init::ProcessReg) != 0x0);
     if (descgate_instance)                                        descgate_instance->Create();
-    if (reggate_instance)                                         reggate_instance->Create();
+    if (registration_receiver_instance)                           registration_receiver_instance->Create();
 #ifndef ECAL_LAYER_ICEORYX
     if (memfile_pool_instance)                                    memfile_pool_instance->Create();
 #endif /* !ECAL_LAYER_ICEORYX */
@@ -267,7 +267,7 @@ namespace eCAL
     if (servicegate_instance)            servicegate_instance->Destroy();
     if (pubgate_instance)                pubgate_instance->Destroy();
     if (subgate_instance)                subgate_instance->Destroy();
-    if (reggate_instance)                reggate_instance->Destroy();
+    if (registration_receiver_instance)  registration_receiver_instance->Destroy();
     if (descgate_instance)               descgate_instance->Destroy();
     if (registration_provider_instance)  registration_provider_instance->Destroy();
 #ifndef ECAL_LAYER_ICEORYX
@@ -282,7 +282,7 @@ namespace eCAL
     servicegate_instance            = nullptr;
     pubgate_instance                = nullptr;
     subgate_instance                = nullptr;
-    reggate_instance                = nullptr;
+    registration_receiver_instance  = nullptr;
     descgate_instance               = nullptr;
     registration_provider_instance  = nullptr;
 #ifndef ECAL_LAYER_ICEORYX

--- a/ecal/core/src/ecal_globals.h
+++ b/ecal/core/src/ecal_globals.h
@@ -27,7 +27,7 @@
 #include "ecal_reggate.h"
 #include "ecal_descgate.h"
 #include "ecal_timegate.h"
-#include "ecal_register.h"
+#include "ecal_registration_provider.h"
 #include "ecal_log_impl.h"
 #include "mon/ecal_monitoring_def.h"
 #include "pubsub/ecal_pubgate.h"
@@ -57,20 +57,20 @@ namespace eCAL
 
     int Finalize(unsigned int components_);
 
-    const std::unique_ptr<CConfig>&                                       config()           { return config_instance; };
-    const std::unique_ptr<CLog>&                                          log()              { return log_instance; };
-    const std::unique_ptr<CMonitoring>&                                   monitoring()       { return monitoring_instance; };
-    const std::unique_ptr<CTimeGate>&                                     timegate()         { return timegate_instance; };
-    const std::unique_ptr<CSubGate>&                                      subgate()          { return subgate_instance; };
-    const std::unique_ptr<CPubGate>&                                      pubgate()          { return pubgate_instance; };
-    const std::unique_ptr<CServiceGate>&                                  servicegate()      { return servicegate_instance; };
-    const std::unique_ptr<CClientGate>&                                   clientgate()       { return clientgate_instance; };
-    const std::unique_ptr<CEntityRegister>&                               entity_register()  { return entity_register_instance; };
-    const std::unique_ptr<CDescGate>&                                     descgate()         { return descgate_instance; };
-    const std::unique_ptr<CRegGate>&                                      reggate()          { return reggate_instance; };
+    const std::unique_ptr<CConfig>&                                       config()                 { return config_instance; };
+    const std::unique_ptr<CLog>&                                          log()                    { return log_instance; };
+    const std::unique_ptr<CMonitoring>&                                   monitoring()             { return monitoring_instance; };
+    const std::unique_ptr<CTimeGate>&                                     timegate()               { return timegate_instance; };
+    const std::unique_ptr<CSubGate>&                                      subgate()                { return subgate_instance; };
+    const std::unique_ptr<CPubGate>&                                      pubgate()                { return pubgate_instance; };
+    const std::unique_ptr<CServiceGate>&                                  servicegate()            { return servicegate_instance; };
+    const std::unique_ptr<CClientGate>&                                   clientgate()             { return clientgate_instance; };
+    const std::unique_ptr<CRegistrationProvider>&                         registration_provider()  { return registration_provider_instance; };
+    const std::unique_ptr<CDescGate>&                                     descgate()               { return descgate_instance; };
+    const std::unique_ptr<CRegGate>&                                      reggate()                { return reggate_instance; };
 #ifndef ECAL_LAYER_ICEORYX
-    const std::unique_ptr<CMemFileThreadPool>&                            memfile_pool()     { return memfile_pool_instance; };
-    const std::unique_ptr<CMemFileMap>&                                   memfile_map()      { return memfile_map_instance; };
+    const std::unique_ptr<CMemFileThreadPool>&                            memfile_pool()           { return memfile_pool_instance; };
+    const std::unique_ptr<CMemFileMap>&                                   memfile_map()            { return memfile_map_instance; };
 #endif /* !ECAL_LAYER_ICEORYX */
 
   private:
@@ -84,7 +84,7 @@ namespace eCAL
     std::unique_ptr<CPubGate>                                             pubgate_instance;
     std::unique_ptr<CServiceGate>                                         servicegate_instance;
     std::unique_ptr<CClientGate>                                          clientgate_instance;
-    std::unique_ptr<CEntityRegister>                                      entity_register_instance;
+    std::unique_ptr<CRegistrationProvider>                                registration_provider_instance;
     std::unique_ptr<CDescGate>                                            descgate_instance;
     std::unique_ptr<CRegGate>                                             reggate_instance;
 #ifndef ECAL_LAYER_ICEORYX

--- a/ecal/core/src/ecal_globals.h
+++ b/ecal/core/src/ecal_globals.h
@@ -24,10 +24,10 @@
 #pragma once
 
 #include "ecal_global_accessors.h"
-#include "ecal_reggate.h"
+#include "ecal_registration_provider.h"
+#include "ecal_registration_receiver.h"
 #include "ecal_descgate.h"
 #include "ecal_timegate.h"
-#include "ecal_registration_provider.h"
 #include "ecal_log_impl.h"
 #include "mon/ecal_monitoring_def.h"
 #include "pubsub/ecal_pubgate.h"
@@ -67,7 +67,7 @@ namespace eCAL
     const std::unique_ptr<CClientGate>&                                   clientgate()             { return clientgate_instance; };
     const std::unique_ptr<CRegistrationProvider>&                         registration_provider()  { return registration_provider_instance; };
     const std::unique_ptr<CDescGate>&                                     descgate()               { return descgate_instance; };
-    const std::unique_ptr<CRegGate>&                                      reggate()                { return reggate_instance; };
+    const std::unique_ptr<CRegistrationReceiver>&                         registration_receiver()  { return registration_receiver_instance; };
 #ifndef ECAL_LAYER_ICEORYX
     const std::unique_ptr<CMemFileThreadPool>&                            memfile_pool()           { return memfile_pool_instance; };
     const std::unique_ptr<CMemFileMap>&                                   memfile_map()            { return memfile_map_instance; };
@@ -86,7 +86,7 @@ namespace eCAL
     std::unique_ptr<CClientGate>                                          clientgate_instance;
     std::unique_ptr<CRegistrationProvider>                                registration_provider_instance;
     std::unique_ptr<CDescGate>                                            descgate_instance;
-    std::unique_ptr<CRegGate>                                             reggate_instance;
+    std::unique_ptr<CRegistrationReceiver>                                registration_receiver_instance;
 #ifndef ECAL_LAYER_ICEORYX
     std::unique_ptr<CMemFileThreadPool>                                   memfile_pool_instance;
     std::unique_ptr<CMemFileMap>                                          memfile_map_instance;

--- a/ecal/core/src/ecal_process.cpp
+++ b/ecal/core/src/ecal_process.cpp
@@ -26,7 +26,7 @@
 
 #include "ecal_def.h"
 #include "ecal_config_reader_hlp.h"
-#include "ecal_register.h"
+#include "ecal_registration_provider.h"
 #include "ecal_reggate.h"
 #include "ecal_globals.h"
 #include "ecal_process.h"

--- a/ecal/core/src/ecal_process.cpp
+++ b/ecal/core/src/ecal_process.cpp
@@ -380,7 +380,7 @@ namespace eCAL
       #ifdef ECAL_OS_WINDOWS
       {
         auto milliseconds = time_ns_ / 1000000 + ((time_ns_ % 1000000) != 0);
-        Sleep(milliseconds);
+        Sleep(static_cast<DWORD>(milliseconds));
       }
       #else
         std::this_thread::sleep_for(std::chrono::nanoseconds(time_ns_));

--- a/ecal/core/src/ecal_process.cpp
+++ b/ecal/core/src/ecal_process.cpp
@@ -27,7 +27,7 @@
 #include "ecal_def.h"
 #include "ecal_config_reader_hlp.h"
 #include "ecal_registration_provider.h"
-#include "ecal_reggate.h"
+#include "ecal_registration_receiver.h"
 #include "ecal_globals.h"
 #include "ecal_process.h"
 
@@ -434,15 +434,15 @@ namespace eCAL
 
     int AddRegistrationCallback(enum eCAL_Registration_Event event_, RegistrationCallbackT callback_)
     {
-      if (!g_reggate()) return -1;
-      if (g_reggate()->AddRegistrationCallback(event_, callback_)) return 0;
+      if (!g_registration_receiver()) return -1;
+      if (g_registration_receiver()->AddRegistrationCallback(event_, callback_)) return 0;
       return -1;
     }
 
     int RemRegistrationCallback(enum eCAL_Registration_Event event_)
     {
-      if (!g_reggate()) return -1;
-      if (g_reggate()->RemRegistrationCallback(event_)) return 0;
+      if (!g_registration_receiver()) return -1;
+      if (g_registration_receiver()->RemRegistrationCallback(event_)) return 0;
       return -1;
     }
   }

--- a/ecal/core/src/ecal_registration_provider.cpp
+++ b/ecal/core/src/ecal_registration_provider.cpp
@@ -32,6 +32,8 @@
 #include "ecal_globals.h"
 #include "ecal_registration_provider.h"
 
+#include "io/snd_sample.h"
+
 namespace eCAL
 {
   extern eCAL_Process_eSeverity  g_process_severity;

--- a/ecal/core/src/ecal_registration_provider.cpp
+++ b/ecal/core/src/ecal_registration_provider.cpp
@@ -18,35 +18,19 @@
 */
 
 /**
- * @brief  eCAL common register class
+ * @brief  eCAL registration provider
+ * 
+ * All process internal publisher/subscriber, server/clients register here with all their attributes.
+ * 
+ * These information will be send cyclic (registration refresh) via UDP to external eCAL processes.
+ * 
 **/
 
-#include <ecal/ecal.h>
 #include <ecal/ecal_config.h>
 
 #include "ecal_def.h"
-#include "ecal_config_reader_hlp.h"
 #include "ecal_globals.h"
-#include "ecal_register.h"
-#include "ecal_timegate.h"
-#include "pubsub/ecal_pubgate.h"
-#include "pubsub/ecal_subgate.h"
-#include "service/ecal_servicegate.h"
-#include "service/ecal_clientgate.h"
-
-#include <sstream>
-#include <iostream>
-#include <chrono>
-#include <thread>
-
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable: 4100 4127 4146 4505 4800 4189 4592) // disable proto warnings
-#endif
-#include <ecal/core/pb/ecal.pb.h>
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
+#include "ecal_registration_provider.h"
 
 namespace eCAL
 {
@@ -59,23 +43,23 @@ namespace eCAL
   extern std::atomic<long long>  g_process_rbytes;
   extern std::atomic<long long>  g_process_rbytes_sum;
 
-  std::atomic<bool> CEntityRegister::m_created;
+  std::atomic<bool> CRegistrationProvider::m_created;
 
-  CEntityRegister::CEntityRegister() :
-                    m_multicast_group(NET_UDP_MULTICAST_GROUP),
-                    m_reg_refresh(CMN_REGISTRATION_REFRESH),
-                    m_reg_topics(false),
-                    m_reg_services(false),
-                    m_reg_process(false)
+  CRegistrationProvider::CRegistrationProvider() :
+                         m_multicast_group(NET_UDP_MULTICAST_GROUP),
+                         m_reg_refresh(CMN_REGISTRATION_REFRESH),
+                         m_reg_topics(false),
+                         m_reg_services(false),
+                         m_reg_process(false)
   {
   };
 
-  CEntityRegister::~CEntityRegister()
+  CRegistrationProvider::~CRegistrationProvider()
   {
     Destroy();
   }
 
-  void CEntityRegister::Create(bool topics_, bool services_, bool process_)
+  void CRegistrationProvider::Create(bool topics_, bool services_, bool process_)
   {
     if(m_created) return;
 
@@ -107,12 +91,12 @@ namespace eCAL
     m_multicast_group = attr.ipaddr;
 
     m_reg_snd.Create(attr);
-    m_reg_snd_thread.Start(Config::GetRegistrationRefreshMs(), std::bind(&CEntityRegister::RegisterSendThread, this));
+    m_reg_snd_thread.Start(Config::GetRegistrationRefreshMs(), std::bind(&CRegistrationProvider::RegisterSendThread, this));
 
     m_created = true;
   }
 
-  void CEntityRegister::Destroy()
+  void CRegistrationProvider::Destroy()
   {
     if(!m_created) return;
 
@@ -121,7 +105,7 @@ namespace eCAL
     m_created = false;
   }
 
-  bool CEntityRegister::RegisterTopic(const std::string& topic_name_, const std::string& topic_id_, const eCAL::pb::Sample& ecal_sample_, const bool force_)
+  bool CRegistrationProvider::RegisterTopic(const std::string& topic_name_, const std::string& topic_id_, const eCAL::pb::Sample& ecal_sample_, const bool force_)
   {
     if(!m_created)    return(false);
     if(!m_reg_topics) return (false);
@@ -137,7 +121,7 @@ namespace eCAL
     return(true);
   }
 
-  bool CEntityRegister::UnregisterTopic(const std::string& topic_name_, const std::string& topic_id_)
+  bool CRegistrationProvider::UnregisterTopic(const std::string& topic_name_, const std::string& topic_id_)
   {
     if(!m_created) return(false);
 
@@ -153,7 +137,7 @@ namespace eCAL
     return(false);
   }
 
-  bool CEntityRegister::RegisterServer(const std::string& service_name_, const std::string& service_id_, const eCAL::pb::Sample& ecal_sample_, const bool force_)
+  bool CRegistrationProvider::RegisterServer(const std::string& service_name_, const std::string& service_id_, const eCAL::pb::Sample& ecal_sample_, const bool force_)
   {
     if(!m_created)      return(false);
     if(!m_reg_services) return(false);
@@ -169,7 +153,7 @@ namespace eCAL
     return(true);
   }
 
-  bool CEntityRegister::UnregisterServer(const std::string& service_name_, const std::string& service_id_)
+  bool CRegistrationProvider::UnregisterServer(const std::string& service_name_, const std::string& service_id_)
   {
     if(!m_created) return(false);
 
@@ -185,7 +169,7 @@ namespace eCAL
     return(false);
   }
 
-  bool CEntityRegister::RegisterClient(const std::string& client_name_, const std::string& client_id_, const eCAL::pb::Sample& ecal_sample_, const bool force_)
+  bool CRegistrationProvider::RegisterClient(const std::string& client_name_, const std::string& client_id_, const eCAL::pb::Sample& ecal_sample_, const bool force_)
   {
     if (!m_created)      return(false);
     if (!m_reg_services) return(false);
@@ -201,7 +185,7 @@ namespace eCAL
     return(true);
   }
 
-  bool CEntityRegister::UnregisterClient(const std::string& client_name_, const std::string& client_id_)
+  bool CRegistrationProvider::UnregisterClient(const std::string& client_name_, const std::string& client_id_)
   {
     if (!m_created) return(false);
 
@@ -217,7 +201,7 @@ namespace eCAL
     return(false);
   }
 
-  size_t CEntityRegister::RegisterProcess()
+  size_t CRegistrationProvider::RegisterProcess()
   {
     if(!m_created)     return(0);
     if(!m_reg_process) return(0);
@@ -286,7 +270,7 @@ namespace eCAL
     return(sent_sum);
   }
 
-  size_t CEntityRegister::RegisterServer()
+  size_t CRegistrationProvider::RegisterServer()
   {
     if(!m_created)      return(0);
     if(!m_reg_services) return(0);
@@ -302,7 +286,7 @@ namespace eCAL
     return(sent_sum);
   }
 
-  size_t CEntityRegister::RegisterClient()
+  size_t CRegistrationProvider::RegisterClient()
   {
     if (!m_created)      return(0);
     if (!m_reg_services) return(0);
@@ -318,7 +302,7 @@ namespace eCAL
     return(sent_sum);
   }
 
-  size_t CEntityRegister::RegisterTopics()
+  size_t CRegistrationProvider::RegisterTopics()
   {
     if(!m_created)    return(0);
     if(!m_reg_topics) return(0);
@@ -333,7 +317,7 @@ namespace eCAL
     return(sent_sum);
   }
 
-  size_t CEntityRegister::RegisterSample(const std::string& sample_name_, const eCAL::pb::Sample& sample_)
+  size_t CRegistrationProvider::RegisterSample(const std::string& sample_name_, const eCAL::pb::Sample& sample_)
   {
     if(!m_created) return(0);
 
@@ -343,7 +327,7 @@ namespace eCAL
     return(sent_size);
   }
 
-  int CEntityRegister::RegisterSendThread()
+  int CRegistrationProvider::RegisterSendThread()
   {
     if(!m_created) return(0);
 

--- a/ecal/core/src/ecal_registration_provider.h
+++ b/ecal/core/src/ecal_registration_provider.h
@@ -18,40 +18,42 @@
 */
 
 /**
- * @brief  eCAL common register class
+ * @brief  eCAL registration provider
+ *
+ * All process internal publisher/subscriber, server/clients register here with all their attributes.
+ *
+ * These information will be send cyclic (registration refresh) via UDP to external eCAL processes.
+ *
 **/
 
 #pragma once
 
-#include "ecal_global_accessors.h"
-
 #include "ecal_thread.h"
-
 #include "io/udp_sender.h"
 #include "io/snd_sample.h"
 
+#include <atomic>
 #include <mutex>
 #include <string>
 #include <unordered_map>
-#include <atomic>
 #include <memory>
 
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4100 4127 4146 4505 4800 4189 4592) // disable proto warnings
 #endif
-#include <ecal/core/pb/service.pb.h>
+#include <ecal/core/pb/ecal.pb.h>
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
 
 namespace eCAL
 {
-  class CEntityRegister
+  class CRegistrationProvider
   {
   public:
-    CEntityRegister();
-    ~CEntityRegister();
+    CRegistrationProvider();
+    ~CRegistrationProvider();
 
     void Create(bool topics_, bool services_, bool process_);
     void Destroy();

--- a/ecal/core/src/ecal_registration_provider.h
+++ b/ecal/core/src/ecal_registration_provider.h
@@ -30,7 +30,6 @@
 
 #include "ecal_thread.h"
 #include "io/udp_sender.h"
-#include "io/snd_sample.h"
 
 #include <atomic>
 #include <mutex>

--- a/ecal/core/src/ecal_registration_receiver.h
+++ b/ecal/core/src/ecal_registration_receiver.h
@@ -18,12 +18,14 @@
 */
 
 /**
- * @brief  eCAL registration gateway class
+ * @brief  eCAL registration receiver
+ *
+ * Receives registration information from external eCAL processes and forwards them to 
+ * the internal publisher/subscriber, server/clients.
+ *
 **/
 
 #pragma once
-
-#include "ecal_global_accessors.h"
 
 #include <ecal/ecal.h>
 
@@ -35,20 +37,28 @@
 #include <string>
 #include <atomic>
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4100 4127 4146 4505 4800 4189 4592) // disable proto warnings
+#endif
+#include <ecal/core/pb/ecal.pb.h>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 namespace eCAL
 {
   class CUdpRegistrationReceiver : public CSampleReceiver
   {
-    bool HasSample(const std::string& sample_name_);
+    bool HasSample(const std::string& /*sample_name_*/) { return(true); };
     size_t ApplySample(const eCAL::pb::Sample& ecal_sample_, eCAL::pb::eTLayerType layer_);
   };
 
-  class CRegGate
+  class CRegistrationReceiver
   {
   public:
-    CRegGate();
-    ~CRegGate();
+    CRegistrationReceiver();
+    ~CRegistrationReceiver();
 
     void Create();
     void Destroy();
@@ -56,7 +66,6 @@ namespace eCAL
     void EnableLoopback(bool state_);
     bool LoopBackEnabled() { return m_loopback; };
 
-    bool HasSample(const std::string& /* sample_name_ */) {return(true);};
     size_t ApplySample(const eCAL::pb::Sample& ecal_sample_);
 
     bool AddRegistrationCallback(enum eCAL_Registration_Event event_, RegistrationCallbackT callback_);

--- a/ecal/core/src/ecal_util.cpp
+++ b/ecal/core/src/ecal_util.cpp
@@ -25,8 +25,9 @@
 #include <ecal/ecal_core.h>
 
 #include "ecal_def.h"
-#include "ecal_reggate.h"
 #include "ecal_descgate.h"
+#include "ecal_process.h"
+#include "ecal_registration_receiver.h"
 #include "pubsub/ecal_pubgate.h"
 #include "mon/ecal_monitoring_def.h"
 
@@ -61,7 +62,7 @@ namespace eCAL
       if (!eCAL::IsInitialized(eCAL::Init::Monitoring))
       {
         eCAL::Initialize(0, nullptr, "", eCAL::Init::Monitoring);
-        Process::SleepMS(1000);
+        eCAL::Process::SleepMS(1000);
       }
 
       eCAL::pb::Monitoring monitoring;
@@ -78,7 +79,7 @@ namespace eCAL
     void ShutdownProcess(const std::string& process_name_)
     {
       eCAL::pb::Monitoring monitoring = GetMonitoring();
-      std::string        host_name = Process::GetHostName();
+      std::string          host_name  = eCAL::Process::GetHostName();
 
       std::vector<int> proc_id_list;
       for (int i = 0; i < monitoring.processes().size(); i++)
@@ -122,7 +123,7 @@ namespace eCAL
     void ShutdownProcesses()
     {
       eCAL::pb::Monitoring monitoring = GetMonitoring();
-      std::string        host_name = Process::GetHostName();
+      std::string          host_name  = eCAL::Process::GetHostName();
 
       std::vector<int> proc_id_list;
       for (int i = 0; i < monitoring.processes().size(); i++)
@@ -158,7 +159,7 @@ namespace eCAL
     void ShutdownCore()
     {
       eCAL::pb::Monitoring monitoring = GetMonitoring();
-      std::string        host_name = Process::GetHostName();
+      std::string          host_name  = eCAL::Process::GetHostName();
 
       std::vector<int> proc_id_list;
       for (int i = 0; i < monitoring.processes().size(); i++)
@@ -197,7 +198,7 @@ namespace eCAL
     **/
     void EnableLoopback(bool state_)
     {
-      if (g_reggate()) g_reggate()->EnableLoopback(state_);
+      if (g_registration_receiver()) g_registration_receiver()->EnableLoopback(state_);
     }
 
     /**

--- a/ecal/core/src/pubsub/ecal_pubgate.cpp
+++ b/ecal/core/src/pubsub/ecal_pubgate.cpp
@@ -25,7 +25,6 @@
 
 #include "ecal_def.h"
 #include "ecal_config_reader_hlp.h"
-#include "ecal_reggate.h"
 #include "ecal_pubgate.h"
 #include "ecal_descgate.h"
 
@@ -108,10 +107,6 @@ namespace eCAL
     }
 
     return(ret_state);
-  }
-
-  void CPubGate::ApplyProcessRegistration(const eCAL::pb::Sample& /*ecal_sample_*/)
-  {
   }
 
   void CPubGate::ApplyLocSubRegistration(const eCAL::pb::Sample& ecal_sample_)

--- a/ecal/core/src/pubsub/ecal_pubgate.h
+++ b/ecal/core/src/pubsub/ecal_pubgate.h
@@ -52,7 +52,6 @@ namespace eCAL
     bool Register(const std::string& topic_name_, CDataWriter* datawriter_);
     bool Unregister(const std::string& topic_name_, CDataWriter* datawriter_);
 
-    void ApplyProcessRegistration(const eCAL::pb::Sample& ecal_sample_);
     void ApplyLocSubRegistration(const eCAL::pb::Sample& ecal_sample_);
     void ApplyExtSubRegistration(const eCAL::pb::Sample& ecal_sample_);
 

--- a/ecal/core/src/pubsub/ecal_publisher.cpp
+++ b/ecal/core/src/pubsub/ecal_publisher.cpp
@@ -29,7 +29,7 @@
 #include "ecal_config_reader_hlp.h"
 #include "ecal_globals.h"
 #include "ecal_pubgate.h"
-#include "ecal_register.h"
+#include "ecal_registration_provider.h"
 
 #include "readwrite/ecal_writer.h"
 
@@ -168,8 +168,8 @@ namespace eCAL
     m_datawriter->Destroy();
 
     // unregister data writer
-    if(g_pubgate())         g_pubgate()->Unregister(m_datawriter->GetTopicName(), m_datawriter);
-    if(g_entity_register()) g_entity_register()->UnregisterTopic(m_datawriter->GetTopicName(), m_datawriter->GetTopicID());
+    if(g_pubgate())               g_pubgate()->Unregister(m_datawriter->GetTopicName(), m_datawriter);
+    if(g_registration_provider()) g_registration_provider()->UnregisterTopic(m_datawriter->GetTopicName(), m_datawriter->GetTopicID());
 #ifndef NDEBUG
     // log it
     if (g_log()) g_log()->Log(log_level_debug1, std::string(m_datawriter->GetTopicName() + "::CPublisher::Destroy"));
@@ -309,7 +309,7 @@ namespace eCAL
     }
 
     // send content via data writer layer
-    bool sent = 0;
+    bool sent(false);
     if (time_ == -1) sent = m_datawriter->Write(buf_, len_, eCAL::Time::GetMicroSeconds(), m_id);
     else             sent = m_datawriter->Write(buf_, len_, time_, m_id);
 

--- a/ecal/core/src/pubsub/ecal_subscriber.cpp
+++ b/ecal/core/src/pubsub/ecal_subscriber.cpp
@@ -25,7 +25,7 @@
 
 #include "ecal_def.h"
 #include "ecal_globals.h"
-#include "ecal_register.h"
+#include "ecal_registration_provider.h"
 #include "ecal_subgate.h"
 
 #include "readwrite/ecal_reader.h"
@@ -137,8 +137,8 @@ namespace eCAL
     RemReceiveCallback();
 
     // first unregister data reader
-    if(g_subgate())         g_subgate()->Unregister(m_datareader->GetTopicName(), m_datareader);
-    if(g_entity_register()) g_entity_register()->UnregisterTopic(m_datareader->GetTopicName(), m_datareader->GetTopicID());
+    if(g_subgate())               g_subgate()->Unregister(m_datareader->GetTopicName(), m_datareader);
+    if(g_registration_provider()) g_registration_provider()->UnregisterTopic(m_datareader->GetTopicName(), m_datareader->GetTopicID());
 #ifndef NDEBUG
     // log it
     if (g_log()) g_log()->Log(log_level_debug1, std::string(m_datareader->GetTopicName() + "::CSubscriber::Destroy"));

--- a/ecal/core/src/readwrite/ecal_reader.cpp
+++ b/ecal/core/src/readwrite/ecal_reader.cpp
@@ -25,7 +25,7 @@
 #include <ecal/ecal_config.h>
 
 #include "ecal_def.h"
-#include "ecal_register.h"
+#include "ecal_registration_provider.h"
 #include "ecal_descgate.h"
 #include "ecal_reader.h"
 #include "ecal_process.h"
@@ -347,7 +347,7 @@ namespace eCAL
     }
 
     // register subscriber
-    if(g_entity_register()) g_entity_register()->RegisterTopic(m_topic_name, m_topic_id, ecal_reg_sample, force_);
+    if(g_registration_provider()) g_registration_provider()->RegisterTopic(m_topic_name, m_topic_id, ecal_reg_sample, force_);
 #ifndef NDEBUG
     // log it
     Logging::Log(log_level_debug4, m_topic_name + "::CDataReader::DoRegister");

--- a/ecal/core/src/readwrite/ecal_writer.cpp
+++ b/ecal/core/src/readwrite/ecal_writer.cpp
@@ -31,7 +31,7 @@
 #include "ecal_writer_base.h"
 #include "ecal_process.h"
 
-#include "ecal_register.h"
+#include "ecal_registration_provider.h"
 #include "pubsub/ecal_pubgate.h"
 
 #include <sstream>
@@ -935,7 +935,7 @@ namespace eCAL
     }
 
     // register publisher
-    if (g_entity_register()) g_entity_register()->RegisterTopic(m_topic_name, m_topic_id, ecal_reg_sample, force_);
+    if (g_registration_provider()) g_registration_provider()->RegisterTopic(m_topic_name, m_topic_id, ecal_reg_sample, force_);
 
 #ifndef NDEBUG
     // log it

--- a/ecal/core/src/readwrite/ecal_writer.cpp
+++ b/ecal/core/src/readwrite/ecal_writer.cpp
@@ -26,13 +26,14 @@
 
 #include "ecal_def.h"
 #include "ecal_config_reader_hlp.h"
-#include "ecal_reggate.h"
+
+#include "ecal_registration_provider.h"
+#include "ecal_registration_receiver.h"
+#include "pubsub/ecal_pubgate.h"
+
 #include "ecal_writer.h"
 #include "ecal_writer_base.h"
 #include "ecal_process.h"
-
-#include "ecal_registration_provider.h"
-#include "pubsub/ecal_pubgate.h"
 
 #include <sstream>
 #include <chrono>
@@ -414,7 +415,7 @@ namespace eCAL
     // if we do not have loopback
     // enabled we can switch off
     // inner process communication
-    if (g_reggate() && !g_reggate()->LoopBackEnabled())
+    if (g_registration_receiver() && !g_registration_receiver()->LoopBackEnabled())
     {
       use_inproc = TLayer::smode_off;
     }

--- a/ecal/core/src/service/ecal_service_client_impl.cpp
+++ b/ecal/core/src/service/ecal_service_client_impl.cpp
@@ -74,8 +74,8 @@ namespace eCAL
   {
     if (!m_created) return(false);
 
-    if (g_clientgate())      g_clientgate()->Unregister(this);
-    if (g_entity_register()) g_entity_register()->UnregisterClient(m_service_name, m_service_id);
+    if (g_clientgate())            g_clientgate()->Unregister(this);
+    if (g_registration_provider()) g_registration_provider()->UnregisterClient(m_service_name, m_service_id);
 
     // reset client map
     {
@@ -351,7 +351,7 @@ namespace eCAL
     service_mutable_client->set_sid(m_service_id);
 
     // register entity
-    if (g_entity_register()) g_entity_register()->RegisterClient(m_service_name, m_service_id, sample, false);
+    if (g_registration_provider()) g_registration_provider()->RegisterClient(m_service_name, m_service_id, sample, false);
 
     // refresh connected services map
     CheckForNewServices();

--- a/ecal/core/src/service/ecal_service_client_impl.cpp
+++ b/ecal/core/src/service/ecal_service_client_impl.cpp
@@ -21,7 +21,9 @@
  * @brief  eCAL service client implementation
 **/
 
-#include "ecal_register.h"
+#include "ecal_global_accessors.h"
+
+#include "ecal_registration_provider.h"
 #include "ecal_clientgate.h"
 #include "ecal_service_client_impl.h"
 

--- a/ecal/core/src/service/ecal_service_server_impl.cpp
+++ b/ecal/core/src/service/ecal_service_server_impl.cpp
@@ -25,7 +25,7 @@
 #include "ecal_config_reader_hlp.h"
 
 #include "ecal_descgate.h"
-#include "ecal_register.h"
+#include "ecal_registration_provider.h"
 #include "ecal_servicegate.h"
 #include "ecal_global_accessors.h"
 #include "ecal_service_server_impl.h"

--- a/ecal/core/src/service/ecal_service_server_impl.cpp
+++ b/ecal/core/src/service/ecal_service_server_impl.cpp
@@ -84,8 +84,8 @@ namespace eCAL
     m_tcp_server.Stop();
     m_tcp_server.Destroy();
 
-    if (g_servicegate())     g_servicegate()->Unregister(this);
-    if (g_entity_register()) g_entity_register()->UnregisterServer(m_service_name, m_service_id);
+    if (g_servicegate())           g_servicegate()->Unregister(this);
+    if (g_registration_provider()) g_registration_provider()->UnregisterServer(m_service_name, m_service_id);
 
     // reset method callback map
     {
@@ -263,7 +263,7 @@ namespace eCAL
     }
 
     // register entity
-    if (g_entity_register()) g_entity_register()->RegisterServer(m_service_name, m_service_id, sample, false);
+    if (g_registration_provider()) g_registration_provider()->RegisterServer(m_service_name, m_service_id, sample, false);
   }
 
   int CServiceServerImpl::RequestCallback(const std::string& request_, std::string& response_)


### PR DESCRIPTION
Please check the type of change your PR introduces:
- [X] Refactoring (no functional changes, no api changes)

**What is the current behavior?**
Some eCAL core class names are misleading, methods are unused. Especially the "gate" classes needs to be named clearly and documented.

**What is the new behavior?**
More consistency in class naming and internal documentation.