### PR TITLE
clang-tidy: disabled cppcoreguidelines-avoid-magic-numbers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,6 +16,7 @@ Checks: "-*,
   -bugprone-narrowing-conversions,
   
   cppcoreguidelines-*,
+  -cppcoreguidelines-avoid-magic-numbers,
   -cppcoreguidelines-macro-usage,
   -cppcoreguidelines-narrowing-conversions,
   -cppcoreguidelines-non-private-member-variables-in-classes,


### PR DESCRIPTION
We have some magic numbers in the code and those are usually fine. The warning is not very helpful.
