### PR TITLE
Properly closing file descriptors on linux after mmap

### DIFF
--- a/ecal/core/src/io/linux/ecal_memfile_os.cpp
+++ b/ecal/core/src/io/linux/ecal_memfile_os.cpp
@@ -106,6 +106,7 @@ namespace eCAL
           if (create_) prot |= PROT_WRITE;
 
           mem_file_info_.mem_address = ::mmap(nullptr, mem_file_info_.size, prot, MAP_SHARED, mem_file_info_.memfile, 0);
+          ::close(mem_file_info_.memfile);
           if (mem_file_info_.mem_address == MAP_FAILED)
           {
             mem_file_info_.mem_address = nullptr;

--- a/lib/ecal_utils/src/filesystem.cpp
+++ b/lib/ecal_utils/src/filesystem.cpp
@@ -340,7 +340,6 @@ namespace EcalUtils
 #else
       FileStatus file_status(source_clean, OsStyle::Current);
       void *mem = mmap(NULL, file_status.FileSize(), PROT_READ, MAP_SHARED, input_fd, 0);
-      ::close(input_fd);
       if(mem != MAP_FAILED)
       {
         ssize_t written_bytes = write(output_fd, mem, file_status.FileSize());

--- a/lib/ecal_utils/src/filesystem.cpp
+++ b/lib/ecal_utils/src/filesystem.cpp
@@ -340,6 +340,7 @@ namespace EcalUtils
 #else
       FileStatus file_status(source_clean, OsStyle::Current);
       void *mem = mmap(NULL, file_status.FileSize(), PROT_READ, MAP_SHARED, input_fd, 0);
+      ::close(input_fd);
       if(mem != MAP_FAILED)
       {
         ssize_t written_bytes = write(output_fd, mem, file_status.FileSize());


### PR DESCRIPTION
This fix is Linux-only. It saves 1 open file descriptor per published topic.
This relates to #723 but is not enough to solve #592