### PR TITLE
Revert "Properly closing file descriptors on linux after mmap (#765)"

### DIFF
--- a/ecal/core/src/io/linux/ecal_memfile_os.cpp
+++ b/ecal/core/src/io/linux/ecal_memfile_os.cpp
@@ -106,7 +106,6 @@ namespace eCAL
           if (create_) prot |= PROT_WRITE;
 
           mem_file_info_.mem_address = ::mmap(nullptr, mem_file_info_.size, prot, MAP_SHARED, mem_file_info_.memfile, 0);
-          ::close(mem_file_info_.memfile);
           if (mem_file_info_.mem_address == MAP_FAILED)
           {
             mem_file_info_.mem_address = nullptr;


### PR DESCRIPTION
This reverts commit 858dfc008d108d3e331ff4afd24558ad9063e56a.
