### PR TITLE
sync/ecal core utils

### DIFF
--- a/app/play/play_cli/CMakeLists.txt
+++ b/app/play/play_cli/CMakeLists.txt
@@ -56,7 +56,7 @@ target_link_libraries(${PROJECT_NAME}
     termcolor::termcolor
     tclap::tclap
     eCAL::play_core
-    eCAL::utils
+    eCAL::ecal-utils
 )
 
 # Create a source tree that mirrors the filesystem

--- a/app/play/play_core/CMakeLists.txt
+++ b/app/play/play_core/CMakeLists.txt
@@ -63,7 +63,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
 
 target_link_libraries(${PROJECT_NAME} PRIVATE
   ThreadingUtils
-  eCAL::utils
+  eCAL::ecal-utils
 )
 
 source_group(TREE "${CMAKE_CURRENT_LIST_DIR}"

--- a/app/play/play_gui/CMakeLists.txt
+++ b/app/play/play_gui/CMakeLists.txt
@@ -131,7 +131,7 @@ target_link_libraries (${PROJECT_NAME}
     Qt5::Widgets
     CustomQt
     eCAL::core_pb
-    eCAL::utils
+    eCAL::ecal-utils
 )
 if (WIN32)
     target_link_libraries (${PROJECT_NAME}

--- a/app/rec/rec_client_cli/CMakeLists.txt
+++ b/app/rec/rec_client_cli/CMakeLists.txt
@@ -45,7 +45,7 @@ target_link_libraries(${PROJECT_NAME}
   eCAL::rec_client_core
   eCAL::core
   tclap::tclap
-  eCAL::utils
+  eCAL::ecal-utils
   EcalParser
 )
 

--- a/app/rec/rec_client_core/CMakeLists.txt
+++ b/app/rec/rec_client_core/CMakeLists.txt
@@ -101,7 +101,7 @@ target_link_libraries(${PROJECT_NAME}
     eCAL::hdf5
     ThreadingUtils
     Threads::Threads
-    eCAL::utils
+    eCAL::ecal-utils
     EcalParser
 )
 

--- a/app/rec/rec_gui/CMakeLists.txt
+++ b/app/rec/rec_gui/CMakeLists.txt
@@ -163,7 +163,7 @@ target_link_libraries (${PROJECT_NAME}
     Qt5::Widgets
     CustomQt
     CustomTclap
-    eCAL::utils
+    eCAL::ecal-utils
     EcalParser
     QEcalParser
     ThreadingUtils

--- a/app/rec/rec_server_cli/CMakeLists.txt
+++ b/app/rec/rec_server_cli/CMakeLists.txt
@@ -88,7 +88,7 @@ target_link_libraries(${PROJECT_NAME}
   termcolor::termcolor
   eCAL::rec_server_core
   eCAL::core
-  eCAL::utils
+  eCAL::ecal-utils
   CustomTclap
   ThreadingUtils
 )

--- a/app/rec/rec_server_core/CMakeLists.txt
+++ b/app/rec/rec_server_core/CMakeLists.txt
@@ -72,7 +72,7 @@ target_link_libraries(${PROJECT_NAME}
     eCAL::app_pb
     ThreadingUtils
     Threads::Threads
-    eCAL::utils
+    eCAL::ecal-utils
     EcalParser
 )
 

--- a/app/sys/sys_client_cli/CMakeLists.txt
+++ b/app/sys/sys_client_cli/CMakeLists.txt
@@ -48,7 +48,7 @@ target_link_libraries(${PROJECT_NAME}
   eCAL::app_pb
   eCAL::sys_client_core
   CustomTclap
-  eCAL::utils
+  eCAL::ecal-utils
 )
 
 ecal_install_app(${PROJECT_NAME})

--- a/app/sys/sys_client_core/CMakeLists.txt
+++ b/app/sys/sys_client_core/CMakeLists.txt
@@ -48,7 +48,7 @@ target_link_libraries(${PROJECT_NAME}
     eCAL::core
     eCAL::core_pb
     eCAL::app_pb
-    eCAL::utils
+    eCAL::ecal-utils
     spdlog::spdlog
   PRIVATE
     Threads::Threads  

--- a/app/sys/sys_gui/CMakeLists.txt
+++ b/app/sys/sys_gui/CMakeLists.txt
@@ -176,7 +176,7 @@ target_link_libraries (${PROJECT_NAME}
     simpleini::simpleini
     EcalParser
     QEcalParser
-    eCAL::utils
+    eCAL::ecal-utils
 )
 
 if(WIN32)

--- a/contrib/ecalhdf5/CMakeLists.txt
+++ b/contrib/ecalhdf5/CMakeLists.txt
@@ -78,7 +78,7 @@ target_link_libraries(${PROJECT_NAME}
   PUBLIC 
     eCAL::message
   PRIVATE  
-    eCAL::utils
+    eCAL::ecal-utils
 )
 
 if (${ECAL_LINK_HDF5_SHARED})

--- a/ecal/core/CMakeLists.txt
+++ b/ecal/core/CMakeLists.txt
@@ -463,7 +463,7 @@ target_link_libraries(${PROJECT_NAME}
     simpleini::simpleini
     eCAL::core_pb
     Threads::Threads
-    eCAL::utils
+    eCAL::ecal-utils
     tcp_pubsub::tcp_pubsub
 )
 

--- a/lib/EcalParser/CMakeLists.txt
+++ b/lib/EcalParser/CMakeLists.txt
@@ -52,7 +52,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE src/)
 
 target_link_libraries (${PROJECT_NAME}
     PRIVATE
-    eCAL::utils
+    eCAL::ecal-utils
 )
 
 if(WIN32)

--- a/lib/ecal_utils/CMakeLists.txt
+++ b/lib/ecal_utils/CMakeLists.txt
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 # ========================= eCAL LICENSE =================================
-project(utils)
+project(ecal-utils)
 
 find_package(Threads REQUIRED)
 


### PR DESCRIPTION
**Pull request type**

To prepare the repository to use ecal utils as external dependency the library is renamed from the common "utils" to the more unique "ecal-utils".

Please check the type of change your PR introduces:
- [X] Refactoring (no functional changes, no api changes)
