### PR TITLE
add ECAL_JOIN_MULTICAST_ON_ALL_INTERFACES feature (issue #695)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,7 @@ option(ECAL_INCLUDE_PY_SAMPLES                 "Include python language sample p
 option(ECAL_INSTALL_SAMPLE_SOURCES             "Install the sources of eCAL samples"                               ON)
 
 option(ECAL_JOIN_MULTICAST_TWICE               "Specific Multicast Network Bug Workaround"                        OFF)
+option(ECAL_JOIN_MULTICAST_ON_ALL_INTERFACES   "Enabling Joining Multicast Groups On All Interfaces"              OFF)
 option(ECAL_NPCAP_SUPPORT                      "Enable the eCAL Npcap Receiver (i.e. the Win10 performance fix)"  OFF)
 
 # Set option regarding third party library builds
@@ -556,6 +557,7 @@ message(STATUS "ECAL_LAYER_ICEORYX                             : ${ECAL_LAYER_IC
 message(STATUS "ECAL_INCLUDE_PY_SAMPLES                        : ${ECAL_INCLUDE_PY_SAMPLES}")
 message(STATUS "ECAL_INSTALL_SAMPLE_SOURCES                    : ${ECAL_INSTALL_SAMPLE_SOURCES}")
 message(STATUS "ECAL_JOIN_MULTICAST_TWICE                      : ${ECAL_JOIN_MULTICAST_TWICE}")
+message(STATUS "ECAL_JOIN_MULTICAST_ON_ALL_INTERFACES          : ${ECAL_JOIN_MULTICAST_ON_ALL_INTERFACES}")
 message(STATUS "ECAL_NPCAP_SUPPORT                             : ${ECAL_NPCAP_SUPPORT}")
 message(STATUS "ECAL_THIRDPARTY_BUILD_CMAKE_FUNCTIONS          : ${ECAL_THIRDPARTY_BUILD_CMAKE_FUNCTIONS}")
 message(STATUS "ECAL_THIRDPARTY_BUILD_SPDLOG                   : ${ECAL_THIRDPARTY_BUILD_SPDLOG}")

--- a/ecal/core/CMakeLists.txt
+++ b/ecal/core/CMakeLists.txt
@@ -29,6 +29,11 @@ if (ECAL_JOIN_MULTICAST_TWICE)
   add_definitions(-DECAL_JOIN_MULTICAST_TWICE)
 endif(ECAL_JOIN_MULTICAST_TWICE)
 
+if (ECAL_JOIN_MULTICAST_ON_ALL_INTERFACES)
+  message(STATUS "eCAL ${PROJECT_NAME}: Enabling Joining Multicast Groups On All Interfaces")
+  add_definitions(-DECAL_JOIN_MULTICAST_ON_ALL_INTERFACES)
+endif(ECAL_JOIN_MULTICAST_ON_ALL_INTERFACES)
+
 # If we're currently doing a build within a git repository, we will configure the header files.
 # Else, (e.g. for source packages such as debian source packages) we will use a preconfigured file.
 # If there is really no information available, it will generate a dummy version file 0.0.0
@@ -195,6 +200,7 @@ if(NOT ECAL_LAYER_ICEORYX)
   if(UNIX)
     set(ecal_io_mem_header_linux_src
         src/io/linux/ecal_memfile_mtx.h
+        src/io/linux/ecal_socket_option_linux.h
   )
   endif()
 endif(NOT ECAL_LAYER_ICEORYX)

--- a/ecal/core/src/io/linux/ecal_socket_option_linux.h
+++ b/ecal/core/src/io/linux/ecal_socket_option_linux.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <ifaddrs.h>
+#include <net/if.h>
+#include <vector>
+#include <iostream>
+
+
+namespace eCAL
+{
+  inline static std::vector<int> get_interface_index_list()
+  {
+    std::vector<int> interface_index_list;
+    ifaddrs* ifa;
+    ifaddrs* ifap;
+
+    // get a list of network interfaces
+    getifaddrs(&ifap);
+
+    // create a list of network interaces indexes
+    for (ifa = ifap; ifa; ifa = ifa->ifa_next)
+    {
+      if (ifa->ifa_addr && ifa->ifa_addr->sa_family == AF_PACKET)
+      {
+        int index = if_nametoindex(ifa->ifa_name);
+        if (index)
+        {
+          interface_index_list.push_back(index);
+        }
+      }
+    }
+
+    freeifaddrs(ifap);
+
+    return interface_index_list;
+  }
+
+  inline static bool set_socket_mcast_group_option(int socket, const char* ipaddr_, int option)
+  {
+    // set the multicast socket option on all interfaces
+    for (int iface : get_interface_index_list())
+    {
+      group_req group_req;
+      sockaddr_in *group;
+
+      memset(&group_req, 0, sizeof(group_req));
+      group_req.gr_interface = iface;
+      group = reinterpret_cast<sockaddr_in*>(&group_req.gr_group);
+      group->sin_family = AF_INET;
+      group->sin_addr.s_addr = inet_addr(ipaddr_);
+      group->sin_port = 0;
+
+      int rc = setsockopt(socket, IPPROTO_IP, option, &group_req, sizeof(group_source_req));
+      if (rc != 0)
+      {
+        std::cerr << "setsockopt failed. Unable to set multicast group option: " << strerror(errno) << std::endl;
+        return(false);
+      }
+    }
+
+    return(true);
+  }
+}

--- a/ecal/core/src/io/linux/ecal_socket_option_linux.h
+++ b/ecal/core/src/io/linux/ecal_socket_option_linux.h
@@ -12,7 +12,7 @@ namespace eCAL
   {
     std::vector<int> interface_index_list;
     ifaddrs* ifa = nullptr;
-    ifaddrs* ifap;
+    ifaddrs* ifap = nullptr;
 
     // get a list of network interfaces
     getifaddrs(&ifap);

--- a/ecal/core/src/io/linux/ecal_socket_option_linux.h
+++ b/ecal/core/src/io/linux/ecal_socket_option_linux.h
@@ -11,7 +11,7 @@ namespace eCAL
   inline static std::vector<int> get_interface_index_list()
   {
     std::vector<int> interface_index_list;
-    ifaddrs* ifa;
+    ifaddrs* ifa = nullptr;
     ifaddrs* ifap;
 
     // get a list of network interfaces

--- a/ecal/core/src/io/linux/ecal_socket_option_linux.h
+++ b/ecal/core/src/io/linux/ecal_socket_option_linux.h
@@ -2,6 +2,7 @@
 
 #include <ifaddrs.h>
 #include <net/if.h>
+#include <netinet/in.h>
 #include <vector>
 #include <iostream>
 
@@ -11,13 +12,13 @@ namespace eCAL
   inline static std::vector<int> get_interface_index_list()
   {
     std::vector<int> interface_index_list;
-    ifaddrs* ifa = nullptr;
+    ifaddrs* ifa  = nullptr;
     ifaddrs* ifap = nullptr;
 
     // get a list of network interfaces
     getifaddrs(&ifap);
 
-    // create a list of network interaces indexes
+    // create a list of network interfaces indexes
     for (ifa = ifap; ifa; ifa = ifa->ifa_next)
     {
       if (ifa->ifa_addr && ifa->ifa_addr->sa_family == AF_PACKET)
@@ -40,8 +41,8 @@ namespace eCAL
     // set the multicast socket option on all interfaces
     for (int iface : get_interface_index_list())
     {
-      group_req group_req;
-      sockaddr_in *group;
+      group_req group_req = {};
+      sockaddr_in *group  = nullptr;
 
       memset(&group_req, 0, sizeof(group_req));
       group_req.gr_interface = iface;


### PR DESCRIPTION
**Pull request type**

Please check the type of change your PR introduces:
- [X] Feature

**What is the current behavior?**
Starting ecal nodes, on a machine with the main network interface down and just the loopback available, will not
start network communication when the main network interface goes up. Nodes need to manually restarted when network interfaces are up and running to get network communication going.

Issue Number: #695

**What is the new behavior?**
Network communication should start when the main network interface comes up and ecal_mon_gui shouldn't be reporting monitoring errors. Also nodes should not need to be restarted to recover communication.