### PR TITLE
GH Actions: clang-tidy(-review) improvements

### DIFF
--- a/.github/workflows/clang-tidy-review-post-comments.yml
+++ b/.github/workflows/clang-tidy-review-post-comments.yml
@@ -1,0 +1,38 @@
+---
+name: Clang-Tidy-Review: Post comments
+
+on:
+  workflow_run:
+    workflows: ["clang-tidy-review"]
+    types:
+      - completed
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 'Download artifact'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{github.event.workflow_run.id }},
+            });
+            const matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "clang-tidy-review"
+            })[0];
+            const download = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip',
+            });
+            const fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/clang-tidy-review.zip', Buffer.from(download.data));
+      - name: 'Unzip artifact'
+        run: unzip clang-tidy-review.zip
+
+      - uses: FlorianReimold/clang-tidy-review/post_comments@feat/split-up-review-and-post-workflows

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -26,13 +26,14 @@ jobs:
           fetch-depth: 0
 
       - name: Run clang-tidy
-        uses: ZedThree/clang-tidy-review@v0.9.0
+        uses: FlorianReimold/clang-tidy-review@feat/split-up-review-and-post-workflows
         id: review
         with:
           build_dir: _build
           apt_packages: "cmake,ninja-build,build-essential,zlib1g-dev,qtbase5-dev,libhdf5-dev,libprotobuf-dev,libprotoc-dev,protobuf-compiler,libcurl4-openssl-dev,libqwt-qt5-dev"
           config_file: ".clang-tidy"
           exclude: "/thirdparty/*,/_build/*,convert_utf.cpp,convert_utf.h"
+          post_comments: false
           lgtm_comment_body: ""
           cmake_command: |
             cmake . -B _build \
@@ -72,10 +73,10 @@ jobs:
                     -DCMAKE_INSTALL_LOCALSTATEDIR=/var \
                     -DCMAKE_INSTALL_LIBDIR=lib/x86_64-linux-gnu
             cmake --build _build
-
-      - name: Passed clang-tidy checks
-        if: steps.review.outputs.total_comments > 0
-        shell: bash
-        run: |
-          echo "Clang Tidy found ${{ steps.review.outputs.total_comments }} issues"
-          exit 1
+            
+      - uses: actions/upload-artifact@v3
+        with:
+          name: clang-tidy-review
+          path: |
+            clang-tidy-review-output.json
+            clang-tidy-review-metadata.json

--- a/.github/workflows/run-clang-tidy.yml
+++ b/.github/workflows/run-clang-tidy.yml
@@ -52,21 +52,21 @@ jobs:
           path: ~/work/ecal/_build/clang_tidy_log_*.txt
           if-no-files-found: warn
 
-      - name: Detect number of clang-tidy warnings
-        id: num_warnings
-        run: |
-          NUM_WARNINGS=0
-          NUM_LOG_FILES=$(ls ~/work/ecal/_build/clang_tidy_log_*.txt 2> /dev/null | wc -l)
-          if [[ ${NUM_LOG_FILES} -gt 0 ]]
-          then
-            NUM_WARNINGS=$(grep -oE "\w+\.\w+:\w+:\w+:\s?warning:\s?.*" -- ~/work/ecal/_build/clang_tidy_log_*.txt | wc -l)
-          fi
-          echo "::set-output name=value::${NUM_WARNINGS}"
+#      - name: Detect number of clang-tidy warnings
+#        id: num_warnings
+#        run: |
+#          NUM_WARNINGS=0
+#          NUM_LOG_FILES=$(ls ~/work/ecal/_build/clang_tidy_log_*.txt 2> /dev/null | wc -l)
+#          if [[ ${NUM_LOG_FILES} -gt 0 ]]
+#          then
+#            NUM_WARNINGS=$(grep -oE "\w+\.\w+:\w+:\w+:\s?warning:\s?.*" -- ~/work/ecal/_build/clang_tidy_log_*.txt | wc -l)
+#          fi
+#          echo "::set-output name=value::${NUM_WARNINGS}"
 
-      # https://github.com/actions/github-script
-      - name: Check clang-tidy warnings
-        if: ${{ steps.num_warnings.outputs.value > 0 }}
-        uses: actions/github-script@v6
-        with:
-          script: |
-            core.setFailed('number of clang-tidy warnings: ${{ steps.num_warnings.outputs.value}}')
+#      # https://github.com/actions/github-script
+#      - name: Check clang-tidy warnings
+#        if: ${{ steps.num_warnings.outputs.value > 0 }}
+#        uses: actions/github-script@v6
+#        with:
+#          script: |
+#            core.setFailed('number of clang-tidy warnings: ${{ steps.num_warnings.outputs.value}}')


### PR DESCRIPTION
- run-clang-tidy action will not report "failed" any more, if there were errors
- clang-tidy-review action will not report "failed" any more, if there were errors. It will only post them as suggestions.
- clang-tidy-review has been updated to a development state of an action that can work with forks