### PR TITLE
clang-tidy: turned off reinterpret_cast warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -22,6 +22,7 @@ Checks: "-*,
   -cppcoreguidelines-non-private-member-variables-in-classes,
   -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
   -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -cppcoreguidelines-pro-type-reinterpret-cast,
   
   misc-*,
   -misc-non-private-member-variables-in-classes,


### PR DESCRIPTION
Reinterpret casts may be ugly, but they are the proper tool for what they do.
