### PR TITLE
Hotfix/python version

### DIFF
--- a/app/play/play_gui/src/ecal_play_gui.cpp
+++ b/app/play/play_gui/src/ecal_play_gui.cpp
@@ -334,7 +334,6 @@ void EcalplayGui::closeEvent(QCloseEvent* event)
   {
     QEcalPlay::instance()->saveChannelMapping();
   }
-// added this just for actions to run
   saveLayout();
   QMainWindow::closeEvent(event);
 }

--- a/app/play/play_gui/src/ecal_play_gui.cpp
+++ b/app/play/play_gui/src/ecal_play_gui.cpp
@@ -334,6 +334,7 @@ void EcalplayGui::closeEvent(QCloseEvent* event)
   {
     QEcalPlay::instance()->saveChannelMapping();
   }
+// added this just for actions to run
   saveLayout();
   QMainWindow::closeEvent(event);
 }

--- a/lang/python/CMakeLists.txt
+++ b/lang/python/CMakeLists.txt
@@ -28,8 +28,6 @@ set(SETUP_PY    "${PYTHON_BINARY_DIR}/setup.py")
 string(REPLACE "." ";" Protobuf_VERSION_components "${Protobuf_VERSION}")
 list(LENGTH Protobuf_VERSION_components Protobuf_VERSION_components_length)
 
-message(STATUS "EAB: protobuf version: ${Protobuf_VERSION}")
-
 if ("${Protobuf_VERSION_components_length}" LESS "2")
   message(FATAL_ERROR "Unable to determine protobuf version for python binding")
 endif()
@@ -37,7 +35,12 @@ list(GET Protobuf_VERSION_components 0 Protobuf_VERSION_major)
 list(GET Protobuf_VERSION_components 1 Protobuf_VERSION_minor)
 MATH(EXPR Protobuf_Version_minor_inc "${Protobuf_VERSION_minor}+1")
 
-set(Protobuf_required_versions ">=${Protobuf_VERSION_major}.${Protobuf_VERSION_minor}.0,<${Protobuf_VERSION_major}.${Protobuf_Version_minor_inc}")
+if (Protobuf_VERSION VERSION_LESS "3.19")
+  set(Protobuf_required_versions ">=${Protobuf_VERSION},<=3.20")
+else()
+  set(Protobuf_required_versions ">=${Protobuf_VERSION}")
+endif()
+
 
 configure_file(${SETUP_PY_IN} ${SETUP_PY} @ONLY)
 

--- a/lang/python/CMakeLists.txt
+++ b/lang/python/CMakeLists.txt
@@ -28,6 +28,8 @@ set(SETUP_PY    "${PYTHON_BINARY_DIR}/setup.py")
 string(REPLACE "." ";" Protobuf_VERSION_components "${Protobuf_VERSION}")
 list(LENGTH Protobuf_VERSION_components Protobuf_VERSION_components_length)
 
+message(STATUS "EAB: protobuf version: ${Protobuf_VERSION}")
+
 if ("${Protobuf_VERSION_components_length}" LESS "2")
   message(FATAL_ERROR "Unable to determine protobuf version for python binding")
 endif()


### PR DESCRIPTION
**Pull request type**

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


**What is the current behavior?**
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, eCAL requires the (more or less) exact version of python3-protobuf that it was built against.

Issue Number: https://github.com/eclipse-ecal/ecal/issues/710

**What is the new behavior?**
Set the required python3-protobuf version to:
protobuf(>=ECAL_PROTO_VERSION,<=3.20)

If ECAL_PROTO_VERSION reaches 3.20 then
   protobuf(>=ECAL_PROTO_VERSION)
**Does this introduce a breaking change?**

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

**Other information**

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
