### PR TITLE
ping_client_dyn sample adapted to demonstrate correct usage of eCAL::…

### DIFF
--- a/samples/cpp/services/ping_client_dyn/src/ping_client_dyn.cpp
+++ b/samples/cpp/services/ping_client_dyn/src/ping_client_dyn.cpp
@@ -61,15 +61,16 @@ int main(int argc, char **argv)
   }
 
   // create dynamic protobuf message decoder to create request and response message objects
-  eCAL::protobuf::CProtoDynDecoder dyn_decoder;
   std::string error_s;
 
   // create the request message object
-  std::shared_ptr<google::protobuf::Message> req_msg(dyn_decoder.GetProtoMessageFromDescriptor(req_desc, req_type, error_s));
+  eCAL::protobuf::CProtoDynDecoder req_decoder;
+  std::shared_ptr<google::protobuf::Message> req_msg(req_decoder.GetProtoMessageFromDescriptor(req_desc, req_type, error_s));
   if (!req_msg) throw std::runtime_error("Could not create request message object: " + error_s);
 
   // create the response message object
-  std::shared_ptr<google::protobuf::Message> resp_msg(dyn_decoder.GetProtoMessageFromDescriptor(resp_desc, resp_type, error_s));
+  eCAL::protobuf::CProtoDynDecoder resp_decoder;
+  std::shared_ptr<google::protobuf::Message> resp_msg(resp_decoder.GetProtoMessageFromDescriptor(resp_desc, resp_type, error_s));
   if (!resp_msg) throw std::runtime_error("Could not create response message object: " + error_s);
 
   int cnt(0);


### PR DESCRIPTION
…protobuf::CProtoDynDecoder (#662)

**Pull request type**

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix

**What is the current behavior?**
Issue when calling `GetProtoMessageFromDescriptor()` multiple times on the same `eCAL::protobuf::CProtoDynDecoder` instance.

```
terminate called after throwing an instance of 'std::runtime_error'
  what():  Could not create request message object: foo.proto foo.proto 10 ERROR: A file with this name is already in the pool.
  ```

Issue Number: #662

**What is the new behavior?**
Sample ping_client_dyn adapted to show how to avoid that behavior by using single instances of 'eCAL::protobuf::CProtoDynDecoder'. The issue seems to be in the internal implementation of google protobufs descriptor pool.

```cpp
  // create the request message object
  eCAL::protobuf::CProtoDynDecoder req_decoder;
  std::shared_ptr<google::protobuf::Message> req_msg(req_decoder.GetProtoMessageFromDescriptor(req_desc, req_type, error_s));
  if (!req_msg) throw std::runtime_error("Could not create request message object: " + error_s);

  // create the response message object
  eCAL::protobuf::CProtoDynDecoder resp_decoder;
  std::shared_ptr<google::protobuf::Message> resp_msg(resp_decoder.GetProtoMessageFromDescriptor(resp_desc, resp_type, error_s));
  if (!resp_msg) throw std::runtime_error("Could not create response message object: " + error_s);
```

**Does this introduce a breaking change?**

- [X] No
