### PR TITLE
eCAL HDF5: fixed Split-Size option

### DIFF
--- a/app/play/play_gui/src/main_window.ui
+++ b/app/play/play_gui/src/main_window.ui
@@ -41,7 +41,7 @@
     </property>
     <widget class="QToolTipMenu" name="menu_recent_measurement">
      <property name="title">
-      <string>&amp;Recent mesurements</string>
+      <string>&amp;Recent measurements</string>
      </property>
      <addaction name="actiondummy"/>
     </widget>

--- a/contrib/ecalhdf5/src/eh5_meas_dir.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_dir.cpp
@@ -158,15 +158,15 @@ size_t eCAL::eh5::HDF5MeasDir::GetMaxSizePerFile() const
   return max_size_per_file_ / 1024 / 1024;
 }
 
-void eCAL::eh5::HDF5MeasDir::SetMaxSizePerFile(size_t size)
+void eCAL::eh5::HDF5MeasDir::SetMaxSizePerFile(size_t max_file_size_mib)
 {
   // Store to internal variable
-  max_size_per_file_ = size * 1024 * 1024;
+  max_size_per_file_ = max_file_size_mib * 1024 * 1024;
 
   // Update all file writers (if there are any)
   for (auto& file_writer : file_writers_)
   {
-    file_writer.second->SetMaxSizePerFile(size);
+    file_writer.second->SetMaxSizePerFile(max_file_size_mib);
   }
 }
 
@@ -507,7 +507,7 @@ bool eCAL::eh5::HDF5MeasDir::OpenRX(const std::string& path, eAccessType access 
     file_writer_it = file_writers_.emplace(one_file_per_channel_ ? channel_name : "", std::make_unique<::eCAL::eh5::HDF5MeasFileWriterV5>()).first;
 
     // Set the current parameters to the new file writer
-    file_writer_it->second->SetMaxSizePerFile(max_size_per_file_);
+    file_writer_it->second->SetMaxSizePerFile(GetMaxSizePerFile());
     file_writer_it->second->SetOneFilePerChannelEnabled(one_file_per_channel_);
     file_writer_it->second->SetFileBaseName(one_file_per_channel_ ? (base_name_ + "_" + channel_name) : (base_name_));
     if (cb_pre_split_)

--- a/contrib/ecalhdf5/src/eh5_meas_dir.h
+++ b/contrib/ecalhdf5/src/eh5_meas_dir.h
@@ -100,9 +100,9 @@ namespace eCAL
       /**
       * @brief Sets maximum allowed size for an individual file
       *
-      * @param size   maximum size in MB
+      * @param max_file_size_mib   maximum size in MB
       **/
-      void SetMaxSizePerFile(size_t size) override;
+      void SetMaxSizePerFile(size_t max_file_size_mib) override;
 
       /**
       * @brief Whether each Channel shall be writte in its own file

--- a/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.cpp
@@ -112,9 +112,9 @@ size_t eCAL::eh5::HDF5MeasFileWriterV5::GetMaxSizePerFile() const
   return max_size_per_file_ / 1024 / 1024;
 }
 
-void eCAL::eh5::HDF5MeasFileWriterV5::SetMaxSizePerFile(size_t size)
+void eCAL::eh5::HDF5MeasFileWriterV5::SetMaxSizePerFile(size_t max_file_size_mib)
 {
-  max_size_per_file_ = size * 1024 * 1024;
+  max_size_per_file_ = max_file_size_mib * 1024 * 1024;
 }
 
 bool eCAL::eh5::HDF5MeasFileWriterV5::IsOneFilePerChannelEnabled() const

--- a/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.h
@@ -98,9 +98,9 @@ namespace eCAL
       /**
       * @brief Sets maximum allowed size for an individual file
       *
-      * @param size   maximum size in MB
+      * @param max_file_size_mib   maximum size in MB
       **/
-      void SetMaxSizePerFile(size_t size) override;
+      void SetMaxSizePerFile(size_t max_file_size_mib) override;
 
       /**
       * @brief Whether each Channel shall be writte in its own file


### PR DESCRIPTION
**Pull request type**

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


**What is the current behavior?**
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
 eCAL HDF5 fails to split the HDF5 files.

Fixes #802

**What is the new behavior?**
<!-- Please describe the behavior or changes that are being added by this PR. -->
 eCAL HDF5 is again splitting the HDF5 files.

**Does this introduce a breaking change?**

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

**Other information**

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
