### PR TITLE
CMakeLists: Removed code that would fix the CXX Standard to 14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,19 +45,11 @@ if(MSVC)
 endif()
 
 # --------------------------------------------------------
-# set mingw specific options
-# --------------------------------------------------------
-if(MINGW)
-  add_definitions(-std=c++14 -DWINVER=0x0601)
-endif()
-
-# --------------------------------------------------------
 # set gcc specific options
 # --------------------------------------------------------
 if(UNIX)
   message(STATUS "GCC detected - Adding flags")
-  set(CMAKE_CXX_STANDARD 14)
-  add_definitions(-Wall -Wextra -std=c++14)
+  add_definitions(-Wall -Wextra)
 
   set(ATOMIC_TEST_CODE "
       #include <atomic>

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -18,7 +18,6 @@
 cmake_minimum_required(VERSION 3.10)
 
 project(eCAL_samples VERSION "${ECAL_VERSION_STRING}")
-set (CMAKE_CXX_STANDARD 14)
 
 if(HAS_HDF5)
 set(SAMPLE_PERSON_MEASUREMENT_PATH ${CMAKE_CURRENT_SOURCE_DIR}/data/person)


### PR DESCRIPTION
This fixes a bug that would prevent FTXUI / Mon TUI to compile, as those targets need C++ 17.

Fixes #830 