### PR TITLE
Switched mime icons from hicolor to Humanity theme

### DIFF
--- a/app/play/play_gui/CMakeLists.txt
+++ b/app/play/play_gui/CMakeLists.txt
@@ -227,5 +227,5 @@ if (UNIX)
             DESTINATION "${CMAKE_INSTALL_DATADIR}/mime/packages/")
 
     INSTALL (FILES "${CMAKE_CURRENT_LIST_DIR}/mimetype/application-ecalmeas.svg"
-            DESTINATION "${CMAKE_INSTALL_DATADIR}/icons/hicolor/scalable/mimetypes/")
+            DESTINATION "${CMAKE_INSTALL_DATADIR}/icons/Humanity/scalable/mimetypes/")
 endif()

--- a/app/rec/rec_gui/CMakeLists.txt
+++ b/app/rec/rec_gui/CMakeLists.txt
@@ -262,5 +262,5 @@ if (UNIX)
             DESTINATION "${CMAKE_INSTALL_DATADIR}/mime/packages/")
 
     INSTALL (FILES "${CMAKE_CURRENT_LIST_DIR}/mimetype/application-ecalrec.svg"
-            DESTINATION "${CMAKE_INSTALL_DATADIR}/icons/hicolor/scalable/mimetypes/")
+            DESTINATION "${CMAKE_INSTALL_DATADIR}/icons/Humanity/scalable/mimetypes/")
 endif()

--- a/app/sys/sys_gui/CMakeLists.txt
+++ b/app/sys/sys_gui/CMakeLists.txt
@@ -222,7 +222,7 @@ if (UNIX)
             DESTINATION "${CMAKE_INSTALL_DATADIR}/mime/packages/")
 
     INSTALL (FILES "${CMAKE_CURRENT_LIST_DIR}/mimetype/application-ecalsys.svg"
-            DESTINATION "${CMAKE_INSTALL_DATADIR}/icons/hicolor/scalable/mimetypes/")
+            DESTINATION "${CMAKE_INSTALL_DATADIR}/icons/Humanity/scalable/mimetypes/")
 endif()
 
 ecal_install_app(${PROJECT_NAME} START_MENU_NAME "eCAL Sys")


### PR DESCRIPTION
Looks like Ubuntu 22.04 has a bug (?) that prevents loading icons from the hicolor theme. The Humanity theme works though. The default Yaru theme inherits from both, so I moved the icons to the Humanity theme and now they show up fine.

Fixes #825