### PR TITLE
Feature/sub receive cv

### DIFF
--- a/ecal/core/src/readwrite/ecal_reader.cpp
+++ b/ecal/core/src/readwrite/ecal_reader.cpp
@@ -60,6 +60,7 @@ namespace eCAL
                  m_topic_type(""),
                  m_topic_size(0),
                  m_connected(false),
+                 m_read_buf_received(false),
                  m_read_time(0),
                  m_receive_timeout(0),
                  m_receive_time(0),
@@ -107,9 +108,6 @@ namespace eCAL
     std::stringstream counter;
     counter << std::chrono::steady_clock::now().time_since_epoch().count();
     m_topic_id = counter.str();
-
-    // create receive event
-    gOpenEvent(&m_receive_event);
 
     // set registration expiration
     std::chrono::milliseconds registration_timeout(Config::GetRegistrationTimeoutMs());
@@ -160,9 +158,6 @@ namespace eCAL
       std::lock_guard<std::mutex> lock(m_event_callback_map_sync);
       m_event_callback_map.clear();
     }
-
-    // destroy receive event
-    gCloseEvent(m_receive_event);
 
     // reset defaults
     m_created                 = false;
@@ -359,21 +354,32 @@ namespace eCAL
     return(true);
   }
 
-  bool CDataReader::Receive(std::string& buf_, long long* time_ /* = nullptr */, int rcv_timeout_ /* = 0 */)
+  bool CDataReader::Receive(std::string& buf_, long long* time_ /* = nullptr */, int rcv_timeout_ms_ /* = 0 */)
   {
     if(!m_created) return(false);
 
+    std::unique_lock<std::mutex> read_buffer_lock(m_read_buf_mutex);
+
+    if (rcv_timeout_ms_ < 0)
+    {
+      m_read_buf_cv.wait(read_buffer_lock, [this]() { return this->m_read_buf_received; });
+    }
+    else if (rcv_timeout_ms_ > 0)
+    {
+      m_read_buf_cv.wait_for(read_buffer_lock, std::chrono::milliseconds(rcv_timeout_ms_), [this]() { return this->m_read_buf_received; });
+    }
+
     // did we receive new samples ?
-    if(gWaitForEvent(m_receive_event, rcv_timeout_))
+    if (m_read_buf_received)
     {
 #ifndef NDEBUG
       // log it
       Logging::Log(log_level_debug3, m_topic_name + "::CDataReader::Receive");
 #endif
       // copy content to target string
-      std::lock_guard<std::mutex> lock(m_read_buf_sync);
       buf_.clear();
       buf_.swap(m_read_buf);
+      m_read_buf_received = false;
 
       // apply time
       if(time_) *time_ = m_read_time;
@@ -381,6 +387,7 @@ namespace eCAL
       // return success
       return(true);
     }
+
     return(false);
   }
 
@@ -463,13 +470,14 @@ namespace eCAL
     if(!processed)
     {
       // push sample into read buffer
-      std::lock_guard<std::mutex> lock1(m_read_buf_sync);
+      std::lock_guard<std::mutex> read_buffer_lock(m_read_buf_mutex);
       m_read_buf.clear();
       m_read_buf.assign(payload_, payload_ + size_);
       m_read_time = time_;
+      m_read_buf_received = true;
 
       // inform receive
-      gSetEvent(m_receive_event);
+      m_read_buf_cv.notify_one();
 #ifndef NDEBUG
       // log it
       Logging::Log(log_level_debug3, m_topic_name + "::CDataReader::AddSample::Receive::Buffered");

--- a/ecal/core/src/readwrite/ecal_reader.h
+++ b/ecal/core/src/readwrite/ecal_reader.h
@@ -59,7 +59,7 @@ namespace eCAL
 
     bool SetQOS(const QOS::SReaderQOS& qos_);
 
-    bool Receive(std::string& buf_, long long* time_ = nullptr, int rcv_timeout_ = 0);
+    bool Receive(std::string& buf_, long long* time_ = nullptr, int rcv_timeout_ms_ = 0);
 
     bool AddReceiveCallback(ReceiveCallbackT callback_);
     bool RemReceiveCallback();
@@ -127,9 +127,9 @@ namespace eCAL
     ConnectedMapT                             m_loc_pub_map;
     ConnectedMapT                             m_ext_pub_map;
 
-    EventHandleT                              m_receive_event;
-
-    std::mutex                                m_read_buf_sync;
+    mutable std::mutex                        m_read_buf_mutex;
+    std::condition_variable                   m_read_buf_cv;
+    bool                                      m_read_buf_received;
     std::string                               m_read_buf;
     long long                                 m_read_time;
 

--- a/ecal/core/src/readwrite/ecal_reader.h
+++ b/ecal/core/src/readwrite/ecal_reader.h
@@ -37,6 +37,7 @@
 
 #include "ecal_expmap.h"
 
+#include <condition_variable>
 #include <mutex>
 #include <atomic>
 #include <set>

--- a/testing/ecal/pubsub_test/CMakeLists.txt
+++ b/testing/ecal/pubsub_test/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(GTest REQUIRED)
 
 set(pubsub_test_src
   src/pubsub_test.cpp
+  src/pubsub_receive_test.cpp
 )
 
 ecal_add_gtest(${PROJECT_NAME}_cpp ${pubsub_test_src})

--- a/testing/ecal/pubsub_test/src/pubsub_receive_test.cpp
+++ b/testing/ecal/pubsub_test/src/pubsub_receive_test.cpp
@@ -39,12 +39,11 @@ namespace std
 {
   namespace chrono
   {
-    template <class Rep, class Period, class = std::enable_if_t<
-      std::chrono::duration<Rep, Period>::min() < std::chrono::duration<Rep, Period>::zero()>>
-      constexpr std::chrono::duration<Rep, Period> abs(std::chrono::duration<Rep, Period> d)
-    {
-      return d >= d.zero() ? d : -d;
-    }
+      template <class T>
+      T abs(T d)
+      {
+        return d >= d.zero() ? d : -d;
+      }
   }
 }
 #endif

--- a/testing/ecal/pubsub_test/src/pubsub_receive_test.cpp
+++ b/testing/ecal/pubsub_test/src/pubsub_receive_test.cpp
@@ -22,6 +22,7 @@
 #include <ecal/msg/string/subscriber.h>
 
 #include <atomic>
+#include <chrono>
 #include <string>
 #include <sstream>
 #include <thread>
@@ -30,11 +31,128 @@
 
 #define CMN_REGISTRATION_REFRESH 1000
 
+using namespace std::chrono_literals;
+
+void measure_execution_within_range(const std::string& description, std::function<void()> func, std::chrono::milliseconds expected_runtime, std::chrono::microseconds epsilon)
+{
+  auto start = std::chrono::steady_clock::now();
+
+  func();
+
+  auto end = std::chrono::steady_clock::now();
+
+  auto duration = end - start;
+  auto divergence = std::chrono::abs(expected_runtime - duration);
+  auto within_epsilon = divergence < epsilon;
+
+  // How to do this nicely?
+  EXPECT_TRUE(within_epsilon) << "Execution of " << description << " took " << duration.count() << " ns but expected was " << expected_runtime.count()*1000000 << "ns";
+}
+
+
+TEST(SUBSCRIBER, TimingSubscriberReceive)
+{
+  // initialize eCAL API
+  EXPECT_EQ(0, eCAL::Initialize(0, nullptr, "subscriber_receive_timing"));
+
+  // publish / subscribe match in the same process
+  eCAL::Util::EnableLoopback(true);
+
+  // create simple string publisher
+  eCAL::string::CPublisher<std::string> pub("CLOCK");
+  eCAL::string::CSubscriber<std::string> sub("CLOCK");
+
+  // let's match them
+  eCAL::Process::SleepMS(2 * CMN_REGISTRATION_REFRESH);
+
+  // Send nothing and make sure the functions return as specified
+  std::string received;
+  // return with immediately
+  measure_execution_within_range(
+    "ReturnImmediate",
+    [&sub, &received]() {sub.Receive(received); },
+    0ms,
+    10ms
+  );
+
+  // return with timeout
+  // lets give a few more milliseconds delta, at least for windows
+  measure_execution_within_range(
+    "Return500ms",
+    [&sub, &received]() {
+      auto res = sub.Receive(received, nullptr, 500); 
+      EXPECT_FALSE(res);
+    },
+    500ms,
+    50ms
+  );
+
+  // All three send functions should return immediately even though timeouts were given, since data is available.
+  pub.Send("Hi");
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  measure_execution_within_range(
+    "ReceiveImmediate",
+    [&sub, &received]() {
+      auto res = sub.Receive(received); 
+      EXPECT_TRUE(res);
+    },
+    0ms,
+    10ms
+  );
+
+  measure_execution_within_range(
+    "Return500ms_2",
+    [&sub, &received]() {
+      auto res = sub.Receive(received, nullptr, 500);
+      EXPECT_FALSE(res);
+    },
+    500ms,
+    50ms
+   );
+
+  pub.Send("There");
+  measure_execution_within_range(
+    "ReceiveImmediateInfinite",
+    [&sub, &received]() {
+      auto res = sub.Receive(received, nullptr, -1); 
+      EXPECT_TRUE(res);
+    },
+    0ms,
+    10ms
+  );
+
+  measure_execution_within_range(
+    "Return500ms_3",
+    [&sub, &received]() {
+      auto res = sub.Receive(received, nullptr, 500);
+      EXPECT_FALSE(res);
+    },
+    500ms,
+    50ms
+  );
+
+  pub.Send("Person");
+  measure_execution_within_range(
+    "ReceiveImmediate500ms",
+    [&sub, &received]() {
+      auto res = sub.Receive(received, nullptr, 500);
+      EXPECT_TRUE(res);
+    },
+    0ms,
+    10ms
+  );
+  
+  // finalize eCAL API
+  EXPECT_EQ(0, eCAL::Finalize());
+}
+
+
+
 // This tests test for sporadically received empty messages which were a problem.
-TEST(SUBSCRIBER, SPORADIC_EMPTY_RECEIVES)
+TEST(SUBSCRIBER, SporadicEmptyReceives)
 { 
   // initialize eCAL API
-  EXPECT_EQ(0, eCAL::Initialize(0, nullptr, "inproc_clock_test"));
+  EXPECT_EQ(0, eCAL::Initialize(0, nullptr, "sporadic_empty_receives"));
 
   // publish / subscribe match in the same process
   eCAL::Util::EnableLoopback(true);

--- a/testing/ecal/pubsub_test/src/pubsub_receive_test.cpp
+++ b/testing/ecal/pubsub_test/src/pubsub_receive_test.cpp
@@ -33,6 +33,22 @@
 
 using namespace std::chrono_literals;
 
+// define std::chrono::abs for < c++17
+#if (__cpp_lib_chrono < 201510L)
+namespace std
+{
+  namespace chrono
+  {
+    template <class Rep, class Period, class = std::enable_if_t<
+      std::chrono::duration<Rep, Period>::min() < std::chrono::duration<Rep, Period>::zero()>>
+      constexpr std::chrono::duration<Rep, Period> abs(std::chrono::duration<Rep, Period> d)
+    {
+      return d >= d.zero() ? d : -d;
+    }
+  }
+}
+#endif
+
 void measure_execution_within_range(const std::string& description, std::function<void()> func, std::chrono::milliseconds expected_runtime, std::chrono::microseconds epsilon)
 {
   auto start = std::chrono::steady_clock::now();

--- a/testing/ecal/pubsub_test/src/pubsub_receive_test.cpp
+++ b/testing/ecal/pubsub_test/src/pubsub_receive_test.cpp
@@ -1,0 +1,84 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+#include <ecal/ecal.h>
+#include <ecal/msg/string/publisher.h>
+#include <ecal/msg/string/subscriber.h>
+
+#include <sstream>
+#include <gtest/gtest.h>
+
+#define CMN_REGISTRATION_REFRESH 1000
+
+// This tests test for sporadically received empty messages which were a problem.
+TEST(SUBSCRIBER, SPORADIC_EMPTY_RECEIVES)
+{ 
+  // initialize eCAL API
+  EXPECT_EQ(0, eCAL::Initialize(0, nullptr, "inproc_clock_test"));
+
+  // publish / subscribe match in the same process
+  eCAL::Util::EnableLoopback(true);
+
+  // create simple string publisher
+  eCAL::string::CPublisher<std::string> pub("CLOCK");
+  eCAL::string::CSubscriber<std::string> sub("CLOCK");
+
+  // let's match them
+  eCAL::Process::SleepMS(2 * CMN_REGISTRATION_REFRESH);
+
+  // start publishing thread
+  std::atomic<bool> pub_stop(false);
+  std::thread pub_t([&pub, &pub_stop]() {
+    std::string abc{ "abc" };
+    while (!pub_stop)
+    {
+
+      pub.Send(abc);
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    });
+
+  std::atomic<bool> sub_stop(false);
+  std::thread sub_t([&]() {
+    std::string received;
+    while (!sub_stop)
+    {
+      bool got_data = sub.Receive(received);
+      if (got_data && received.empty())
+      {
+        FAIL("received empty string");
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    });
+
+  // let them work together
+  std::this_thread::sleep_for(std::chrono::seconds(10));
+
+  // stop publishing thread
+  pub_stop = true;
+  pub_t.join();
+
+  sub_stop = true;
+  sub_t.join();
+
+
+  // finalize eCAL API
+  EXPECT_EQ(0, eCAL::Finalize());
+}

--- a/testing/ecal/pubsub_test/src/pubsub_receive_test.cpp
+++ b/testing/ecal/pubsub_test/src/pubsub_receive_test.cpp
@@ -21,7 +21,11 @@
 #include <ecal/msg/string/publisher.h>
 #include <ecal/msg/string/subscriber.h>
 
+#include <atomic>
+#include <string>
 #include <sstream>
+#include <thread>
+
 #include <gtest/gtest.h>
 
 #define CMN_REGISTRATION_REFRESH 1000
@@ -62,7 +66,7 @@ TEST(SUBSCRIBER, SPORADIC_EMPTY_RECEIVES)
       bool got_data = sub.Receive(received);
       if (got_data && received.empty())
       {
-        FAIL("received empty string");
+        FAIL() << "received empty string";
       }
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }


### PR DESCRIPTION
**Pull request type**

Please check the type of change your PR introduces:
- [x] Bugfix

**What is the current behavior?**
Sometimes, the synchronous receive function would return true with empty data, e.g. even though nothing was received.

Fixes #834

**What is the new behavior?**
It correctly returns false when no data was received.

**Does this introduce a breaking change?**

- [ ] Yes
- [x] No

**Other information**

Please review this PR carefully! It was tested, but not extensively.
@FlorianReimold: can we safely use this or will we run in trouble regarding time jumps (back / forth) like we did before? (e.g. may there be the chance that it never times out?)