### PR TITLE
Remove double tests (which before went through old C - C++ Wrapper).

### DIFF
--- a/testing/ecal/clientserver_test/CMakeLists.txt
+++ b/testing/ecal/clientserver_test/CMakeLists.txt
@@ -34,21 +34,13 @@ set(clientserver_test_proto
 )
 
 ecal_add_static_library(clientserver_proto src/dummy.cpp)
-PROTOBUF_TARGET_CPP(clientserver_proto ${CMAKE_CURRENT_SOURCE_DIR}/src/protobuf ${clientserver_test_proto})
+PROTOBUF_TARGET(clientserver_proto ${CMAKE_CURRENT_SOURCE_DIR}/src/protobuf ${clientserver_test_proto})
 target_link_libraries(clientserver_proto PRIVATE protobuf::libprotobuf)
 set_property(TARGET clientserver_proto PROPERTY FOLDER testing/ecal/service)
 
-ecal_add_gtest(${PROJECT_NAME}_cpp ${clientserver_test_src})
-target_link_libraries(${PROJECT_NAME}_cpp
+ecal_add_gtest(${PROJECT_NAME} ${clientserver_test_src})
+target_link_libraries(${PROJECT_NAME}
   PRIVATE eCAL::core clientserver_proto Threads::Threads)
 
-  ecal_install_gtest(${PROJECT_NAME}_cpp)
-set_property(TARGET ${PROJECT_NAME}_cpp PROPERTY FOLDER testing/ecal/service)
-
-if(WIN32)
-  ecal_add_gtest(${PROJECT_NAME}_c   ${clientserver_test_src})
-  target_link_libraries(${PROJECT_NAME}_c PRIVATE
-    eCAL::core_c clientserver_proto Threads::Threads)
-  ecal_install_gtest(${PROJECT_NAME}_c)
-  set_property(TARGET ${PROJECT_NAME}_c   PROPERTY FOLDER testing/ecal/service)
-endif()
+  ecal_install_gtest(${PROJECT_NAME})
+set_property(TARGET ${PROJECT_NAME} PROPERTY FOLDER testing/ecal/service)

--- a/testing/ecal/core_test/CMakeLists.txt
+++ b/testing/ecal/core_test/CMakeLists.txt
@@ -25,17 +25,9 @@ set(core_test_src
   src/core_test.cpp
 )
 
-ecal_add_gtest(${PROJECT_NAME}_cpp ${core_test_src})
-target_include_directories(${PROJECT_NAME}_cpp PRIVATE $<TARGET_PROPERTY:eCAL::core,INCLUDE_DIRECTORIES>)
-target_link_libraries(${PROJECT_NAME}_cpp
+ecal_add_gtest(${PROJECT_NAME} ${core_test_src})
+target_include_directories(${PROJECT_NAME} PRIVATE $<TARGET_PROPERTY:eCAL::core,INCLUDE_DIRECTORIES>)
+target_link_libraries(${PROJECT_NAME}
   PRIVATE eCAL::core Threads::Threads)
-ecal_install_gtest(${PROJECT_NAME}_cpp)
-set_property(TARGET ${PROJECT_NAME}_cpp PROPERTY FOLDER testing/ecal/core)
-
-if(WIN32)
-  ecal_add_gtest(${PROJECT_NAME}_c   ${core_test_src})
-  target_include_directories(${PROJECT_NAME}_c   PRIVATE $<TARGET_PROPERTY:eCAL::core,INCLUDE_DIRECTORIES>)
-  target_link_libraries(${PROJECT_NAME}_c PRIVATE eCAL::core_c Threads::Threads)
-  ecal_install_gtest(${PROJECT_NAME}_c)
-  set_property(TARGET ${PROJECT_NAME}_c   PROPERTY FOLDER testing/ecal/core)
-endif()
+ecal_install_gtest(${PROJECT_NAME})
+set_property(TARGET ${PROJECT_NAME} PROPERTY FOLDER testing/ecal/core)

--- a/testing/ecal/pubsub_inproc_test/CMakeLists.txt
+++ b/testing/ecal/pubsub_inproc_test/CMakeLists.txt
@@ -25,20 +25,10 @@ set(pubsub_inproc_test_src
   src/pubsub_inproc_test.cpp
 )
 
-ecal_add_gtest(${PROJECT_NAME}_cpp ${pubsub_inproc_test_src})
-target_link_libraries(${PROJECT_NAME}_cpp
+ecal_add_gtest(${PROJECT_NAME} ${pubsub_inproc_test_src})
+target_link_libraries(${PROJECT_NAME}
   PRIVATE
    eCAL::core
    Threads::Threads)
-ecal_install_gtest(${PROJECT_NAME}_cpp)
-set_property(TARGET ${PROJECT_NAME}_cpp PROPERTY FOLDER testing/ecal/pubsub)
-
-if(WIN32)
-  ecal_add_gtest(${PROJECT_NAME}_c   ${pubsub_inproc_test_src})
-  target_link_libraries(${PROJECT_NAME}_c
-    PRIVATE
-      eCAL::core_c
-      Threads::Threads)
-  ecal_install_gtest(${PROJECT_NAME}_c)
-  set_property(TARGET ${PROJECT_NAME}_c PROPERTY FOLDER testing/ecal/pubsub)
-endif()
+ecal_install_gtest(${PROJECT_NAME})
+set_property(TARGET ${PROJECT_NAME} PROPERTY FOLDER testing/ecal/pubsub)

--- a/testing/ecal/pubsub_test/CMakeLists.txt
+++ b/testing/ecal/pubsub_test/CMakeLists.txt
@@ -25,20 +25,10 @@ set(pubsub_test_src
   src/pubsub_test.cpp
 )
 
-ecal_add_gtest(${PROJECT_NAME}_cpp ${pubsub_test_src})
-target_link_libraries(${PROJECT_NAME}_cpp
+ecal_add_gtest(${PROJECT_NAME} ${pubsub_test_src})
+target_link_libraries(${PROJECT_NAME}
   PRIVATE
     eCAL::core
     Threads::Threads)
-ecal_install_gtest(${PROJECT_NAME}_cpp)
-set_property(TARGET ${PROJECT_NAME}_cpp PROPERTY FOLDER testing/ecal/pubsub)
-
-if(WIN32)
-  ecal_add_gtest(${PROJECT_NAME}_c   ${pubsub_test_src})
-  target_link_libraries(${PROJECT_NAME}_c
-    PRIVATE
-      eCAL::core_c
-      Threads::Threads)
-  ecal_install_gtest(${PROJECT_NAME}_c)
-  set_property(TARGET ${PROJECT_NAME}_c PROPERTY FOLDER testing/ecal/pubsub)
-endif()
+ecal_install_gtest(${PROJECT_NAME})
+set_property(TARGET ${PROJECT_NAME} PROPERTY FOLDER testing/ecal/pubsub)


### PR DESCRIPTION
Currently all tests are build twice. 