### PR TITLE
Core@Linux: Add option to join MC group on all interfaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,6 @@ option(ECAL_INCLUDE_PY_SAMPLES                 "Include python language sample p
 option(ECAL_INSTALL_SAMPLE_SOURCES             "Install the sources of eCAL samples"                               ON)
 
 option(ECAL_JOIN_MULTICAST_TWICE               "Specific Multicast Network Bug Workaround"                        OFF)
-option(ECAL_JOIN_MULTICAST_ON_ALL_INTERFACES   "Enabling Joining Multicast Groups On All Interfaces"              OFF)
 option(ECAL_NPCAP_SUPPORT                      "Enable the eCAL Npcap Receiver (i.e. the Win10 performance fix)"  OFF)
 
 # Set option regarding third party library builds
@@ -561,7 +560,6 @@ message(STATUS "ECAL_LAYER_ICEORYX                             : ${ECAL_LAYER_IC
 message(STATUS "ECAL_INCLUDE_PY_SAMPLES                        : ${ECAL_INCLUDE_PY_SAMPLES}")
 message(STATUS "ECAL_INSTALL_SAMPLE_SOURCES                    : ${ECAL_INSTALL_SAMPLE_SOURCES}")
 message(STATUS "ECAL_JOIN_MULTICAST_TWICE                      : ${ECAL_JOIN_MULTICAST_TWICE}")
-message(STATUS "ECAL_JOIN_MULTICAST_ON_ALL_INTERFACES          : ${ECAL_JOIN_MULTICAST_ON_ALL_INTERFACES}")
 message(STATUS "ECAL_NPCAP_SUPPORT                             : ${ECAL_NPCAP_SUPPORT}")
 message(STATUS "ECAL_THIRDPARTY_BUILD_CMAKE_FUNCTIONS          : ${ECAL_THIRDPARTY_BUILD_CMAKE_FUNCTIONS}")
 message(STATUS "ECAL_THIRDPARTY_BUILD_SPDLOG                   : ${ECAL_THIRDPARTY_BUILD_SPDLOG}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ option(ECAL_INCLUDE_PY_SAMPLES                 "Include python language sample p
 option(ECAL_INSTALL_SAMPLE_SOURCES             "Install the sources of eCAL samples"                               ON)
 
 option(ECAL_JOIN_MULTICAST_TWICE               "Specific Multicast Network Bug Workaround"                        OFF)
+option(ECAL_JOIN_MULTICAST_ON_ALL_INTERFACES   "Enabling Joining Multicast Groups On All Interfaces"              OFF)
 option(ECAL_NPCAP_SUPPORT                      "Enable the eCAL Npcap Receiver (i.e. the Win10 performance fix)"  OFF)
 
 # Set option regarding third party library builds
@@ -560,6 +561,7 @@ message(STATUS "ECAL_LAYER_ICEORYX                             : ${ECAL_LAYER_IC
 message(STATUS "ECAL_INCLUDE_PY_SAMPLES                        : ${ECAL_INCLUDE_PY_SAMPLES}")
 message(STATUS "ECAL_INSTALL_SAMPLE_SOURCES                    : ${ECAL_INSTALL_SAMPLE_SOURCES}")
 message(STATUS "ECAL_JOIN_MULTICAST_TWICE                      : ${ECAL_JOIN_MULTICAST_TWICE}")
+message(STATUS "ECAL_JOIN_MULTICAST_ON_ALL_INTERFACES          : ${ECAL_JOIN_MULTICAST_ON_ALL_INTERFACES}")
 message(STATUS "ECAL_NPCAP_SUPPORT                             : ${ECAL_NPCAP_SUPPORT}")
 message(STATUS "ECAL_THIRDPARTY_BUILD_CMAKE_FUNCTIONS          : ${ECAL_THIRDPARTY_BUILD_CMAKE_FUNCTIONS}")
 message(STATUS "ECAL_THIRDPARTY_BUILD_SPDLOG                   : ${ECAL_THIRDPARTY_BUILD_SPDLOG}")

--- a/ecal/core/CMakeLists.txt
+++ b/ecal/core/CMakeLists.txt
@@ -29,6 +29,11 @@ if (ECAL_JOIN_MULTICAST_TWICE)
   add_definitions(-DECAL_JOIN_MULTICAST_TWICE)
 endif(ECAL_JOIN_MULTICAST_TWICE)
 
+if (ECAL_JOIN_MULTICAST_ON_ALL_INTERFACES)
+  message(STATUS "eCAL ${PROJECT_NAME}: Enabling Joining Multicast Groups On All Interfaces")
+  add_definitions(-DECAL_JOIN_MULTICAST_ON_ALL_INTERFACES)
+endif(ECAL_JOIN_MULTICAST_ON_ALL_INTERFACES)
+
 # If we're currently doing a build within a git repository, we will configure the header files.
 # Else, (e.g. for source packages such as debian source packages) we will use a preconfigured file.
 # If there is really no information available, it will generate a dummy version file 0.0.0

--- a/ecal/core/CMakeLists.txt
+++ b/ecal/core/CMakeLists.txt
@@ -29,11 +29,6 @@ if (ECAL_JOIN_MULTICAST_TWICE)
   add_definitions(-DECAL_JOIN_MULTICAST_TWICE)
 endif(ECAL_JOIN_MULTICAST_TWICE)
 
-if (ECAL_JOIN_MULTICAST_ON_ALL_INTERFACES)
-  message(STATUS "eCAL ${PROJECT_NAME}: Enabling Joining Multicast Groups On All Interfaces")
-  add_definitions(-DECAL_JOIN_MULTICAST_ON_ALL_INTERFACES)
-endif(ECAL_JOIN_MULTICAST_ON_ALL_INTERFACES)
-
 # If we're currently doing a build within a git repository, we will configure the header files.
 # Else, (e.g. for source packages such as debian source packages) we will use a preconfigured file.
 # If there is really no information available, it will generate a dummy version file 0.0.0

--- a/ecal/core/CMakeLists.txt
+++ b/ecal/core/CMakeLists.txt
@@ -175,6 +175,12 @@ set(ecal_io_header_src
     ${ecal_io_header_src_npcap}
 )
 
+if (UNIX)
+  list (APPEND
+        ecal_io_header_src
+        "src/io/linux/ecal_socket_option_linux.h")
+endif()
+
 if(NOT ECAL_LAYER_ICEORYX)
   set(ecal_io_mem_header_src
       src/io/ecal_memfile.h

--- a/ecal/core/cfg/ecal.ini
+++ b/ecal/core/cfg/ecal.ini
@@ -18,7 +18,9 @@
 ;  
 ; multicast_rcvbuf           = 1024 * x             UDP receive buffer in bytes
 ;
-; multicast_join_all_if      = false                Join multicast group on all interfacs (Linux only)
+; multicast_join_all_if      = false                Linux specific setting to enable joining multicast groups on all network interfacs
+;                                                   independent of their link state. Enabling this makes sure that eCAL processes
+;                                                   receive data if they are started before network devices are up and running.
 ;  
 ; bandwidth_max_udp          = -1                   UDP bandwidth limit for eCAL udp layer (-1 == unlimited)
 ;  

--- a/ecal/core/cfg/ecal.ini
+++ b/ecal/core/cfg/ecal.ini
@@ -17,6 +17,8 @@
 ; multicast_sndbuf           = 1024 * x             UDP send buffer in bytes
 ;  
 ; multicast_rcvbuf           = 1024 * x             UDP receive buffer in bytes
+;
+; multicast_join_all_if      = false                Join multicast group on all interfacs (Linux only)
 ;  
 ; bandwidth_max_udp          = -1                   UDP bandwidth limit for eCAL udp layer (-1 == unlimited)
 ;  
@@ -40,6 +42,8 @@ multicast_port            = 14000
 multicast_ttl             = 2
 multicast_sndbuf          = 5242880
 multicast_rcvbuf          = 5242880
+
+multicast_join_all_if     = false
 
 bandwidth_max_udp         = -1
 

--- a/ecal/core/include/ecal/ecal_config.h
+++ b/ecal/core/include/ecal/ecal_config.h
@@ -49,7 +49,7 @@ namespace eCAL
     ECAL_API int               GetUdpMulticastSndBufSizeBytes       ();
     ECAL_API int               GetUdpMulticastRcvBufSizeBytes       ();
 
-    ECAL_API bool              GetUdpMulticastJoinAllIfEnabled      ();
+    ECAL_API bool              IsUdpMulticastJoinAllIfEnabled       ();
 
     ECAL_API int               GetMaxUdpBandwidthBytesPerSecond     ();
 

--- a/ecal/core/include/ecal/ecal_config.h
+++ b/ecal/core/include/ecal/ecal_config.h
@@ -49,6 +49,8 @@ namespace eCAL
     ECAL_API int               GetUdpMulticastSndBufSizeBytes       ();
     ECAL_API int               GetUdpMulticastRcvBufSizeBytes       ();
 
+    ECAL_API bool              GetUdpMulticastJoinAllIfEnabled      ();
+
     ECAL_API int               GetMaxUdpBandwidthBytesPerSecond     ();
 
     ECAL_API bool              IsUdpMulticastRecEnabled             ();

--- a/ecal/core/src/ecal_config.cpp
+++ b/ecal/core/src/ecal_config.cpp
@@ -107,6 +107,8 @@ namespace eCAL
 
     ECAL_API int               GetUdpMulticastSndBufSizeBytes       () { return eCALPAR(NET, UDP_MULTICAST_SNDBUF); }
     ECAL_API int               GetUdpMulticastRcvBufSizeBytes       () { return eCALPAR(NET, UDP_MULTICAST_RCVBUF); }
+    ECAL_API bool              GetUdpMulticastJoinAllIfEnabled      () { return eCALPAR(NET, UDP_MULTICAST_JOIN_ALL_IF_ENABLED); }
+
 
     ECAL_API int               GetMaxUdpBandwidthBytesPerSecond     () { return eCALPAR(NET, BANDWIDTH_MAX_UDP); }
 

--- a/ecal/core/src/ecal_config.cpp
+++ b/ecal/core/src/ecal_config.cpp
@@ -107,7 +107,7 @@ namespace eCAL
 
     ECAL_API int               GetUdpMulticastSndBufSizeBytes       () { return eCALPAR(NET, UDP_MULTICAST_SNDBUF); }
     ECAL_API int               GetUdpMulticastRcvBufSizeBytes       () { return eCALPAR(NET, UDP_MULTICAST_RCVBUF); }
-    ECAL_API bool              GetUdpMulticastJoinAllIfEnabled      () { return eCALPAR(NET, UDP_MULTICAST_JOIN_ALL_IF_ENABLED); }
+    ECAL_API bool              IsUdpMulticastJoinAllIfEnabled       () { return eCALPAR(NET, UDP_MULTICAST_JOIN_ALL_IF_ENABLED); }
 
 
     ECAL_API int               GetMaxUdpBandwidthBytesPerSecond     () { return eCALPAR(NET, BANDWIDTH_MAX_UDP); }

--- a/ecal/core/src/ecal_def.h
+++ b/ecal/core/src/ecal_def.h
@@ -75,6 +75,7 @@
 #define NET_UDP_MULTICAST_PORT_SAMPLE_OFF              2
 #define NET_UDP_MULTICAST_SNDBUF            (5*1024*1024)  /* 5 MByte */
 #define NET_UDP_MULTICAST_RCVBUF            (5*1024*1024)  /* 5 MByte */
+#define NET_UDP_MULTICAST_JOIN_ALL_IF_ENABLED      false
 
 #define NET_UDP_RECBUFFER_TIMEOUT                   1000   /* ms */
 #define NET_UDP_RECBUFFER_CLEANUP                     10   /* ms */

--- a/ecal/core/src/ecal_def_ini.h
+++ b/ecal/core/src/ecal_def_ini.h
@@ -45,6 +45,8 @@
 #define  NET_UDP_MULTICAST_SNDBUF_S       "multicast_sndbuf"
 #define  NET_UDP_MULTICAST_RCVBUF_S       "multicast_rcvbuf"
 
+#define  NET_UDP_MULTICAST_JOIN_ALL_IF_ENABLED_S  "multicast_join_all_if"
+
 #define  NET_BANDWIDTH_MAX_UDP_S          "bandwidth_max_udp"
 
 #define  NET_UDP_MC_REC_ENABLED_S         "udp_mc_rec_enabled"

--- a/ecal/core/src/ecal_process.cpp
+++ b/ecal/core/src/ecal_process.cpp
@@ -235,6 +235,7 @@ namespace eCAL
       sstream << "Multicast mask           : " << Config::GetUdpMulticastMask() << std::endl;
       int port = Config::GetUdpMulticastPort();
       sstream << "Multicast ports          : " << port << " - " << port + 10 << std::endl;
+      sstream << "Multicast join all IFs   : " << (Config::IsUdpMulticastJoinAllIfEnabled() ? "on" : "off") << std::endl;
       auto bandwidth = Config::GetMaxUdpBandwidthBytesPerSecond();
       if (bandwidth < 0)
       {

--- a/ecal/core/src/io/linux/ecal_socket_option_linux.h
+++ b/ecal/core/src/io/linux/ecal_socket_option_linux.h
@@ -1,0 +1,84 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2022 - Teknique Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+#pragma once
+
+#include <cstring>
+#include <ifaddrs.h>
+#include <iostream>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <vector>
+
+
+namespace eCAL
+{
+  inline static std::vector<int> get_interface_index_list()
+  {
+    std::vector<int> interface_index_list;
+    ifaddrs* ifa = nullptr;
+    ifaddrs* ifap = nullptr;
+
+    // get a list of network interfaces
+    getifaddrs(&ifap);
+
+    // create a list of network interfaces indexes
+    for (ifa = ifap; ifa; ifa = ifa->ifa_next)
+    {
+      if (ifa->ifa_addr && ifa->ifa_addr->sa_family == AF_PACKET)
+      {
+        int index = if_nametoindex(ifa->ifa_name);
+        if (index)
+        {
+          interface_index_list.push_back(index);
+        }
+      }
+    }
+
+    freeifaddrs(ifap);
+
+    return interface_index_list;
+  }
+
+  inline static bool set_socket_mcast_group_option(int socket, const char* ipaddr_, int option)
+  {
+    // set the multicast socket option on all interfaces
+    for (int iface : get_interface_index_list())
+    {
+      group_req group_req = {};
+      sockaddr_in *group = nullptr;
+
+      memset(&group_req, 0, sizeof(group_req));
+      group_req.gr_interface = iface;
+      group = reinterpret_cast<sockaddr_in*>(&group_req.gr_group);
+      group->sin_family = AF_INET;
+      group->sin_addr.s_addr = inet_addr(ipaddr_);
+      group->sin_port = 0;
+
+      int rc = setsockopt(socket, IPPROTO_IP, option, &group_req, sizeof(group_source_req));
+      if (rc != 0)
+      {
+        std::cerr << "setsockopt failed. Unable to set multicast group option: " << strerror(errno) << std::endl;
+        return(false);
+      }
+    }
+
+    return(true);
+  }
+}

--- a/ecal/core/src/io/linux/ecal_socket_option_linux.h
+++ b/ecal/core/src/io/linux/ecal_socket_option_linux.h
@@ -24,6 +24,7 @@
 #include <iostream>
 #include <net/if.h>
 #include <netinet/in.h>
+#include <arpa/inet.h>
 #include <vector>
 
 

--- a/ecal/core/src/io/udp_receiver_asio.cpp
+++ b/ecal/core/src/io/udp_receiver_asio.cpp
@@ -20,7 +20,7 @@
 
 #include <io/udp_receiver_asio.h>
 
-#ifdef ECAL_JOIN_MULTICAST_ON_ALL_INTERFACES
+#ifdef ECAL_OS_LINUX
 #include "linux/ecal_socket_option_linux.h"
 #endif
 
@@ -112,7 +112,16 @@ namespace eCAL
     if (!m_broadcast && !m_unicast)
     {
       // join multicast group
-#ifndef ECAL_JOIN_MULTICAST_ON_ALL_INTERFACES
+#ifdef ECAL_OS_LINUX
+      if (eCAL::Config::GetUdpMulticastJoinAllIfEnabled())
+      {
+        if (!set_socket_mcast_group_option(m_socket.native_handle(), ipaddr_, MCAST_JOIN_GROUP))
+        {
+          return(false);
+        }
+      }
+      else
+#endif
       {
         asio::error_code ec;
         m_socket.set_option(asio::ip::multicast::join_group(asio::ip::make_address(ipaddr_)), ec);
@@ -122,12 +131,6 @@ namespace eCAL
           return(false);
         }
       }
-#else
-      if (!set_socket_mcast_group_option(m_socket.native_handle(), ipaddr_, MCAST_JOIN_GROUP))
-      {
-        return(false);
-      }
-#endif
 
 #ifdef ECAL_JOIN_MULTICAST_TWICE
       // this is a very bad workaround because of an identified bug on a specific embedded device
@@ -145,7 +148,16 @@ namespace eCAL
     if (!m_broadcast && !m_unicast)
     {
       // Leave multicast group
-#ifndef ECAL_JOIN_MULTICAST_ON_ALL_INTERFACES
+#ifdef ECAL_OS_LINUX
+      if (eCAL::Config::GetUdpMulticastJoinAllIfEnabled())
+      {
+        if (!set_socket_mcast_group_option(m_socket.native_handle(), ipaddr_, MCAST_LEAVE_GROUP))
+        {
+          return(false);
+        }
+      }
+      else
+#endif
       {
         asio::error_code ec;
         m_socket.set_option(asio::ip::multicast::leave_group(asio::ip::make_address(ipaddr_)), ec);
@@ -155,12 +167,6 @@ namespace eCAL
           return(false);
         }
       }
-#else
-      if (!set_socket_mcast_group_option(m_socket.native_handle(), ipaddr_, MCAST_LEAVE_GROUP))
-      {
-        return(false);
-      }
-#endif
     }
     return(true);
   }

--- a/ecal/core/src/io/udp_receiver_asio.cpp
+++ b/ecal/core/src/io/udp_receiver_asio.cpp
@@ -113,7 +113,7 @@ namespace eCAL
     {
       // join multicast group
 #ifdef __linux__
-      if (eCAL::Config::GetUdpMulticastJoinAllIfEnabled())
+      if (eCAL::Config::IsUdpMulticastJoinAllIfEnabled())
       {
         if (!set_socket_mcast_group_option(m_socket.native_handle(), ipaddr_, MCAST_JOIN_GROUP))
         {
@@ -149,7 +149,7 @@ namespace eCAL
     {
       // Leave multicast group
 #ifdef __linux__
-      if (eCAL::Config::GetUdpMulticastJoinAllIfEnabled())
+      if (eCAL::Config::IsUdpMulticastJoinAllIfEnabled())
       {
         if (!set_socket_mcast_group_option(m_socket.native_handle(), ipaddr_, MCAST_LEAVE_GROUP))
         {

--- a/ecal/core/src/io/udp_receiver_asio.cpp
+++ b/ecal/core/src/io/udp_receiver_asio.cpp
@@ -20,7 +20,7 @@
 
 #include <io/udp_receiver_asio.h>
 
-#ifdef ECAL_OS_LINUX
+#ifdef __linux__
 #include "linux/ecal_socket_option_linux.h"
 #endif
 
@@ -112,7 +112,7 @@ namespace eCAL
     if (!m_broadcast && !m_unicast)
     {
       // join multicast group
-#ifdef ECAL_OS_LINUX
+#ifdef __linux__
       if (eCAL::Config::GetUdpMulticastJoinAllIfEnabled())
       {
         if (!set_socket_mcast_group_option(m_socket.native_handle(), ipaddr_, MCAST_JOIN_GROUP))
@@ -148,7 +148,7 @@ namespace eCAL
     if (!m_broadcast && !m_unicast)
     {
       // Leave multicast group
-#ifdef ECAL_OS_LINUX
+#ifdef __linux__
       if (eCAL::Config::GetUdpMulticastJoinAllIfEnabled())
       {
         if (!set_socket_mcast_group_option(m_socket.native_handle(), ipaddr_, MCAST_LEAVE_GROUP))


### PR DESCRIPTION
Added `ecal.ini` option to join the Multicast groups on all Interfaces. The setting is Linux only. By default it is turned off.

New version of #776
Fixes #695