### PR TITLE
Feature/decouple memfile observer

### DIFF
--- a/ecal/core/src/io/ecal_memfile_pool.cpp
+++ b/ecal/core/src/io/ecal_memfile_pool.cpp
@@ -22,12 +22,7 @@
  * @brief  memory file pool handler
 **/
 
-//#include <ecal/ecal.h>
-//#include <ecal/ecal_config.h>
-
 #include "ecal_def.h"
-//#include "ecal_config_reader_hlp.h"
-
 #include "ecal_memfile_pool.h"
 
 #include <chrono>

--- a/ecal/core/src/io/ecal_memfile_pool.h
+++ b/ecal/core/src/io/ecal_memfile_pool.h
@@ -23,19 +23,23 @@
 
 #pragma once
 
-#include <ecal/ecal.h>
+#include <ecal/ecal_event.h>
+#include <ecal/ecal_log.h>
 
 #include "ecal_memfile.h"
 #include "ecal_memfile_header.h"
 
-#include <mutex>
 #include <atomic>
+#include <functional>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <thread>
 
 namespace eCAL
 {
+  typedef std::function<size_t(const std::string& topic_name_, const std::string& topic_id_, const char* buf_, size_t len_, long long id_, long long clock_, long long time_, size_t hash_)> MemFileDataCallbackT;
+
   ////////////////////////////////////////
   // CMemFileObserver
   ////////////////////////////////////////
@@ -45,10 +49,10 @@ namespace eCAL
     CMemFileObserver();
     ~CMemFileObserver();
 
-    bool Create(const std::string& memfile_name_, const std::string& memfile_event_);
+    bool Create(const std::string& memfile_name_, const std::string& memfile_event_, int timeout_ack_ms);
     bool Destroy();
 
-    bool Start(const std::string& topic_name_, const std::string& topic_id_, const int timeout_);
+    bool Start(const std::string& topic_name_, const std::string& topic_id_, const int timeout_, MemFileDataCallbackT callback_);
     bool Stop();
     bool IsObserving() {return(m_is_observing);};
 
@@ -64,6 +68,8 @@ namespace eCAL
 
     std::atomic<long long>  m_timeout_read;
     std::atomic<int>        m_timeout_ack;
+
+    MemFileDataCallbackT    m_data_callback;
 
     std::thread             m_thread;
     EventHandleT            m_event_snd;
@@ -84,7 +90,7 @@ namespace eCAL
     void Create();
     void Destroy();
 
-    bool ObserveFile(const std::string& memfile_name_, const std::string& memfile_event_, const std::string& topic_name_, const std::string& topic_id_);
+    bool ObserveFile(const std::string& memfile_name_, const std::string& memfile_event_, const std::string& topic_name_, const std::string& topic_id_, int timeout_observation_ms, int timeout_ack_ms, MemFileDataCallbackT callback_);
 
   protected:
     void CleanupPool();

--- a/ecal/core/src/readwrite/ecal_reader_shm.cpp
+++ b/ecal/core/src/readwrite/ecal_reader_shm.cpp
@@ -33,6 +33,7 @@
 #endif
 
 #include "ecal_global_accessors.h"
+#include "pubsub/ecal_subgate.h"
 #include "io/ecal_memfile_pool.h"
 #include "readwrite/ecal_reader_shm.h"
 
@@ -94,8 +95,17 @@ namespace eCAL
       {
         std::string process_id = std::to_string(Process::GetProcessID());
         std::string memfile_event = memfile_name + "_" + process_id;
-        g_memfile_pool()->ObserveFile(memfile_name, memfile_event, par_.topic_name, par_.topic_id);
+        MemFileDataCallbackT memfile_data_callback = std::bind(&CSHMReaderLayer::OnNewShmFileContent, this,
+          std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, std::placeholders::_5, std::placeholders::_6, std::placeholders::_7, std::placeholders::_8);
+        g_memfile_pool()->ObserveFile(memfile_name, memfile_event, par_.topic_name, par_.topic_id, Config::GetRegistrationTimeoutMs(), Config::GetMemfileAckTimeoutMs(), memfile_data_callback);
       }
     }
+  }
+
+  size_t CSHMReaderLayer::OnNewShmFileContent(const std::string& topic_name_, const std::string& topic_id_, const char* buf_, size_t len_, long long id_, long long clock_, long long time_, size_t hash_)
+  {
+    size_t ret_size(0);
+    if (g_subgate()) ret_size = g_subgate()->ApplySample(topic_name_, topic_id_, buf_, len_, id_, clock_, time_, hash_, eCAL::pb::tl_ecal_shm);
+    return ret_size;
   }
 }

--- a/ecal/core/src/readwrite/ecal_reader_shm.h
+++ b/ecal/core/src/readwrite/ecal_reader_shm.h
@@ -44,5 +44,8 @@ namespace eCAL
     void RemSubscription(const std::string& /*host_name_*/, const std::string& /*topic_name_*/, const std::string& /*topic_id_*/) {}
 
     void SetConnectionParameter(SReaderLayerPar& par_);
+
+  private:
+    size_t OnNewShmFileContent(const std::string& topic_name_, const std::string& topic_id_, const char* buf_, size_t len_, long long id_, long long clock_, long long time_, size_t hash_);
   };
 }


### PR DESCRIPTION
**Pull request type**

Please check the type of change your PR introduces:
- [X] Refactoring (no functional changes, no api changes)


**What is the current behavior?**
The low level ecal shm memfile observer forwards received data to the eCAL subscribers gate in a direct way. For better testing the shm layer this needs to be decoupled by providing a callback function interface.

**What is the new behavior?**
MemFileObserver now decoupled and ready to test standalone here (https://github.com/rex-schilasky/ecal-shm-layer)

**Does this introduce a breaking change?**
- [X] No
