### PR TITLE
shm memory file mutex should not be unlinked on subscriber destruction

### DIFF
--- a/ecal/core/src/io/ecal_memfile.cpp
+++ b/ecal/core/src/io/ecal_memfile.cpp
@@ -148,11 +148,19 @@ namespace eCAL
     // destroy memory file
     ret_state &= memfile::db::RemoveFile(m_name, remove_);
 
-    // unlock mutex
-    ret_state &= DestroyMtx(&m_memfile_info.mutex);
+    if (remove_)
+    {
+      // destroy mutex
+      ret_state &= DestroyMtx(&m_memfile_info.mutex);
 
-    // cleanup mutex
-    ret_state &= CleanupMtx(m_name);
+      // cleanup mutex
+      ret_state &= CleanupMtx(m_name);
+    }
+    else
+    {
+      // unlock mutex
+      ret_state &= UnlockMtx(&m_memfile_info.mutex);
+    }
 
     // reset states
     m_created      = false;


### PR DESCRIPTION
shm memory file mutex should not be unlinked if memory file is not owned (created) by the caller (fixing issue #854)

**Pull request type**

Please check the type of change your PR introduces:
- [X] Bugfix

**What is the current behavior?**
See issue description.

Fixes #854

**Does this introduce a breaking change?**

- [X] No
