### PR TITLE
CMake build on macos should use Python 3.9...

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -12,7 +12,8 @@ jobs:
 
     steps:
     - name: Downgrade Python version
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
+      id: cp39
       with:
         python-version: '3.9'
 
@@ -85,7 +86,9 @@ jobs:
         -DECAL_THIRDPARTY_BUILD_QWT=ON \
         -DECAL_THIRDPARTY_BUILD_YAML-CPP=ON \
         -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_CXX_STANDARD=14
+        -DCMAKE_CXX_STANDARD=14 \
+        -DPython_FIND_STRATEGY=LOCATION \
+        -DPython_FIND_REGISTRY=NEVER
         sudo mkdir /etc/ecal
         sudo cp "$GITHUB_WORKSPACE/ecal/core/cfg/ecal.ini" /etc/ecal
       shell: bash


### PR DESCRIPTION
Modify the github actions in such a way that they actually use the Python 3.9 installation.