### PR TITLE
Made eCAL::app_pb, ::core_pb and ::time_pb shared libraries on Linux

### DIFF
--- a/app/app_pb/CMakeLists.txt
+++ b/app/app_pb/CMakeLists.txt
@@ -35,7 +35,28 @@ set(ProtoFiles
   ${CMAKE_CURRENT_SOURCE_DIR}/src/ecal/app/pb/sys/process.proto
 )
 
-ecal_add_shared_library(${PROJECT_NAME} src/app_pb.cpp)
+# Compile statically on Windows and shared for all other systems. 
+# 
+# We compile shared on Linux etc., as we must only load the proto descriptors 
+# once; otherwise, protobuf would throw an exception on runtime. A shared object 
+# achieves that, as it is only loaded into memory once, even when being linked 
+# against from different libraries.
+# We don't have to do that on Windows, as we compile against protobuf statically 
+# and therefore each .dll has it's own descriptor pool. Having a static lib here 
+# also has the advantage that we need to export the symbols, which is default 
+# disabled on Windows.
+# 
+# TODO: Having code like that probably isn't the best solution ever. We should 
+# maybe always link against protobuf statically. Currently the reason why we 
+# don't do that is, that the default Ubuntu libprotobuf.a doesn't contain 
+# position independent code and can therefore not be statically compiled into a 
+# shared object library.
+if(WIN32)
+  ecal_add_static_library(${PROJECT_NAME} src/app_pb.cpp)
+else()
+  ecal_add_shared_library(${PROJECT_NAME} src/app_pb.cpp)
+endif()
+
 add_library(eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 protobuf_target_cpp(${PROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/src INSTALL_FOLDER include ${ProtoFiles})

--- a/app/app_pb/CMakeLists.txt
+++ b/app/app_pb/CMakeLists.txt
@@ -35,7 +35,7 @@ set(ProtoFiles
   ${CMAKE_CURRENT_SOURCE_DIR}/src/ecal/app/pb/sys/process.proto
 )
 
-ecal_add_library(${PROJECT_NAME} src/app_pb.cpp)
+ecal_add_shared_library(${PROJECT_NAME} src/app_pb.cpp)
 add_library(eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 protobuf_target_cpp(${PROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/src INSTALL_FOLDER include ${ProtoFiles})

--- a/contrib/ecaltime/ecaltime_pb/CMakeLists.txt
+++ b/contrib/ecaltime/ecaltime_pb/CMakeLists.txt
@@ -24,7 +24,7 @@ set(ProtoFiles
   ${CMAKE_CURRENT_SOURCE_DIR}/src/ecal/ecaltime/pb/sim_time.proto
 )
 
-ecal_add_library(${PROJECT_NAME} src/ecaltime_pb.cpp)
+ecal_add_shared_library(${PROJECT_NAME} src/ecaltime_pb.cpp)
 add_library(eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 protobuf_target_cpp(${PROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/src INSTALL_FOLDER include ${ProtoFiles})

--- a/contrib/ecaltime/ecaltime_pb/CMakeLists.txt
+++ b/contrib/ecaltime/ecaltime_pb/CMakeLists.txt
@@ -24,7 +24,28 @@ set(ProtoFiles
   ${CMAKE_CURRENT_SOURCE_DIR}/src/ecal/ecaltime/pb/sim_time.proto
 )
 
-ecal_add_shared_library(${PROJECT_NAME} src/ecaltime_pb.cpp)
+# Compile statically on Windows and shared for all other systems. 
+# 
+# We compile shared on Linux etc., as we must only load the proto descriptors 
+# once; otherwise, protobuf would throw an exception on runtime. A shared object
+# achieves that, as it is only loaded into memory once, even when being linked 
+# against from different libraries.
+# We don't have to do that on Windows, as we compile against protobuf statically 
+# and therefore each .dll has it's own descriptor pool. Having a static lib here 
+# also has the advantage that we need to export the symbols, which is default 
+# disabled on Windows.
+# 
+# TODO: Having code like that probably isn't the best solution ever. We should 
+# maybe always link against protobuf statically. Currently the reason why we 
+# don't do that is, that the default Ubuntu libprotobuf.a doesn't contain 
+# position independent code and can therefore not be statically compiled into a 
+# shared object library.
+if (WIN32)
+  ecal_add_static_library(${PROJECT_NAME} src/ecaltime_pb.cpp)
+else()
+  ecal_add_shared_library(${PROJECT_NAME} src/ecaltime_pb.cpp)
+endif()
+
 add_library(eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 protobuf_target_cpp(${PROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/src INSTALL_FOLDER include ${ProtoFiles})

--- a/ecal/core_pb/CMakeLists.txt
+++ b/ecal/core_pb/CMakeLists.txt
@@ -30,7 +30,28 @@ set(ProtoFiles
   ${CMAKE_CURRENT_SOURCE_DIR}/src/ecal/core/pb/topic.proto
 )
 
-ecal_add_shared_library(${PROJECT_NAME} src/core_pb.cpp)
+# Compile statically on Windows and shared for all other systems. 
+# 
+# We compile shared on Linux etc., as we must only load the proto descriptors 
+# once; otherwise, protobuf would throw an exception on runtime. A shared object
+# achieves that, as it is only loaded into memory once, even when being linked 
+# against from different libraries.
+# We don't have to do that on Windows, as we compile against protobuf statically 
+# and therefore each .dll has it's own descriptor pool. Having a static lib here 
+# also has the advantage that we need to export the symbols, which is default 
+# disabled on Windows.
+# 
+# TODO: Having code like that probably isn't the best solution ever. We should 
+# maybe always link against protobuf statically. Currently the reason why we 
+# don't do that is, that the default Ubuntu libprotobuf.a doesn't contain 
+# position independent code and can therefore not be statically compiled into a 
+# shared object library.
+if (WIN32)
+  ecal_add_static_library(${PROJECT_NAME} src/core_pb.cpp)
+else()
+  ecal_add_shared_library(${PROJECT_NAME} src/core_pb.cpp)
+endif()
+
 add_library(eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 protobuf_target_cpp(${PROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/src INSTALL_FOLDER include ${ProtoFiles})

--- a/ecal/core_pb/CMakeLists.txt
+++ b/ecal/core_pb/CMakeLists.txt
@@ -30,7 +30,7 @@ set(ProtoFiles
   ${CMAKE_CURRENT_SOURCE_DIR}/src/ecal/core/pb/topic.proto
 )
 
-ecal_add_library(${PROJECT_NAME} src/core_pb.cpp)
+ecal_add_shared_library(${PROJECT_NAME} src/core_pb.cpp)
 add_library(eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 protobuf_target_cpp(${PROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/src INSTALL_FOLDER include ${ProtoFiles})


### PR DESCRIPTION
On Linux, the targets are hardcoded compiled as shared objects. On Windows they are hardcoded as static libs. Even though this may not be optimal, it fixes #687.