### PR TITLE
Build Python wheels for older versions in Windows

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -14,6 +14,7 @@ jobs:
     - name: Install Qt
       uses: jurplel/install-qt-action@v3
       with:
+        setup-python: 'false'
         version: '5.15.2'
         target: 'desktop'
         arch: 'win64_msvc2015_64'


### PR DESCRIPTION
**Pull request type**

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


**What is the current behavior?**
Currently, the Windows GH Action only builds the Python 3.11 wheel.

Fixes #885

**What is the new behavior?**
Build 5 different wheels for Python 3.11/3.10/3.9/3.8/3.7.

**Does this introduce a breaking change?**

- [ ] Yes
- [x] No

