### PR TITLE
CMake: Excluded FTXUI and libcurl libs from installation

### DIFF
--- a/thirdparty/build-curl.cmake
+++ b/thirdparty/build-curl.cmake
@@ -5,7 +5,7 @@ endif()
 set(BUILD_CURL_EXE OFF CACHE BOOL "Don't build the curl executable" FORCE)
 set(ENABLE_MANUAL  OFF CACHE BOOL "Disable built-in manual" FORCE)
 
-add_subdirectory(thirdparty/curl)
+add_subdirectory(thirdparty/curl EXCLUDE_FROM_ALL)
 
 if (NOT TARGET CURL::libcurl)
   add_library(CURL::libcurl ALIAS libcurl)

--- a/thirdparty/build-ftxui.cmake
+++ b/thirdparty/build-ftxui.cmake
@@ -1,6 +1,6 @@
 option(FTXUI_BUILD_EXAMPLES "Set to ON to build examples" OFF)
 
-add_subdirectory(thirdparty/ftxui)
+add_subdirectory(thirdparty/ftxui EXCLUDE_FROM_ALL)
 
 # Upgrade Visual studio toolset version if necessary. Minimum working version is v142
 # TODO: Remove this code block as soon as possible


### PR DESCRIPTION
Installing the static libs of FTXUI and curl should not be a responsibility of eCAL.