### PR TITLE
adding new publisher API function, SetType (fixing issue #880)

### DIFF
--- a/ecal/core/include/ecal/cimpl/ecal_publisher_cimpl.h
+++ b/ecal/core/include/ecal/cimpl/ecal_publisher_cimpl.h
@@ -67,6 +67,17 @@ extern "C"
   ECALC_API int eCAL_Pub_Destroy(ECAL_HANDLE handle_);
 
   /**
+   * @brief Setup topic type name.
+   *
+   * @param handle_          Publisher handle.
+   * @param topic_type_      Topic type name.
+   * @param topic_type_len_  Topic type name length.
+   *
+   * @return  None zero if succeeded.
+  **/
+  ECALC_API int eCAL_Pub_SetType(ECAL_HANDLE handle_, const char* topic_type_, int topic_type_len_);
+
+  /**
    * @brief Setup topic type description. 
    *
    * @param handle_          Publisher handle. 

--- a/ecal/core/include/ecal/ecal_clang.h
+++ b/ecal/core/include/ecal/ecal_clang.h
@@ -224,7 +224,7 @@ ECAL_API bool pub_destroy(ECAL_HANDLE handle_);
  *
  * @return  True if succeeded.
 **/
-ECAL_API bool pub_set_type(ECAL_HANDLE handle_, const char* topic_type_, const int topic_type_length_);
+ECAL_API bool pub_set_topic_type(ECAL_HANDLE handle_, const char* topic_type_, const int topic_type_length_);
 
 /**
  * @brief Setup topic type description.
@@ -235,7 +235,7 @@ ECAL_API bool pub_set_type(ECAL_HANDLE handle_, const char* topic_type_, const i
  *
  * @return  True if succeeded.
 **/
-ECAL_API bool pub_set_description(ECAL_HANDLE handle_, const char* topic_desc_, const int topic_desc_length_);
+ECAL_API bool pub_set_topic_description(ECAL_HANDLE handle_, const char* topic_desc_, const int topic_desc_length_);
 
 /**
  * @brief Set publisher quality of service attributes.

--- a/ecal/core/include/ecal/ecal_clang.h
+++ b/ecal/core/include/ecal/ecal_clang.h
@@ -216,6 +216,17 @@ ECAL_API ECAL_HANDLE pub_create(const char* topic_name_, const char* topic_type_
 ECAL_API bool pub_destroy(ECAL_HANDLE handle_);
 
 /**
+ * @brief Setup topic type name.
+ *
+ * @param handle_             Publisher handle.
+ * @param topic_type_         Topic type name.
+ * @param topic_type_length_  Topic type name length.
+ *
+ * @return  True if succeeded.
+**/
+ECAL_API bool pub_set_type(ECAL_HANDLE handle_, const char* topic_type_, const int topic_type_length_);
+
+/**
  * @brief Setup topic type description.
  *
  * @param handle_             Publisher handle.

--- a/ecal/core/include/ecal/ecal_process.h
+++ b/ecal/core/include/ecal/ecal_process.h
@@ -97,7 +97,7 @@ namespace eCAL
      * on Windows, Sleep function from synchapi.h had to be used for Windows. This insures time
      * robustness on all platforms from a thread sleep perspective. Used with ns unit to obtain bigger precision.
      *
-     * @param  time_ms_  Time to sleep in ns.
+     * @param  time_ns_  Time to sleep in ns.
     **/
     ECAL_API void SleepNS(const long long time_ns_);
 

--- a/ecal/core/include/ecal/ecal_publisher.h
+++ b/ecal/core/include/ecal/ecal_publisher.h
@@ -123,6 +123,15 @@ namespace eCAL
     bool Destroy();
 
     /**
+     * @brief Setup topic type name.
+     *
+     * @param topic_type_   Topic type name.
+     *
+     * @return  True if it succeeds, false if it fails.
+    **/
+    bool SetType(const std::string& topic_type_);
+
+    /**
      * @brief Setup topic description. 
      *
      * @param topic_desc_   Description string. 

--- a/ecal/core/src/ecal_clang.cpp
+++ b/ecal/core/src/ecal_clang.cpp
@@ -258,6 +258,19 @@ ECAL_API bool pub_destroy(ECAL_HANDLE handle_)
 }
 
 /****************************************/
+/*      pub_settype                     */
+/****************************************/
+ECAL_API bool pub_set_type(ECAL_HANDLE handle_, const char* topic_type_, const int topic_type_length_)
+{
+  eCAL::CPublisher* pub = static_cast<eCAL::CPublisher*>(handle_);
+  if (pub)
+  {
+    return(pub->SetType(std::string(topic_type_, static_cast<size_t>(topic_type_length_))));
+  }
+  return(false);
+}
+
+/****************************************/
 /*      pub_setdescription              */
 /****************************************/
 ECAL_API bool pub_set_description(ECAL_HANDLE handle_, const char* topic_desc_, const int topic_desc_length_)

--- a/ecal/core/src/ecal_clang.cpp
+++ b/ecal/core/src/ecal_clang.cpp
@@ -258,9 +258,9 @@ ECAL_API bool pub_destroy(ECAL_HANDLE handle_)
 }
 
 /****************************************/
-/*      pub_settype                     */
+/*      pub_set_topic_type              */
 /****************************************/
-ECAL_API bool pub_set_type(ECAL_HANDLE handle_, const char* topic_type_, const int topic_type_length_)
+ECAL_API bool pub_set_topic_type(ECAL_HANDLE handle_, const char* topic_type_, const int topic_type_length_)
 {
   eCAL::CPublisher* pub = static_cast<eCAL::CPublisher*>(handle_);
   if (pub)
@@ -271,9 +271,9 @@ ECAL_API bool pub_set_type(ECAL_HANDLE handle_, const char* topic_type_, const i
 }
 
 /****************************************/
-/*      pub_setdescription              */
+/*      pub_set_topic_description       */
 /****************************************/
-ECAL_API bool pub_set_description(ECAL_HANDLE handle_, const char* topic_desc_, const int topic_desc_length_)
+ECAL_API bool pub_set_topic_description(ECAL_HANDLE handle_, const char* topic_desc_, const int topic_desc_length_)
 {
   eCAL::CPublisher* pub = static_cast<eCAL::CPublisher*>(handle_);
   if(pub)

--- a/ecal/core/src/ecalc.cpp
+++ b/ecal/core/src/ecalc.cpp
@@ -551,6 +551,14 @@ extern "C"
     return(1);
   }
 
+  ECALC_API int eCAL_Pub_SetType(ECAL_HANDLE handle_, const char* topic_type_, int topic_type_len_)
+  {
+    if (handle_ == NULL) return(0);
+    eCAL::CPublisher* pub = static_cast<eCAL::CPublisher*>(handle_);
+    if (pub->SetType(std::string(topic_type_, static_cast<size_t>(topic_type_len_)))) return(1);
+    return(0);
+  }
+
   ECALC_API int eCAL_Pub_SetDescription(ECAL_HANDLE handle_, const char* topic_desc_, int topic_desc_len_)
   {
     if (handle_ == NULL) return(0);

--- a/ecal/core/src/pubsub/ecal_publisher.cpp
+++ b/ecal/core/src/pubsub/ecal_publisher.cpp
@@ -203,6 +203,30 @@ namespace eCAL
     return(true);
   }
 
+  bool CPublisher::SetType(const std::string& topic_type_)
+  {
+    if (!m_datawriter) return false;
+
+    if (g_descgate())
+    {
+      const std::string topic_desc = m_datawriter->GetDescription();
+
+      // Calculate the quality of the current info
+      ::eCAL::CDescGate::QualityFlags quality = ::eCAL::CDescGate::QualityFlags::NO_QUALITY;
+      if (!topic_type_.empty())
+        quality |= ::eCAL::CDescGate::QualityFlags::TYPE_AVAILABLE;
+      if (!topic_desc.empty())
+        quality |= ::eCAL::CDescGate::QualityFlags::DESCRIPTION_AVAILABLE;
+      quality |= ::eCAL::CDescGate::QualityFlags::INFO_COMES_FROM_THIS_PROCESS;
+      quality |= ::eCAL::CDescGate::QualityFlags::INFO_COMES_FROM_CORRECT_TOPIC;
+      quality |= ::eCAL::CDescGate::QualityFlags::INFO_COMES_FROM_PUBLISHER;
+
+      g_descgate()->ApplyTopicDescription(m_datawriter->GetTopicName(), topic_type_, topic_desc, quality);
+    }
+
+    return m_datawriter->SetType(topic_type_);
+  }
+
   bool CPublisher::SetDescription(const std::string& topic_desc_)
   {
     if(!m_datawriter) return false;

--- a/ecal/core/src/readwrite/ecal_writer.cpp
+++ b/ecal/core/src/readwrite/ecal_writer.cpp
@@ -210,6 +210,22 @@ namespace eCAL
     return(true);
   }
 
+  bool CDataWriter::SetType(const std::string& topic_type_)
+  {
+    bool force = m_topic_type != topic_type_;
+    m_topic_type = topic_type_;
+
+#ifndef NDEBUG
+    // log it
+    Logging::Log(log_level_debug2, m_topic_name + "::CDataWriter::SetType");
+#endif
+
+    // register it
+    DoRegister(force);
+
+    return(true);
+  }
+
   bool CDataWriter::SetDescription(const std::string& topic_desc_)
   {
     bool force = m_topic_desc != topic_desc_;

--- a/ecal/core/src/readwrite/ecal_writer.h
+++ b/ecal/core/src/readwrite/ecal_writer.h
@@ -56,6 +56,7 @@ namespace eCAL
     bool Create(const std::string& topic_name_, const std::string& topic_type_, const std::string& topic_desc_);
     bool Destroy();
 
+    bool SetType(const std::string& topic_type_);
     bool SetDescription(const std::string& topic_desc_);
 
     bool SetAttribute(const std::string& attr_name_, const std::string& attr_value_);

--- a/lang/python/core/ecal/core/core.py
+++ b/lang/python/core/ecal/core/core.py
@@ -162,7 +162,7 @@ def pub_create(topic_name, topic_type, topic_desc):
 
   """
   topic_handle = _ecal.pub_create(topic_name, topic_type)
-  pub_set_description(topic_handle, topic_desc)
+  pub_set_topic_description(topic_handle, topic_desc)
   return topic_handle
 
 
@@ -175,7 +175,7 @@ def pub_destroy(topic_handle):
   return _ecal.pub_destroy(topic_handle)
 
 
-def pub_set_type(topic_handle, topic_type):
+def pub_set_topic_type(topic_handle, topic_type):
   """ set publisher topic type name
 
   :param topic_handle: the topic handle
@@ -184,9 +184,9 @@ def pub_set_type(topic_handle, topic_type):
   :type topic_type: bytes
 
   """
-  return _ecal.pub_set_type(topic_handle, topic_type)
+  return _ecal.pub_set_topic_type(topic_handle, topic_type)
 
-def pub_set_description(topic_handle, topic_desc):
+def pub_set_topic_description(topic_handle, topic_desc):
   """ set publisher topic type description
 
   :param topic_handle: the topic handle
@@ -195,7 +195,7 @@ def pub_set_description(topic_handle, topic_desc):
   :type topic_desc: bytes
 
   """
-  return _ecal.pub_set_description(topic_handle, topic_desc)
+  return _ecal.pub_set_topic_description(topic_handle, topic_desc)
 
 
 def pub_set_qos_historykind(topic_handle, qpolicy, depth):
@@ -599,7 +599,7 @@ class publisher(object):
 
     """
 
-    return pub_set_type(self.thandle, topic_type)
+    return pub_set_topic_type(self.thandle, topic_type)
 
   def set_topic_description(self, topic_desc):
     """ set topic description
@@ -609,7 +609,7 @@ class publisher(object):
 
     """
 
-    return pub_set_description(self.thandle, topic_desc)
+    return pub_set_topic_description(self.thandle, topic_desc)
 
   def set_qos_historykind(self, qpolicy, depth):
     """ set quality of service historykind mode and depth

--- a/lang/python/core/ecal/core/core.py
+++ b/lang/python/core/ecal/core/core.py
@@ -175,16 +175,27 @@ def pub_destroy(topic_handle):
   return _ecal.pub_destroy(topic_handle)
 
 
-def pub_set_description(topic_handle, description):
-  """ set publisher description
+def pub_set_type(topic_handle, topic_type):
+  """ set publisher topic type name
 
   :param topic_handle: the topic handle
   :type topic_handle: string
-  :param description:  the topic description
-  :type description: bytes
+  :param topic_type: the topic type name
+  :type topic_type: bytes
 
   """
-  return _ecal.pub_set_description(topic_handle, description)
+  return _ecal.pub_set_type(topic_handle, topic_type)
+
+def pub_set_description(topic_handle, topic_desc):
+  """ set publisher topic type description
+
+  :param topic_handle: the topic handle
+  :type topic_handle: string
+  :param topic_desc:  the topic type description
+  :type topic_desc: bytes
+
+  """
+  return _ecal.pub_set_description(topic_handle, topic_desc)
 
 
 def pub_set_qos_historykind(topic_handle, qpolicy, depth):
@@ -560,9 +571,9 @@ class publisher(object):
 
     :param topic_name: the unique topic name
     :type topic_name:  string
-    :param topic_type: optional type name
+    :param topic_type: optional topic type name
     :type topic_type:  string
-    :param topic_desc: optional type description
+    :param topic_desc: optional topic type description
     :type topic_desc:  bytes
 
     """
@@ -579,6 +590,26 @@ class publisher(object):
     """ destroy publisher
     """
     return pub_destroy(self.thandle)
+
+  def set_topic_type(self, topic_type):
+    """ set topic type name
+
+    :param topic_type: the topic type name
+    :type topic_type: bytes
+
+    """
+
+    return pub_set_type(self.thandle, topic_type)
+
+  def set_topic_description(self, topic_desc):
+    """ set topic description
+
+    :param topic_desc: the topic type description
+    :type topic_desc: bytes
+
+    """
+
+    return pub_set_description(self.thandle, topic_desc)
 
   def set_qos_historykind(self, qpolicy, depth):
     """ set quality of service historykind mode and depth
@@ -641,7 +672,7 @@ class subscriber(object):
 
     :param topic_name: the unique topic name
     :type topic_name:  string
-    :param topic_type: optional topic type
+    :param topic_type: optional topic type name
     :type topic_type:  string
 
     """

--- a/lang/python/core/ecal/core/publisher.py
+++ b/lang/python/core/ecal/core/publisher.py
@@ -49,6 +49,26 @@ class MessagePublisher(object):
     """
     raise NotImplementedError("Please Implement this method")
 
+  def set_topic_type(self, topic_type):
+    """ set topic type name
+
+    :param topic_type: the topic type name
+    :type topic_type: bytes
+
+    """
+
+    return self.c_publisher.set_topic_type(topic_type)
+
+  def set_topic_description(self, topic_desc):
+    """ set topic description
+
+    :param topic_desc: the topic type description
+    :type topic_desc: bytes
+
+    """
+
+    return self.c_publisher.set_topic_description(topic_desc)
+
   def set_qos(self, qos):
     """ set publisher quality of service
 

--- a/lang/python/core/src/ecal_wrap.cxx
+++ b/lang/python/core/src/ecal_wrap.cxx
@@ -329,9 +329,9 @@ PyObject* pub_destroy(PyObject* /*self*/, PyObject* args)
 }
 
 /****************************************/
-/*      pub_set_type                    */
+/*      pub_set_topic_type              */
 /****************************************/
-PyObject* pub_set_type(PyObject* /*self*/, PyObject* args)
+PyObject* pub_set_topic_type(PyObject* /*self*/, PyObject* args)
 {
   ECAL_HANDLE topic_handle = nullptr;
   char* topic_type = nullptr;
@@ -340,13 +340,13 @@ PyObject* pub_set_type(PyObject* /*self*/, PyObject* args)
   if (!PyArg_ParseTuple(args, "ny#", &topic_handle, &topic_type, &topic_type_len))
     return nullptr;
 
-  return(Py_BuildValue("i", pub_set_type(topic_handle, topic_type, (int)topic_type_len)));
+  return(Py_BuildValue("i", pub_set_topic_type(topic_handle, topic_type, (int)topic_type_len)));
 }
 
 /****************************************/
-/*      pub_set_description             */
+/*      pub_set_topic_description       */
 /****************************************/
-PyObject* pub_set_description(PyObject* /*self*/, PyObject* args)
+PyObject* pub_set_topic_description(PyObject* /*self*/, PyObject* args)
 {
   ECAL_HANDLE topic_handle   = nullptr;
   char*       topic_desc     = nullptr;
@@ -355,7 +355,7 @@ PyObject* pub_set_description(PyObject* /*self*/, PyObject* args)
   if (!PyArg_ParseTuple(args, "ny#", &topic_handle, &topic_desc, &topic_desc_len)) 
     return nullptr;
 
-  return(Py_BuildValue("i", pub_set_description(topic_handle, topic_desc, (int)topic_desc_len)));
+  return(Py_BuildValue("i", pub_set_topic_description(topic_handle, topic_desc, (int)topic_desc_len)));
 }
 
 /****************************************/
@@ -1574,8 +1574,8 @@ static PyMethodDef _ecal_methods[] =
   {"pub_create",                    pub_create,                    METH_VARARGS,  "pub_create(topic_name, topic_type)"},
   {"pub_destroy",                   pub_destroy,                   METH_VARARGS,  "pub_destroy(topic_handle)"},
 
-  {"pub_set_type",                  pub_set_type,                  METH_VARARGS,  "pub_set_type(topic_handle, topic_type)"},
-  {"pub_set_description",           pub_set_description,           METH_VARARGS,  "pub_set_description(topic_handle, topic_description)"},
+  {"pub_set_topic_type",            pub_set_topic_type,            METH_VARARGS,  "pub_set_topic_type(topic_handle, topic_type)"},
+  {"pub_set_topic_description",     pub_set_topic_description,     METH_VARARGS,  "pub_set_topic_description(topic_handle, topic_description)"},
 
   {"pub_set_qos_historykind",       pub_set_qos_historykind,       METH_VARARGS,  "pub_set_qos_historykind(topic_handle, qpolicy, depth)"},
   {"pub_set_qos_reliability",       pub_set_qos_reliability,       METH_VARARGS,  "pub_set_qos_reliability(topic_handle, qpolicy)"},

--- a/lang/python/core/src/ecal_wrap.cxx
+++ b/lang/python/core/src/ecal_wrap.cxx
@@ -329,6 +329,21 @@ PyObject* pub_destroy(PyObject* /*self*/, PyObject* args)
 }
 
 /****************************************/
+/*      pub_set_type                    */
+/****************************************/
+PyObject* pub_set_type(PyObject* /*self*/, PyObject* args)
+{
+  ECAL_HANDLE topic_handle = nullptr;
+  char* topic_type = nullptr;
+  Py_ssize_t  topic_type_len = 0;
+
+  if (!PyArg_ParseTuple(args, "ny#", &topic_handle, &topic_type, &topic_type_len))
+    return nullptr;
+
+  return(Py_BuildValue("i", pub_set_type(topic_handle, topic_type, (int)topic_type_len)));
+}
+
+/****************************************/
 /*      pub_set_description             */
 /****************************************/
 PyObject* pub_set_description(PyObject* /*self*/, PyObject* args)
@@ -1556,10 +1571,12 @@ static PyMethodDef _ecal_methods[] =
   {"log_message",                   log_message,                   METH_VARARGS,  "log_message(message)"},
   {"log_setcoretime",               log_setcoretime,               METH_VARARGS,  "log_setcoretime(time)"},
 
-  {"pub_create",                    pub_create,                    METH_VARARGS,  "pub_create(topic_name, topuic_type)"},
+  {"pub_create",                    pub_create,                    METH_VARARGS,  "pub_create(topic_name, topic_type)"},
   {"pub_destroy",                   pub_destroy,                   METH_VARARGS,  "pub_destroy(topic_handle)"},
 
+  {"pub_set_type",                  pub_set_type,                  METH_VARARGS,  "pub_set_type(topic_handle, topic_type)"},
   {"pub_set_description",           pub_set_description,           METH_VARARGS,  "pub_set_description(topic_handle, topic_description)"},
+
   {"pub_set_qos_historykind",       pub_set_qos_historykind,       METH_VARARGS,  "pub_set_qos_historykind(topic_handle, qpolicy, depth)"},
   {"pub_set_qos_reliability",       pub_set_qos_reliability,       METH_VARARGS,  "pub_set_qos_reliability(topic_handle, qpolicy)"},
   {"pub_set_layer_mode",            pub_set_layer_mode,            METH_VARARGS,  "pub_set_layer_mode(topic_handle, layer, mode)"},


### PR DESCRIPTION
**Pull request type**

Adding new SetType API function for eCAL Publisher. (Maybe we call it SetTopicType, maybe not. I called it SetType to be in synch with SetDescription).

Please check the type of change your PR introduces:
- [X] Feature

Fixes: #880
