### PR TITLE
handling of long time consuming rpc calls

### DIFF
--- a/ecal/core/src/service/ecal_service_server_impl.cpp
+++ b/ecal/core/src/service/ecal_service_server_impl.cpp
@@ -315,7 +315,7 @@ namespace eCAL
       {
         // set error message
         response_pb_mutable_header->set_state(eCAL::pb::ServiceHeader_eCallState_failed);
-        std::string emsg = "Service " + m_service_name + " has no method " + request_pb_header.mname();
+        std::string emsg = "Service '" + m_service_name + "' has no method named '" + request_pb_header.mname() + "'";
         response_pb_mutable_header->set_error(emsg);
 
         // serialize response and return "method not found"
@@ -338,7 +338,20 @@ namespace eCAL
     int service_return_state = method.callback(method.method_pb.mname(), method.method_pb.req_type(), method.method_pb.resp_type(), request_s, response_s);
 
     // fill response
-    response_pb_mutable_header->set_state(eCAL::pb::ServiceHeader_eCallState_executed);
+    switch (service_return_state)
+    {
+    case -1:
+    {
+      response_pb_mutable_header->set_state(eCAL::pb::ServiceHeader_eCallState_failed);
+      std::string emsg = "Service '" + m_service_name + "' call of method '" + method.method_pb.mname() + "' failed.";
+      response_pb.mutable_header()->set_error(emsg);
+    }
+      break;
+    case 0:
+    default:
+      response_pb_mutable_header->set_state(eCAL::pb::ServiceHeader_eCallState_executed);
+      break;
+    }
     response_pb.set_response(response_s);
     response_pb.set_ret_state(service_return_state);
 


### PR DESCRIPTION
Please check the type of change your PR introduces:
- [X] Bugfix


**What is the current behavior?**

Dear eCAL community,

In our system, we use both pub/sub and service methods a.k.a RPCs.

We have one particular RPC that can take up to 10 seconds to complete (it's not actually doing work, it's just waiting for something to happen), but when it does take that long, the process it is running in loses its subscriber information, i.e. any topic it publishes to from that point onwards does not actually make it to the subscribers.

In the registration_timeout in ecal.ini is set to 10000 (10 seconds), if I increase that number to something higher, the problem goes away, so I have a solution to my problem that works.

My question is, though, whether it's the right solution. It appears as though a long running RPC blocks some maintenance/monitoring tasks needed to maintain the registration info, and if that happens for long enough, the registration_timeout is hit. Do you have any guidance on long-running RPCs? Is there a way give the maintenance/monitoring tasks an explicit chance to run while the RPC is waiting, or is the official advice to either steer clear of long-running RPCs or make sure the registration_timeout is long enough?

Regards,
Sam

Fixes: #903
