### PR TITLE
Core Services: Fixed bug that caused the monitoring loop to block in case of long running RPC calls

### DIFF
--- a/ecal/core/src/service/ecal_service_client_impl.cpp
+++ b/ecal/core/src/service/ecal_service_client_impl.cpp
@@ -424,12 +424,12 @@ namespace eCAL
         {
           // execute request
           SServiceResponse service_response;
-          bool ret = SendRequest(client.second, method_name_, request_, timeout_, service_response);
-          if (ret == false)
+          ret_state = SendRequest(client.second, method_name_, request_, timeout_, service_response);
+          if (ret_state == false)
           {
             std::cerr << "CServiceClientImpl::SendRequests failed." << std::endl;
-            return false;
           }
+          
           // call response callback
           if (service_response.call_state != call_state_none)
           {

--- a/ecal/core/src/service/ecal_service_server_impl.cpp
+++ b/ecal/core/src/service/ecal_service_server_impl.cpp
@@ -312,8 +312,9 @@ namespace eCAL
       auto requested_method_iterator = m_method_map.find(request_pb_header.mname());
       if (requested_method_iterator == m_method_map.end())
       {
-        // set error message
+        // set method call state 'failed'
         response_pb_mutable_header->set_state(eCAL::pb::ServiceHeader_eCallState_failed);
+        // set error message
         std::string emsg = "Service '" + m_service_name + "' has no method named '" + request_pb_header.mname() + "'";
         response_pb_mutable_header->set_error(emsg);
 
@@ -340,25 +341,16 @@ namespace eCAL
     std::string response_s;
     int service_return_state = method.callback(method.method_pb.mname(), method.method_pb.req_type(), method.method_pb.resp_type(), request_s, response_s);
 
-    // fill response
-    if (service_return_state == 0)
-    {
-      response_pb_mutable_header->set_state(eCAL::pb::ServiceHeader_eCallState_executed);
-    }
-    else
-    {
-      response_pb_mutable_header->set_state(eCAL::pb::ServiceHeader_eCallState_failed);
-      std::string emsg = "Service '" + m_service_name + "' call of method '" + method.method_pb.mname() + "' failed.";
-      response_pb.mutable_header()->set_error(emsg);
-    }
-
+    // set method call state 'executed'
+    response_pb_mutable_header->set_state(eCAL::pb::ServiceHeader_eCallState_executed);
+    // set method response and return state
     response_pb.set_response(response_s);
     response_pb.set_ret_state(service_return_state);
 
     // serialize response and return
     response_ = response_pb.SerializeAsString();
 
-    // Return success (error code 0)
+    // return success (error code 0)
     return 0;
   }
 

--- a/ecal/core/src/service/ecal_service_server_impl.cpp
+++ b/ecal/core/src/service/ecal_service_server_impl.cpp
@@ -281,7 +281,7 @@ namespace eCAL
   {
     // prepare response
     eCAL::pb::Response response_pb;
-    auto response_pb_mutable_header = response_pb.mutable_header();
+    auto* response_pb_mutable_header = response_pb.mutable_header();
     response_pb_mutable_header->set_hname(eCAL::Process::GetHostName());
     response_pb_mutable_header->set_sname(m_service_name);
     response_pb_mutable_header->set_sid(m_service_id);
@@ -294,7 +294,7 @@ namespace eCAL
 
       response_pb_mutable_header->set_state(eCAL::pb::ServiceHeader_eCallState_failed);
       std::string emsg = "Service '" + m_service_name + "' request message could not be parsed.";
-      response_pb.mutable_header()->set_error(emsg);
+      response_pb_mutable_header->set_error(emsg);
 
       // serialize response and return "request message could not be parsed"
       response_ = response_pb.SerializeAsString();

--- a/ecal/core/src/service/ecal_service_server_impl.cpp
+++ b/ecal/core/src/service/ecal_service_server_impl.cpp
@@ -315,7 +315,7 @@ namespace eCAL
       {
         // set error message
         response_pb_mutable_header->set_state(eCAL::pb::ServiceHeader_eCallState_failed);
-        std::string emsg = "Service " + m_service_name + " has no method " + request_pb_header.mname();
+        std::string emsg = "Service '" + m_service_name + "' has no method named '" + request_pb_header.mname() + "'";
         response_pb_mutable_header->set_error(emsg);
 
         // serialize response and return "method not found"
@@ -338,7 +338,20 @@ namespace eCAL
     int service_return_state = method.callback(method.method_pb.mname(), method.method_pb.req_type(), method.method_pb.resp_type(), request_s, response_s);
 
     // fill response
-    response_pb_mutable_header->set_state(eCAL::pb::ServiceHeader_eCallState_executed);
+    switch (service_return_state)
+    {
+    case -1:
+    {
+      response_pb_mutable_header->set_state(eCAL::pb::ServiceHeader_eCallState_failed);
+      std::string emsg = "Service '" + m_service_name + "' call of method '" + method.method_pb.mname() + "' failed.";
+      response_pb.mutable_header()->set_error(emsg);
+    }
+      break;
+    case 0:
+    default:
+      response_pb_mutable_header->set_state(eCAL::pb::ServiceHeader_eCallState_executed);
+      break;
+    }
     response_pb.set_response(response_s);
     response_pb.set_ret_state(service_return_state);
 

--- a/ecal/core/src/service/ecal_service_server_impl.h
+++ b/ecal/core/src/service/ecal_service_server_impl.h
@@ -84,12 +84,12 @@ namespace eCAL
 
   protected:
     /**
-     * @brief Calls the requrest callback based on the request and fills the response
+     * @brief Calls the request callback based on the request and fills the response
      * 
      * @param[in]  request_   The service request in serialized protobuf form
-     * @param[out] response_  A serialialized protobuf response. My not be set at all.
+     * @param[out] response_  A serialized protobuf response. My not be set at all.
      * 
-     * @return An errorcode. 0 if success and -1 if failed.
+     * @return always 0.
      */
     int RequestCallback(const std::string& request_, std::string& response_);
     void EventCallback(eCAL_Server_Event event_, const std::string& message_);

--- a/ecal/core/src/service/ecal_service_server_impl.h
+++ b/ecal/core/src/service/ecal_service_server_impl.h
@@ -83,6 +83,14 @@ namespace eCAL
     CServiceServerImpl& operator=(const CServiceServerImpl&) = delete;
 
   protected:
+    /**
+     * @brief Calls the requrest callback based on the request and fills the response
+     * 
+     * @param[in]  request_   The service request in serialized protobuf form
+     * @param[out] response_  A serialialized protobuf response. My not be set at all.
+     * 
+     * @return An errorcode. 0 if success and -1 if failed.
+     */
     int RequestCallback(const std::string& request_, std::string& response_);
     void EventCallback(eCAL_Server_Event event_, const std::string& message_);
 

--- a/testing/ecal/clientserver_test/CMakeLists.txt
+++ b/testing/ecal/clientserver_test/CMakeLists.txt
@@ -24,7 +24,7 @@ find_package(Protobuf REQUIRED)
 
 create_targets_protobuf()
 
-set(clientserver_test_src
+set(${PROJECT_NAME}_src
   src/clientserver_test.cpp
 )
 
@@ -33,14 +33,17 @@ set(clientserver_test_proto
   ${CMAKE_CURRENT_SOURCE_DIR}/src/protobuf/ping.proto
 )
 
-ecal_add_static_library(clientserver_proto src/dummy.cpp)
-PROTOBUF_TARGET(clientserver_proto ${CMAKE_CURRENT_SOURCE_DIR}/src/protobuf ${clientserver_test_proto})
-target_link_libraries(clientserver_proto PRIVATE protobuf::libprotobuf)
-set_property(TARGET clientserver_proto PROPERTY FOLDER testing/ecal/service)
+ecal_add_gtest(${PROJECT_NAME} ${${PROJECT_NAME}_src})
+PROTOBUF_TARGET_CPP(${PROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/src/protobuf ${clientserver_test_proto})
 
-ecal_add_gtest(${PROJECT_NAME} ${clientserver_test_src})
 target_link_libraries(${PROJECT_NAME}
-  PRIVATE eCAL::core clientserver_proto Threads::Threads)
+  PRIVATE
+    eCAL::core
+    protobuf::libprotobuf
+    Threads::Threads)
 
-  ecal_install_gtest(${PROJECT_NAME})
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
+
+ecal_install_gtest(${PROJECT_NAME})
+
 set_property(TARGET ${PROJECT_NAME} PROPERTY FOLDER testing/ecal/service)

--- a/testing/ecal/clientserver_test/src/clientserver_test.cpp
+++ b/testing/ecal/clientserver_test/src/clientserver_test.cpp
@@ -147,12 +147,6 @@ TEST(IO, ClientConnectEvent)
   // informed about disconnection without calling a service method
   client.Call("foo", "");
   eCAL::Process::SleepMS(1000);
-  EXPECT_EQ(1, event_disconnected_fired);
-  client.Call("foo", "");
-  eCAL::Process::SleepMS(1000);
-  EXPECT_EQ(2, event_disconnected_fired);
-  client.Call("foo", "");
-  eCAL::Process::SleepMS(1000);
   EXPECT_EQ(2, event_disconnected_fired);
 
   // finalize eCAL API


### PR DESCRIPTION
This PR fixes a bug that caused long running RPC calls to block a mutex for the entire time of the RPC call. As this mutex is also needed by the monitoring loop, long running RPC calls caused the eCAL nodes to disappear from the system.

The commit is a Qick-and-dirty hotfix. The code now contains many TODOs, as during review a lot of other questions arose. Please also check #905 for more details regarding those questions. It should however solve the actual problem.

Fixes #903 