### PR TITLE
Feature/csharp bindings extension

### DIFF
--- a/lang/csharp/Continental/eCAL/Core/ecal_clr.cpp
+++ b/lang/csharp/Continental/eCAL/Core/ecal_clr.cpp
@@ -246,8 +246,7 @@ Subscriber::ReceiveCallbackData^ Subscriber::Receive(const int rcv_timeout_)
     rcv_data->id = 0;
     rcv_data->clock = 0;
     rcv_data->time = rcv_time;
-    rcv_data->data = (void*)rcv_buf.data();
-    rcv_data->size = size;
+    rcv_data->data = StlStringToString(rcv_buf);
     return rcv_data;
   }
   else
@@ -311,9 +310,9 @@ System::String^ Subscriber::Dump()
 
 void Subscriber::OnReceive(const char* topic_name_, const ::eCAL::SReceiveCallbackData* data_)
 {
+  std::string received_bytes = std::string(static_cast<const char*>(data_->buf), static_cast<size_t>(data_->size));
   ReceiveCallbackData^ data = gcnew ReceiveCallbackData();
-  data->data    = data_->buf;
-  data->size    = data_->size;
+  data->data    = StlStringToString(received_bytes);
   data->id      = data_->id;
   data->time    = data_->time;
   data->clock   = data_->clock;

--- a/lang/csharp/Continental/eCAL/Core/ecal_clr.cpp
+++ b/lang/csharp/Continental/eCAL/Core/ecal_clr.cpp
@@ -246,7 +246,8 @@ Subscriber::ReceiveCallbackData^ Subscriber::Receive(const int rcv_timeout_)
     rcv_data->id = 0;
     rcv_data->clock = 0;
     rcv_data->time = rcv_time;
-    rcv_data->data = StlStringToString(rcv_buf);
+    rcv_data->data = (void*)rcv_buf.data();
+    rcv_data->size = size;
     return rcv_data;
   }
   else
@@ -310,9 +311,9 @@ System::String^ Subscriber::Dump()
 
 void Subscriber::OnReceive(const char* topic_name_, const ::eCAL::SReceiveCallbackData* data_)
 {
-  std::string received_bytes = std::string(static_cast<const char*>(data_->buf), static_cast<size_t>(data_->size));
   ReceiveCallbackData^ data = gcnew ReceiveCallbackData();
-  data->data    = StlStringToString(received_bytes);
+  data->data    = data_->buf;
+  data->size    = data_->size;
   data->id      = data_->id;
   data->time    = data_->time;
   data->clock   = data_->clock;

--- a/lang/csharp/Continental/eCAL/Core/ecal_clr.cpp
+++ b/lang/csharp/Continental/eCAL/Core/ecal_clr.cpp
@@ -168,6 +168,16 @@ size_t Publisher::Send(System::String^ s_, long long time_)
   return(m_pub->Send(buf, len, time_));
 }
 
+size_t Publisher::Send(array<Byte>^ buffer, long long time_)
+{
+  if(m_pub == nullptr) return(0); 
+  GCHandle handle = GCHandle::Alloc(buffer, GCHandleType::Pinned);
+  size_t len = buffer->Length;
+  size_t ret = m_pub->Send((void*)handle.AddrOfPinnedObject(), len, time_);
+  handle.Free();
+  return(ret);
+}
+
 bool Publisher::IsCreated()
 {
   if(m_pub == nullptr) return(false);

--- a/lang/csharp/Continental/eCAL/Core/ecal_clr.cpp
+++ b/lang/csharp/Continental/eCAL/Core/ecal_clr.cpp
@@ -322,6 +322,55 @@ void Subscriber::OnReceive(const char* topic_name_, const ::eCAL::SReceiveCallba
 
 
 
+/////////////////////////////////////////////////////////////////////////////
+// ServiceClient
+/////////////////////////////////////////////////////////////////////////////
+ServiceClient::ServiceClient() : m_client(new ::eCAL::CServiceClient())
+{
+}
+
+ServiceClient::ServiceClient(System::String^ service_name_)
+{
+    m_client = new ::eCAL::CServiceClient(StringToStlString(service_name_));
+}
+
+ServiceClient::~ServiceClient()
+{
+    if (m_client == nullptr) return;
+    delete m_client;
+}
+
+List<ServiceClient::ServiceClientCallbackData^>^ ServiceClient::Call(System::String^ method_name_, System::String^ request, const int rcv_timeout_)
+{
+    if (m_client == nullptr) return(nullptr);
+    ::eCAL::ServiceResponseVecT responseVecT;
+
+    if (m_client->Call(StringToStlString(method_name_), StringToStlString(request), rcv_timeout_, &responseVecT))
+    {
+        List<ServiceClientCallbackData^>^ rcv_Datas = gcnew List<ServiceClientCallbackData^>();
+
+        for each (::eCAL::SServiceResponse response in responseVecT)
+        {
+            ServiceClientCallbackData^ rcv_data = gcnew ServiceClientCallbackData;
+            rcv_data->call_state = response.call_state;
+            rcv_data->error_msg = StlStringToString(response.error_msg);
+            rcv_data->host_name = StlStringToString(response.host_name);
+            rcv_data->method_name = StlStringToString(response.method_name);
+            rcv_data->ret_state = response.ret_state;
+            rcv_data->service_id = StlStringToString(response.service_id);
+            rcv_data->service_name = StlStringToString(response.service_name);
+            rcv_data->ret_state = response.ret_state;
+            rcv_data->response = StlStringToString(response.response);
+            rcv_Datas->Add(rcv_data);
+        }
+        return rcv_Datas;
+    }
+    else
+    {
+        return nullptr;
+    }
+}
+
 
 
 /////////////////////////////////////////////////////////////////////////////

--- a/lang/csharp/Continental/eCAL/Core/ecal_clr.cpp
+++ b/lang/csharp/Continental/eCAL/Core/ecal_clr.cpp
@@ -528,7 +528,21 @@ void Monitoring::Terminate()
   ::eCAL::Finalize();
 }
 
-array<Byte>^ Monitoring::GetMonitoring()
+String^ Monitoring::GetMonitoring()
+{
+    std::string monitoring;
+    ::eCAL::Monitoring::GetMonitoring(monitoring);
+    return StlStringToString(monitoring);
+}
+
+String^ Monitoring::GetLogging()
+{
+    std::string logging;
+    ::eCAL::Monitoring::GetLogging(logging);
+    return StlStringToString(logging);
+}
+
+array<Byte>^ Monitoring::GetMonitoringBytes()
 {
     std::string monitoring;
     ::eCAL::Monitoring::GetMonitoring(monitoring);
@@ -537,7 +551,7 @@ array<Byte>^ Monitoring::GetMonitoring()
     return data;
 }
 
-array<Byte>^ Monitoring::GetLogging()
+array<Byte>^ Monitoring::GetLoggingBytes()
 {
     std::string logging;
     ::eCAL::Monitoring::GetLogging(logging);

--- a/lang/csharp/Continental/eCAL/Core/ecal_clr.cpp
+++ b/lang/csharp/Continental/eCAL/Core/ecal_clr.cpp
@@ -528,18 +528,22 @@ void Monitoring::Terminate()
   ::eCAL::Finalize();
 }
 
-String^ Monitoring::GetMonitoring()
+array<Byte>^ Monitoring::GetMonitoring()
 {
     std::string monitoring;
     ::eCAL::Monitoring::GetMonitoring(monitoring);
-    return StlStringToString(monitoring);
+    array<Byte>^ data = gcnew array<Byte>(monitoring.size());
+    System::Runtime::InteropServices::Marshal::Copy(IntPtr(&monitoring[0]), data, 0, monitoring.size());
+    return data;
 }
 
-String^ Monitoring::GetLogging()
+array<Byte>^ Monitoring::GetLogging()
 {
     std::string logging;
     ::eCAL::Monitoring::GetLogging(logging);
-    return StlStringToString(logging);
+    array<Byte>^ data = gcnew array<Byte>(logging.size());
+    System::Runtime::InteropServices::Marshal::Copy(IntPtr(&logging[0]), data, 0, logging.size());
+    return data;
 }
 
 DateTime Continental::eCAL::Core::Monitoring::GetTime()

--- a/lang/csharp/Continental/eCAL/Core/ecal_clr.cpp
+++ b/lang/csharp/Continental/eCAL/Core/ecal_clr.cpp
@@ -408,16 +408,21 @@ void Monitoring::Terminate()
   ::eCAL::Finalize();
 }
 
-System::String^ Monitoring::GetMonitoring()
+String^ Monitoring::GetMonitoring()
 {
-  std::string monitoring;
-  ::eCAL::Monitoring::GetMonitoring(monitoring);
-  return(StlStringToString(monitoring));
+    std::string monitoring;
+    ::eCAL::Monitoring::GetMonitoring(monitoring);
+    return StlStringToString(monitoring);
 }
 
-System::String^ Monitoring::GetLogging()
+String^ Monitoring::GetLogging()
 {
-  std::string logging;
-  ::eCAL::Monitoring::GetLogging(logging);
-  return(StlStringToString(logging));
+    std::string logging;
+    ::eCAL::Monitoring::GetLogging(logging);
+    return StlStringToString(logging);
+}
+
+DateTime Continental::eCAL::Core::Monitoring::GetTime()
+{
+    return DateTime(::eCAL::Time::GetMicroSeconds());
 }

--- a/lang/csharp/Continental/eCAL/Core/ecal_clr.h
+++ b/lang/csharp/Continental/eCAL/Core/ecal_clr.h
@@ -374,6 +374,63 @@ namespace Continental
         typedef void(__stdcall * stdcall_eCAL_ReceiveCallbackT)(const char*, const ::eCAL::SReceiveCallbackData*);
       };
 
+
+      /**
+       * @brief eCAL service client class.
+       *
+       * The CServiceClient class is used to call a matching eCAL server.
+       *
+      **/
+      public ref class ServiceClient
+      {
+      public:
+          /**
+           * @brief Constructor.
+          **/
+          ServiceClient();
+
+          /**
+           * @brief Constructor.
+           *
+           * @param service_name_   Unique service name.
+          **/
+          ServiceClient(System::String^ service_name_);
+
+          /**
+           * @brief Destructor.
+          **/
+          ~ServiceClient();
+
+          /**
+           * @brief structure which contains the data for callback functions
+          **/
+          ref struct ServiceClientCallbackData
+          {
+              String^  host_name;      //!< service host name
+              String^  service_name;   //!< name of the service
+              String^  service_id;     //!< id of the service
+              String^  method_name;    //!< name of the service method
+              String^  error_msg;      //!< human readable error message
+              int          ret_state;      //!< return state of the called service method
+              eCallState   call_state;     //!< call state (see eCallState)
+              String^ response;       //!< service response
+          };
+
+          /**
+           * @brief Call a server.
+           *
+           * @param method_name_
+           * @param request
+           * @param rcv_timeout_  Maximum time before receive operation returns (in milliseconds, -1 means infinite).
+           *
+           * @return  List<ServiceClientCallbackData> or null (if timed out)
+          **/
+          List<ServiceClientCallbackData^>^ Call(System::String^ method_name_, System::String^ request, const int rcv_timeout_);
+
+      private:
+          ::eCAL::CServiceClient* m_client;
+      };
+
       /**
        * @brief eCAL protobuf json subscriber class.
        *

--- a/lang/csharp/Continental/eCAL/Core/ecal_clr.h
+++ b/lang/csharp/Continental/eCAL/Core/ecal_clr.h
@@ -376,6 +376,88 @@ namespace Continental
 
 
       /**
+       * @brief eCAL server class.
+       *
+       * The CServiceServer class is used to answer calls from matching eCAL clients.
+       *
+      **/
+      public ref class ServiceServer
+      {
+      public:
+          /**
+           * @brief Constructor.
+          **/
+          ServiceServer();
+
+          /**
+           * @brief Constructor.
+           *
+           * @param topic_name_   Unique server name.
+          **/
+          ServiceServer(System::String^ server_name_);
+
+          /**
+           * @brief Destructor.
+          **/
+          ~ServiceServer();
+
+        /**
+         * @brief delegate definition for callback functions
+        **/
+        delegate String^ MethodCallback(String^ methodName, String^ reqType, String^ responseType, String^ request);
+
+        /**
+         * @brief Destroys this object.
+         *
+         * @return  true if it succeeds, false if it fails.
+        **/
+        bool Destroy();
+
+        /**
+         * @brief Add callback function for incoming calls.
+         *
+         * @param callback_  The callback function set to connect.
+         *
+         * @return  True if succeeded, false if not.
+        **/
+        bool AddMethodCallback(String^ methodName, String^ reqType, String^ responseType, MethodCallback^ callback_);
+
+        /**
+         * @brief Remove callback function for incoming calls.
+         *
+         * @param callback_  The callback function set to disconnect.
+         *
+         * @return  True if succeeded, false if not.
+        **/
+        bool RemMethodCallback(String^ methodName, MethodCallback^ callback_);
+
+      private:
+        ::eCAL::CServiceServer* m_serv;
+        /**
+         * @brief managed callbacks that will get executed during the eCAL method callback
+        **/
+        MethodCallback^ m_callbacks;
+
+        /**
+         * @brief private member which holds the pointer to OnMethodCall, to avoid function relocation
+        **/
+        GCHandle m_gch;
+
+        /**
+         * @brief The callback of the subscriber, that is registered with the unmanaged code
+        **/
+        delegate int servCallback(const std::string& method_, const std::string& req_type_, const std::string& resp_type_, const std::string& request_, std::string& response_);
+        servCallback^ m_sub_callback;
+        int OnMethodCall(const std::string& method_, const std::string& req_type_, const std::string& resp_type_, const std::string& request_, std::string& response_);
+
+        /**
+         * @brief stdcall function pointer definition of eCAL::ReceiveCallbackT
+        **/
+        typedef int(__stdcall * stdcall_eCAL_MethodCallbackT)(const std::string& method_, const std::string& req_type_, const std::string& resp_type_, const std::string& request_, std::string& response_);
+      };
+
+
+      /**
        * @brief eCAL service client class.
        *
        * The CServiceClient class is used to call a matching eCAL server.

--- a/lang/csharp/Continental/eCAL/Core/ecal_clr.h
+++ b/lang/csharp/Continental/eCAL/Core/ecal_clr.h
@@ -273,11 +273,20 @@ namespace Continental
           long long clock;       /*!< Message write clock */
         };
 
+				ref struct ReceiveCallbackDataUnsafe
+				{
+					void* data;           /*!< Message payload     */
+					unsigned long long size;   /*!< Message payload length*/
+					long long id;         /*!< Message id          */
+					long long time;       /*!< Message time stamp  */
+					long long clock;      /*!< Message write clock */
+				};
         /**
          * @brief delegate definition for callback functions
         **/
         delegate void ReceiverCallback(String^ str, ReceiveCallbackData^ data);
 
+				delegate void ReceiverCallbackUnsafe(String^ str, ReceiveCallbackDataUnsafe^ data);
         /**
          * @brief Creates this object.
          *
@@ -304,6 +313,7 @@ namespace Continental
         **/
         ReceiveCallbackData^ Receive(const int rcv_timeout_);
 
+				ReceiveCallbackDataUnsafe^ ReceiveUnsafe(const int rcv_timeout_);
         /**
          * @brief Add callback function for incoming receives.
          *
@@ -313,6 +323,7 @@ namespace Continental
         **/
         bool AddReceiveCallback(ReceiverCallback^ callback_);
 
+				bool AddReceiveCallback(ReceiverCallbackUnsafe^ callback_);
         /**
          * @brief Remove callback function for incoming receives.
          *
@@ -322,6 +333,7 @@ namespace Continental
         **/
         bool RemReceiveCallback(ReceiverCallback^ callback_);
 
+				bool RemReceiveCallback(ReceiverCallbackUnsafe^ callback_);
         /**
          * @brief Query if this object is created.
          *
@@ -357,18 +369,20 @@ namespace Continental
         **/
         ReceiverCallback^ m_callbacks;
 
+				ReceiverCallbackUnsafe^ m_callbacks_unsafe;
         /**
          * @brief private member which holds the the pointer to OnReceive, to avoid function relocation
         **/
         GCHandle m_gch;
 
+				GCHandle m_gch_unsafe;
         /**
          * @brief The callback of the subscriber, that is registered with the unmanaged code
         **/
         delegate void subCallback(const char* topic_name_, const ::eCAL::SReceiveCallbackData* data_);
         subCallback^ m_sub_callback;
         void OnReceive(const char* topic_name_, const ::eCAL::SReceiveCallbackData* data_);
-
+				void OnReceiveUnsafe(const char* topic_name_, const ::eCAL::SReceiveCallbackData* data_);
         /**
          * @brief stdcall function pointer definition of eCAL::ReceiveCallbackT
         **/

--- a/lang/csharp/Continental/eCAL/Core/ecal_clr.h
+++ b/lang/csharp/Continental/eCAL/Core/ecal_clr.h
@@ -267,11 +267,10 @@ namespace Continental
         **/
         ref struct ReceiveCallbackData
         {
-          void* data;           /*!< Message payload     */
-          unsigned long long size;   /*!< Message payload length*/
-          long long id;         /*!< Message id          */
-          long long time;       /*!< Message time stamp  */
-          long long clock;      /*!< Message write clock */
+          System::String^ data;  /*!< Message payload     */
+          long long id;          /*!< Message id          */
+          long long time;        /*!< Message time stamp  */
+          long long clock;       /*!< Message write clock */
         };
 
         /**

--- a/lang/csharp/Continental/eCAL/Core/ecal_clr.h
+++ b/lang/csharp/Continental/eCAL/Core/ecal_clr.h
@@ -191,6 +191,16 @@ namespace Continental
         size_t Send(System::String^ s_, const long long time_);
 
         /**
+         * @brief Send a message to all subscribers.
+         *
+         * @param buffer_ byte[] that contains the message content.
+         * @param time_   Send time (-1 = use eCAL system time in us, default = -1).
+         *
+         * @return  number of bytes sent.
+        **/
+        size_t Send(array<Byte>^ buffer_, long long time_);
+
+        /**
          * @brief Query if this object is created.
          *
          * @return  true if created, false if not.

--- a/lang/csharp/Continental/eCAL/Core/ecal_clr.h
+++ b/lang/csharp/Continental/eCAL/Core/ecal_clr.h
@@ -266,10 +266,11 @@ namespace Continental
         **/
         ref struct ReceiveCallbackData
         {
-          System::String^ data;  /*!< Message payload     */
-          long long id;          /*!< Message id          */
-          long long time;        /*!< Message time stamp  */
-          long long clock;       /*!< Message write clock */
+          void* data;           /*!< Message payload     */
+          unsigned long long size;   /*!< Message payload length*/
+          long long id;         /*!< Message id          */
+          long long time;       /*!< Message time stamp  */
+          long long clock;      /*!< Message write clock */
         };
 
         /**

--- a/lang/csharp/Continental/eCAL/Core/ecal_clr.h
+++ b/lang/csharp/Continental/eCAL/Core/ecal_clr.h
@@ -27,6 +27,7 @@
 #include <ecal/msg/protobuf/dynamic_json_subscriber.h>
 
 using namespace System;
+using namespace System::Collections::Generic;
 using namespace System::Runtime::InteropServices;
 
 namespace Continental
@@ -642,12 +643,22 @@ namespace Continental
         /**
          * @brief Get host, process and topic protobuf string.
         **/
-        static array<Byte>^ GetMonitoring();
+        static String^ GetMonitoring();
 
         /**
          * @brief Get global log message protobuf string.
         **/
-        static array<Byte>^ GetLogging();
+        static String^ GetLogging();
+
+        /**
+         * @brief Get host, process and topic protobuf message bytes.
+        **/
+        static array<Byte>^ GetMonitoringBytes();
+
+        /**
+         * @brief Get global log message protobuf message bytes.
+        **/
+        static array<Byte>^ GetLoggingBytes();
 
         /*
         * @brief Get eCAL time

--- a/lang/csharp/Continental/eCAL/Core/ecal_clr.h
+++ b/lang/csharp/Continental/eCAL/Core/ecal_clr.h
@@ -642,12 +642,12 @@ namespace Continental
         /**
          * @brief Get host, process and topic protobuf string.
         **/
-        static String^ GetMonitoring();
+        static array<Byte>^ GetMonitoring();
 
         /**
          * @brief Get global log message protobuf string.
         **/
-        static String^ GetLogging();
+        static array<Byte>^ GetLogging();
 
         /*
         * @brief Get eCAL time

--- a/lang/csharp/Continental/eCAL/Core/ecal_clr.h
+++ b/lang/csharp/Continental/eCAL/Core/ecal_clr.h
@@ -492,12 +492,17 @@ namespace Continental
         /**
          * @brief Get host, process and topic protobuf string.
         **/
-        static System::String^ GetMonitoring();
+        static String^ GetMonitoring();
 
         /**
          * @brief Get global log message protobuf string.
         **/
-        static System::String^ GetLogging();
+        static String^ GetLogging();
+
+        /*
+        * @brief Get eCAL time
+        */
+        static DateTime GetTime();
       };
     }
   }


### PR DESCRIPTION
**Pull request type**

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


**What is the current behavior?**
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The C# bindings in Continental.eCAL.Core.dll are lacking some of the features of eCAL and some of the existing ones are not easy to use / break if used with .NET 5+

**What is the new behavior?**
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added minimal ServiceClient implementation
- Added minimal ServiceServer implementation
- Added overload to Publisher.Send() that takes a byte[] to bypass string conversion
- Added GetTime() to Monitoring class

- *Changed ReceiveCallbackData->data of Subscriber from string to pointer + length
- *Changed return type of GetMonitoring and GetLogging() from string to byte[] 

**Does this introduce a breaking change?**

- [x] Yes (Marked with *)
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
The string conversion is cumbersome to use if eCAL is used to transmit anything (e.g. byte[]) other than strings. Also if used with .NET 5 or above the string conversion outright breaks due to breaking changes in the way encodings are handled. 
I therefore suggest changing these methods or adding alternative ways to get a raw byte array which can then be handled by the consumer.

**Other information**

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
