### PR TITLE
Udp build script: Fixed variable

### DIFF
--- a/thirdparty/build-udpcap.cmake
+++ b/thirdparty/build-udpcap.cmake
@@ -7,8 +7,8 @@ if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/npcap/pcapplusplus.zip")
 endif()
 
 # Build as static library
-set(CMAKE_BUILD_SHARED_LIBS_OLD ${CMAKE_BUILD_SHARED_LIBS})
-set(CMAKE_BUILD_SHARED_LIBS OFF)
+set(BUILD_SHARED_LIBS_OLD ${BUILD_SHARED_LIBS})
+set(BUILD_SHARED_LIBS OFF)
 
 # Let udpcap pull the dependencies
 set(UDPCAP_BUILD_SAMPLES               OFF)
@@ -20,8 +20,8 @@ add_subdirectory(thirdparty/udpcap/ EXCLUDE_FROM_ALL)
 add_library(udpcap::udpcap ALIAS udpcap)
 
 # Reset static / shared libs to old value
-set(CMAKE_BUILD_SHARED_LIBS ${CMAKE_BUILD_SHARED_LIBS_OLD})
-unset(CMAKE_BUILD_SHARED_LIBS_OLD)
+set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS_OLD})
+unset(BUILD_SHARED_LIBS_OLD)
 
 # move the udpcap target to a subdirectory in the IDE
 set_property(TARGET udpcap PROPERTY FOLDER lib/udpcap)


### PR DESCRIPTION
Replaced the CMAKE_BUILD_SHARED_LIBS (that does nothing) with the correct BUILD_SHARED_LIBS variable.

Fixes #912
