### PR TITLE
Fix tcp server/client request

### DIFF
--- a/ecal/core/src/service/ecal_tcpclient.h
+++ b/ecal/core/src/service/ecal_tcpclient.h
@@ -89,6 +89,7 @@ namespace eCAL
     std::atomic<bool>                       m_async_request_in_progress;
 
   private:
+    std::vector<char> PackRequest(const std::string &request);
     bool SendRequest(const std::string &request_);
     size_t ReceiveResponse(std::string &response_, int timeout_);
     void ReceiveResponseAsync(AsyncCallbackT callback_, int timeout_);


### PR DESCRIPTION


**Pull request type**
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


**What is the current behavior?**
Issue Number: https://github.com/eclipse-ecal/ecal/issues/907

**What is the new behavior?**
Pretend eCAL::STcpHeader before the request data and set the payload size on the client. Read and decode the header and read until all request data has been received before executing the callback on the server.

**Does this introduce a breaking change?**

- [ ] Yes
- [x] No

**Other information**

We might need to put some thought into timeouts. I haven't added any server side timeouts. There is something in the client, but I cannot confirm that it works.