### PR TITLE
new events pub/sub_event_update_connection

### DIFF
--- a/ecal/core/include/ecal/cimpl/ecal_callback_cimpl.h
+++ b/ecal/core/include/ecal/cimpl/ecal_callback_cimpl.h
@@ -30,12 +30,13 @@
 **/
 enum eCAL_Subscriber_Event
 {
-  sub_event_none            = 0,
-  sub_event_connected       = 1,
-  sub_event_disconnected    = 2,
-  sub_event_dropped         = 3,
-  sub_event_timeout         = 4,
-  sub_event_corrupted       = 5,
+  sub_event_none              = 0,
+  sub_event_connected         = 1,
+  sub_event_disconnected      = 2,
+  sub_event_dropped           = 3,
+  sub_event_timeout           = 4,
+  sub_event_corrupted         = 5,
+  sub_event_update_connection = 6,
 };
 
 /**
@@ -43,10 +44,11 @@ enum eCAL_Subscriber_Event
 **/
 enum eCAL_Publisher_Event
 {
-  pub_event_none            = 0,
-  pub_event_connected       = 1,
-  pub_event_disconnected    = 2,
-  pub_event_dropped         = 3,
+  pub_event_none              = 0,
+  pub_event_connected         = 1,
+  pub_event_disconnected      = 2,
+  pub_event_dropped           = 3,
+  pub_event_update_connection = 4,
 };
 
 /**
@@ -107,6 +109,9 @@ struct SPubEventCallbackDataC
   enum eCAL_Publisher_Event  type;  //!< event type
   long long                  time;  //!< event time stamp
   long long                  clock; //!< event clock
+  const char*                tid;   //!< topic id of the connected subscriber                     (for pub_event_update_connection only)
+  const char*                ttype; //!< topic type information of the connected subscriber       (for pub_event_update_connection only)
+  const char*                tdesc; //!< topic descriptor information of the connected subscriber (for pub_event_update_connection only)
 };
 
 /**
@@ -117,6 +122,9 @@ struct SSubEventCallbackDataC
   enum eCAL_Subscriber_Event type;  //!< event type
   long long                  time;  //!< event time stamp
   long long                  clock; //!< event clock
+  const char*                tid;   //!< topic id of the connected publisher                     (for sub_event_update_connection only)
+  const char*                ttype; //!< topic type information of the connected publisher       (for sub_event_update_connection only)
+  const char*                tdesc; //!< topic descriptor information of the connected publisher (for sub_event_update_connection only)
 };
 
 /**

--- a/ecal/core/include/ecal/ecal_callback.h
+++ b/ecal/core/include/ecal/ecal_callback.h
@@ -65,6 +65,9 @@ namespace eCAL
     eCAL_Publisher_Event type;    //!< publisher event type
     long long            time;    //!< publisher event time in µs
     long long            clock;   //!< publisher event clock
+    std::string          tid;     //!< topic id of the of the connected subscriber              (for pub_event_update_connection only)
+    std::string          ttype;   //!< topic type information of the connected subscriber       (for pub_event_update_connection only)
+    std::string          tdesc;   //!< topic descriptor information of the connected subscriber (for pub_event_update_connection only)
   };
 
   /**
@@ -81,6 +84,9 @@ namespace eCAL
     eCAL_Subscriber_Event type;   //!< subscriber event type
     long long             time;   //!< subscriber event time in µs
     long long             clock;  //!< subscriber event clock
+    std::string           tid;    //!< topic id of the of the connected publisher              (for sub_event_update_connection only)
+    std::string           ttype;  //!< topic type information of the connected publisher       (for sub_event_update_connection only)
+    std::string           tdesc;  //!< topic descriptor information of the connected publisher (for sub_event_update_connection only)
   };
 
   /**

--- a/ecal/core/src/ecal_clang.cpp
+++ b/ecal/core/src/ecal_clang.cpp
@@ -372,6 +372,9 @@ static void g_pub_event_callback(const char* topic_name_, const struct eCAL::SPu
   data.type  = data_->type;
   data.time  = data_->time;
   data.clock = data_->clock;
+  data.tid   = data_->tid.c_str();
+  data.ttype = data_->ttype.c_str();
+  data.tdesc = data_->tdesc.c_str();
   callback_(topic_name_, &data, par_);
 }
 
@@ -560,6 +563,9 @@ static void g_sub_event_callback(const char* topic_name_, const struct eCAL::SSu
   data.type  = data_->type;
   data.time  = data_->time;
   data.clock = data_->clock;
+  data.tid   = data_->tid.c_str();
+  data.ttype = data_->ttype.c_str();
+  data.tdesc = data_->tdesc.c_str();
   callback_(topic_name_, &data, par_);
 }
 

--- a/ecal/core/src/ecalc.cpp
+++ b/ecal/core/src/ecalc.cpp
@@ -520,9 +520,12 @@ static void g_pub_event_callback(const char* topic_name_, const struct eCAL::SPu
 {
   std::lock_guard<std::recursive_mutex> lock(g_pub_callback_mtx);
   SPubEventCallbackDataC data;
-  data.time  = data_->time;
   data.type  = data_->type;
+  data.time  = data_->time;
   data.clock = data_->clock;
+  data.tid   = data_->tid.c_str();
+  data.ttype = data_->ttype.c_str();
+  data.tdesc = data_->tdesc.c_str();
   callback_(topic_name_, &data, par_);
 }
 
@@ -738,9 +741,12 @@ static void g_sub_event_callback(const char* topic_name_, const struct eCAL::SSu
 {
   std::lock_guard<std::recursive_mutex> lock(g_sub_callback_mtx);
   SSubEventCallbackDataC data;
-  data.time  = data_->time;
   data.type  = data_->type;
+  data.time  = data_->time;
   data.clock = data_->clock;
+  data.tid   = data_->tid.c_str();
+  data.ttype = data_->ttype.c_str();
+  data.tdesc = data_->tdesc.c_str();
   callback_(topic_name_, &data, par_);
 }
 

--- a/ecal/core/src/pubsub/ecal_pubgate.cpp
+++ b/ecal/core/src/pubsub/ecal_pubgate.cpp
@@ -115,7 +115,11 @@ namespace eCAL
 
     const auto& ecal_sample_topic = ecal_sample_.topic();
     const std::string& topic_name = ecal_sample_topic.tname();
-    std::string process_id = std::to_string(ecal_sample_topic.pid());
+    const std::string& topic_id   = ecal_sample_topic.tid();
+    const std::string& topic_type = ecal_sample_topic.ttype();
+    const std::string& topic_desc = ecal_sample_topic.tdesc();
+    const std::string& process_id = std::to_string(ecal_sample_topic.pid());
+
     std::string reader_par;
     for (const auto& layer : ecal_sample_topic.tlayer())
     {
@@ -128,9 +132,6 @@ namespace eCAL
     // store description
     if (g_descgate())
     {
-      const std::string& topic_type = ecal_sample_topic.ttype();
-      const std::string& topic_desc = ecal_sample_topic.tdesc();
-
       // Calculate the quality of the current info
       ::eCAL::CDescGate::QualityFlags quality = ::eCAL::CDescGate::QualityFlags::NO_QUALITY;
       if (!topic_type.empty())
@@ -147,7 +148,7 @@ namespace eCAL
     auto res = m_topic_name_datawriter_map.equal_range(topic_name);
     for(TopicNameDataWriterMapT::const_iterator iter = res.first; iter != res.second; ++iter)
     {
-      iter->second->ApplyLocSubscription(process_id, reader_par);
+      iter->second->ApplyLocSubscription(process_id, topic_id, topic_type, topic_desc, reader_par);
     }
   }
 
@@ -158,7 +159,11 @@ namespace eCAL
     const auto& ecal_sample_topic = ecal_sample_.topic();
     const std::string& host_name  = ecal_sample_topic.hname();
     const std::string& topic_name = ecal_sample_topic.tname();
-    std::string process_id = std::to_string(ecal_sample_topic.pid());
+    const std::string& topic_id   = ecal_sample_topic.tid();
+    const std::string& topic_type = ecal_sample_topic.ttype();
+    const std::string& topic_desc = ecal_sample_topic.tdesc();
+    const std::string& process_id = std::to_string(ecal_sample_topic.pid());
+
     std::string reader_par;
     for (const auto& layer : ecal_sample_topic.tlayer())
     {
@@ -171,9 +176,6 @@ namespace eCAL
     // store description
     if (g_descgate())
     {
-      const std::string& topic_type = ecal_sample_topic.ttype();
-      const std::string& topic_desc = ecal_sample_topic.tdesc();
-
       // Calculate the quality of the current info
       ::eCAL::CDescGate::QualityFlags quality = ::eCAL::CDescGate::QualityFlags::NO_QUALITY;
       if (!topic_type.empty())
@@ -190,7 +192,7 @@ namespace eCAL
     auto res = m_topic_name_datawriter_map.equal_range(topic_name);
     for(TopicNameDataWriterMapT::const_iterator iter = res.first; iter != res.second; ++iter)
     {
-      iter->second->ApplyExtSubscription(host_name, process_id, reader_par);
+      iter->second->ApplyExtSubscription(host_name, process_id, topic_id, topic_type, topic_desc, reader_par);
     }
   }
 

--- a/ecal/core/src/pubsub/ecal_pubgate.cpp
+++ b/ecal/core/src/pubsub/ecal_pubgate.cpp
@@ -118,7 +118,7 @@ namespace eCAL
     const std::string& topic_id   = ecal_sample_topic.tid();
     const std::string& topic_type = ecal_sample_topic.ttype();
     const std::string& topic_desc = ecal_sample_topic.tdesc();
-    const std::string& process_id = std::to_string(ecal_sample_topic.pid());
+    const std::string  process_id = std::to_string(ecal_sample_topic.pid());
 
     std::string reader_par;
     for (const auto& layer : ecal_sample_topic.tlayer())
@@ -162,7 +162,7 @@ namespace eCAL
     const std::string& topic_id   = ecal_sample_topic.tid();
     const std::string& topic_type = ecal_sample_topic.ttype();
     const std::string& topic_desc = ecal_sample_topic.tdesc();
-    const std::string& process_id = std::to_string(ecal_sample_topic.pid());
+    const std::string  process_id = std::to_string(ecal_sample_topic.pid());
 
     std::string reader_par;
     for (const auto& layer : ecal_sample_topic.tlayer())

--- a/ecal/core/src/pubsub/ecal_subgate.cpp
+++ b/ecal/core/src/pubsub/ecal_subgate.cpp
@@ -208,6 +208,7 @@ namespace eCAL
     const std::string& topic_name = ecal_sample_topic.tname();
     if (topic_name.empty()) return;
 
+    const std::string& topic_id   = ecal_sample_topic.tid();
     const std::string& topic_type = ecal_sample_topic.ttype();
     const std::string& topic_desc = ecal_sample_topic.tdesc();
 
@@ -267,7 +268,7 @@ namespace eCAL
         iter->second->ApplyLocLayerParameter(process_id, tlayer.type(), writer_par);
       }
       // inform for local publisher connection
-      iter->second->ApplyLocPublication(process_id);
+      iter->second->ApplyLocPublication(process_id, topic_id, topic_type, topic_desc);
     }
   }
 
@@ -278,6 +279,7 @@ namespace eCAL
     const auto& sample_topic = ecal_sample_.topic();
     const std::string& host_name  = sample_topic.hname();
     const std::string& topic_name = sample_topic.tname();
+    const std::string& topic_id   = sample_topic.tid();
     const std::string& topic_type = sample_topic.ttype();
     const std::string& topic_desc = sample_topic.tdesc();
 
@@ -306,7 +308,7 @@ namespace eCAL
         iter->second->ApplyExtLayerParameter(host_name, tlayer.type(), writer_par);
       }
       // inform for external publisher connection
-      iter->second->ApplyExtPublication(host_name);
+      iter->second->ApplyExtPublication(host_name, topic_id, topic_type, topic_desc);
     }
   }
 

--- a/ecal/core/src/readwrite/ecal_reader.cpp
+++ b/ecal/core/src/readwrite/ecal_reader.cpp
@@ -570,9 +570,9 @@ namespace eCAL
     m_id_set = id_set_;
   }
 
-  void CDataReader::ApplyLocPublication(const std::string& process_id_)
+  void CDataReader::ApplyLocPublication(const std::string& process_id_, const std::string& tid_, const std::string& ttype_, const std::string& tdesc_)
   {
-    SetConnected(true);
+    Connect(tid_, ttype_, tdesc_);
     {
       std::lock_guard<std::mutex> lock(m_pub_map_sync);
       m_loc_pub_map[process_id_] = true;
@@ -580,9 +580,9 @@ namespace eCAL
     m_loc_published = true;
   }
 
-  void CDataReader::ApplyExtPublication(const std::string& host_name_)
+  void CDataReader::ApplyExtPublication(const std::string& host_name_, const std::string& tid_, const std::string& ttype_, const std::string& tdesc_)
   {
-    SetConnected(true);
+    Connect(tid_, ttype_, tdesc_);
     {
       std::lock_guard<std::mutex> lock(m_pub_map_sync);
       m_ext_pub_map[host_name_] = true;
@@ -650,26 +650,48 @@ namespace eCAL
     }
   }
 
-  void CDataReader::SetConnected(bool state_)
+  void CDataReader::Connect(const std::string& tid_, const std::string& ttype_, const std::string& tdesc_)
   {
-    if(m_connected == state_) return;
-    m_connected = state_;
-    if(m_connected)
+    SSubEventCallbackData data;
+    data.time  = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
+    data.clock = 0;
+
+    if (m_connected == false)
     {
-      auto iter = m_event_callback_map.find(sub_event_connected);
-      if(iter != m_event_callback_map.end())
+      m_connected = true;
+
+      // fire sub_event_connected
       {
-        SSubEventCallbackData data;
-        data.type  = sub_event_connected;
-        data.time  = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
-        data.clock = 0;
-        (iter->second)(m_topic_name.c_str(), &data);
+        auto iter = m_event_callback_map.find(sub_event_connected);
+        if (iter != m_event_callback_map.end())
+        {
+          data.type = sub_event_connected;
+          (iter->second)(m_topic_name.c_str(), &data);
+        }
       }
     }
-    else
+
+    // fire sub_event_update_connection
+    auto iter = m_event_callback_map.find(sub_event_update_connection);
+    if (iter != m_event_callback_map.end())
     {
+      data.type  = sub_event_update_connection;
+      data.tid   = tid_;
+      data.ttype = ttype_;
+      data.tdesc = tdesc_;
+      (iter->second)(m_topic_name.c_str(), &data);
+    }
+  }
+
+  void CDataReader::Disconnect()
+  {
+    if (m_connected == true)
+    {
+      m_connected = false;
+
+      // fire sub_event_disconnected
       auto iter = m_event_callback_map.find(sub_event_disconnected);
-      if(iter != m_event_callback_map.end())
+      if (iter != m_event_callback_map.end())
       {
         SSubEventCallbackData data;
         data.type  = sub_event_disconnected;
@@ -766,7 +788,7 @@ namespace eCAL
 
     if (!m_loc_published && !m_ext_published)
     {
-      SetConnected(false);
+      Disconnect();
     }
   }
 

--- a/ecal/core/src/readwrite/ecal_reader.cpp
+++ b/ecal/core/src/readwrite/ecal_reader.cpp
@@ -656,7 +656,7 @@ namespace eCAL
     data.time  = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
     data.clock = 0;
 
-    if (m_connected == false)
+    if (!m_connected)
     {
       m_connected = true;
 
@@ -685,7 +685,7 @@ namespace eCAL
 
   void CDataReader::Disconnect()
   {
-    if (m_connected == true)
+    if (m_connected)
     {
       m_connected = false;
 

--- a/ecal/core/src/readwrite/ecal_reader.h
+++ b/ecal/core/src/readwrite/ecal_reader.h
@@ -75,8 +75,8 @@ namespace eCAL
 
     void SetID(const std::set<long long>& id_set_);
 
-    void ApplyLocPublication(const std::string& process_id_);
-    void ApplyExtPublication(const std::string& host_name_);
+    void ApplyLocPublication(const std::string& process_id_, const std::string& tid_, const std::string& ttype_, const std::string& tdesc_);
+    void ApplyExtPublication(const std::string& host_name_, const std::string& tid_, const std::string& ttype_, const std::string& tdesc_);
 
     void ApplyLocLayerParameter(const std::string& process_id_, eCAL::pb::eTLayerType type_, const std::string& parameter_);
     void ApplyExtLayerParameter(const std::string& host_name_,  eCAL::pb::eTLayerType type_, const std::string& parameter_);
@@ -106,7 +106,8 @@ namespace eCAL
     void UnsubscribeFromLayers();
 
     bool DoRegister(const bool force_);
-    void SetConnected(bool state_);
+    void Connect(const std::string& tid_, const std::string& ttype_, const std::string& tdesc_);
+    void Disconnect();
     void CheckCounter(const std::string& tid_, long long counter_);
 
     std::string                               m_host_name;

--- a/ecal/core/src/readwrite/ecal_writer.cpp
+++ b/ecal/core/src/readwrite/ecal_writer.cpp
@@ -698,9 +698,9 @@ namespace eCAL
     return(written);
   }
 
-  void CDataWriter::ApplyLocSubscription(const std::string& process_id_, const std::string& reader_par_)
+  void CDataWriter::ApplyLocSubscription(const std::string& process_id_, const std::string& tid_, const std::string& ttype_, const std::string& tdesc_, const std::string& reader_par_)
   {
-    SetConnected(true);
+    Connect(tid_, ttype_, tdesc_);
     {
       std::lock_guard<std::mutex> lock(m_sub_map_sync);
       m_loc_sub_map[process_id_] = true;
@@ -729,9 +729,9 @@ namespace eCAL
 #endif
   }
 
-  void CDataWriter::ApplyExtSubscription(const std::string& host_name_, const std::string& process_id_, const std::string& reader_par_)
+  void CDataWriter::ApplyExtSubscription(const std::string& host_name_, const std::string& process_id_, const std::string& tid_, const std::string& ttype_, const std::string& tdesc_, const std::string& reader_par_)
   {
-    SetConnected(true);
+    Connect(tid_, ttype_, tdesc_);
     {
       std::lock_guard<std::mutex> lock(m_sub_map_sync);
       m_ext_sub_map[host_name_] = true;
@@ -806,7 +806,7 @@ namespace eCAL
 
     if (!m_loc_subscribed && !m_ext_subscribed)
     {
-      SetConnected(false);
+      Disconnect();
     }
   }
 
@@ -976,24 +976,44 @@ namespace eCAL
     return(true);
   }
 
-  void CDataWriter::SetConnected(bool state_)
+  void CDataWriter::Connect(const std::string& tid_, const std::string& ttype_, const std::string& tdesc_)
   {
-    if (m_connected == state_) return;
-    m_connected = state_;
-    if (m_connected)
+    SPubEventCallbackData data;
+    data.time  = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
+    data.clock = 0;
+
+    if (m_connected == false)
     {
+      m_connected = true;
+
+      // fire pub_event_connected
       auto iter = m_event_callback_map.find(pub_event_connected);
       if (iter != m_event_callback_map.end())
       {
-        SPubEventCallbackData data;
-        data.type  = pub_event_connected;
-        data.time  = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
-        data.clock = 0;
+        data.type = pub_event_connected;
         (iter->second)(m_topic_name.c_str(), &data);
       }
     }
-    else
+
+    // fire pub_event_update_connection
+    auto iter = m_event_callback_map.find(pub_event_update_connection);
+    if (iter != m_event_callback_map.end())
     {
+      data.type  = pub_event_update_connection;
+      data.tid   = tid_;
+      data.ttype = ttype_;
+      data.tdesc = tdesc_;
+      (iter->second)(m_topic_name.c_str(), &data);
+    }
+  }
+
+  void CDataWriter::Disconnect()
+  {
+    if (m_connected == true)
+    {
+      m_connected = false;
+      
+      // fire pub_event_disconnected
       auto iter = m_event_callback_map.find(pub_event_disconnected);
       if (iter != m_event_callback_map.end())
       {

--- a/ecal/core/src/readwrite/ecal_writer.cpp
+++ b/ecal/core/src/readwrite/ecal_writer.cpp
@@ -982,7 +982,7 @@ namespace eCAL
     data.time  = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
     data.clock = 0;
 
-    if (m_connected == false)
+    if (!m_connected)
     {
       m_connected = true;
 
@@ -1009,7 +1009,7 @@ namespace eCAL
 
   void CDataWriter::Disconnect()
   {
-    if (m_connected == true)
+    if (m_connected)
     {
       m_connected = false;
       

--- a/ecal/core/src/readwrite/ecal_writer.h
+++ b/ecal/core/src/readwrite/ecal_writer.h
@@ -81,10 +81,10 @@ namespace eCAL
 
     bool Write(const void* const buf_, size_t len_, long long time_, long long id_);
 
-    void ApplyLocSubscription(const std::string& process_id_, const std::string& reader_par_);
+    void ApplyLocSubscription(const std::string& process_id_, const std::string& tid_, const std::string& ttype_, const std::string& tdesc_, const std::string& reader_par_);
     void RemoveLocSubscription(const std::string & process_id_);
 
-    void ApplyExtSubscription(const std::string& host_name_, const std::string& process_id_, const std::string& reader_par_);
+    void ApplyExtSubscription(const std::string& host_name_, const std::string& process_id_, const std::string& tid_, const std::string& ttype_, const std::string& tdesc_, const std::string& reader_par_);
     void RemoveExtSubscription(const std::string & host_name_, const std::string & process_id_);
 
     void RefreshRegistration();
@@ -110,7 +110,8 @@ namespace eCAL
 
   protected:
     bool DoRegister(bool force_);
-    void SetConnected(bool state_);
+    void Connect(const std::string& tid_, const std::string& ttype_, const std::string& tdesc_);
+    void Disconnect();
 
     bool SetUseUdpMC(TLayer::eSendMode mode_);
     bool SetUseShm(TLayer::eSendMode mode_);

--- a/samples/cpp/person/person_rec_events/src/person_rec_events.cpp
+++ b/samples/cpp/person/person_rec_events/src/person_rec_events.cpp
@@ -45,32 +45,17 @@ void OnEvent(const char* topic_name_, const struct eCAL::SSubEventCallbackData* 
   case sub_event_corrupted:
     std::cout << "event        : " << "sub_event_corrupted" << std::endl;
     break;
+  case sub_event_update_connection:
+    std::cout << "event        : " << "sub_event_update_connection" << std::endl;
+    std::cout << "  topic_id   : " << data_->tid << std::endl;
+    std::cout << "  topic_type : " << data_->ttype << std::endl;
+    //std::cout << "  topic_desc : " << data_->tdesc << std::endl;
+    break;
   default:
     std::cout << "event        : " << "unknown" << std::endl;
     break;
   }
   std::cout << std::endl;
-}
-
-void OnPerson(const char* topic_name_, const pb::People::Person& person_, const long long time_, const long long clock_)
-{
-  std::cout << "------------------------------------------" << std::endl;
-  std::cout << " HEAD "                                     << std::endl;
-  std::cout << "------------------------------------------" << std::endl;
-  std::cout << "topic name   : " << topic_name_             << std::endl;
-  std::cout << "topic time   : " << time_                   << std::endl;
-  std::cout << "topic clock  : " << clock_                  << std::endl;
-  std::cout << "------------------------------------------" << std::endl;
-  std::cout << " CONTENT "                                  << std::endl;
-  std::cout << "------------------------------------------" << std::endl;
-  std::cout << "person id    : " << person_.id()            << std::endl;
-  std::cout << "person name  : " << person_.name()          << std::endl;
-  std::cout << "person stype : " << person_.stype()         << std::endl;
-  std::cout << "person email : " << person_.email()         << std::endl;
-  std::cout << "dog.name     : " << person_.dog().name()    << std::endl;
-  std::cout << "house.rooms  : " << person_.house().rooms() << std::endl;
-  std::cout << "------------------------------------------" << std::endl;
-  std::cout                                                 << std::endl;
 }
 
 int main(int argc, char **argv)
@@ -87,17 +72,17 @@ int main(int argc, char **argv)
   // set receive timeout in ms
   sub.SetTimeout(1000);
 
-  // add receive callback function (_1 = topic_name, _2 = msg, _3 = time, , _4 = clock)
-  auto rec_callback = std::bind(OnPerson, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4);
-  sub.AddReceiveCallback(rec_callback);
-
   // add event callback function (_1 = topic_name, _2 = event data struct)
   auto evt_callback = std::bind(OnEvent, std::placeholders::_1, std::placeholders::_2);
-  sub.AddEventCallback(sub_event_connected,    evt_callback);
-  sub.AddEventCallback(sub_event_disconnected, evt_callback);
-  sub.AddEventCallback(sub_event_dropped,      evt_callback);
-  sub.AddEventCallback(sub_event_timeout,      evt_callback);
-  sub.AddEventCallback(sub_event_corrupted,    evt_callback);
+  sub.AddEventCallback(sub_event_connected,         evt_callback);
+  sub.AddEventCallback(sub_event_disconnected,      evt_callback);
+  sub.AddEventCallback(sub_event_dropped,           evt_callback);
+  sub.AddEventCallback(sub_event_timeout,           evt_callback);
+  sub.AddEventCallback(sub_event_corrupted,         evt_callback);
+  sub.AddEventCallback(sub_event_update_connection, evt_callback);
+
+  // start application and wait for events
+  std::cout << "Please start 'person_snd_events sample." << std::endl << std::endl;
 
   while(eCAL::Ok())
   {

--- a/samples/cpp/person/person_snd_events/src/person_snd_events.cpp
+++ b/samples/cpp/person/person_snd_events/src/person_snd_events.cpp
@@ -39,6 +39,12 @@ void OnEvent(const char* topic_name_, const struct eCAL::SPubEventCallbackData* 
   case pub_event_dropped:
     std::cout << "event        : " << "pub_event_dropped" << std::endl;
     break;
+  case pub_event_update_connection:
+    std::cout << "event        : " << "pub_event_update_connection" << std::endl;
+    std::cout << "  topic_id   : " << data_->tid << std::endl;
+    std::cout << "  topic_type : " << data_->ttype << std::endl;
+    //std::cout << "  topic_desc : " << data_->tdesc << std::endl;
+    break;
   default:
     std::cout << "event        : " << "unknown" << std::endl;
     break;
@@ -59,11 +65,15 @@ int main(int argc, char **argv)
 
   // add event callback function (_1 = topic_name, _2 = event data struct)
   auto evt_callback = std::bind(OnEvent, std::placeholders::_1, std::placeholders::_2);
-  pub.AddEventCallback(pub_event_connected,    evt_callback);
-  pub.AddEventCallback(pub_event_disconnected, evt_callback);
+  pub.AddEventCallback(pub_event_connected,         evt_callback);
+  pub.AddEventCallback(pub_event_disconnected,      evt_callback);
+  pub.AddEventCallback(pub_event_update_connection, evt_callback);
 
   // generate a class instance of Person
   pb::People::Person person;
+
+  // start application and wait for events
+  std::cout << "Please start 'person_rec_events sample." << std::endl << std::endl;
 
   // enter main loop
   auto cnt(0);
@@ -79,15 +89,6 @@ int main(int argc, char **argv)
 
     // send the person object
     pub.Send(person);
-
-    // print content
-    std::cout << "person id    : " << person.id()            << std::endl;
-    std::cout << "person name  : " << person.name()          << std::endl;
-    std::cout << "person stype : " << person.stype()         << std::endl;
-    std::cout << "person email : " << person.email()         << std::endl;
-    std::cout << "dog.name     : " << person.dog().name()    << std::endl;
-    std::cout << "house.rooms  : " << person.house().rooms() << std::endl;
-    std::cout                                                << std::endl;
 
     // sleep 500 ms
     eCAL::Process::SleepMS(500);


### PR DESCRIPTION
Please check the type of change your PR introduces:
- [X] Feature

**What is the current behavior?**
Connection refresh event to inform publisher / subscriber permanently about established connections and their attributes is not existing.

Fixes: #919

**What is the new behavior?**
New events pub_event_update_connection and sub_event_update_connection introduced.
Event callback information structs SPubEventCallbackData and SSubEventCallbackData extended to provide additional topic. Attributes samples person_snd_events and person_rec_events adapted to show usage.

**Does this introduce a breaking change?**

- [X] Yes

ABI compatibility break