### PR TITLE
Fix crash based on wrong acknowledgment event handling.

### DIFF
--- a/ecal/core/src/io/ecal_memfile_sync.cpp
+++ b/ecal/core/src/io/ecal_memfile_sync.cpp
@@ -365,7 +365,7 @@ namespace eCAL
       // take start time for all acknowledge timeouts
       const auto start_time = std::chrono::steady_clock::now();
 
-      for (auto event_handle : m_event_handle_map)
+      for (auto& event_handle : m_event_handle_map)
       {
         const auto time_since_start = std::chrono::steady_clock::now() - start_time;
         const auto time_to_wait     = std::chrono::milliseconds(m_attr.timeout_ack_ms)- time_since_start;


### PR DESCRIPTION
**Pull request type**

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix

**What is the current behavior?**
Exiting a subscription node will affect the publishing node when shm shared memory acknowledge feature is activated.

Fixes: #925

**What is the new behavior?**
Acknowledge feature is working properly again by invalidating the acknowledge event after the first timeout (not a local copy of that event).

**Does this introduce a breaking change?**

- [X] No
