### PR TITLE
Fix: `rec_addon_dummy` finds and links threads.

### DIFF
--- a/app/rec/rec_addon_dummy/CMakeLists.txt
+++ b/app/rec/rec_addon_dummy/CMakeLists.txt
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 # ========================= eCAL LICENSE =================================
+find_package(Threads REQUIRED)
 
 project(rec_addon_dummy)
 
@@ -24,7 +25,11 @@ set(source_files src/recorder_impl.cpp
 ecal_add_rec_addon(${PROJECT_NAME} ${source_files})
 
 target_include_directories(${PROJECT_NAME} PRIVATE src)
-target_link_libraries(${PROJECT_NAME} PRIVATE eCAL::rec_addon_core)
+target_link_libraries(${PROJECT_NAME} 
+  PRIVATE 
+    eCAL::rec_addon_core 
+    Threads::Threads
+)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER app/rec)


### PR DESCRIPTION
**Pull request type**

Please check the type of change your PR introduces:
- [x] Bugfix


**What is the current behavior?**
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes #933
Cannot build eCAL on FreeBSD

**What is the new behavior?**

- `ecal_rec_dummy` which directly uses threads now has a CMake find package call and properly links threads.

**Does this introduce a breaking change?**

- [ ] Yes
- [x] No


