### PR TITLE
[5.11] Core Services Bugfix: Service response header now contains the method name again

### DIFF
--- a/ecal/core/src/service/ecal_service_server_impl.cpp
+++ b/ecal/core/src/service/ecal_service_server_impl.cpp
@@ -306,6 +306,7 @@ namespace eCAL
     // get method
     SMethod method;
     auto& request_pb_header = request_pb.header();
+    response_pb_mutable_header->set_mname(request_pb_header.mname());
     {
       std::lock_guard<std::mutex> lock(m_method_map_sync);
 


### PR DESCRIPTION
Fixes #937, a bug that was introduced with commit 419d7f33edca6cf4b02c50b8e879981f4043f873
