### PR TITLE
Core: Added proper topic_name -> UDP MC group computation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -476,6 +476,7 @@ endif(NOT ECAL_LAYER_ICEORYX)
   add_subdirectory(testing/ecal/pubsub_inproc_test)
   add_subdirectory(testing/ecal/pubsub_proto_test)
   add_subdirectory(testing/ecal/pubsub_test)
+  add_subdirectory(testing/ecal/topic2mcast_test)
 endif()
 
 # --------------------------------------------------------

--- a/doc/rst/configuration/options.rst
+++ b/doc/rst/configuration/options.rst
@@ -54,18 +54,38 @@ The network setting drive how and which ...
    
    ``false`` = local host only communication
    
+.. option:: multicast_config_version
+
+   ``v1`` / ``v2``, default: ``v1`` 
+
+   UDP configuration version (Since eCAL 5.12.)
+   
+   ``v1`` = default behavior
+
+   ``v2`` = new behavior, comes with a bit more intuitive handling regarding masking of the groups
+
 .. option:: multicast_group
 
    IPV4 Adress, default ``239.0.0.1``
 
-   UDP multicast group base. 
+   UDP multicast group base. All registration and logging information is sent on this address.
 
 .. option:: multicast_mask
 
+   ``v1`` **behavior:** 
+   
    ``0.0.0.1``-``0.0.0.255``
 
    Mask maximum number of dynamic multicast group
 
+   ``v2`` **behavior:** 
+   
+   ``255.0.0.0``-``255.255.255.255`` 
+   
+   Mask for the multicast group. Topic traffic may be set on any of the unmasked addresses.
+   
+   With ``multicast_group``: ``239.0.0.1`` and ``multicast_mask``: ``255.255.255.255``, topic traffic will be sent on addresses ``239.0.0.0``-``239.0.0.255``.
+   
 .. option:: multicast_port     
    
    ``14000 + x``

--- a/doc/rst/configuration/options.rst
+++ b/doc/rst/configuration/options.rst
@@ -84,7 +84,7 @@ The network setting drive how and which ...
    
    Mask for the multicast group. Topic traffic may be set on any of the unmasked addresses.
    
-   With ``multicast_group``: ``239.0.0.1`` and ``multicast_mask``: ``255.255.255.255``, topic traffic will be sent on addresses ``239.0.0.0``-``239.0.0.255``.
+   With ``multicast_group``: ``239.0.0.1`` and ``multicast_mask``: ``255.255.255.0``, topic traffic will be sent on addresses ``239.0.0.0``-``239.0.0.255``.
    
 .. option:: multicast_port     
    

--- a/ecal/core/CMakeLists.txt
+++ b/ecal/core/CMakeLists.txt
@@ -72,6 +72,7 @@ set(ecal_io_cpp_src
     src/io/rcv_sample.cpp
     src/io/snd_raw_buffer.cpp
     src/io/snd_sample.cpp
+    src/io/udp_configurations.cpp
     src/io/udp_init.cpp
     src/io/udp_receiver.cpp
     src/io/udp_receiver_asio.cpp
@@ -195,6 +196,7 @@ set(ecal_io_header_src
     src/io/rcv_sample.h
     src/io/snd_raw_buffer.h
     src/io/snd_sample.h
+    src/io/udp_configurations.h
     src/io/udp_init.h
     src/io/udp_receiver.h
     src/io/udp_receiver_base.h

--- a/ecal/core/cfg/ecal.ini
+++ b/ecal/core/cfg/ecal.ini
@@ -4,9 +4,9 @@
 ; network_enabled           = true / false          true  = all eCAL components communicate over network boundaries
 ;                                                   false = local host only communication
 ;
-; multicast_config_version  = v1 / v2               UDP configuration version
-;                                                   v1 (legacy, but default)
-;                                                   v2 (introduced in eCAL 5.12.0)
+; multicast_config_version  = v1 / v2               UDP configuration version (Since eCAL 5.12.)
+;                                                   v1: default behavior
+;                                                   v2: new behavior, comes with a bit more intuitive handling regarding masking of the groups
 ; multicast_group           = 239.0.0.1             UDP multicast group base
 ;                                                   All registration and logging is sent on this address
 ; multicast_mask            = 0.0.0.1-0.0.0.255     v1: Mask maximum number of dynamic multicast group

--- a/ecal/core/cfg/ecal.ini
+++ b/ecal/core/cfg/ecal.ini
@@ -4,9 +4,13 @@
 ; network_enabled           = true / false          true  = all eCAL components communicate over network boundaries
 ;                                                   false = local host only communication
 ;
+; multicast_config_version  = v1 / v2               UDP configuration version
+;                                                   v1 (legacy, but default)
+;                                                   v2 (introduced in eCAL 5.12.0)
 ; multicast_group           = 239.0.0.1             UDP multicast group base
-;
-; multicast_mask             = 0.0.0.1-0.0.0.255    Mask maximum number of dynamic multicast group
+;                                                   All registration and logging is sent on this address
+; multicast_mask            = 0.0.0.1-0.0.0.255     v1: Mask maximum number of dynamic multicast group
+;                             255.0.0.0-255.255.255.255 v2: masks are now considered like routes masking
 ;
 ; multicast_port             = 14000 + x            UDP multicast port number (eCAL will use at least the 2 following port
 ;                                                   numbers too, so please modify in steps of 10 (e.g. 1010, 1020 ...)
@@ -38,6 +42,7 @@
 
 [network]
 network_enabled           = false
+multicast_config_version  = v1
 multicast_group           = 239.0.0.1
 multicast_mask            = 0.0.0.15
 multicast_port            = 14000

--- a/ecal/core/include/ecal/ecal_config.h
+++ b/ecal/core/include/ecal/ecal_config.h
@@ -17,6 +17,8 @@
  * ========================= eCAL LICENSE =================================
 */
 
+#pragma once
+
 #include <ecal/ecal_os.h>
 #include <ecal/ecal_tlayer.h>
 #include <ecal/ecal_log_level.h>
@@ -27,6 +29,12 @@ namespace eCAL
 {
   namespace Config
   {
+    enum class UDPConfigVersion
+    {
+      V1 = 1, // Legacy
+      V2 = 2
+    };
+
     /////////////////////////////////////
     // common
     /////////////////////////////////////
@@ -40,7 +48,7 @@ namespace eCAL
     /////////////////////////////////////
 
     ECAL_API bool              IsNetworkEnabled                     ();
-
+    ECAL_API UDPConfigVersion  GetUdpMulticastConfigVersion         ();
     ECAL_API std::string       GetUdpMulticastGroup                 ();
     ECAL_API std::string       GetUdpMulticastMask                  ();
     ECAL_API int               GetUdpMulticastPort                  ();

--- a/ecal/core/include/ecal/ecal_config.h
+++ b/ecal/core/include/ecal/ecal_config.h
@@ -29,7 +29,7 @@ namespace eCAL
 {
   namespace Config
   {
-    enum class UDPConfigVersion
+    enum class UdpConfigVersion
     {
       V1 = 1, // Legacy
       V2 = 2
@@ -48,7 +48,7 @@ namespace eCAL
     /////////////////////////////////////
 
     ECAL_API bool              IsNetworkEnabled                     ();
-    ECAL_API UDPConfigVersion  GetUdpMulticastConfigVersion         ();
+    ECAL_API UdpConfigVersion  GetUdpMulticastConfigVersion         ();
     ECAL_API std::string       GetUdpMulticastGroup                 ();
     ECAL_API std::string       GetUdpMulticastMask                  ();
     ECAL_API int               GetUdpMulticastPort                  ();

--- a/ecal/core/src/ecal_config.cpp
+++ b/ecal/core/src/ecal_config.cpp
@@ -100,15 +100,15 @@ namespace eCAL
 
     ECAL_API bool              IsNetworkEnabled                     () { return eCALPAR(NET, ENABLED); }
 
-    ECAL_API UDPConfigVersion  GetUdpMulticastConfigVersion()
+    ECAL_API UdpConfigVersion  GetUdpMulticastConfigVersion()
     {
       std::string udp_config_version_string = eCALPAR(NET, UDP_MULTICAST_CONFIG_VERSION);
       if (udp_config_version_string == "v1")
-        return UDPConfigVersion::V1;
+        return UdpConfigVersion::V1;
       if (udp_config_version_string == "v2")
-        return UDPConfigVersion::V2;
+        return UdpConfigVersion::V2;
       // TODO: Log error. However not sure if logging is initialized at this place.
-      return UDPConfigVersion::V1;
+      return UdpConfigVersion::V1;
     }
 
     ECAL_API std::string       GetUdpMulticastGroup                 () { return eCALPAR(NET, UDP_MULTICAST_GROUP); }

--- a/ecal/core/src/ecal_config.cpp
+++ b/ecal/core/src/ecal_config.cpp
@@ -100,6 +100,17 @@ namespace eCAL
 
     ECAL_API bool              IsNetworkEnabled                     () { return eCALPAR(NET, ENABLED); }
 
+    ECAL_API UDPConfigVersion  GetUdpMulticastConfigVersion()
+    {
+      std::string udp_config_version_string = eCALPAR(NET, UDP_MULTICAST_CONFIG_VERSION);
+      if (udp_config_version_string == "v1")
+        return UDPConfigVersion::V1;
+      if (udp_config_version_string == "v2")
+        return UDPConfigVersion::V2;
+      // TODO: Log error. However not sure if logging is initialized at this place.
+      return UDPConfigVersion::V1;
+    }
+
     ECAL_API std::string       GetUdpMulticastGroup                 () { return eCALPAR(NET, UDP_MULTICAST_GROUP); }
     ECAL_API std::string       GetUdpMulticastMask                  () { return eCALPAR(NET, UDP_MULTICAST_MASK); }
     ECAL_API int               GetUdpMulticastPort                  () { return eCALPAR(NET, UDP_MULTICAST_PORT); }

--- a/ecal/core/src/ecal_def.h
+++ b/ecal/core/src/ecal_def.h
@@ -66,6 +66,7 @@
 #define NET_ENABLED                                 false
 
 /* eCAL udp multicast defines */
+#define NET_UDP_MULTICAST_CONFIG_VERSION           "v1"
 #define NET_UDP_MULTICAST_GROUP                    "239.0.0.1"
 #define NET_UDP_MULTICAST_MASK                     "0.0.0.15"
 #define NET_UDP_MULTICAST_PORT                     14000

--- a/ecal/core/src/ecal_def_ini.h
+++ b/ecal/core/src/ecal_def_ini.h
@@ -37,6 +37,7 @@
 
 #define  NET_ENABLED_S                    "network_enabled"
 
+#define  NET_UDP_MULTICAST_CONFIG_VERSION_S "multicast_config_version"
 #define  NET_UDP_MULTICAST_GROUP_S        "multicast_group"
 #define  NET_UDP_MULTICAST_MASK_S         "multicast_mask"
 #define  NET_UDP_MULTICAST_PORT_S         "multicast_port"

--- a/ecal/core/src/ecal_log_impl.cpp
+++ b/ecal/core/src/ecal_log_impl.cpp
@@ -32,6 +32,8 @@
 
 #include "ecal_log_impl.h"
 
+#include "io/udp_configurations.h"
+
 #include <mutex>
 #include <stdio.h>
 
@@ -159,14 +161,13 @@ namespace eCAL
       // for local only communication we switch to local broadcasting to bypass vpn's or firewalls
       if (local_only)
       {
-        attr.ipaddr    = "127.255.255.255";
         attr.broadcast = true;
       }
       else
       {
-        attr.ipaddr    = Config::GetUdpMulticastGroup();
         attr.broadcast = false;
       }
+      attr.ipaddr   = UDP::GetLoggingMulticastAdress();
       attr.port     = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_LOG_OFF;
       attr.loopback = true;
       attr.ttl      = Config::GetUdpMulticastTtl();

--- a/ecal/core/src/ecal_log_impl.cpp
+++ b/ecal/core/src/ecal_log_impl.cpp
@@ -167,7 +167,7 @@ namespace eCAL
       {
         attr.broadcast = false;
       }
-      attr.ipaddr   = UDP::GetLoggingMulticastAdress();
+      attr.ipaddr   = UDP::GetLoggingMulticastAddress();
       attr.port     = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_LOG_OFF;
       attr.loopback = true;
       attr.ttl      = Config::GetUdpMulticastTtl();

--- a/ecal/core/src/ecal_process.cpp
+++ b/ecal/core/src/ecal_process.cpp
@@ -231,6 +231,7 @@ namespace eCAL
       sstream << "Network ttl              : " << Config::GetUdpMulticastTtl() << std::endl;
       sstream << "Network sndbuf           : " << GetBufferStr(Config::GetUdpMulticastSndBufSizeBytes()) << std::endl;
       sstream << "Network rcvbuf           : " << GetBufferStr(Config::GetUdpMulticastRcvBufSizeBytes()) << std::endl;
+      sstream << "Multicast cfg version    : v" << static_cast<uint32_t>(Config::GetUdpMulticastConfigVersion()) << std::endl;
       sstream << "Multicast group          : " << Config::GetUdpMulticastGroup() << std::endl;
       sstream << "Multicast mask           : " << Config::GetUdpMulticastMask() << std::endl;
       int port = Config::GetUdpMulticastPort();

--- a/ecal/core/src/ecal_registration_provider.cpp
+++ b/ecal/core/src/ecal_registration_provider.cpp
@@ -32,6 +32,7 @@
 #include "ecal_globals.h"
 #include "ecal_registration_provider.h"
 
+#include "io/udp_configurations.h"
 #include "io/snd_sample.h"
 
 namespace eCAL
@@ -84,14 +85,13 @@ namespace eCAL
       // for local only communication we switch to local broadcasting to bypass vpn's or firewalls
       if (local_only)
       {
-        attr.ipaddr = "127.255.255.255";
         attr.broadcast = true;
       }
       else
       {
-        attr.ipaddr = Config::GetUdpMulticastGroup();
         attr.broadcast = false;
       }
+      attr.ipaddr = UDP::GetRegistrationMulticastAdress();
       attr.port = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_REG_OFF;
       attr.loopback = true;
       attr.ttl = Config::GetUdpMulticastTtl();

--- a/ecal/core/src/ecal_registration_provider.cpp
+++ b/ecal/core/src/ecal_registration_provider.cpp
@@ -91,7 +91,7 @@ namespace eCAL
       {
         attr.broadcast = false;
       }
-      attr.ipaddr = UDP::GetRegistrationMulticastAdress();
+      attr.ipaddr = UDP::GetRegistrationMulticastAddress();
       attr.port = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_REG_OFF;
       attr.loopback = true;
       attr.ttl = Config::GetUdpMulticastTtl();

--- a/ecal/core/src/ecal_registration_receiver.cpp
+++ b/ecal/core/src/ecal_registration_receiver.cpp
@@ -145,7 +145,7 @@ namespace eCAL
       {
         attr.broadcast = false;
       }
-      attr.ipaddr = UDP::GetRegistrationMulticastAdress();
+      attr.ipaddr = UDP::GetRegistrationMulticastAddress();
       attr.port = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_REG_OFF;
       attr.loopback = true;
       attr.rcvbuf = Config::GetUdpMulticastRcvBufSizeBytes();

--- a/ecal/core/src/ecal_registration_receiver.cpp
+++ b/ecal/core/src/ecal_registration_receiver.cpp
@@ -32,6 +32,8 @@
 #include "service/ecal_clientgate.h"
 #include "service/ecal_servicegate.h"
 
+#include "io/udp_configurations.h"
+
 namespace eCAL
 {
   size_t CUdpRegistrationReceiver::ApplySample(const eCAL::pb::Sample& ecal_sample_, eCAL::pb::eTLayerType /*layer_*/)
@@ -137,14 +139,13 @@ namespace eCAL
       // for local only communication we switch to local broadcasting to bypass vpn's or firewalls
       if (local_only)
       {
-        attr.ipaddr = "127.255.255.255";
         attr.broadcast = true;
       }
       else
       {
-        attr.ipaddr = Config::GetUdpMulticastGroup();
         attr.broadcast = false;
       }
+      attr.ipaddr = UDP::GetRegistrationMulticastAdress();
       attr.port = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_REG_OFF;
       attr.loopback = true;
       attr.rcvbuf = Config::GetUdpMulticastRcvBufSizeBytes();

--- a/ecal/core/src/io/udp_configurations.cpp
+++ b/ecal/core/src/io/udp_configurations.cpp
@@ -6,7 +6,7 @@
 const std::string localhost_udp_address{ "127.255.255.255" };
 
 
-std::string eCAL::UDP::GetRegistrationMulticastAdress()
+std::string eCAL::UDP::GetRegistrationMulticastAddress()
 {
   bool local_only = !Config::IsNetworkEnabled();
   if (local_only)
@@ -20,16 +20,16 @@ std::string eCAL::UDP::GetRegistrationMulticastAdress()
   }
 }
 
-std::string eCAL::UDP::GetLoggingMulticastAdress()
+std::string eCAL::UDP::GetLoggingMulticastAddress()
 {
   //TODO: At the moment, both logging and monitoring addresses seem to be the same
   // Should it be kept or changed?
-  return GetRegistrationMulticastAdress();
+  return GetRegistrationMulticastAddress();
 }
 
-std::string eCAL::UDP::GetTopicMulticastAdress(const std::string& topic_name)
+std::string eCAL::UDP::GetTopicMulticastAddress(const std::string& topic_name)
 {
-  if (Config::GetUdpMulticastConfigVersion() == Config::UDPConfigVersion::V1)
+  if (Config::GetUdpMulticastConfigVersion() == Config::UdpConfigVersion::V1)
     return UDP::V1::topic2mcast(topic_name, Config::GetUdpMulticastGroup(), Config::GetUdpMulticastMask());
   // v2
   return  UDP::V2::topic2mcast(topic_name, Config::GetUdpMulticastGroup(), Config::GetUdpMulticastMask());

--- a/ecal/core/src/io/udp_configurations.cpp
+++ b/ecal/core/src/io/udp_configurations.cpp
@@ -15,6 +15,7 @@ std::string eCAL::UDP::GetRegistrationMulticastAdress()
   }
   else
   {
+    // both in v1 and v2, the mulicast group is returned as the adress for the registration layer
     return Config::GetUdpMulticastGroup();
   }
 }
@@ -28,5 +29,8 @@ std::string eCAL::UDP::GetLoggingMulticastAdress()
 
 std::string eCAL::UDP::GetTopicMulticastAdress(const std::string& topic_name)
 {
-  return topic2mcast(topic_name, Config::GetUdpMulticastGroup(), Config::GetUdpMulticastMask());
+  if (Config::GetUdpMulticastConfigVersion() == Config::UDPConfigVersion::V1)
+    return UDP::V1::topic2mcast(topic_name, Config::GetUdpMulticastGroup(), Config::GetUdpMulticastMask());
+  // v2
+  return  UDP::V2::topic2mcast(topic_name, Config::GetUdpMulticastGroup(), Config::GetUdpMulticastMask());
 }

--- a/ecal/core/src/io/udp_configurations.cpp
+++ b/ecal/core/src/io/udp_configurations.cpp
@@ -1,0 +1,32 @@
+#include "io/udp_configurations.h"
+
+#include <ecal/ecal_config.h>
+#include "topic2mcast.h"
+
+const std::string localhost_udp_address{ "127.255.255.255" };
+
+
+std::string eCAL::UDP::GetRegistrationMulticastAdress()
+{
+  bool local_only = !Config::IsNetworkEnabled();
+  if (local_only)
+  {
+    return localhost_udp_address;
+  }
+  else
+  {
+    return Config::GetUdpMulticastGroup();
+  }
+}
+
+std::string eCAL::UDP::GetLoggingMulticastAdress()
+{
+  //TODO: At the moment, both logging and monitoring addresses seem to be the same
+  // Should it be kept or changed?
+  return GetRegistrationMulticastAdress();
+}
+
+std::string eCAL::UDP::GetTopicMulticastAdress(const std::string& topic_name)
+{
+  return topic2mcast(topic_name, Config::GetUdpMulticastGroup(), Config::GetUdpMulticastMask());
+}

--- a/ecal/core/src/io/udp_configurations.h
+++ b/ecal/core/src/io/udp_configurations.h
@@ -1,0 +1,40 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+/**
+ * @brief  common configurations for eCAL UDP communication
+**/
+
+#pragma once
+
+#include <string>
+
+namespace eCAL
+{
+  namespace UDP
+  {
+    // Return the Multicast Adress used for sending Registration information
+    std::string GetRegistrationMulticastAdress();
+
+    std::string GetLoggingMulticastAdress();
+
+    std::string GetTopicMulticastAdress(const std::string& topic_name);
+  }
+
+}

--- a/ecal/core/src/io/udp_configurations.h
+++ b/ecal/core/src/io/udp_configurations.h
@@ -30,11 +30,11 @@ namespace eCAL
   namespace UDP
   {
     // Return the Multicast Adress used for sending Registration information
-    std::string GetRegistrationMulticastAdress();
+    std::string GetRegistrationMulticastAddress();
 
-    std::string GetLoggingMulticastAdress();
+    std::string GetLoggingMulticastAddress();
 
-    std::string GetTopicMulticastAdress(const std::string& topic_name);
+    std::string GetTopicMulticastAddress(const std::string& topic_name);
   }
 
 }

--- a/ecal/core/src/mon/ecal_monitoring_threads.cpp
+++ b/ecal/core/src/mon/ecal_monitoring_threads.cpp
@@ -56,7 +56,7 @@ namespace eCAL
     {
       attr.broadcast = false;
     }
-    attr.ipaddr   = UDP::GetLoggingMulticastAdress();
+    attr.ipaddr   = UDP::GetLoggingMulticastAddress();
     attr.port     = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_LOG_OFF;
     attr.loopback = true;
     attr.rcvbuf   = Config::GetUdpMulticastRcvBufSizeBytes();

--- a/ecal/core/src/mon/ecal_monitoring_threads.cpp
+++ b/ecal/core/src/mon/ecal_monitoring_threads.cpp
@@ -26,6 +26,7 @@
 
 #include "ecal_def.h"
 #include "io/msg_type.h"
+#include "io/udp_configurations.h"
 
 #include "ecal_config_reader_hlp.h"
 #include "ecal_monitoring_threads.h"
@@ -49,14 +50,13 @@ namespace eCAL
     // for local only communication we switch to local broadcasting to bypass vpn's or firewalls
     if (local_only)
     {
-      attr.ipaddr    = "127.255.255.255";
       attr.broadcast = true;
     }
     else
     {
-      attr.ipaddr    = Config::GetUdpMulticastGroup();
       attr.broadcast = false;
     }
+    attr.ipaddr   = UDP::GetLoggingMulticastAdress();
     attr.port     = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_LOG_OFF;
     attr.loopback = true;
     attr.rcvbuf   = Config::GetUdpMulticastRcvBufSizeBytes();

--- a/ecal/core/src/readwrite/ecal_reader_udp_mc.cpp
+++ b/ecal/core/src/readwrite/ecal_reader_udp_mc.cpp
@@ -26,7 +26,7 @@
 #include "ecal_global_accessors.h"
 #include "pubsub/ecal_subgate.h"
 
-#include "topic2mcast.h"
+#include "io/udp_configurations.h"
 
 namespace eCAL
 {
@@ -76,7 +76,7 @@ namespace eCAL
       started = true;
     }
     // add topic name based multicast address
-    std::string mcast_address = topic2mcast(topic_name_, Config::GetUdpMulticastGroup(), Config::GetUdpMulticastMask());
+    std::string mcast_address = UDP::GetTopicMulticastAdress(topic_name_);
     if (topic_name_mcast_map.find(mcast_address) == topic_name_mcast_map.end())
     {
       topic_name_mcast_map.emplace(std::pair<std::string, int>(mcast_address, 0));
@@ -87,7 +87,7 @@ namespace eCAL
 
   void CUDPReaderLayer::RemSubscription(const std::string& /*host_name_*/, const std::string& topic_name_, const std::string& /*topic_id_*/)
   {
-    std::string mcast_address = topic2mcast(topic_name_, Config::GetUdpMulticastGroup(), Config::GetUdpMulticastMask());
+    std::string mcast_address = UDP::GetTopicMulticastAdress(topic_name_);
     if (topic_name_mcast_map.find(mcast_address) == topic_name_mcast_map.end())
     {
       // this should never happen

--- a/ecal/core/src/readwrite/ecal_reader_udp_mc.cpp
+++ b/ecal/core/src/readwrite/ecal_reader_udp_mc.cpp
@@ -76,7 +76,7 @@ namespace eCAL
       started = true;
     }
     // add topic name based multicast address
-    std::string mcast_address = UDP::GetTopicMulticastAdress(topic_name_);
+    std::string mcast_address = UDP::GetTopicMulticastAddress(topic_name_);
     if (topic_name_mcast_map.find(mcast_address) == topic_name_mcast_map.end())
     {
       topic_name_mcast_map.emplace(std::pair<std::string, int>(mcast_address, 0));
@@ -87,7 +87,7 @@ namespace eCAL
 
   void CUDPReaderLayer::RemSubscription(const std::string& /*host_name_*/, const std::string& topic_name_, const std::string& /*topic_id_*/)
   {
-    std::string mcast_address = UDP::GetTopicMulticastAdress(topic_name_);
+    std::string mcast_address = UDP::GetTopicMulticastAddress(topic_name_);
     if (topic_name_mcast_map.find(mcast_address) == topic_name_mcast_map.end())
     {
       // this should never happen

--- a/ecal/core/src/readwrite/ecal_writer_udp_mc.cpp
+++ b/ecal/core/src/readwrite/ecal_writer_udp_mc.cpp
@@ -29,7 +29,7 @@
 #include "ecal_config_reader_hlp.h"
 #include "ecal_writer_udp_mc.h"
 
-#include "topic2mcast.h"
+#include "io/udp_configurations.h"
 #include "io/snd_sample.h"
 
 namespace eCAL
@@ -65,7 +65,7 @@ namespace eCAL
     m_topic_name  = topic_name_;
     m_topic_id    = topic_id_;
 
-    m_udp_ipaddr  = topic2mcast(topic_name_, Config::GetUdpMulticastGroup(), Config::GetUdpMulticastMask());
+    m_udp_ipaddr = UDP::GetTopicMulticastAdress(topic_name_);
 
     SSenderAttr attr;
     attr.ipaddr     = m_udp_ipaddr;

--- a/ecal/core/src/readwrite/ecal_writer_udp_mc.cpp
+++ b/ecal/core/src/readwrite/ecal_writer_udp_mc.cpp
@@ -65,7 +65,7 @@ namespace eCAL
     m_topic_name  = topic_name_;
     m_topic_id    = topic_id_;
 
-    m_udp_ipaddr = UDP::GetTopicMulticastAdress(topic_name_);
+    m_udp_ipaddr = UDP::GetTopicMulticastAddress(topic_name_);
 
     SSenderAttr attr;
     attr.ipaddr     = m_udp_ipaddr;

--- a/ecal/core/src/topic2mcast.h
+++ b/ecal/core/src/topic2mcast.h
@@ -29,62 +29,157 @@
  
 namespace eCAL
 {
-  /**
-   * @brief  FNV hash.
-  **/
-  struct fnv_hash
+  namespace UDP
   {
-    size_t operator()( std::string const& s ) const
+    /**
+     * @brief  FNV hash.
+    **/
+    struct fnv_hash
     {
-      size_t result = static_cast<size_t>(2166136261U);
-      std::string::const_iterator end = s.end() ;
-      for ( std::string::const_iterator iter = s.begin() ;
-        iter != end ;
-        ++ iter ) {
+      size_t operator()(std::string const& s) const
+      {
+        size_t result = static_cast<size_t>(2166136261U);
+        std::string::const_iterator end = s.end();
+        for (std::string::const_iterator iter = s.begin();
+          iter != end;
+          ++iter) {
           result = (16777619 * result)
-            ^ static_cast< unsigned char >( *iter ) ;
+            ^ static_cast<unsigned char>(*iter);
+        }
+        return result;
       }
-      return result ;
+    };
+
+    namespace V2 {
+
+      inline uint32_t parse_ipv4(const std::string& ipv4_str_)
+      {
+        uint32_t ipv4 = 0;
+        std::stringstream ss(ipv4_str_);
+        std::string token;
+        int i = 0;
+        while (std::getline(ss, token, '.') && (i < 4)) //-V112
+        {
+          unsigned char mask = static_cast<unsigned char>(atoi(token.c_str()));
+          ipv4 = ipv4 << 8 | mask;
+          i++;
+        }
+        return ipv4;
+      }
+
+      inline std::string serialize_ipv4(uint32_t ipv4)
+      {
+        std::ostringstream address;
+        address << (ipv4 >> 24) << '.' << ((ipv4 & 0x00ffffff) >> 16) << '.'
+          << ((ipv4 & 0x0000ffff) >> 8) << '.' << (ipv4 & 0x000000ff);
+        return address.str();
+      }
+
+      /**
+      * combines an ip address and a hash with a mask, that determines the to be used MC adress
+      * e.g. samples adress:           0xFFAAAAAA
+      *              hash:             0x6789ABCD
+      *              mask:             0x00FFFFFF
+      *              expected result:  0xFF89ABCD
+      *
+      **/
+      inline uint32_t combine_ip_and_hash_with_mask(uint32_t address, uint32_t hash, uint32_t mask)
+      {
+        return (address & mask) | (hash & ~mask);
+      }
+
+      inline uint32_t increase_adress_by_one(uint32_t address, uint32_t mask)
+      {
+        return (address & mask) | ((address + 1) & ~mask);
+      }
+
+      inline std::string topic2mcast_hash(uint32_t hash_v, const std::string& mcast_base_, const std::string& mcast_mask_)
+      {
+        uint32_t address_mask = parse_ipv4(mcast_mask_);
+        uint32_t address_ip = parse_ipv4(mcast_base_);
+
+        auto mcast{ combine_ip_and_hash_with_mask(address_ip, hash_v, address_mask) };
+
+        // avoid collision on mcast_base
+        // we don't want to publish a topic on the same adress as registration information
+        if (mcast == address_ip)
+          mcast = increase_adress_by_one(address_ip, address_mask);
+
+        return serialize_ipv4(mcast);
+
+      }
+
+      /**
+       * @brief Get multicast address based on the topic_name.
+       *
+       * @param  tname_       The topic name.
+       * @param  mcast_base_  Multicast group base address (e.g. 239.x.x.x).
+       * @param  mcast_mask_  Multicast group mask (e.g. x.255.255.255).
+       *
+       * @return  The multicast address (e.g. "239.151.128.177").
+      **/
+      inline std::string topic2mcast(const std::string& tname_, const std::string& mcast_base_, const std::string& mcast_mask_)
+      {
+        struct fnv_hash thash;
+        uint32_t hash_v = static_cast<uint32_t>(thash(tname_));
+
+        return topic2mcast_hash(hash_v, mcast_base_, mcast_mask_);
+      }
+
     }
-  };
 
-  /**
-   * @brief Get multicast address based on the topic_name.
-   *
-   * @param  tname_       The topic name.
-   * @param  mcast_base_  Multicast group base address (e.g. 239.x.x.x).
-   * @param  mcast_mask_  Multicast group mask (e.g. x.255.255.255).
-   *
-   * @return  The multicast address (e.g. "293.151.128.177").
-  **/
-  inline std::string topic2mcast(const std::string& tname_, const std::string& mcast_base_, const std::string& mcast_mask_)
-  {
-    struct fnv_hash thash;
-    size_t hash_v = thash(tname_);
-
-    unsigned char address_mask[4] = {0, 0xFF, 0xFF, 0xFF}; //-V112
-    std::stringstream ss(mcast_mask_);
-    std::string token;
-    int i = 0;
-    while(std::getline(ss, token, '.') && (i < 4)) //-V112
+    namespace V1
     {
-      unsigned char mask = static_cast<unsigned char>(atoi(token.c_str()));
-      address_mask[i] = mask;
-      i++;
-    }
+      // We split it in two functions for better testing
+      // the content is the same!!!
+      inline std::string topic2mcast_hash(size_t hash_v, const std::string& mcast_base_, const std::string& mcast_mask_)
+      {
+        unsigned char address_mask[4] = { 0, 0xFF, 0xFF, 0xFF }; //-V112
+        std::stringstream ss(mcast_mask_);
+        std::string token;
+        int i = 0;
+        while (std::getline(ss, token, '.') && (i < 4)) //-V112
+        {
+          unsigned char mask = static_cast<unsigned char>(atoi(token.c_str()));
+          address_mask[i] = mask;
+          i++;
+        }
 
-    unsigned char address_ip[4] = {0}; //-V112
-    address_ip[1] = static_cast<unsigned char>((hash_v >> 16) & address_mask[1]);
-    address_ip[2] = static_cast<unsigned char>((hash_v >>  8) & address_mask[2]);
-    address_ip[3] = static_cast<unsigned char>((hash_v      ) & address_mask[3]);
-    if(address_ip[3] < 2) address_ip[3] = 2; // avoid 0.0.0 and 0.0.1
+        unsigned char address_ip[4] = { 0 }; //-V112
+        address_ip[1] = static_cast<unsigned char>((hash_v >> 16) & address_mask[1]);
+        address_ip[2] = static_cast<unsigned char>((hash_v >> 8) & address_mask[2]);
+        address_ip[3] = static_cast<unsigned char>((hash_v)&address_mask[3]);
+        if (address_ip[3] < 2) address_ip[3] = 2; // avoid 0.0.0 and 0.0.1
 
-    std::string address = mcast_base_.substr(0, 3);
-    for(auto t = 1; t < 4; ++t) //-V112
-    {
-      address += ".";
-      address += std::to_string(address_ip[t]);
+        std::string address = mcast_base_.substr(0, 3);
+        for (auto t = 1; t < 4; ++t) //-V112
+        {
+          address += ".";
+          address += std::to_string(address_ip[t]);
+        }
+        return(address);
+      }
+
+      /**
+      * @brief This is the legacy way to compute the mcast address based on the topic name
+      *        It behaves incorrectly (meaning not what the user would expect)
+      *        It is kept here for compatibility purposes (can be activated in the ini file)
+      *
+      * @param  tname_       The topic name.
+      * @param  mcast_base_  Multicast group base address (e.g. 239.x.x.x).
+      * @param  mcast_mask_  Multicast group mask (e.g. x.255.255.255).
+      *
+      * @return  The multicast address (e.g. "239.151.128.177").
+      **/
+      inline std::string topic2mcast(const std::string& tname_, const std::string& mcast_base_, const std::string& mcast_mask_)
+      {
+        struct fnv_hash thash;
+        size_t hash_v = thash(tname_);
+
+        return topic2mcast_hash(hash_v, mcast_base_, mcast_mask_);
+      }
     }
-    return(address);
+  
+
   }
 }

--- a/testing/ecal/topic2mcast_test/CMakeLists.txt
+++ b/testing/ecal/topic2mcast_test/CMakeLists.txt
@@ -1,0 +1,42 @@
+# ========================= eCAL LICENSE =================================
+#
+# Copyright (C) 2016 - 2019 Continental Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ========================= eCAL LICENSE =================================
+
+project(test_topic2mcast)
+
+find_package(Threads REQUIRED)
+find_package(GTest REQUIRED)
+
+set(topic2mcast_test_src
+  src/topic2mcast_test.cpp
+)
+
+ecal_add_gtest(${PROJECT_NAME} ${topic2mcast_test_src})
+
+target_include_directories(${PROJECT_NAME} PRIVATE $<TARGET_PROPERTY:eCAL::core,INCLUDE_DIRECTORIES>)
+
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    eCAL::core
+    Threads::Threads
+)
+
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+
+ecal_install_gtest(${PROJECT_NAME})
+
+set_property(TARGET ${PROJECT_NAME} PROPERTY FOLDER testing/ecal/core)

--- a/testing/ecal/topic2mcast_test/CMakeLists.txt
+++ b/testing/ecal/topic2mcast_test/CMakeLists.txt
@@ -35,7 +35,7 @@ target_link_libraries(${PROJECT_NAME}
     Threads::Threads
 )
 
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 
 ecal_install_gtest(${PROJECT_NAME})
 

--- a/testing/ecal/topic2mcast_test/src/topic2mcast_test.cpp
+++ b/testing/ecal/topic2mcast_test/src/topic2mcast_test.cpp
@@ -1,0 +1,160 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+#include <ecal/ecal.h>
+#include "topic2mcast.h"
+
+#include <string>
+#include <chrono>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include <iostream>
+
+std::vector<std::pair<uint32_t, std::string>> ipv4_int_string_vector
+{
+  {0, "0.0.0.0"},
+  {0xFFFFFFFF,  "255.255.255.255"},
+  {0xEF000001,  "239.0.0.1"},
+  {0x0000000F,  "0.0.0.15"},
+  {0xC88A00FA,  "200.138.0.250"},
+};
+
+struct IPHashMaskResult
+{
+  uint32_t ip;
+  uint32_t hash;
+  uint32_t mask;
+  uint32_t result;
+};
+
+std::vector<IPHashMaskResult> ip_hash_mask_result_vector
+{                                                     // multicast group  computed hash    mutlicast mask   computed mcast address
+  {0xFFAAAAAA, 0x6789ABCD, 0xFF000000, 0xFF89ABCD },  // 255.170.170.170, 103.137.171.205, 255.0.0.0,       255.137.171.205
+  {0xFFAAAAAA, 0x6789ABCD, 0xFFFF0000, 0xFFAAABCD },  // 255.170.170.170, 103.137.171.205, 255.255.0.0,     255.170.171.205
+  {0xFFAAAAAA, 0x6789ABCD, 0xFFFFFF00, 0xFFAAAACD },  // 255.170.170.170, 103.137.171.205, 255.255.255.0,   255.170.170.205
+  {0xFFAAAAAA, 0x6789ABCD, 0xFFFFFFF0, 0xFFAAAAAD },  // 255.170.170.170, 103.137.171.205, 255.255.255.240, 255.170.170.173
+  {0xFFAAAAAA, 0x6789ABCD, 0xFFFFFFFF, 0xFFAAAAAA },
+  {0xFFAAAAAA, 0x0000AA00, 0xFF000000, 0xFF00AA00 }
+};
+
+struct IpMaskResult
+{
+  uint32_t ip;
+  uint32_t mask;
+  uint32_t result;
+};
+
+// We don't want to collide on addresses. thus the calculated mcast address needs to be increased by one if collision occurs
+// however, we need to wrap according to the mask.
+std::vector<IpMaskResult> increase_by_one_vector
+{
+  {0xFFAAAAAA, 0xFF000000, 0xFFAAAAAB },  // 255.170.170.170, 255.0.0.0, 255.170.170.171
+  {0xABFFFFFF, 0xFF000000, 0xAB000000 },  // 171.255.255.255, 255.0.0.0, 171.0.0.0         
+  {0xABFFFFFF, 0xFFFF0000, 0xABFF0000 },  
+  {0xABFFFFFF, 0xFFFFFF00, 0xABFFFF00 }, 
+  {0xABFFFFFF, 0xFFFFFF00, 0xABFFFF00 },
+  {0xABFFFFFF, 0xFFFFFFF0, 0xABFFFFF0 },
+  {0xABFFFFFF, 0xFFFFFFFF, 0xABFFFFFF },
+  {0xABFFFFAB, 0xFFFFFFFF, 0xABFFFFAB }
+};
+
+
+
+struct Topic2MCastLegacy
+{
+  size_t hash;
+  std::string ip;
+  std::string mask;
+  std::string result;
+};
+
+std::vector<Topic2MCastLegacy> v1_behavior_vector
+{
+  {0xAAAAAA00, "239.0.0.1", "0.0.0.15", "239.0.0.2" },  
+  {0xAAAAAA01, "239.0.0.1", "0.0.0.15", "239.0.0.2" },  
+  {0xAAAAAA02, "239.0.0.1", "0.0.0.15", "239.0.0.2" },  
+  {0xAAAAAA03, "239.0.0.1", "0.0.0.15", "239.0.0.3" },  
+  {0xAAAAAA04, "239.0.0.1", "0.0.0.15", "239.0.0.4" },
+  {0xFFAAAAA5, "239.0.0.1", "0.0.0.15", "239.0.0.5" },
+  {0xFFAAAAA5, "239.100.100.1", "0.0.0.15", "239.0.0.5" }
+};
+
+std::vector<Topic2MCastLegacy> v2_behavior_vector
+{
+  {0xAAAAAA00, "239.0.0.1", "255.255.255.170", "239.0.0.0" },
+  {0xAAAAAA01, "239.0.0.1", "255.255.255.170", "239.0.0.2" },
+  {0xAAAAAA02, "239.0.0.1", "255.255.255.170", "239.0.0.2" },
+  {0xAAAAAA03, "239.0.0.1", "255.255.255.170", "239.0.0.3" },
+  {0xAAAAAA04, "239.0.0.1", "255.255.255.170", "239.0.0.4" },
+  {0xFFAAAAA5, "239.0.0.1", "255.255.255.170", "239.0.0.5" },
+  {0xFFAAAAAF, "239.100.100.15", "255.255.255.170", "239.100.100.0" }
+};
+
+struct Topic2McastInput
+{
+  std::string multicast_group;
+  std::string mulitcast_mask;
+  std::string topic_name;
+};
+
+std::vector<std::tuple<Topic2McastInput, std::string, std::string>> test;
+
+
+TEST(Topic2Mcast, ParseIPV4)
+{ 
+   for (const auto& [ipv4_int, ipv4_string] : ipv4_int_string_vector)
+   {
+     EXPECT_EQ(eCAL::UDP::V2::parse_ipv4(ipv4_string), ipv4_int);
+   }
+}
+
+TEST(Topic2Mcast, SerializeIPV4)
+{
+  for (const auto& [ipv4_int, ipv4_string] : ipv4_int_string_vector)
+  {
+    EXPECT_EQ(eCAL::UDP::V2::serialize_ipv4(ipv4_int), ipv4_string);
+  }
+}
+
+TEST(Topic2Mcast, CombineIpAndHashWithMask)
+{
+  for (const auto& object : ip_hash_mask_result_vector)
+  {
+    EXPECT_EQ(eCAL::UDP::V2::combine_ip_and_hash_with_mask(object.ip, object.hash, object.mask), object.result);
+  } 
+}
+
+TEST(Topic2Mcast, IncreaseByOne)
+{
+  for (const auto& object : increase_by_one_vector)
+  {
+    EXPECT_EQ(eCAL::UDP::V2::increase_adress_by_one(object.ip, object.mask), object.result);
+  }
+}
+
+TEST(Topic2Mcast, LegacyBehavior)
+{
+  for (const auto& object : v1_behavior_vector)
+  {
+    EXPECT_EQ(eCAL::UDP::V1::topic2mcast_hash(object.hash, object.ip, object.mask), object.result);
+  }
+}
+

--- a/testing/ecal/topic2mcast_test/src/topic2mcast_test.cpp
+++ b/testing/ecal/topic2mcast_test/src/topic2mcast_test.cpp
@@ -23,12 +23,20 @@
 #include <string>
 #include <chrono>
 #include <thread>
+#include <cstdint>
 
 #include <gtest/gtest.h>
 
 #include <iostream>
 
-std::vector<std::pair<uint32_t, std::string>> ipv4_int_string_vector
+
+struct IP
+{
+  uint32_t int_ip;
+  std::string string_ip;
+};
+
+std::vector<IP> ipv4_int_string_vector
 {
   {0, "0.0.0.0"},
   {0xFFFFFFFF,  "255.255.255.255"},
@@ -120,17 +128,17 @@ std::vector<std::tuple<Topic2McastInput, std::string, std::string>> test;
 
 TEST(Topic2Mcast, ParseIPV4)
 { 
-   for (const auto& [ipv4_int, ipv4_string] : ipv4_int_string_vector)
+   for (const auto& ip : ipv4_int_string_vector)
    {
-     EXPECT_EQ(eCAL::UDP::V2::parse_ipv4(ipv4_string), ipv4_int);
+     EXPECT_EQ(eCAL::UDP::V2::parse_ipv4(ip.string_ip), ip.int_ip);
    }
 }
 
 TEST(Topic2Mcast, SerializeIPV4)
 {
-  for (const auto& [ipv4_int, ipv4_string] : ipv4_int_string_vector)
+  for (const auto& ip : ipv4_int_string_vector)
   {
-    EXPECT_EQ(eCAL::UDP::V2::serialize_ipv4(ipv4_int), ipv4_string);
+    EXPECT_EQ(eCAL::UDP::V2::serialize_ipv4(ip.int_ip), ip.string_ip);
   }
 }
 


### PR DESCRIPTION
**Pull request type**
- [x] Feature

**What is the current behavior?**
Unintuitive masking for multicast addresses

Issue Number: #873

**What is the new behavior?**
This PR introduces a new multicast configuration version mode, e.g. V2. The previous mode is called V1.
V1 stays the standard mode for now, to be compatible with older eCAL Versions. 
V2 is introduced, and allows better configuration.

Please review:
The behavior to treat collisions:
Per default, `multicast_group` is the MC address to send registration information on.
If a topic is to be sent on the same MC address as registration information, it is send on +1. If this causes "overflow" (e.g. multicast group `139.0.0.255` and mask of `255.255.255.0`, the topic will be sent on `139.0.0.0`.
It is to be discussed if this is a favorable behavior.

The behavior is now somewhat documented in the ini file, it should probably be documented extensively in the documentation.

**Does this introduce a breaking change?**
- [x] No

It's not a breaking change as the default configuration stays as is.