### PR TITLE
eCAL Rec: ClearConfig (GUI: File/New Config) now properly clears the one-file-per-channel-option

### DIFF
--- a/app/rec/rec_gui/src/qecalrec.cpp
+++ b/app/rec/rec_gui/src/qecalrec.cpp
@@ -859,6 +859,7 @@ bool QEcalRec::clearConfig()
     emit measRootDirChangedSignal        (rec_server_->GetMeasRootDir());
     emit measNameChangedSignal           (rec_server_->GetMeasName());
     emit maxFileSizeMibChangedSignal     (rec_server_->GetMaxFileSizeMib());
+    emit oneFilePerTopicEnabledChangedSignal(rec_server_->GetOneFilePerTopicEnabled());
     emit descriptionChangedSignal        (rec_server_->GetDescription());
 
     emit loadedConfigChangedSignal(rec_server_->GetLoadedConfigPath(), rec_server_->GetLoadedConfigVersion());

--- a/app/rec/rec_server_core/src/rec_server_impl.cpp
+++ b/app/rec/rec_server_core/src/rec_server_impl.cpp
@@ -1894,6 +1894,7 @@ namespace eCAL
       SetMeasRootDir        ("");
       SetMeasName           ("");
       SetMaxFileSizeMib     (100);
+      SetOneFilePerTopicEnabled(false);
       SetDescription        ("");
       
       loaded_config_path_    = "";


### PR DESCRIPTION
Fixes #951 