### PR TITLE
eCAL Rec: When calling GetConfig via RPC, the Upload settings are now properly included

### DIFF
--- a/app/app_pb/src/ecal/app/pb/rec/server_config.proto
+++ b/app/app_pb/src/ecal/app/pb/rec/server_config.proto
@@ -65,4 +65,5 @@ message RecServerConfig
   bool                           built_in_recorder_enabled  =  8;               // Whether the built-in recorder is enabled. If false, the rec server application will look for a separate ecal_rec_client for recording on localhost.
   RecordMode                     record_mode                =  9;               // Whether to record all topics or just a subset (Whitelisted or blacklisted).
   repeated string                listed_topics              = 10;               // Only relevant when not recording all topics. If a whitelist or blacklist is used, this holds the according list.
+  UploadConfig                   upload_config              = 12;               // The configuration used for uploading any new measurement.
 }

--- a/app/rec/rec_server_core/src/proto_helpers.cpp
+++ b/app/rec/rec_server_core/src/proto_helpers.cpp
@@ -108,6 +108,8 @@ namespace eCAL
         {
           rec_server_config_pb.add_listed_topics(topic_name);
         }
+
+        ToProtobuf(rec_server_config.upload_config_, *rec_server_config_pb.mutable_upload_config());
       }
 
       void ToProtobuf(const eCAL::rec_server::ClientJobStatus& client_job_status, eCAL::pb::rec_server::ClientJobStatus& client_job_status_pb)
@@ -346,6 +348,8 @@ namespace eCAL
         {
           rec_server_config.listed_topics_.emplace(topic_name);
         }
+
+        FromProtobuf(rec_server_config_pb.upload_config(), rec_server_config.upload_config_);
       }
 
       void FromProtobuf(const eCAL::pb::rec_server::ClientJobStatus& client_job_status_pb, eCAL::rec_server::ClientJobStatus& client_job_status)


### PR DESCRIPTION
For this, the server_config.proto description had to be extended with a field for the upload_config.

Fixes #953 