### PR TITLE
eCAL Rec CLI: getconfig command now also displays the one-file-per-topic setting

### DIFF
--- a/app/rec/rec_server_cli/src/commands/get_config.cpp
+++ b/app/rec/rec_server_cli/src/commands/get_config.cpp
@@ -90,6 +90,11 @@ namespace eCAL
           ss << "Max hdf5 file size:  "  << config.max_file_size_ << " MiB" << std::endl;
         }
 
+        // One-file-per-topic
+        {
+          ss << "One file per topic:  "  << (config.one_file_per_topic_ ? "Yes" : "No") << std::endl;
+        }
+
         // Description
         {
           ss << "Description:" << std::endl;


### PR DESCRIPTION
Fixes #955 