### PR TITLE
eCAL Rec: Added RPC Service "SetConfig"

### DIFF
--- a/.github/workflows/build-ubuntu-18.yml
+++ b/.github/workflows/build-ubuntu-18.yml
@@ -10,6 +10,10 @@ jobs:
   build-ubuntu:
     runs-on: ubuntu-18.04
     
+    env:
+      # enable starting Qt GUI Applications
+      QT_QPA_PLATFORM: offscreen
+    
     steps:
     - name: Getting closer to vanilla Ubuntu 18.04
       run: |

--- a/.github/workflows/build-ubuntu-20.yml
+++ b/.github/workflows/build-ubuntu-20.yml
@@ -9,7 +9,11 @@ on:
 jobs:
   build-ubuntu:
     runs-on: ubuntu-20.04
-
+    
+    env:
+      # enable starting Qt GUI Applications
+      QT_QPA_PLATFORM: offscreen
+      
     steps:
     - name: Install Dependencies
       run: |

--- a/.github/workflows/build-ubuntu-22.yml
+++ b/.github/workflows/build-ubuntu-22.yml
@@ -10,6 +10,10 @@ jobs:
   build-ubuntu:
     runs-on: ubuntu-22.04
 
+    env:
+      # enable starting Qt GUI Applications
+      QT_QPA_PLATFORM: offscreen
+      
     steps:
     - name: Install Dependencies
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -477,6 +477,13 @@ endif(NOT ECAL_LAYER_ICEORYX)
   add_subdirectory(testing/ecal/pubsub_proto_test)
   add_subdirectory(testing/ecal/pubsub_test)
   add_subdirectory(testing/ecal/topic2mcast_test)
+  
+  # ------------------------------------------------------
+  # test apps
+  # ------------------------------------------------------
+  if (HAS_HDF5 AND HAS_QT5)
+    add_subdirectory(app/rec/rec_tests/rec_rpc_tests)
+  endif()
 endif()
 
 # --------------------------------------------------------

--- a/app/app_pb/src/ecal/app/pb/rec/server_service.proto
+++ b/app/app_pb/src/ecal/app/pb/rec/server_service.proto
@@ -88,4 +88,5 @@ service EcalRecServerService
   rpc DeleteMeasurement (GenericMeasurementRequest) returns (eCAL.pb.rec_server.ServiceResult);           // Deletes the measurement given by meas_id. If no ID is given, the last measurement will be deleted.
   rpc GetStatus         (GenericRequest)            returns (eCAL.pb.rec_server.Status);                  // Get the rec server status that includes the currently recording meas_id, the entire measurement history and other information
   rpc GetConfig         (GenericRequest)            returns (eCAL.pb.rec_server.RecServerConfig);         // Get the current configuration of this rec server instance
+  rpc SetConfig         (RecServerConfig)           returns (eCAL.pb.rec_server.ServiceResult);           // Set the configuration of this rec server instance to the given config. ATTENTION: The config is not set differential. Everything that is not specified in the given config will be interpreted as to empty / false / 0 etc. So you should definitively call GetConfig, work on that and then call SetConfig with the changed configuration, if you don't want to set an entirely fresh config
 }

--- a/app/rec/rec_client_core/include/rec_client_core/rec_error.h
+++ b/app/rec/rec_client_core/include/rec_client_core/rec_error.h
@@ -75,16 +75,6 @@ namespace eCAL
       Error(ErrorCode error_code, const std::string& message) : error_code_(error_code), message_(message) {}
       Error(ErrorCode error_code) : error_code_(error_code) {}
 
-      // Copy
-      Error(const Error&)            = default;
-      Error& operator=(const Error&) = default;
-
-      // Move
-      Error& operator=(Error&&)      = default;
-      Error(Error&&)                 = default;
-
-      ~Error() {}
-
     //////////////////////////////////////////
     // Public API
     //////////////////////////////////////////

--- a/app/rec/rec_client_core/include/rec_client_core/rec_error.h
+++ b/app/rec/rec_client_core/include/rec_client_core/rec_error.h
@@ -74,7 +74,14 @@ namespace eCAL
     public:
       Error(ErrorCode error_code, const std::string& message) : error_code_(error_code), message_(message) {}
       Error(ErrorCode error_code) : error_code_(error_code) {}
-      Error(const Error& error) : error_code_(error.error_code_), message_(error.message_) {}
+
+      // Copy
+      Error(const Error&)            = default;
+      Error& operator=(const Error&) = default;
+
+      // Move
+      Error& operator=(Error&&)      = default;
+      Error(Error&&)                 = default;
 
       ~Error() {}
 
@@ -139,14 +146,9 @@ namespace eCAL
     //////////////////////////////////////////
       inline operator bool() const { return error_code_ != ErrorCode::OK; }
       inline bool operator== (const Error& other) const { return error_code_ == other.error_code_; }
+      inline bool operator== (const ErrorCode other) const { return error_code_ == other; }
       inline bool operator!= (const Error& other) const { return error_code_ != other.error_code_; }
-
-      Error& operator=(const Error& other)
-      {
-        error_code_ = other.error_code_;
-        message_    = other.message_;
-        return *this;
-      }
+      inline bool operator!= (const ErrorCode other) const { return error_code_ != other; }
 
       Error& operator=(ErrorCode error_code)
       {

--- a/app/rec/rec_client_core/src/job_config.cpp
+++ b/app/rec/rec_client_core/src/job_config.cpp
@@ -32,7 +32,7 @@ namespace eCAL
 
     JobConfig::JobConfig()
       : job_id_(0)
-      , max_file_size_mb_(50)
+      , max_file_size_mb_(1000)
       , one_file_per_topic_(false)
     {}
 

--- a/app/rec/rec_gui/src/qecalrec.cpp
+++ b/app/rec/rec_gui/src/qecalrec.cpp
@@ -842,7 +842,7 @@ eCAL::rec_server::RecServerConfig QEcalRec::config() const
 
 eCAL::rec::Error QEcalRec::setConfig(const eCAL::rec_server::RecServerConfig& config, bool omit_dialogs)
 {
-  auto error = rec_server_->SetConfig(config);
+  const auto error = rec_server_->SetConfig(config);
 
   if (error && !omit_dialogs)
   {

--- a/app/rec/rec_gui/src/qecalrec.cpp
+++ b/app/rec/rec_gui/src/qecalrec.cpp
@@ -840,6 +840,27 @@ eCAL::rec_server::RecServerConfig QEcalRec::config() const
   return rec_server_->GetConfig();
 }
 
+eCAL::rec::Error QEcalRec::setConfig(const eCAL::rec_server::RecServerConfig& config, bool omit_dialogs)
+{
+  auto error = rec_server_->SetConfig(config);
+
+  if (error && !omit_dialogs)
+  {
+    QMessageBox error_message;
+    error_message.setWindowIcon(QIcon(":/ecalrec/APP_ICON"));
+    error_message.setIcon(QMessageBox::Icon::Critical);
+    error_message.setWindowTitle("Error");
+    error_message.setText(tr("Error Setting config: \n") + QString::fromStdString(error.ToString()));
+    error_message.exec();
+  }
+
+  emitAndUpdateEntirelyNewConfig();
+
+  updateConfigModified(true);
+
+  return error;
+}
+
 bool QEcalRec::clearConfig()
 {
   bool success = rec_server_->ClearConfig();
@@ -899,40 +920,7 @@ bool QEcalRec::loadConfigFromFile(const std::string& path, bool omit_dialogs)
 
   if (success)
   {
-    emit connectedToEcalStateChangedSignal     (rec_server_->IsConnectedToEcal());
-    emit connectionToClientsActiveChangedSignal(rec_server_->IsConnectionToClientsActive());
-    emit enabledRecClientsChangedSignal        (rec_server_->GetEnabledRecClients());
-    emit maxPreBufferLengthChangedSignal       (rec_server_->GetMaxPreBufferLength());
-    emit preBufferingEnabledChangedSignal      (rec_server_->GetPreBufferingEnabled());
-    emit recordModeChangedSignal               (rec_server_->GetRecordMode());
-
-    if (rec_server_->GetRecordMode() == eCAL::rec::RecordMode::Blacklist)
-    {
-      topic_blacklist_ = rec_server_->GetListedTopics();
-      topic_whitelist_.clear();
-      emit topicBlacklistChangedSignal(rec_server_->GetListedTopics());
-    }
-    else if (rec_server_->GetRecordMode() == eCAL::rec::RecordMode::Whitelist)
-    {
-      topic_blacklist_.clear();
-      topic_whitelist_ = rec_server_->GetListedTopics();
-      emit topicWhitelistChangedSignal(rec_server_->GetListedTopics());
-    }
-    else if (rec_server_->GetRecordMode() == eCAL::rec::RecordMode::All)
-    {
-      topic_blacklist_.clear();
-      topic_whitelist_.clear();
-    }
-    emit topicBlacklistChangedSignal(topic_blacklist_);
-    emit topicWhitelistChangedSignal(topic_whitelist_);
-
-    emit measRootDirChangedSignal   (rec_server_->GetMeasRootDir());
-    emit measNameChangedSignal      (rec_server_->GetMeasName());
-    emit maxFileSizeMibChangedSignal(rec_server_->GetMaxFileSizeMib());
-    emit descriptionChangedSignal   (rec_server_->GetDescription());
-    emit oneFilePerTopicEnabledChangedSignal(rec_server_->GetOneFilePerTopicEnabled());
-
-    emit usingBuiltInRecorderEnabledChangedSignal(rec_server_->IsUsingBuiltInRecorderEnabled());
+    emitAndUpdateEntirelyNewConfig();
 
     emit loadedConfigChangedSignal(rec_server_->GetLoadedConfigPath(), rec_server_->GetLoadedConfigVersion());
 
@@ -988,6 +976,44 @@ void QEcalRec::updateConfigModified(bool modified)
     config_has_been_modified_ = modified;
     emit configHasBeenModifiedChangedSignal(config_has_been_modified_);
   }
+}
+
+void QEcalRec::emitAndUpdateEntirelyNewConfig()
+{
+  emit connectedToEcalStateChangedSignal     (rec_server_->IsConnectedToEcal());
+  emit connectionToClientsActiveChangedSignal(rec_server_->IsConnectionToClientsActive());
+  emit enabledRecClientsChangedSignal        (rec_server_->GetEnabledRecClients());
+  emit maxPreBufferLengthChangedSignal       (rec_server_->GetMaxPreBufferLength());
+  emit preBufferingEnabledChangedSignal      (rec_server_->GetPreBufferingEnabled());
+  emit recordModeChangedSignal               (rec_server_->GetRecordMode());
+
+  if (rec_server_->GetRecordMode() == eCAL::rec::RecordMode::Blacklist)
+  {
+    topic_blacklist_ = rec_server_->GetListedTopics();
+    topic_whitelist_.clear();
+    emit topicBlacklistChangedSignal(rec_server_->GetListedTopics());
+  }
+  else if (rec_server_->GetRecordMode() == eCAL::rec::RecordMode::Whitelist)
+  {
+    topic_blacklist_.clear();
+    topic_whitelist_ = rec_server_->GetListedTopics();
+    emit topicWhitelistChangedSignal(rec_server_->GetListedTopics());
+  }
+  else if (rec_server_->GetRecordMode() == eCAL::rec::RecordMode::All)
+  {
+    topic_blacklist_.clear();
+    topic_whitelist_.clear();
+  }
+  emit topicBlacklistChangedSignal(topic_blacklist_);
+  emit topicWhitelistChangedSignal(topic_whitelist_);
+
+  emit measRootDirChangedSignal   (rec_server_->GetMeasRootDir());
+  emit measNameChangedSignal      (rec_server_->GetMeasName());
+  emit maxFileSizeMibChangedSignal(rec_server_->GetMaxFileSizeMib());
+  emit descriptionChangedSignal   (rec_server_->GetDescription());
+  emit oneFilePerTopicEnabledChangedSignal(rec_server_->GetOneFilePerTopicEnabled());
+
+  emit usingBuiltInRecorderEnabledChangedSignal(rec_server_->IsUsingBuiltInRecorderEnabled());
 }
 
 ////////////////////////////////////

--- a/app/rec/rec_gui/src/qecalrec.h
+++ b/app/rec/rec_gui/src/qecalrec.h
@@ -230,6 +230,7 @@ signals:
 ////////////////////////////////////
 public slots:
   eCAL::rec_server::RecServerConfig config() const;
+  eCAL::rec::Error setConfig(const eCAL::rec_server::RecServerConfig& config, bool omit_dialogs = false);
 
   bool clearConfig();
   bool saveConfigToFile  (const std::string& path);
@@ -243,6 +244,7 @@ public slots:
 
 private:
   void updateConfigModified(bool modified);
+  void emitAndUpdateEntirelyNewConfig();
 
 signals:
   void loadedConfigChangedSignal(const std::string& path, int version);

--- a/app/rec/rec_gui/src/service/rec_server_service.cpp
+++ b/app/rec/rec_gui/src/service/rec_server_service.cpp
@@ -365,3 +365,15 @@ void RecServerService::GetConfig(::google::protobuf::RpcController*             
 
   eCAL::rec_server::proto_helpers::ToProtobuf(config, *response);
 }
+
+void RecServerService::SetConfig(::google::protobuf::RpcController*                /*controller*/
+                                  , const ::eCAL::pb::rec_server::RecServerConfig* request
+                                  , ::eCAL::pb::rec_server::ServiceResult*         response
+                                  , ::google::protobuf::Closure*                   /*done*/)
+{
+  //eCAL::rec_server::RecServerConfig config = eCAL::rec_server::proto_helpers::FromProtobuf(*request);
+  //sdf
+  //QMetaObject::invokeMethod(QEcalRec::instance(), "setConfig", Qt::BlockingQueuedConnection, Q_RETURN_ARG(eCAL::rec_server::RecServerConfig, config));
+
+  //eCAL::rec_server::proto_helpers::ToProtobuf(config, *response);
+}

--- a/app/rec/rec_gui/src/service/rec_server_service.cpp
+++ b/app/rec/rec_gui/src/service/rec_server_service.cpp
@@ -371,9 +371,19 @@ void RecServerService::SetConfig(::google::protobuf::RpcController*             
                                   , ::eCAL::pb::rec_server::ServiceResult*         response
                                   , ::google::protobuf::Closure*                   /*done*/)
 {
-  //eCAL::rec_server::RecServerConfig config = eCAL::rec_server::proto_helpers::FromProtobuf(*request);
-  //sdf
-  //QMetaObject::invokeMethod(QEcalRec::instance(), "setConfig", Qt::BlockingQueuedConnection, Q_RETURN_ARG(eCAL::rec_server::RecServerConfig, config));
+  eCAL::rec_server::RecServerConfig config = eCAL::rec_server::proto_helpers::FromProtobuf(*request);
+  eCAL::rec::Error error = eCAL::rec::Error::GENERIC_ERROR;
+  
+  QMetaObject::invokeMethod(QEcalRec::instance(), "setConfig", Qt::BlockingQueuedConnection, Q_RETURN_ARG(eCAL::rec::Error, error), Q_ARG(eCAL::rec_server::RecServerConfig, config), Q_ARG(bool, true));
 
-  //eCAL::rec_server::proto_helpers::ToProtobuf(config, *response);
+  if (!error)
+  {
+    response->set_error_code(eCAL::pb::rec_server::ServiceResult::ErrorCode::ServiceResult_ErrorCode_no_error);
+    response->set_info_message("Successfully set config");
+  }
+  else
+  {
+    response->set_error_code(eCAL::pb::rec_server::ServiceResult::ErrorCode::ServiceResult_ErrorCode_error_internal);
+    response->set_info_message(error.ToString());
+  }
 }

--- a/app/rec/rec_gui/src/service/rec_server_service.h
+++ b/app/rec/rec_gui/src/service/rec_server_service.h
@@ -89,5 +89,10 @@ public:
                             , const ::eCAL::pb::rec_server::GenericRequest* request
                             , ::eCAL::pb::rec_server::RecServerConfig*      response
                             , ::google::protobuf::Closure*                  done) override;
+
+  virtual void SetConfig(::google::protobuf::RpcController*                  controller
+                            , const ::eCAL::pb::rec_server::RecServerConfig* request
+                            , ::eCAL::pb::rec_server::ServiceResult*         response
+                            , ::google::protobuf::Closure*                   done) override;
 };
 

--- a/app/rec/rec_server_cli/src/commands/set_config.cpp
+++ b/app/rec/rec_server_cli/src/commands/set_config.cpp
@@ -22,6 +22,7 @@
 #include <ecal_utils/string.h>
 #include <ecal_utils/ecal_utils.h>
 
+#include <rec_server_core/proto_helpers.h>
 
 #include <clocale> // localeconv
 
@@ -235,9 +236,662 @@ namespace eCAL
         return eCAL::rec::Error::ErrorCode::OK;
       }
 
-      eCAL::rec::Error SetConfig::Execute(const std::string& /*hostname*/, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& /*remote_rec_server_service*/, const std::vector<std::string>& /*argv*/) const
+      eCAL::rec::Error SetConfig::Execute(const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::vector<std::string>& argv) const
       {
-        return eCAL::rec::Error(eCAL::rec::Error::ErrorCode::COMMAND_NOT_AVAILABLE_IN_REMOTE_MODE);
+        CmdLine cmdline;
+        cmdline.parse(argv);
+
+        if (cmdline.help_arg.isSet())
+        {
+          // Help
+          std::cout << cmdline.help() << std::endl;
+        }
+        else
+        {
+          // Paramter validation
+          if (cmdline.unlabled_arg.isSet() && !cmdline.unlabled_arg.getValue().empty())
+          {
+            std::cerr << "WARNING: Unrecognized parameters: " + EcalUtils::CommandLine::ToCommandLine(cmdline.unlabled_arg.getValue()) << std::endl;
+          }
+
+          // Get current config
+          eCAL::pb::rec_server::GenericRequest            request_pb;
+          eCAL::pb::rec_server::RecServerConfig           rec_server_config_pb;
+
+          {
+            eCAL::rec::Error service_call_error = CallRemoteEcalrecService(remote_rec_server_service, hostname, "GetConfig", request_pb, rec_server_config_pb);
+
+            // Service call failed
+            if (service_call_error)
+            {
+              return service_call_error;
+            }
+          }
+
+          // Parse the protobuf config to the intern config struct.
+          // We are going to work on that for ease of use.
+          // Later however we are NOT going to convert it back and set the entire
+          // config, again. In cases where we are cummunicating with a newer
+          // eCAL rec this would cause settings to get lost and being set to
+          // default values.
+          // Instead, we are going to work on the original config_pb, that still
+          // contains all unknown values, and change only what we need to.
+
+          // TODO: Set-config in Remote mode needs to also work from command line!!!!
+
+          // Set clients
+          if (cmdline.set_client_arg.isSet())
+          {
+            auto error = SetClient(rec_server_config_pb, cmdline.set_client_arg.getValue());
+            if (error)
+              return error;
+          }
+
+          // Set Addons
+          if (cmdline.set_addons_arg.isSet())
+          {
+            auto error = SetAddons(rec_server_config_pb, cmdline.set_addons_arg.getValue());
+            if (error)
+              return error;
+          }
+
+          // Remove Client 
+          if (cmdline.remove_client_arg.isSet())
+          {
+            auto error = RemoveClient(rec_server_config_pb, cmdline.remove_client_arg.getValue());
+            if (error)
+              return error;
+          }
+
+          // Set FTP Server
+          if (cmdline.ftp_server_arg.isSet())
+          {
+            auto error = setFtpServer(rec_server_config_pb, cmdline.ftp_server_arg.getValue());
+            if (error)
+              return error;
+          }
+
+          // Set Delete-after-upload
+          if (cmdline.delete_after_upload_arg.isSet())
+          {
+            auto error = setDeleteAfterUpload(rec_server_config_pb, cmdline.delete_after_upload_arg.getValue());
+            if (error)
+              return error;
+          }
+
+          // Build-in client
+          if (cmdline.enable_built_in_client_arg.isSet())
+          {
+            auto error = setBuiltInClientEnabled(rec_server_config_pb, cmdline.enable_built_in_client_arg.getValue());
+            if (error)
+              return error;
+          }
+
+          // setPreBuffer
+          if (cmdline.pre_buffer_secs_arg.isSet())
+          {
+            auto error = setPreBuffer(rec_server_config_pb, cmdline.pre_buffer_secs_arg.getValue());
+            if (error)
+              return error;
+          }
+
+          // setBlacklist
+          if (cmdline.blacklist_arg.isSet())
+          {
+            auto error = setBlacklist(rec_server_config_pb, cmdline.blacklist_arg.getValue());
+            if (error)
+              return error;
+          }
+
+          // setWhitelist
+          if (cmdline.whitelist_arg.isSet())
+          {
+            auto error = setWhitelist(rec_server_config_pb, cmdline.whitelist_arg.getValue());
+            if (error)
+              return error;
+          }
+
+          // setMeasRootDir
+          if (cmdline.meas_root_dir_arg.isSet())
+          {
+            auto error = setMeasRootDir(rec_server_config_pb, cmdline.meas_root_dir_arg.getValue());
+            if (error)
+              return error;
+          }
+
+          // setMeasName
+          if (cmdline.meas_name_arg.isSet())
+          {
+            auto error = setMeasName(rec_server_config_pb, cmdline.meas_name_arg.getValue());
+            if (error)
+              return error;
+          }
+
+          // setMaxFileSize
+          if (cmdline.max_file_size_mib_arg.isSet())
+          {
+            auto error = setMaxFileSize(rec_server_config_pb, cmdline.max_file_size_mib_arg.getValue());
+            if (error)
+              return error;
+          }
+
+          // setDescription
+          if (cmdline.description_arg.isSet())
+          {
+            auto error = setDescription(rec_server_config_pb, cmdline.description_arg.getValue());
+            if (error)
+              return error;
+          }
+
+          // setOneFilePerTopicEnabled
+          if (cmdline.enable_one_file_per_topic_arg.isSet())
+          {
+            auto error = setOneFilePerTopicEnabled(rec_server_config_pb, cmdline.enable_one_file_per_topic_arg.getValue());
+            if (error)
+              return error;
+          }
+
+          // Call the SetConfig RPC Service
+          {
+            eCAL::pb::rec_server::ServiceResult service_call_response_pb;
+            eCAL::rec::Error service_call_error = CallRemoteEcalrecService(remote_rec_server_service, hostname, "SetConfig", rec_server_config_pb, service_call_response_pb);
+
+            // Service call failed
+            if (service_call_error)
+              return service_call_error;
+
+            // Service call reported error
+            {
+              eCAL::rec::Error error = eCAL::rec_server::proto_helpers::FromProtobuf(service_call_response_pb);
+              if (error)
+                return error;
+            }
+          }
+        }
+
+        return eCAL::rec::Error::OK;
+      }
+
+      //////////////////////////////////////////////
+      /// Parse Param Functions
+      //////////////////////////////////////////////
+
+      eCAL::rec::Error SetConfig::ParseParams_SetClient         (const std::vector<std::string>& param, std::map<std::string, eCAL::rec_server::ClientConfig>& client_configs_out)
+      {
+        client_configs_out.clear();
+
+        for(const std::string& client : param)
+        {
+          std::string           client_hostname;
+          std::set<std::string> client_host_filter;
+
+          // 1. Parse the input (Hostname:List,of,hosts)
+          size_t colon_pos = client.find_first_of(":");
+          if (colon_pos == std::string::npos)
+          {
+            client_hostname = EcalUtils::String::Trim(client);
+          }
+          else
+          {
+            client_hostname    = EcalUtils::String::Trim(client.substr(0, colon_pos));
+            std::vector<std::string> tmp_client_host_filter;
+            EcalUtils::String::Split(client.substr(colon_pos + 1), ",", tmp_client_host_filter);
+            for(auto& host : tmp_client_host_filter)
+            {
+              std::string trimmed_host = EcalUtils::String::Trim(host);
+              if (trimmed_host.empty())
+                continue;
+
+              client_host_filter.emplace(trimmed_host);
+            }
+          }
+
+          // Return error, if the hostname is unclear
+          if (client_hostname.empty())
+            return eCAL::rec::Error(eCAL::rec::Error::ErrorCode::PARAMETER_ERROR, "Hostname of client is mandatory, but got: \"" + client + "\"");
+
+          // Add the config to the client config map
+          eCAL::rec_server::ClientConfig client_config;
+          client_config.host_filter_ = client_host_filter;
+
+          client_configs_out.emplace(client_hostname, client_config);
+        }
+
+        return eCAL::rec::Error::OK;
+      }
+
+      eCAL::rec::Error SetConfig::ParseParams_SetAddons         (const std::vector<std::string>& param, std::map<std::string, eCAL::rec_server::ClientConfig>& client_configs_out)
+      {
+        client_configs_out.clear();
+
+        for (const std::string& client : param)
+        { 
+          std::string           client_hostname;
+          std::set<std::string> enabled_addons;
+
+          // 1. Parse the input (Hostname:List,of,addon_ids)
+          size_t colon_pos = client.find_first_of(":");
+          if (colon_pos == std::string::npos)
+          {
+            client_hostname = EcalUtils::String::Trim(client);
+          }
+          else
+          {
+            client_hostname    = EcalUtils::String::Trim(client.substr(0, colon_pos));
+            std::vector<std::string> tmp_enabled_addon_ids;
+            EcalUtils::String::Split(client.substr(colon_pos + 1), ",", tmp_enabled_addon_ids);
+            for (auto& host : tmp_enabled_addon_ids)
+            {
+              std::string trimmed_addon_id = EcalUtils::String::Trim(host);
+              if (trimmed_addon_id.empty())
+                continue;
+
+              enabled_addons.emplace(trimmed_addon_id);
+            }
+          }
+
+          // Return error, if the hostname is unclear
+          if (client_hostname.empty())
+            return eCAL::rec::Error(eCAL::rec::Error::ErrorCode::PARAMETER_ERROR, "Hostname of client is mandatory, but got: \"" + client + "\"");
+
+          // Add the config to the client config map
+          eCAL::rec_server::ClientConfig client_config;
+          client_config.enabled_addons_ = enabled_addons;
+
+          client_configs_out.emplace(client_hostname, client_config);
+        }
+
+        return eCAL::rec::Error::OK;
+      }
+
+      eCAL::rec::Error SetConfig::ParseParams_SetFtpServer      (const std::string& param,              eCAL::rec_server::UploadConfig&                        upload_config_out)
+      {
+        if (param.empty())
+          return eCAL::rec::Error(eCAL::rec::Error::ErrorCode::PARAMETER_ERROR, "Parameter for FTP Server must not be empty");
+
+        if (param == "internal")
+        {
+          upload_config_out.type_ = eCAL::rec_server::UploadConfig::Type::INTERNAL_FTP;
+        }
+        else
+        {
+          const std::regex ftp_path_regex(R"_(ftp://((.*):(.*)@)?([0-9A-Za-z\.\-]+)(:([0-9]+))?(/.*)?)_");
+          std::smatch      ftp_path_match;
+          if (std::regex_match(param, ftp_path_match, ftp_path_regex))
+          {
+
+            // Regex match structure:
+            // 
+            // [0]: complete match
+            // [1]: USER:PASS@    (optional)
+            //   [2]: USER        (optional)
+            //   [3]: PASS        (optional)
+            // [4]: HOSTNAME
+            // [5]: :PORT         (optional)
+            //   [6]: PORT        (optional)
+            // [7]: ROOT_PATH     (optional)
+
+            if (ftp_path_match.size() != 8)
+              return eCAL::rec::Error(eCAL::rec::Error::PARAMETER_ERROR, "Failed regex-parsing " + param);
+
+            upload_config_out.username_ = ftp_path_match[2].str();
+            upload_config_out.password_ = ftp_path_match[3].str();
+            upload_config_out.host_     = ftp_path_match[4].str();
+
+            std::string port_string     = ftp_path_match[6].str();
+            if (port_string.empty())
+            {
+              upload_config_out.port_ = 21;
+            }
+            else
+            {
+              try
+              {
+                unsigned long port_long = std::stoul(port_string);
+                if ((port_long > std::numeric_limits<uint16_t>::max()) || (port_long <= 0))
+                  return eCAL::rec::Error(eCAL::rec::Error::PARAMETER_ERROR, "Invalid port: " + port_string);
+
+                upload_config_out.port_ = static_cast<uint16_t>(port_long);
+              }
+              catch (const std::exception& /*e*/)
+              {
+                return eCAL::rec::Error(eCAL::rec::Error::PARAMETER_ERROR, "Invalid port: " + port_string);
+              }
+            }
+
+            upload_config_out.root_path_ = ftp_path_match[7].str();
+            upload_config_out.type_      = eCAL::rec_server::UploadConfig::Type::FTP;
+          }
+          else
+          {
+            return eCAL::rec::Error(eCAL::rec::Error::PARAMETER_ERROR, "Malformed FTP server setting: " + param);
+          }
+        }
+
+        return eCAL::rec::Error::OK;
+      }
+
+      eCAL::rec::Error SetConfig::ParseParams_SetPreBuffer      (const std::string& param,              std::chrono::duration<double>&                         pre_buffer_length_out)
+      {
+        char decimal_point = std::localeconv()->decimal_point[0]; // decimal point for std::stod()
+
+        double pre_buffer_secs;
+        std::string pre_buffer_secs_string = param;
+        std::replace(pre_buffer_secs_string.begin(), pre_buffer_secs_string.end(), '.', decimal_point);
+
+        if (pre_buffer_secs_string.empty())
+        {
+          return eCAL::rec::Error(eCAL::rec::Error::ErrorCode::PARAMETER_ERROR, "Value for pre-buffer length must not  be empty");
+        }
+
+        try
+        {
+          pre_buffer_secs = std::stod(pre_buffer_secs_string);
+        }
+        catch (const std::exception& e)
+        {
+          return eCAL::rec::Error(eCAL::rec::Error::ErrorCode::PARAMETER_ERROR, "Failed parsing value \"" + pre_buffer_secs_string + "\": " + e.what());
+        }
+
+        if (pre_buffer_secs >= 0)
+        {
+          pre_buffer_length_out = std::chrono::duration<double>(pre_buffer_secs);
+        }
+        else
+        {
+          pre_buffer_length_out = std::chrono::duration<double>(0.0);
+        }
+
+        return eCAL::rec::Error::OK;
+
+      }
+
+      eCAL::rec::Error SetConfig::ParseParam_TopicList          (const std::string& param,              std::set<std::string>&                                 topic_list_out)
+      {
+        topic_list_out.clear();
+        std::vector<std::string> topic_list_tmp;
+
+        EcalUtils::String::Split(param, ",", topic_list_tmp);
+
+        for (const std::string& topic : topic_list_tmp)
+        {
+          // TODO: strip out empty strings?
+          topic_list_out.insert(EcalUtils::String::Trim(topic));
+        }
+
+        return eCAL::rec::Error::OK;
+      }
+
+      eCAL::rec::Error SetConfig::ParseParam_SetMaxFileSize     (const std::string& param,              unsigned int&                                          max_file_size_mib_out)
+      {
+        if (param.empty())
+          return eCAL::rec::Error(eCAL::rec::Error::ErrorCode::PARAMETER_ERROR, "Value for max HDF5 file size must not  be empty");
+
+        try
+        {
+          max_file_size_mib_out = std::stoul(param);
+        }
+        catch (const std::exception& e)
+        {
+          return eCAL::rec::Error(eCAL::rec::Error::ErrorCode::PARAMETER_ERROR, "Failed parsing value \"" + param + "\": " + e.what());
+        }
+        
+        return eCAL::rec::Error::OK;
+      }
+
+      //////////////////////////////////////////////
+      /// SetConfig functions (Protobuf config)
+      //////////////////////////////////////////////
+
+      eCAL::rec::Error SetConfig::SetClient                (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::vector<std::string>& param)
+      {
+        std::map<std::string, eCAL::rec_server::ClientConfig> client_config_map;
+
+        // Parse input parameters
+        {
+          auto parse_error = ParseParams_SetClient(param, client_config_map);
+          if (parse_error)
+            return parse_error;
+        }
+
+        // Apply to config
+        {
+          for (const auto& client : client_config_map)
+          {
+            auto existing_client_it = config_pb.mutable_enabled_clients_config()->find(client.first);
+            if (existing_client_it != config_pb.mutable_enabled_clients_config()->end())
+            {
+              // Modify existing entry by only changing the host filter
+              existing_client_it->second.clear_host_filter();
+              for (const std::string& host : client.second.host_filter_)
+              {
+                existing_client_it->second.add_host_filter(host);
+              }
+            }
+            else
+            {
+              // Create an entirely new entry
+              (*config_pb.mutable_enabled_clients_config())[client.first] = eCAL::rec_server::proto_helpers::ToProtobuf(client.second);
+            }
+          }
+        }
+        return eCAL::rec::Error::OK;
+      }
+
+      eCAL::rec::Error SetConfig::SetAddons                (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::vector<std::string>& param)
+      {
+        std::map<std::string, eCAL::rec_server::ClientConfig> client_config_map;
+
+        // Parse input parameters
+        {
+          auto parse_error = ParseParams_SetAddons(param, client_config_map);
+          if (parse_error)
+            return parse_error;
+        }
+
+        // Apply to config
+        {
+          for (const auto& client : client_config_map)
+          {
+            auto existing_client_it = config_pb.mutable_enabled_clients_config()->find(client.first);
+            if (existing_client_it != config_pb.mutable_enabled_clients_config()->end())
+            {
+              // Modify existing entry by only changing the host filter
+              existing_client_it->second.clear_enabled_addons();
+              for (const std::string& addon_id : client.second.enabled_addons_)
+              {
+                existing_client_it->second.add_enabled_addons(addon_id);
+              }
+            }
+            else
+            {
+              return eCAL::rec::Error(eCAL::rec::Error::ErrorCode::CLIENT_UNKNOWN, "Client \"" + client.first + "\" does not exist");
+            }
+          }
+        }
+        return eCAL::rec::Error::OK;
+      }
+
+      eCAL::rec::Error SetConfig::RemoveClient             (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::vector<std::string>& param)
+      {
+        for (const std::string& client_hostname : param)
+        {
+          // Check if that hostname exists
+          auto existing_rec_client_it = config_pb.mutable_enabled_clients_config()->find(client_hostname);
+          if (existing_rec_client_it == config_pb.mutable_enabled_clients_config()->end())
+            return eCAL::rec::Error(eCAL::rec::Error::ErrorCode::CLIENT_UNKNOWN, "Client \"" + client_hostname + "\" does not exist and cannot be removed");
+
+          config_pb.mutable_enabled_clients_config()->erase(existing_rec_client_it);
+        }
+
+        return eCAL::rec::Error::OK;
+      }
+
+      eCAL::rec::Error SetConfig::setFtpServer             (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param)
+      {
+        eCAL::rec_server::UploadConfig upload_config;
+
+        // Parse input parameters
+        {
+          auto parse_error = ParseParams_SetFtpServer(param, upload_config);
+          if (parse_error)
+            return parse_error;
+        }
+
+        // Apply to config
+        {
+          if (upload_config.type_ == eCAL::rec_server::UploadConfig::Type::FTP)
+          {
+            // External FTP
+            config_pb.mutable_upload_config()->set_type     (eCAL::pb::rec_server::UploadConfig::Type::UploadConfig_Type_Ftp);
+            config_pb.mutable_upload_config()->set_host     (upload_config.host_);
+            config_pb.mutable_upload_config()->set_port     (upload_config.port_);
+            config_pb.mutable_upload_config()->set_username (upload_config.username_);
+            config_pb.mutable_upload_config()->set_password (upload_config.password_);
+            config_pb.mutable_upload_config()->set_root_path(upload_config.root_path_);
+          }
+          else
+          {
+            // Default: Internal FTP
+            config_pb.mutable_upload_config()->set_type     (eCAL::pb::rec_server::UploadConfig::Type::UploadConfig_Type_InternalFtp);
+          }
+        }
+
+        return eCAL::rec::Error::OK;
+      }
+
+      eCAL::rec::Error SetConfig::setDeleteAfterUpload     (eCAL::pb::rec_server::RecServerConfig& config_pb, bool param)
+      {
+        config_pb.mutable_upload_config()->set_delete_after_upload(param);
+        return eCAL::rec::Error::OK;
+      }
+
+      eCAL::rec::Error SetConfig::setBuiltInClientEnabled  (eCAL::pb::rec_server::RecServerConfig& config_pb, bool param)
+      {
+        config_pb.set_built_in_recorder_enabled(param);
+        return eCAL::rec::Error::OK;
+      }
+
+      eCAL::rec::Error SetConfig::setPreBuffer             (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param)
+      {
+        std::chrono::duration<double> pre_buffer_length;
+
+        // Parse Parameter
+        {
+          auto error = ParseParams_SetPreBuffer(param, pre_buffer_length);
+          if (error)
+            return error;
+        }
+
+        // Apply to config
+        if (pre_buffer_length > std::chrono::duration<double>(0.0))
+        {
+          config_pb.set_pre_buffer_enabled(true);
+          config_pb.set_pre_buffer_length_nsecs(std::chrono::duration_cast<std::chrono::nanoseconds>(pre_buffer_length).count());
+        }
+        else
+        {
+          config_pb.set_pre_buffer_enabled(false);
+        }
+        return eCAL::rec::Error::OK;
+      }
+
+      eCAL::rec::Error SetConfig::setBlacklist             (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param)
+      {
+        std::set<std::string> topic_list;
+
+        // Parse param
+        {
+          auto error = ParseParam_TopicList(param, topic_list);
+          if (error)
+            return error;
+        }
+
+        // Apply to config
+        {
+          if (topic_list.empty())
+          {
+            config_pb.set_record_mode(eCAL::pb::rec_server::RecordMode::All);
+          }
+          else
+          {
+            config_pb.set_record_mode(eCAL::pb::rec_server::RecordMode::Blacklist);
+
+            config_pb.clear_listed_topics();
+            for (const std::string& topic : topic_list)
+            {
+              config_pb.add_listed_topics(topic);
+            }
+          }
+        }
+
+        return eCAL::rec::Error::OK;
+      }
+
+      eCAL::rec::Error SetConfig::setWhitelist             (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param)
+      {
+        std::set<std::string> topic_list;
+
+        // Parse param
+        {
+          auto error = ParseParam_TopicList(param, topic_list);
+          if (error)
+            return error;
+        }
+
+        // Apply to config
+        {
+          config_pb.set_record_mode(eCAL::pb::rec_server::RecordMode::Whitelist);
+
+          config_pb.clear_listed_topics();
+          for (const std::string& topic : topic_list)
+          {
+            config_pb.add_listed_topics(topic);
+          }
+        }
+
+        return eCAL::rec::Error::OK;
+      }
+
+      eCAL::rec::Error SetConfig::setMeasRootDir           (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param)
+      {
+        config_pb.set_root_dir(param);
+        return eCAL::rec::Error::OK;
+      }
+
+      eCAL::rec::Error SetConfig::setMeasName              (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param)
+      {
+        config_pb.set_meas_name(param);
+        return eCAL::rec::Error::OK;
+      }
+
+      eCAL::rec::Error SetConfig::setMaxFileSize           (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param)
+      {
+        unsigned int max_file_size_mib{0};
+
+        // Parse Parameter
+        {
+          auto error = ParseParam_SetMaxFileSize(param, max_file_size_mib);
+          if (error)
+            return error;
+        }
+
+        // Apply to config
+        config_pb.set_max_file_size_mib(max_file_size_mib);
+
+        return eCAL::rec::Error::OK;
+      }
+
+      eCAL::rec::Error SetConfig::setDescription           (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param)
+      {
+        config_pb.set_description(param);
+        return eCAL::rec::Error::OK;
+      }
+
+      eCAL::rec::Error SetConfig::setOneFilePerTopicEnabled(eCAL::pb::rec_server::RecServerConfig& config_pb, bool param)
+      {
+        config_pb.set_one_file_per_topic(param);
+        return eCAL::rec::Error::OK;
       }
 
       //////////////////////////////////////////////
@@ -293,7 +947,8 @@ namespace eCAL
         if (success)
           return eCAL::rec::Error::ErrorCode::OK;
         else
-          return eCAL::rec::Error(eCAL::rec::Error::ErrorCode::GENERIC_ERROR, "Failed to set rec clients");      }
+          return eCAL::rec::Error(eCAL::rec::Error::ErrorCode::GENERIC_ERROR, "Failed to set rec clients");      
+      }
 
       eCAL::rec::Error SetConfig::SetAddons           (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::vector<std::string>& param)
       {
@@ -363,7 +1018,8 @@ namespace eCAL
         if (success)
           return eCAL::rec::Error::ErrorCode::OK;
         else
-          return eCAL::rec::Error(eCAL::rec::Error::ErrorCode::GENERIC_ERROR, "Failed to set rec clients");      }
+          return eCAL::rec::Error(eCAL::rec::Error::ErrorCode::GENERIC_ERROR, "Failed to set rec clients");
+      }
 
       eCAL::rec::Error SetConfig::setFtpServer        (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param)
       {

--- a/app/rec/rec_server_cli/src/commands/set_config.cpp
+++ b/app/rec/rec_server_cli/src/commands/set_config.cpp
@@ -25,6 +25,7 @@
 #include <rec_server_core/proto_helpers.h>
 
 #include <clocale> // localeconv
+#include <functional>
 
 #include <regex>
 
@@ -277,7 +278,6 @@ namespace eCAL
           // Instead, we are going to work on the original config_pb, that still
           // contains all unknown values, and change only what we need to.
 
-          // TODO: Set-config in Remote mode needs to also work from command line!!!!
 
           // Set clients
           if (cmdline.set_client_arg.isSet())
@@ -606,7 +606,7 @@ namespace eCAL
 
       }
 
-      eCAL::rec::Error SetConfig::ParseParam_TopicList          (const std::string& param,              std::set<std::string>&                                 topic_list_out)
+      eCAL::rec::Error SetConfig::ParseParams_TopicList          (const std::string& param,              std::set<std::string>&                                 topic_list_out)
       {
         topic_list_out.clear();
         std::vector<std::string> topic_list_tmp;
@@ -615,14 +615,15 @@ namespace eCAL
 
         for (const std::string& topic : topic_list_tmp)
         {
-          // TODO: strip out empty strings?
-          topic_list_out.insert(EcalUtils::String::Trim(topic));
+          std::string trimmed_topic = EcalUtils::String::Trim(topic);
+          if (!trimmed_topic.empty())
+            topic_list_out.insert(trimmed_topic);
         }
 
         return eCAL::rec::Error::OK;
       }
 
-      eCAL::rec::Error SetConfig::ParseParam_SetMaxFileSize     (const std::string& param,              unsigned int&                                          max_file_size_mib_out)
+      eCAL::rec::Error SetConfig::ParseParams_SetMaxFileSize     (const std::string& param,              unsigned int&                                          max_file_size_mib_out)
       {
         if (param.empty())
           return eCAL::rec::Error(eCAL::rec::Error::ErrorCode::PARAMETER_ERROR, "Value for max HDF5 file size must not  be empty");
@@ -637,6 +638,135 @@ namespace eCAL
         }
         
         return eCAL::rec::Error::OK;
+      }
+
+      //////////////////////////////////////////////
+      /// SetConfig functions (remote directly)
+      //////////////////////////////////////////////
+      eCAL::rec::Error SetConfig::SetClient                 (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::vector<std::string>& param)
+      {
+        // Select the correct overload of the function and bind it to an std::function object
+        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, const std::vector<std::string>&)>(SetClient);
+
+        // Call the wrapper function that will set the according setting
+        return SetConfigDirectly<const std::vector<std::string>&>(hostname, remote_rec_server_service, param, f);
+      }
+
+      eCAL::rec::Error SetConfig::SetAddons                 (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::vector<std::string>& param)
+      {
+        // Select the correct overload of the function and bind it to an std::function object
+        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, const std::vector<std::string>&)>(SetAddons);
+
+        // Call the wrapper function that will set the according setting
+        return SetConfigDirectly<const std::vector<std::string>&>(hostname, remote_rec_server_service, param, f);
+      }
+
+      eCAL::rec::Error SetConfig::RemoveClient              (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::vector<std::string>& param)
+      {
+        // Select the correct overload of the function and bind it to an std::function object
+        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, const std::vector<std::string>&)>(RemoveClient);
+
+        // Call the wrapper function that will set the according setting
+        return SetConfigDirectly<const std::vector<std::string>&>(hostname, remote_rec_server_service, param, f);
+      }
+
+      eCAL::rec::Error SetConfig::setFtpServer              (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param)
+      {
+        // Select the correct overload of the function and bind it to an std::function object
+        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, const std::string&)>(setFtpServer);
+
+        // Call the wrapper function that will set the according setting
+        return SetConfigDirectly<const std::string&>(hostname, remote_rec_server_service, param, f);
+      }
+
+      eCAL::rec::Error SetConfig::setDeleteAfterUpload      (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, bool param)
+      {
+        // Select the correct overload of the function and bind it to an std::function object
+        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, bool)>(setDeleteAfterUpload);
+
+        // Call the wrapper function that will set the according setting
+        return SetConfigDirectly<bool>(hostname, remote_rec_server_service, param, f);
+      }
+
+      eCAL::rec::Error SetConfig::setBuiltInClientEnabled   (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, bool param)
+      {
+        // Select the correct overload of the function and bind it to an std::function object
+        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, bool)>(setBuiltInClientEnabled);
+
+        // Call the wrapper function that will set the according setting
+        return SetConfigDirectly<bool>(hostname, remote_rec_server_service, param, f);
+      }
+
+      eCAL::rec::Error SetConfig::setPreBuffer              (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param)
+      {
+        // Select the correct overload of the function and bind it to an std::function object
+        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, const std::string&)>(setPreBuffer);
+
+        // Call the wrapper function that will set the according setting
+        return SetConfigDirectly<const std::string&>(hostname, remote_rec_server_service, param, f);
+      }
+
+      eCAL::rec::Error SetConfig::setBlacklist              (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param)
+      {
+        // Select the correct overload of the function and bind it to an std::function object
+        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, const std::string&)>(setBlacklist);
+
+        // Call the wrapper function that will set the according setting
+        return SetConfigDirectly<const std::string&>(hostname, remote_rec_server_service, param, f);
+      }
+
+      eCAL::rec::Error SetConfig::setWhitelist              (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param)
+      {
+        // Select the correct overload of the function and bind it to an std::function object
+        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, const std::string&)>(setWhitelist);
+
+        // Call the wrapper function that will set the according setting
+        return SetConfigDirectly<const std::string&>(hostname, remote_rec_server_service, param, f);
+      }
+
+      eCAL::rec::Error SetConfig::setMeasRootDir            (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param)
+      {
+        // Select the correct overload of the function and bind it to an std::function object
+        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, const std::string&)>(setMeasRootDir);
+
+        // Call the wrapper function that will set the according setting
+        return SetConfigDirectly<const std::string&>(hostname, remote_rec_server_service, param, f);
+      }
+
+      eCAL::rec::Error SetConfig::setMeasName               (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param)
+      {
+        // Select the correct overload of the function and bind it to an std::function object
+        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, const std::string&)>(setMeasName);
+
+        // Call the wrapper function that will set the according setting
+        return SetConfigDirectly<const std::string&>(hostname, remote_rec_server_service, param, f);
+      }
+
+      eCAL::rec::Error SetConfig::setMaxFileSize            (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param)
+      {
+        // Select the correct overload of the function and bind it to an std::function object
+        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, const std::string&)>(setMaxFileSize);
+
+        // Call the wrapper function that will set the according setting
+        return SetConfigDirectly<const std::string&>(hostname, remote_rec_server_service, param, f);
+      }
+
+      eCAL::rec::Error SetConfig::setDescription            (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param)
+      {
+        // Select the correct overload of the function and bind it to an std::function object
+        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, const std::string&)>(setDescription);
+
+        // Call the wrapper function that will set the according setting
+        return SetConfigDirectly<const std::string&>(hostname, remote_rec_server_service, param, f);
+      }
+
+      eCAL::rec::Error SetConfig::setOneFilePerTopicEnabled (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, bool param)
+      {
+        // Select the correct overload of the function and bind it to an std::function object
+        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, bool)>(setOneFilePerTopicEnabled);
+
+        // Call the wrapper function that will set the according setting
+        return SetConfigDirectly<bool>(hostname, remote_rec_server_service, param, f);
       }
 
       //////////////////////////////////////////////
@@ -802,7 +932,7 @@ namespace eCAL
 
         // Parse param
         {
-          auto error = ParseParam_TopicList(param, topic_list);
+          auto error = ParseParams_TopicList(param, topic_list);
           if (error)
             return error;
         }
@@ -834,7 +964,7 @@ namespace eCAL
 
         // Parse param
         {
-          auto error = ParseParam_TopicList(param, topic_list);
+          auto error = ParseParams_TopicList(param, topic_list);
           if (error)
             return error;
         }
@@ -871,7 +1001,7 @@ namespace eCAL
 
         // Parse Parameter
         {
-          auto error = ParseParam_SetMaxFileSize(param, max_file_size_mib);
+          auto error = ParseParams_SetMaxFileSize(param, max_file_size_mib);
           if (error)
             return error;
         }

--- a/app/rec/rec_server_cli/src/commands/set_config.cpp
+++ b/app/rec/rec_server_cli/src/commands/set_config.cpp
@@ -256,7 +256,7 @@ namespace eCAL
           }
 
           // Get current config
-          eCAL::pb::rec_server::GenericRequest            request_pb;
+          const eCAL::pb::rec_server::GenericRequest      request_pb;
           eCAL::pb::rec_server::RecServerConfig           rec_server_config_pb;
 
           {
@@ -426,7 +426,7 @@ namespace eCAL
           std::set<std::string> client_host_filter;
 
           // 1. Parse the input (Hostname:List,of,hosts)
-          size_t colon_pos = client.find_first_of(":");
+          const size_t colon_pos = client.find_first_of(':');
           if (colon_pos == std::string::npos)
           {
             client_hostname = EcalUtils::String::Trim(client);
@@ -438,7 +438,7 @@ namespace eCAL
             EcalUtils::String::Split(client.substr(colon_pos + 1), ",", tmp_client_host_filter);
             for(auto& host : tmp_client_host_filter)
             {
-              std::string trimmed_host = EcalUtils::String::Trim(host);
+              const std::string trimmed_host = EcalUtils::String::Trim(host);
               if (trimmed_host.empty())
                 continue;
 
@@ -470,7 +470,7 @@ namespace eCAL
           std::set<std::string> enabled_addons;
 
           // 1. Parse the input (Hostname:List,of,addon_ids)
-          size_t colon_pos = client.find_first_of(":");
+          const size_t colon_pos = client.find_first_of(':');
           if (colon_pos == std::string::npos)
           {
             client_hostname = EcalUtils::String::Trim(client);
@@ -482,7 +482,7 @@ namespace eCAL
             EcalUtils::String::Split(client.substr(colon_pos + 1), ",", tmp_enabled_addon_ids);
             for (auto& host : tmp_enabled_addon_ids)
             {
-              std::string trimmed_addon_id = EcalUtils::String::Trim(host);
+              const std::string trimmed_addon_id = EcalUtils::String::Trim(host);
               if (trimmed_addon_id.empty())
                 continue;
 
@@ -538,7 +538,7 @@ namespace eCAL
             upload_config_out.password_ = ftp_path_match[3].str();
             upload_config_out.host_     = ftp_path_match[4].str();
 
-            std::string port_string     = ftp_path_match[6].str();
+            const std::string port_string     = ftp_path_match[6].str();
             if (port_string.empty())
             {
               upload_config_out.port_ = 21;
@@ -547,7 +547,7 @@ namespace eCAL
             {
               try
               {
-                unsigned long port_long = std::stoul(port_string);
+                const unsigned long port_long = std::stoul(port_string);
                 if ((port_long > std::numeric_limits<uint16_t>::max()) || (port_long <= 0))
                   return eCAL::rec::Error(eCAL::rec::Error::PARAMETER_ERROR, "Invalid port: " + port_string);
 
@@ -573,9 +573,9 @@ namespace eCAL
 
       eCAL::rec::Error SetConfig::ParseParams_SetPreBuffer      (const std::string& param,              std::chrono::duration<double>&                         pre_buffer_length_out)
       {
-        char decimal_point = std::localeconv()->decimal_point[0]; // decimal point for std::stod()
+        const char decimal_point = std::localeconv()->decimal_point[0]; // decimal point for std::stod()
 
-        double pre_buffer_secs;
+        double pre_buffer_secs{0};
         std::string pre_buffer_secs_string = param;
         std::replace(pre_buffer_secs_string.begin(), pre_buffer_secs_string.end(), '.', decimal_point);
 
@@ -615,7 +615,7 @@ namespace eCAL
 
         for (const std::string& topic : topic_list_tmp)
         {
-          std::string trimmed_topic = EcalUtils::String::Trim(topic);
+          const std::string trimmed_topic = EcalUtils::String::Trim(topic);
           if (!trimmed_topic.empty())
             topic_list_out.insert(trimmed_topic);
         }
@@ -904,7 +904,7 @@ namespace eCAL
 
       eCAL::rec::Error SetConfig::SetPreBuffer             (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param)
       {
-        std::chrono::duration<double> pre_buffer_length;
+        std::chrono::duration<double> pre_buffer_length{0};
 
         // Parse Parameter
         {
@@ -1038,7 +1038,7 @@ namespace eCAL
           std::set<std::string> client_host_filter;
 
           // 1. Parse the input (Hostname:List,of,hosts)
-          size_t colon_pos = client.find_first_of(":");
+          const size_t colon_pos = client.find_first_of(':');
           if (colon_pos == std::string::npos)
           {
             client_hostname = EcalUtils::String::Trim(client);
@@ -1050,7 +1050,7 @@ namespace eCAL
             EcalUtils::String::Split(client.substr(colon_pos + 1), ",", tmp_client_host_filter);
             for (auto& host : tmp_client_host_filter)
             {
-              std::string trimmed_host = EcalUtils::String::Trim(host);
+              const std::string trimmed_host = EcalUtils::String::Trim(host);
               if (trimmed_host.empty())
                 continue;
 
@@ -1073,7 +1073,7 @@ namespace eCAL
           existing_rec_client_it->second.host_filter_ = client_host_filter;
         }
 
-        bool success = rec_server_instance->SetEnabledRecClients(enabled_rec_clients);
+        const bool success = rec_server_instance->SetEnabledRecClients(enabled_rec_clients);
         if (success)
           return eCAL::rec::Error::ErrorCode::OK;
         else
@@ -1090,7 +1090,7 @@ namespace eCAL
           std::set<std::string> enabled_addons;
 
           // 1. Parse the input (Hostname:List,of,addon_ids)
-          size_t colon_pos = client.find_first_of(":");
+          const size_t colon_pos = client.find_first_of(':');
           if (colon_pos == std::string::npos)
           {
             client_hostname = EcalUtils::String::Trim(client);
@@ -1102,7 +1102,7 @@ namespace eCAL
             EcalUtils::String::Split(client.substr(colon_pos + 1), ",", tmp_enabled_addon_ids);
             for (auto& host : tmp_enabled_addon_ids)
             {
-              std::string trimmed_addon_id = EcalUtils::String::Trim(host);
+              const std::string trimmed_addon_id = EcalUtils::String::Trim(host);
               if (trimmed_addon_id.empty())
                 continue;
 
@@ -1123,7 +1123,7 @@ namespace eCAL
           existing_rec_client_it->second.enabled_addons_ = enabled_addons;
         }
 
-        bool success = rec_server_instance->SetEnabledRecClients(enabled_rec_clients);
+        const bool success = rec_server_instance->SetEnabledRecClients(enabled_rec_clients);
         if (success)
           return eCAL::rec::Error::ErrorCode::OK;
         else
@@ -1144,7 +1144,7 @@ namespace eCAL
           enabled_rec_clients.erase(existing_rec_client_it);
         }
 
-        bool success = rec_server_instance->SetEnabledRecClients(enabled_rec_clients);
+        const bool success = rec_server_instance->SetEnabledRecClients(enabled_rec_clients);
         if (success)
           return eCAL::rec::Error::ErrorCode::OK;
         else
@@ -1187,7 +1187,7 @@ namespace eCAL
             new_upload_config.password_ = ftp_path_match[3].str();
             new_upload_config.host_     = ftp_path_match[4].str();
 
-            std::string port_string     = ftp_path_match[6].str();
+            const std::string port_string     = ftp_path_match[6].str();
             if (port_string.empty())
             {
               new_upload_config.port_ = 21;
@@ -1196,7 +1196,7 @@ namespace eCAL
             {
               try
               {
-                unsigned long port_long = std::stoul(port_string);
+                const unsigned long port_long = std::stoul(port_string);
                 if ((port_long > std::numeric_limits<uint16_t>::max()) || (port_long <= 0))
                   return eCAL::rec::Error(eCAL::rec::Error::PARAMETER_ERROR, "Invalid port: " + port_string);
 
@@ -1234,7 +1234,7 @@ namespace eCAL
         if (rec_server_instance->IsRecording())
           return eCAL::rec::Error::ErrorCode::CURRENTLY_RECORDING;
 
-        bool success = rec_server_instance->SetUsingBuiltInRecorderEnabled(param);
+        const bool success = rec_server_instance->SetUsingBuiltInRecorderEnabled(param);
 
         if (success)
           return eCAL::rec::Error::OK;
@@ -1244,9 +1244,9 @@ namespace eCAL
 
       eCAL::rec::Error SetConfig::SetPreBuffer        (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param)
       {
-        char decimal_point = std::localeconv()->decimal_point[0]; // decimal point for std::stod()
+        const char decimal_point = std::localeconv()->decimal_point[0]; // decimal point for std::stod()
 
-        double pre_buffer_secs;
+        double pre_buffer_secs{0};
         std::string pre_buffer_secs_string = param;
         std::replace(pre_buffer_secs_string.begin(), pre_buffer_secs_string.end(), '.', decimal_point);
 
@@ -1314,7 +1314,7 @@ namespace eCAL
           topic = EcalUtils::String::Trim(topic);
         }
 
-        bool success = rec_server_instance->SetRecordMode(eCAL::rec::RecordMode::Whitelist, whitelist);
+        const bool success = rec_server_instance->SetRecordMode(eCAL::rec::RecordMode::Whitelist, whitelist);
 
         if (!success)
           return eCAL::rec::Error(eCAL::rec::Error::ErrorCode::GENERIC_ERROR, "Failed to set whitelist");
@@ -1339,7 +1339,7 @@ namespace eCAL
         if (param.empty())
           return eCAL::rec::Error(eCAL::rec::Error::ErrorCode::PARAMETER_ERROR, "Value for max HDF5 file size must not  be empty");
 
-        unsigned int max_file_size_mib;
+        unsigned int max_file_size_mib{0};
 
         try
         {

--- a/app/rec/rec_server_cli/src/commands/set_config.cpp
+++ b/app/rec/rec_server_cli/src/commands/set_config.cpp
@@ -148,7 +148,7 @@ namespace eCAL
           // Ftp Server
           if (cmdline.ftp_server_arg.isSet())
           {
-            auto error = setFtpServer(rec_server_instance, cmdline.ftp_server_arg.getValue());
+            auto error = SetFtpServer(rec_server_instance, cmdline.ftp_server_arg.getValue());
             if (error)
               return error;
           }
@@ -156,7 +156,7 @@ namespace eCAL
           // Delete after upload
           if (cmdline.delete_after_upload_arg.isSet())
           {
-            auto error = setDeleteAfterUpload(rec_server_instance, cmdline.delete_after_upload_arg.getValue());
+            auto error = SetDeleteAfterUpload(rec_server_instance, cmdline.delete_after_upload_arg.getValue());
             if (error)
               return error;
           }
@@ -164,7 +164,7 @@ namespace eCAL
           // Set built-in client enabled
           if (cmdline.enable_built_in_client_arg.isSet())
           {
-            auto error = setBuiltInClientEnabled(rec_server_instance, cmdline.enable_built_in_client_arg.getValue());
+            auto error = SetBuiltInClientEnabled(rec_server_instance, cmdline.enable_built_in_client_arg.getValue());
             if (error)
               return error;
           }
@@ -172,7 +172,7 @@ namespace eCAL
           // Pre-buffer
           if (cmdline.pre_buffer_secs_arg.isSet())
           {
-            auto error = setPreBuffer(rec_server_instance, cmdline.pre_buffer_secs_arg.getValue());
+            auto error = SetPreBuffer(rec_server_instance, cmdline.pre_buffer_secs_arg.getValue());
             if (error)
               return error;
           }
@@ -180,7 +180,7 @@ namespace eCAL
           // blacklist
           if (cmdline.blacklist_arg.isSet())
           {
-            auto error = setBlacklist(rec_server_instance, cmdline.blacklist_arg.getValue());
+            auto error = SetBlacklist(rec_server_instance, cmdline.blacklist_arg.getValue());
             if (error)
               return error;
           }
@@ -188,7 +188,7 @@ namespace eCAL
           // whitelist
           if (cmdline.whitelist_arg.isSet())
           {
-            auto error = setWhitelist(rec_server_instance, cmdline.whitelist_arg.getValue());
+            auto error = SetWhitelist(rec_server_instance, cmdline.whitelist_arg.getValue());
             if (error)
               return error;
           }
@@ -196,7 +196,7 @@ namespace eCAL
           // meas-root-dir
           if (cmdline.meas_root_dir_arg.isSet())
           {
-            auto error = setMeasRootDir(rec_server_instance, cmdline.meas_root_dir_arg.getValue());
+            auto error = SetMeasRootDir(rec_server_instance, cmdline.meas_root_dir_arg.getValue());
             if (error)
               return error;
           }
@@ -204,7 +204,7 @@ namespace eCAL
           // meas-name
           if (cmdline.meas_name_arg.isSet())
           {
-            auto error = setMeasName(rec_server_instance, cmdline.meas_name_arg.getValue());
+            auto error = SetMeasName(rec_server_instance, cmdline.meas_name_arg.getValue());
             if (error)
               return error;
           }
@@ -212,7 +212,7 @@ namespace eCAL
           // max-file-size
           if (cmdline.max_file_size_mib_arg.isSet())
           {
-            auto error = setMaxFileSize(rec_server_instance, cmdline.max_file_size_mib_arg.getValue());
+            auto error = SetMaxFileSize(rec_server_instance, cmdline.max_file_size_mib_arg.getValue());
             if (error)
               return error;
           }
@@ -220,7 +220,7 @@ namespace eCAL
           // description
           if (cmdline.description_arg.isSet())
           {
-            auto error = setDescription(rec_server_instance, cmdline.description_arg.getValue());
+            auto error = SetDescription(rec_server_instance, cmdline.description_arg.getValue());
             if (error)
               return error;
           }
@@ -228,7 +228,7 @@ namespace eCAL
           // Enable one file per topic
           if (cmdline.enable_one_file_per_topic_arg.isSet())
           {
-            auto error = setOneFilePerTopicEnabled(rec_server_instance, cmdline.enable_one_file_per_topic_arg.getValue());
+            auto error = SetOneFilePerTopicEnabled(rec_server_instance, cmdline.enable_one_file_per_topic_arg.getValue());
             if (error)
               return error;
           }
@@ -306,7 +306,7 @@ namespace eCAL
           // Set FTP Server
           if (cmdline.ftp_server_arg.isSet())
           {
-            auto error = setFtpServer(rec_server_config_pb, cmdline.ftp_server_arg.getValue());
+            auto error = SetFtpServer(rec_server_config_pb, cmdline.ftp_server_arg.getValue());
             if (error)
               return error;
           }
@@ -314,7 +314,7 @@ namespace eCAL
           // Set Delete-after-upload
           if (cmdline.delete_after_upload_arg.isSet())
           {
-            auto error = setDeleteAfterUpload(rec_server_config_pb, cmdline.delete_after_upload_arg.getValue());
+            auto error = SetDeleteAfterUpload(rec_server_config_pb, cmdline.delete_after_upload_arg.getValue());
             if (error)
               return error;
           }
@@ -322,71 +322,71 @@ namespace eCAL
           // Build-in client
           if (cmdline.enable_built_in_client_arg.isSet())
           {
-            auto error = setBuiltInClientEnabled(rec_server_config_pb, cmdline.enable_built_in_client_arg.getValue());
+            auto error = SetBuiltInClientEnabled(rec_server_config_pb, cmdline.enable_built_in_client_arg.getValue());
             if (error)
               return error;
           }
 
-          // setPreBuffer
+          // SetPreBuffer
           if (cmdline.pre_buffer_secs_arg.isSet())
           {
-            auto error = setPreBuffer(rec_server_config_pb, cmdline.pre_buffer_secs_arg.getValue());
+            auto error = SetPreBuffer(rec_server_config_pb, cmdline.pre_buffer_secs_arg.getValue());
             if (error)
               return error;
           }
 
-          // setBlacklist
+          // SetBlacklist
           if (cmdline.blacklist_arg.isSet())
           {
-            auto error = setBlacklist(rec_server_config_pb, cmdline.blacklist_arg.getValue());
+            auto error = SetBlacklist(rec_server_config_pb, cmdline.blacklist_arg.getValue());
             if (error)
               return error;
           }
 
-          // setWhitelist
+          // SetWhitelist
           if (cmdline.whitelist_arg.isSet())
           {
-            auto error = setWhitelist(rec_server_config_pb, cmdline.whitelist_arg.getValue());
+            auto error = SetWhitelist(rec_server_config_pb, cmdline.whitelist_arg.getValue());
             if (error)
               return error;
           }
 
-          // setMeasRootDir
+          // SetMeasRootDir
           if (cmdline.meas_root_dir_arg.isSet())
           {
-            auto error = setMeasRootDir(rec_server_config_pb, cmdline.meas_root_dir_arg.getValue());
+            auto error = SetMeasRootDir(rec_server_config_pb, cmdline.meas_root_dir_arg.getValue());
             if (error)
               return error;
           }
 
-          // setMeasName
+          // SetMeasName
           if (cmdline.meas_name_arg.isSet())
           {
-            auto error = setMeasName(rec_server_config_pb, cmdline.meas_name_arg.getValue());
+            auto error = SetMeasName(rec_server_config_pb, cmdline.meas_name_arg.getValue());
             if (error)
               return error;
           }
 
-          // setMaxFileSize
+          // SetMaxFileSize
           if (cmdline.max_file_size_mib_arg.isSet())
           {
-            auto error = setMaxFileSize(rec_server_config_pb, cmdline.max_file_size_mib_arg.getValue());
+            auto error = SetMaxFileSize(rec_server_config_pb, cmdline.max_file_size_mib_arg.getValue());
             if (error)
               return error;
           }
 
-          // setDescription
+          // SetDescription
           if (cmdline.description_arg.isSet())
           {
-            auto error = setDescription(rec_server_config_pb, cmdline.description_arg.getValue());
+            auto error = SetDescription(rec_server_config_pb, cmdline.description_arg.getValue());
             if (error)
               return error;
           }
 
-          // setOneFilePerTopicEnabled
+          // SetOneFilePerTopicEnabled
           if (cmdline.enable_one_file_per_topic_arg.isSet())
           {
-            auto error = setOneFilePerTopicEnabled(rec_server_config_pb, cmdline.enable_one_file_per_topic_arg.getValue());
+            auto error = SetOneFilePerTopicEnabled(rec_server_config_pb, cmdline.enable_one_file_per_topic_arg.getValue());
             if (error)
               return error;
           }
@@ -670,100 +670,100 @@ namespace eCAL
         return SetConfigDirectly<const std::vector<std::string>&>(hostname, remote_rec_server_service, param, f);
       }
 
-      eCAL::rec::Error SetConfig::setFtpServer              (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param)
+      eCAL::rec::Error SetConfig::SetFtpServer              (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param)
       {
         // Select the correct overload of the function and bind it to an std::function object
-        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, const std::string&)>(setFtpServer);
+        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, const std::string&)>(SetFtpServer);
 
         // Call the wrapper function that will set the according setting
         return SetConfigDirectly<const std::string&>(hostname, remote_rec_server_service, param, f);
       }
 
-      eCAL::rec::Error SetConfig::setDeleteAfterUpload      (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, bool param)
+      eCAL::rec::Error SetConfig::SetDeleteAfterUpload      (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, bool param)
       {
         // Select the correct overload of the function and bind it to an std::function object
-        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, bool)>(setDeleteAfterUpload);
+        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, bool)>(SetDeleteAfterUpload);
 
         // Call the wrapper function that will set the according setting
         return SetConfigDirectly<bool>(hostname, remote_rec_server_service, param, f);
       }
 
-      eCAL::rec::Error SetConfig::setBuiltInClientEnabled   (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, bool param)
+      eCAL::rec::Error SetConfig::SetBuiltInClientEnabled   (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, bool param)
       {
         // Select the correct overload of the function and bind it to an std::function object
-        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, bool)>(setBuiltInClientEnabled);
+        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, bool)>(SetBuiltInClientEnabled);
 
         // Call the wrapper function that will set the according setting
         return SetConfigDirectly<bool>(hostname, remote_rec_server_service, param, f);
       }
 
-      eCAL::rec::Error SetConfig::setPreBuffer              (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param)
+      eCAL::rec::Error SetConfig::SetPreBuffer              (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param)
       {
         // Select the correct overload of the function and bind it to an std::function object
-        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, const std::string&)>(setPreBuffer);
+        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, const std::string&)>(SetPreBuffer);
 
         // Call the wrapper function that will set the according setting
         return SetConfigDirectly<const std::string&>(hostname, remote_rec_server_service, param, f);
       }
 
-      eCAL::rec::Error SetConfig::setBlacklist              (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param)
+      eCAL::rec::Error SetConfig::SetBlacklist              (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param)
       {
         // Select the correct overload of the function and bind it to an std::function object
-        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, const std::string&)>(setBlacklist);
+        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, const std::string&)>(SetBlacklist);
 
         // Call the wrapper function that will set the according setting
         return SetConfigDirectly<const std::string&>(hostname, remote_rec_server_service, param, f);
       }
 
-      eCAL::rec::Error SetConfig::setWhitelist              (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param)
+      eCAL::rec::Error SetConfig::SetWhitelist              (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param)
       {
         // Select the correct overload of the function and bind it to an std::function object
-        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, const std::string&)>(setWhitelist);
+        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, const std::string&)>(SetWhitelist);
 
         // Call the wrapper function that will set the according setting
         return SetConfigDirectly<const std::string&>(hostname, remote_rec_server_service, param, f);
       }
 
-      eCAL::rec::Error SetConfig::setMeasRootDir            (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param)
+      eCAL::rec::Error SetConfig::SetMeasRootDir            (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param)
       {
         // Select the correct overload of the function and bind it to an std::function object
-        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, const std::string&)>(setMeasRootDir);
+        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, const std::string&)>(SetMeasRootDir);
 
         // Call the wrapper function that will set the according setting
         return SetConfigDirectly<const std::string&>(hostname, remote_rec_server_service, param, f);
       }
 
-      eCAL::rec::Error SetConfig::setMeasName               (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param)
+      eCAL::rec::Error SetConfig::SetMeasName               (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param)
       {
         // Select the correct overload of the function and bind it to an std::function object
-        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, const std::string&)>(setMeasName);
+        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, const std::string&)>(SetMeasName);
 
         // Call the wrapper function that will set the according setting
         return SetConfigDirectly<const std::string&>(hostname, remote_rec_server_service, param, f);
       }
 
-      eCAL::rec::Error SetConfig::setMaxFileSize            (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param)
+      eCAL::rec::Error SetConfig::SetMaxFileSize            (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param)
       {
         // Select the correct overload of the function and bind it to an std::function object
-        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, const std::string&)>(setMaxFileSize);
+        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, const std::string&)>(SetMaxFileSize);
 
         // Call the wrapper function that will set the according setting
         return SetConfigDirectly<const std::string&>(hostname, remote_rec_server_service, param, f);
       }
 
-      eCAL::rec::Error SetConfig::setDescription            (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param)
+      eCAL::rec::Error SetConfig::SetDescription            (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param)
       {
         // Select the correct overload of the function and bind it to an std::function object
-        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, const std::string&)>(setDescription);
+        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, const std::string&)>(SetDescription);
 
         // Call the wrapper function that will set the according setting
         return SetConfigDirectly<const std::string&>(hostname, remote_rec_server_service, param, f);
       }
 
-      eCAL::rec::Error SetConfig::setOneFilePerTopicEnabled (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, bool param)
+      eCAL::rec::Error SetConfig::SetOneFilePerTopicEnabled (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, bool param)
       {
         // Select the correct overload of the function and bind it to an std::function object
-        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, bool)>(setOneFilePerTopicEnabled);
+        auto f = static_cast<eCAL::rec::Error(*)(eCAL::pb::rec_server::RecServerConfig&, bool)>(SetOneFilePerTopicEnabled);
 
         // Call the wrapper function that will set the according setting
         return SetConfigDirectly<bool>(hostname, remote_rec_server_service, param, f);
@@ -857,7 +857,7 @@ namespace eCAL
         return eCAL::rec::Error::OK;
       }
 
-      eCAL::rec::Error SetConfig::setFtpServer             (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param)
+      eCAL::rec::Error SetConfig::SetFtpServer             (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param)
       {
         eCAL::rec_server::UploadConfig upload_config;
 
@@ -890,19 +890,19 @@ namespace eCAL
         return eCAL::rec::Error::OK;
       }
 
-      eCAL::rec::Error SetConfig::setDeleteAfterUpload     (eCAL::pb::rec_server::RecServerConfig& config_pb, bool param)
+      eCAL::rec::Error SetConfig::SetDeleteAfterUpload     (eCAL::pb::rec_server::RecServerConfig& config_pb, bool param)
       {
         config_pb.mutable_upload_config()->set_delete_after_upload(param);
         return eCAL::rec::Error::OK;
       }
 
-      eCAL::rec::Error SetConfig::setBuiltInClientEnabled  (eCAL::pb::rec_server::RecServerConfig& config_pb, bool param)
+      eCAL::rec::Error SetConfig::SetBuiltInClientEnabled  (eCAL::pb::rec_server::RecServerConfig& config_pb, bool param)
       {
         config_pb.set_built_in_recorder_enabled(param);
         return eCAL::rec::Error::OK;
       }
 
-      eCAL::rec::Error SetConfig::setPreBuffer             (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param)
+      eCAL::rec::Error SetConfig::SetPreBuffer             (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param)
       {
         std::chrono::duration<double> pre_buffer_length;
 
@@ -926,7 +926,7 @@ namespace eCAL
         return eCAL::rec::Error::OK;
       }
 
-      eCAL::rec::Error SetConfig::setBlacklist             (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param)
+      eCAL::rec::Error SetConfig::SetBlacklist             (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param)
       {
         std::set<std::string> topic_list;
 
@@ -958,7 +958,7 @@ namespace eCAL
         return eCAL::rec::Error::OK;
       }
 
-      eCAL::rec::Error SetConfig::setWhitelist             (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param)
+      eCAL::rec::Error SetConfig::SetWhitelist             (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param)
       {
         std::set<std::string> topic_list;
 
@@ -983,19 +983,19 @@ namespace eCAL
         return eCAL::rec::Error::OK;
       }
 
-      eCAL::rec::Error SetConfig::setMeasRootDir           (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param)
+      eCAL::rec::Error SetConfig::SetMeasRootDir           (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param)
       {
         config_pb.set_root_dir(param);
         return eCAL::rec::Error::OK;
       }
 
-      eCAL::rec::Error SetConfig::setMeasName              (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param)
+      eCAL::rec::Error SetConfig::SetMeasName              (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param)
       {
         config_pb.set_meas_name(param);
         return eCAL::rec::Error::OK;
       }
 
-      eCAL::rec::Error SetConfig::setMaxFileSize           (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param)
+      eCAL::rec::Error SetConfig::SetMaxFileSize           (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param)
       {
         unsigned int max_file_size_mib{0};
 
@@ -1012,13 +1012,13 @@ namespace eCAL
         return eCAL::rec::Error::OK;
       }
 
-      eCAL::rec::Error SetConfig::setDescription           (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param)
+      eCAL::rec::Error SetConfig::SetDescription           (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param)
       {
         config_pb.set_description(param);
         return eCAL::rec::Error::OK;
       }
 
-      eCAL::rec::Error SetConfig::setOneFilePerTopicEnabled(eCAL::pb::rec_server::RecServerConfig& config_pb, bool param)
+      eCAL::rec::Error SetConfig::SetOneFilePerTopicEnabled(eCAL::pb::rec_server::RecServerConfig& config_pb, bool param)
       {
         config_pb.set_one_file_per_topic(param);
         return eCAL::rec::Error::OK;
@@ -1151,7 +1151,7 @@ namespace eCAL
           return eCAL::rec::Error(eCAL::rec::Error::ErrorCode::GENERIC_ERROR, "Failed to set rec clients");
       }
 
-      eCAL::rec::Error SetConfig::setFtpServer        (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param)
+      eCAL::rec::Error SetConfig::SetFtpServer        (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param)
       {
         if (param.empty())
           return eCAL::rec::Error(eCAL::rec::Error::ErrorCode::PARAMETER_ERROR, "Parameter for FTP Server must not be empty");
@@ -1221,7 +1221,7 @@ namespace eCAL
         return eCAL::rec::Error::OK;
       }
 
-      eCAL::rec::Error SetConfig::setDeleteAfterUpload(const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, bool param)
+      eCAL::rec::Error SetConfig::SetDeleteAfterUpload(const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, bool param)
       {
         auto new_upload_config = rec_server_instance->GetUploadConfig();
         new_upload_config.delete_after_upload_ = param;
@@ -1229,7 +1229,7 @@ namespace eCAL
         return eCAL::rec::Error::OK;
       }
 
-      eCAL::rec::Error SetConfig::setBuiltInClientEnabled(const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, bool param)
+      eCAL::rec::Error SetConfig::SetBuiltInClientEnabled(const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, bool param)
       {
         if (rec_server_instance->IsRecording())
           return eCAL::rec::Error::ErrorCode::CURRENTLY_RECORDING;
@@ -1242,7 +1242,7 @@ namespace eCAL
           return eCAL::rec::Error(eCAL::rec::Error::ErrorCode::GENERIC_ERROR, std::string("Failed to set built-in client enabled to ") + (param ? "true" : "false"));
       }
 
-      eCAL::rec::Error SetConfig::setPreBuffer        (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param)
+      eCAL::rec::Error SetConfig::SetPreBuffer        (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param)
       {
         char decimal_point = std::localeconv()->decimal_point[0]; // decimal point for std::stod()
 
@@ -1277,7 +1277,7 @@ namespace eCAL
         return eCAL::rec::Error::OK;
       }
 
-      eCAL::rec::Error SetConfig::setBlacklist        (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param)
+      eCAL::rec::Error SetConfig::SetBlacklist        (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param)
       {
         std::set<std::string> blacklist;
         EcalUtils::String::Split(param, ",", blacklist);
@@ -1304,7 +1304,7 @@ namespace eCAL
           return eCAL::rec::Error::OK;
       }
 
-      eCAL::rec::Error SetConfig::setWhitelist        (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param)
+      eCAL::rec::Error SetConfig::SetWhitelist        (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param)
       {
         std::set<std::string> whitelist;
         EcalUtils::String::Split(param, ",", whitelist);
@@ -1322,19 +1322,19 @@ namespace eCAL
           return eCAL::rec::Error::ErrorCode::OK;
       }
 
-      eCAL::rec::Error SetConfig::setMeasRootDir      (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param)
+      eCAL::rec::Error SetConfig::SetMeasRootDir      (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param)
       {
         rec_server_instance->SetMeasRootDir(param);
         return eCAL::rec::Error::OK;
       }
 
-      eCAL::rec::Error SetConfig::setMeasName         (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param)
+      eCAL::rec::Error SetConfig::SetMeasName         (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param)
       {
         rec_server_instance->SetMeasName(param);
         return eCAL::rec::Error::OK;
       }
 
-      eCAL::rec::Error SetConfig::setMaxFileSize      (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param)
+      eCAL::rec::Error SetConfig::SetMaxFileSize      (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param)
       {
         if (param.empty())
           return eCAL::rec::Error(eCAL::rec::Error::ErrorCode::PARAMETER_ERROR, "Value for max HDF5 file size must not  be empty");
@@ -1354,13 +1354,13 @@ namespace eCAL
         return eCAL::rec::Error::OK;
       }
 
-      eCAL::rec::Error SetConfig::setDescription      (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param)
+      eCAL::rec::Error SetConfig::SetDescription      (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param)
       {
         rec_server_instance->SetDescription(param);
         return eCAL::rec::Error::OK;
       }
 
-      eCAL::rec::Error SetConfig::setOneFilePerTopicEnabled (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, bool param)
+      eCAL::rec::Error SetConfig::SetOneFilePerTopicEnabled (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, bool param)
       {
         rec_server_instance->SetOneFilePerTopicEnabled(param);
         return eCAL::rec::Error::OK;

--- a/app/rec/rec_server_cli/src/commands/set_config.h
+++ b/app/rec/rec_server_cli/src/commands/set_config.h
@@ -171,7 +171,7 @@ namespace eCAL
                                                 , param_t param
                                                 , const std::function<eCAL::rec::Error(eCAL::pb::rec_server::RecServerConfig&, param_t)> set_config_function)
         {
-          eCAL::pb::rec_server::GenericRequest            request_pb;
+          const eCAL::pb::rec_server::GenericRequest      request_pb;
           eCAL::pb::rec_server::RecServerConfig           rec_server_config_pb;
 
           // Get current config

--- a/app/rec/rec_server_cli/src/commands/set_config.h
+++ b/app/rec/rec_server_cli/src/commands/set_config.h
@@ -210,17 +210,17 @@ namespace eCAL
         static eCAL::rec::Error SetClient                (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::vector<std::string>& param);
         static eCAL::rec::Error SetAddons                (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::vector<std::string>& param);
         static eCAL::rec::Error RemoveClient             (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::vector<std::string>& param);
-        static eCAL::rec::Error setFtpServer             (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param);
-        static eCAL::rec::Error setDeleteAfterUpload     (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, bool param);
-        static eCAL::rec::Error setBuiltInClientEnabled  (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, bool param);
-        static eCAL::rec::Error setPreBuffer             (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param);
-        static eCAL::rec::Error setBlacklist             (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param);
-        static eCAL::rec::Error setWhitelist             (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param);
-        static eCAL::rec::Error setMeasRootDir           (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param);
-        static eCAL::rec::Error setMeasName              (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param);
-        static eCAL::rec::Error setMaxFileSize           (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param);
-        static eCAL::rec::Error setDescription           (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param);
-        static eCAL::rec::Error setOneFilePerTopicEnabled(const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, bool param);
+        static eCAL::rec::Error SetFtpServer             (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param);
+        static eCAL::rec::Error SetDeleteAfterUpload     (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, bool param);
+        static eCAL::rec::Error SetBuiltInClientEnabled  (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, bool param);
+        static eCAL::rec::Error SetPreBuffer             (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param);
+        static eCAL::rec::Error SetBlacklist             (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param);
+        static eCAL::rec::Error SetWhitelist             (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param);
+        static eCAL::rec::Error SetMeasRootDir           (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param);
+        static eCAL::rec::Error SetMeasName              (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param);
+        static eCAL::rec::Error SetMaxFileSize           (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param);
+        static eCAL::rec::Error SetDescription           (const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::string& param);
+        static eCAL::rec::Error SetOneFilePerTopicEnabled(const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, bool param);
 
       //////////////////////////////////////////////
       /// SetConfig functions (Protobuf config)
@@ -229,17 +229,17 @@ namespace eCAL
         static eCAL::rec::Error SetClient                (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::vector<std::string>& param);
         static eCAL::rec::Error SetAddons                (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::vector<std::string>& param);
         static eCAL::rec::Error RemoveClient             (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::vector<std::string>& param);
-        static eCAL::rec::Error setFtpServer             (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param);
-        static eCAL::rec::Error setDeleteAfterUpload     (eCAL::pb::rec_server::RecServerConfig& config_pb, bool param);
-        static eCAL::rec::Error setBuiltInClientEnabled  (eCAL::pb::rec_server::RecServerConfig& config_pb, bool param);
-        static eCAL::rec::Error setPreBuffer             (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param);
-        static eCAL::rec::Error setBlacklist             (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param);
-        static eCAL::rec::Error setWhitelist             (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param);
-        static eCAL::rec::Error setMeasRootDir           (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param);
-        static eCAL::rec::Error setMeasName              (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param);
-        static eCAL::rec::Error setMaxFileSize           (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param);
-        static eCAL::rec::Error setDescription           (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param);
-        static eCAL::rec::Error setOneFilePerTopicEnabled(eCAL::pb::rec_server::RecServerConfig& config_pb, bool param);
+        static eCAL::rec::Error SetFtpServer             (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param);
+        static eCAL::rec::Error SetDeleteAfterUpload     (eCAL::pb::rec_server::RecServerConfig& config_pb, bool param);
+        static eCAL::rec::Error SetBuiltInClientEnabled  (eCAL::pb::rec_server::RecServerConfig& config_pb, bool param);
+        static eCAL::rec::Error SetPreBuffer             (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param);
+        static eCAL::rec::Error SetBlacklist             (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param);
+        static eCAL::rec::Error SetWhitelist             (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param);
+        static eCAL::rec::Error SetMeasRootDir           (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param);
+        static eCAL::rec::Error SetMeasName              (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param);
+        static eCAL::rec::Error SetMaxFileSize           (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param);
+        static eCAL::rec::Error SetDescription           (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param);
+        static eCAL::rec::Error SetOneFilePerTopicEnabled(eCAL::pb::rec_server::RecServerConfig& config_pb, bool param);
 
       //////////////////////////////////////////////
       /// SetConfig functions (local)
@@ -249,17 +249,17 @@ namespace eCAL
         static eCAL::rec::Error SetClient           (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::vector<std::string>& param);
         static eCAL::rec::Error SetAddons           (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::vector<std::string>& param);
         static eCAL::rec::Error RemoveClient        (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::vector<std::string>& param);
-        static eCAL::rec::Error setFtpServer        (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param);
-        static eCAL::rec::Error setDeleteAfterUpload(const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, bool param);
-        static eCAL::rec::Error setBuiltInClientEnabled(const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, bool param);
-        static eCAL::rec::Error setPreBuffer        (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param);
-        static eCAL::rec::Error setBlacklist        (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param);
-        static eCAL::rec::Error setWhitelist        (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param);
-        static eCAL::rec::Error setMeasRootDir      (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param);
-        static eCAL::rec::Error setMeasName         (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param);
-        static eCAL::rec::Error setMaxFileSize      (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param);
-        static eCAL::rec::Error setDescription      (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param);
-        static eCAL::rec::Error setOneFilePerTopicEnabled(const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, bool param);
+        static eCAL::rec::Error SetFtpServer        (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param);
+        static eCAL::rec::Error SetDeleteAfterUpload(const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, bool param);
+        static eCAL::rec::Error SetBuiltInClientEnabled(const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, bool param);
+        static eCAL::rec::Error SetPreBuffer        (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param);
+        static eCAL::rec::Error SetBlacklist        (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param);
+        static eCAL::rec::Error SetWhitelist        (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param);
+        static eCAL::rec::Error SetMeasRootDir      (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param);
+        static eCAL::rec::Error SetMeasName         (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param);
+        static eCAL::rec::Error SetMaxFileSize      (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param);
+        static eCAL::rec::Error SetDescription      (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::string& param);
+        static eCAL::rec::Error SetOneFilePerTopicEnabled(const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, bool param);
       };
     }
   }

--- a/app/rec/rec_server_cli/src/commands/set_config.h
+++ b/app/rec/rec_server_cli/src/commands/set_config.h
@@ -148,9 +148,65 @@ namespace eCAL
         eCAL::rec::Error Execute(const std::string& hostname, const std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>& remote_rec_server_service, const std::vector<std::string>& argv) const override;
 
       //////////////////////////////////////////////
-      /// SetConfig functions              
+      /// SetConfig functions           
+      //////////////////////////////////////////////
+      //private:
+      //  static eCAL::rec::Error SetClient           (eCAL::rec_server::RecServerConfig& config, const std::vector<std::string>& param);
+      //  //static eCAL::rec::Error SetAddons           (eCAL::rec_server::RecServerConfig& config, const std::vector<std::string>& param);
+      //  static eCAL::rec::Error RemoveClient        (eCAL::rec_server::RecServerConfig& config, const std::vector<std::string>& param);
+      //  //static eCAL::rec::Error setFtpServer        (eCAL::rec_server::RecServerConfig& config, const std::string& param);
+      //  //static eCAL::rec::Error setDeleteAfterUpload(eCAL::rec_server::RecServerConfig& config, bool param);
+      //  //static eCAL::rec::Error setBuiltInClientEnabled(eCAL::rec_server::RecServerConfig& config, bool param);
+      //  //static eCAL::rec::Error setPreBuffer        (eCAL::rec_server::RecServerConfig& config, const std::string& param);
+      //  //static eCAL::rec::Error setBlacklist        (eCAL::rec_server::RecServerConfig& config, const std::string& param);
+      //  //static eCAL::rec::Error setWhitelist        (eCAL::rec_server::RecServerConfig& config, const std::string& param);
+      //  //static eCAL::rec::Error setMeasRootDir      (eCAL::rec_server::RecServerConfig& config, const std::string& param);
+      //  //static eCAL::rec::Error setMeasName         (eCAL::rec_server::RecServerConfig& config, const std::string& param);
+      //  //static eCAL::rec::Error setMaxFileSize      (eCAL::rec_server::RecServerConfig& config, const std::string& param);
+      //  static eCAL::rec::Error setDescription      (eCAL::rec_server::RecServerConfig& config, const std::string& param);
+        //static eCAL::rec::Error setOneFilePerTopicEnabled(eCAL::rec_server::RecServerConfig& config, bool param);
+
+      //////////////////////////////////////////////
+      /// Parse Param Functions
+      //////////////////////////////////////////////
+      
+      private:
+        // TODO: either plural or singular, but currently I have both ParseParam and ParseParams
+        static eCAL::rec::Error ParseParams_SetClient    (const std::vector<std::string>& param, std::map<std::string, eCAL::rec_server::ClientConfig>& client_configs_out);
+        static eCAL::rec::Error ParseParams_SetAddons    (const std::vector<std::string>& param, std::map<std::string, eCAL::rec_server::ClientConfig>& client_configs_out);
+        static eCAL::rec::Error ParseParams_SetFtpServer (const std::string& param,              eCAL::rec_server::UploadConfig&                        upload_config_out);
+        static eCAL::rec::Error ParseParams_SetPreBuffer (const std::string& param,              std::chrono::duration<double>&                         pre_buffer_length_out);
+        static eCAL::rec::Error ParseParam_TopicList     (const std::string& param,              std::set<std::string>&                                 topic_list_out);
+        static eCAL::rec::Error ParseParam_SetMaxFileSize(const std::string& param,              unsigned int&                                          max_file_size_mib_out);
+
+      //////////////////////////////////////////////
+      /// SetConfig functions (remote directly)
+      //////////////////////////////////////////////
+      
+      //////////////////////////////////////////////
+      /// SetConfig functions (Protobuf config)
+      //////////////////////////////////////////////
+      private:
+        static eCAL::rec::Error SetClient                (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::vector<std::string>& param);
+        static eCAL::rec::Error SetAddons                (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::vector<std::string>& param);
+        static eCAL::rec::Error RemoveClient             (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::vector<std::string>& param);
+        static eCAL::rec::Error setFtpServer             (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param);
+        static eCAL::rec::Error setDeleteAfterUpload     (eCAL::pb::rec_server::RecServerConfig& config_pb, bool param);
+        static eCAL::rec::Error setBuiltInClientEnabled  (eCAL::pb::rec_server::RecServerConfig& config_pb, bool param);
+        static eCAL::rec::Error setPreBuffer             (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param);
+        static eCAL::rec::Error setBlacklist             (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param);
+        static eCAL::rec::Error setWhitelist             (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param);
+        static eCAL::rec::Error setMeasRootDir           (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param);
+        static eCAL::rec::Error setMeasName              (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param);
+        static eCAL::rec::Error setMaxFileSize           (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param);
+        static eCAL::rec::Error setDescription           (eCAL::pb::rec_server::RecServerConfig& config_pb, const std::string& param);
+        static eCAL::rec::Error setOneFilePerTopicEnabled(eCAL::pb::rec_server::RecServerConfig& config_pb, bool param);
+
+      //////////////////////////////////////////////
+      /// SetConfig functions (local)
       //////////////////////////////////////////////
       public:
+        // TODO: Fix Uppercase / Lowercase
         static eCAL::rec::Error SetClient           (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::vector<std::string>& param);
         static eCAL::rec::Error SetAddons           (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::vector<std::string>& param);
         static eCAL::rec::Error RemoveClient        (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::vector<std::string>& param);

--- a/app/rec/rec_server_cli/src/commands/set_config.h
+++ b/app/rec/rec_server_cli/src/commands/set_config.h
@@ -33,6 +33,8 @@
 #include <custom_tclap/advanced_tclap_output.h>
 #include <custom_tclap/fuzzy_value_switch_arg_bool.h>
 
+#include <rec_server_core/proto_helpers.h>
+
 namespace eCAL
 {
   namespace rec_cli

--- a/app/rec/rec_server_cli/src/commands/set_config.h
+++ b/app/rec/rec_server_cli/src/commands/set_config.h
@@ -245,7 +245,6 @@ namespace eCAL
       /// SetConfig functions (local)
       //////////////////////////////////////////////
       public:
-        // TODO: Fix Uppercase / Lowercase
         static eCAL::rec::Error SetClient           (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::vector<std::string>& param);
         static eCAL::rec::Error SetAddons           (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::vector<std::string>& param);
         static eCAL::rec::Error RemoveClient        (const std::shared_ptr<eCAL::rec_server::RecServer>& rec_server_instance, const std::vector<std::string>& param);

--- a/app/rec/rec_server_cli/src/ecal_rec_server_cli.cpp
+++ b/app/rec/rec_server_cli/src/ecal_rec_server_cli.cpp
@@ -181,25 +181,25 @@ int main(int argc, char** argv)
   /////////////////////////////////////////////////
   
   // Client management
-  TCLAP::MultiArg<std::string>  set_client_arg     ("", "set-client",    "Sets which hosts shall be recorded by the given client. Use the syntax \"Hostname:Host,To,Record\". For instance, to let PC1 record itself and PC2, use \"PC1:PC1,PC2\". If no tailing list is provided, the client will record topcis from all hosts by default. If a configuration file is being loaded, this will override the setting from the config. Not available in remote-control mode.", false, "Hostname:Hosts,To,Record");
-  TCLAP::MultiArg<std::string>  set_addons_arg     ("", "set-addons",    "Sets the addons that the given client shall enable. Use the syntax \"Hostname:List,Of,Addon,IDs\". You can only set enabled addons for clients that have already been added; i.e. the client will not be added automatically. If no tailing list of addon IDs is provided, all addons will be disabled. If a configuration file is being loaded, this will override the setting from the config. Not available in remote-control mode.",        false, "Hostname:List,Of,Addon,IDs");
+  TCLAP::MultiArg<std::string>  set_client_arg     ("", "set-client",    "Sets which hosts shall be recorded by the given client. Use the syntax \"Hostname:Host,To,Record\". For instance, to let PC1 record itself and PC2, use \"PC1:PC1,PC2\". If no tailing list is provided, the client will record topcis from all hosts by default. If a configuration file is being loaded, this will override the setting from the config.", false, "Hostname:Hosts,To,Record");
+  TCLAP::MultiArg<std::string>  set_addons_arg     ("", "set-addons",    "Sets the addons that the given client shall enable. Use the syntax \"Hostname:List,Of,Addon,IDs\". You can only set enabled addons for clients that have already been added; i.e. the client will not be added automatically. If no tailing list of addon IDs is provided, all addons will be disabled. If a configuration file is being loaded, this will override the setting from the config.",        false, "Hostname:List,Of,Addon,IDs");
   TCLAP::MultiArg<std::string>  remove_client_arg  ("", "remove-client", "Removes the given client. If the client had any addons enabled, those are removed as well. Not available in remote-control mode.",        false, "Hostname");
 
   // Settings args
-  TCLAP::ValueArg<std::string>  pre_buffer_arg     ("b", "pre-buffer",      "Pre-buffer data for some seconds. To turn off pre-buffering, provide a value <= 0.0. If a configuration file is being loaded, this will override the setting from the config. Not available in remote-control mode.", false, "-1.0", "Seconds");
-  TCLAP::ValueArg<std::string>  blacklist_arg      ("",  "blacklist",       "Record all topics except the listed ones (Comma separated list, e.g.: \"Topic1,Topic2\"). If a configuration file is being loaded, this will override the setting from the config. Not available in remote-control mode.", false, "", "List");
-  TCLAP::ValueArg<std::string>  whitelist_arg      ("",  "whitelist",       "Only record these topics (Comma separated list, e.g.: \"Topic1,Topic2\"). If a configuration file is being loaded, this will override the setting from the config. Not available in remote-control mode.", false, "", "List");
+  TCLAP::ValueArg<std::string>  pre_buffer_arg     ("b", "pre-buffer",      "Pre-buffer data for some seconds. To turn off pre-buffering, provide a value <= 0.0. If a configuration file is being loaded, this will override the setting from the config.", false, "-1.0", "Seconds");
+  TCLAP::ValueArg<std::string>  blacklist_arg      ("",  "blacklist",       "Record all topics except the listed ones (Comma separated list, e.g.: \"Topic1,Topic2\"). If a configuration file is being loaded, this will override the setting from the config.", false, "", "List");
+  TCLAP::ValueArg<std::string>  whitelist_arg      ("",  "whitelist",       "Only record these topics (Comma separated list, e.g.: \"Topic1,Topic2\"). If a configuration file is being loaded, this will override the setting from the config.", false, "", "List");
 
   // Job-config args
-  TCLAP::ValueArg<std::string>  meas_root_dir_arg  ("d", "meas-root-dir",   "Root dir used for recording when " + start_recording_arg.toString() + " is set. If a configuration file is being loaded, this will override the setting from the config. Not available in remote-control mode.", false, "", "Path");
-  TCLAP::ValueArg<std::string>  meas_name_arg      ("n", "meas-name",       "Name of the measurement, when " + start_recording_arg.toString() + " is set. This will create a folder in the directory provided by " + meas_root_dir_arg.toString() + ". If a configuration file is being loaded, this will override the setting from the config.  Not available in remote-control mode.",     false, "", "Directory");
-  TCLAP::ValueArg<std::string>  max_file_size_arg  ("",  "max-file-size",   "Maximum file size of the recording files, when " + start_recording_arg.toString() + " is set. If a configuration file is being loaded, this will override the setting from the config. Not available in remote-control mode.", false, "", "megabytes");
-  TCLAP::ValueArg<std::string>  description_arg    ("",  "description",     "Description stored in the measurement folder, when " + start_recording_arg.toString() + " is set. If a configuration file is being loaded, this will override the setting from the config. Not available in remote-control mode.", false, "", "String");
+  TCLAP::ValueArg<std::string>  meas_root_dir_arg  ("d", "meas-root-dir",   "Root dir used for recording when " + start_recording_arg.toString() + " is set. If a configuration file is being loaded, this will override the setting from the config.", false, "", "Path");
+  TCLAP::ValueArg<std::string>  meas_name_arg      ("n", "meas-name",       "Name of the measurement, when " + start_recording_arg.toString() + " is set. This will create a folder in the directory provided by " + meas_root_dir_arg.toString() + ". If a configuration file is being loaded, this will override the setting from the config.",     false, "", "Directory");
+  TCLAP::ValueArg<std::string>  max_file_size_arg  ("",  "max-file-size",   "Maximum file size of the recording files, when " + start_recording_arg.toString() + " is set. If a configuration file is being loaded, this will override the setting from the config.", false, "", "megabytes");
+  TCLAP::ValueArg<std::string>  description_arg    ("",  "description",     "Description stored in the measurement folder, when " + start_recording_arg.toString() + " is set. If a configuration file is being loaded, this will override the setting from the config.", false, "", "String");
   CustomTclap::FuzzyValueSwitchArgBool enable_one_file_per_topic_arg   ("", "enable-one-file-per-topic", "Whether to separate each topic in HDF5 file. This helps faster file transfer and less network congestion in case of interest of specific topics only.", false, false, "yes/no");
 
-  TCLAP::ValueArg<std::string>         ftp_server_arg            ("", "ftp-server",          "The server where to upload to when uploading a measurement. Use \"internal\" for the integrated FTP Server. When using an external FTP Server, provide it in the following form: ftp://USERNAME:PASSWORD@HOSTNAME:PORT/path/to/root_dir. If a configuration file is being loaded, this will override the setting from the config. Not available in remote-control mode.", false, "", "FTP_Server");
-  CustomTclap::FuzzyValueSwitchArgBool delete_after_upload_arg   ("", "delete-after-upload", "Whether to delete the local measurement files after they have been uploaded to an FTP server. If a configuration file is being loaded, this will override the setting from the config. Not available in remote-control mode.", false, false, "yes/no");
-  CustomTclap::FuzzyValueSwitchArgBool enable_built_in_client_arg("", "enable-built-in-client", "Whether the built-in recorder client of the host-application shall be used for recording. If turned off, the host application will rely on the presence of a separate rec-client for localhost recording. If a configuration file is being loaded, this will override the setting from the config. Not available in remote-control mode.", false, false, "yes/no");
+  TCLAP::ValueArg<std::string>         ftp_server_arg            ("", "ftp-server",          "The server where to upload to when uploading a measurement. Use \"internal\" for the integrated FTP Server. When using an external FTP Server, provide it in the following form: ftp://USERNAME:PASSWORD@HOSTNAME:PORT/path/to/root_dir. If a configuration file is being loaded, this will override the setting from the config.", false, "", "FTP_Server");
+  CustomTclap::FuzzyValueSwitchArgBool delete_after_upload_arg   ("", "delete-after-upload", "Whether to delete the local measurement files after they have been uploaded to an FTP server. If a configuration file is being loaded, this will override the setting from the config.", false, false, "yes/no");
+  CustomTclap::FuzzyValueSwitchArgBool enable_built_in_client_arg("", "enable-built-in-client", "Whether the built-in recorder client of the host-application shall be used for recording. If turned off, the host application will rely on the presence of a separate rec-client for localhost recording. If a configuration file is being loaded, this will override the setting from the config.", false, false, "yes/no");
 
   /////////////////////////////////////////////////
   /// Interactive mode
@@ -477,7 +477,7 @@ int main(int argc, char** argv)
       }
       else
       {
-        error = eCAL::rec::Error(eCAL::rec::Error::ErrorCode::COMMAND_NOT_AVAILABLE_IN_REMOTE_MODE, set_client_arg.toString());
+        error = eCAL::rec_cli::command::SetConfig::SetClient(remote_control_host_arg.getValue(), remote_rec_server_service, set_client_arg.getValue());
       }
 
       if (error)
@@ -508,7 +508,7 @@ int main(int argc, char** argv)
       }
       else
       {
-        error = eCAL::rec::Error(eCAL::rec::Error::ErrorCode::COMMAND_NOT_AVAILABLE_IN_REMOTE_MODE, set_addons_arg.toString());
+        error = eCAL::rec_cli::command::SetConfig::SetAddons(remote_control_host_arg.getValue(), remote_rec_server_service, set_addons_arg.getValue());
       }
 
       if (error)
@@ -539,7 +539,7 @@ int main(int argc, char** argv)
       }
       else
       {
-        error = eCAL::rec::Error(eCAL::rec::Error::ErrorCode::COMMAND_NOT_AVAILABLE_IN_REMOTE_MODE, remove_client_arg.toString());
+        error = eCAL::rec_cli::command::SetConfig::RemoveClient(remote_control_host_arg.getValue(), remote_rec_server_service, remove_client_arg.getValue());
       }
 
       if (error)
@@ -570,7 +570,7 @@ int main(int argc, char** argv)
       }
       else
       {
-        error = eCAL::rec::Error(eCAL::rec::Error::ErrorCode::COMMAND_NOT_AVAILABLE_IN_REMOTE_MODE, pre_buffer_arg.toString());
+        error = eCAL::rec_cli::command::SetConfig::setPreBuffer(remote_control_host_arg.getValue(), remote_rec_server_service, pre_buffer_arg.getValue());
       }
 
       if (error)
@@ -601,7 +601,7 @@ int main(int argc, char** argv)
       }
       else
       {
-        error = eCAL::rec::Error(eCAL::rec::Error::ErrorCode::COMMAND_NOT_AVAILABLE_IN_REMOTE_MODE, blacklist_arg.toString());
+        error = eCAL::rec_cli::command::SetConfig::setBlacklist(remote_control_host_arg.getValue(), remote_rec_server_service, blacklist_arg.getValue());
       }
 
       if (error)
@@ -632,7 +632,7 @@ int main(int argc, char** argv)
       }
       else
       {
-        error = eCAL::rec::Error(eCAL::rec::Error::ErrorCode::COMMAND_NOT_AVAILABLE_IN_REMOTE_MODE, whitelist_arg.toString());
+        error = eCAL::rec_cli::command::SetConfig::setWhitelist(remote_control_host_arg.getValue(), remote_rec_server_service, whitelist_arg.getValue());
       }
 
       if (error)
@@ -663,7 +663,7 @@ int main(int argc, char** argv)
       }
       else
       {
-        error = eCAL::rec::Error(eCAL::rec::Error::ErrorCode::COMMAND_NOT_AVAILABLE_IN_REMOTE_MODE, meas_root_dir_arg.toString());
+        error = eCAL::rec_cli::command::SetConfig::setMeasRootDir(remote_control_host_arg.getValue(), remote_rec_server_service, meas_root_dir_arg.getValue());
       }
 
       if (error)
@@ -694,7 +694,7 @@ int main(int argc, char** argv)
       }
       else
       {
-        error = eCAL::rec::Error(eCAL::rec::Error::ErrorCode::COMMAND_NOT_AVAILABLE_IN_REMOTE_MODE, meas_name_arg.toString());
+        error = eCAL::rec_cli::command::SetConfig::setMeasName(remote_control_host_arg.getValue(), remote_rec_server_service, meas_name_arg.getValue());
       }
 
       if (error)
@@ -725,7 +725,7 @@ int main(int argc, char** argv)
       }
       else
       {
-        error = eCAL::rec::Error(eCAL::rec::Error::ErrorCode::COMMAND_NOT_AVAILABLE_IN_REMOTE_MODE, max_file_size_arg.toString());
+        error = eCAL::rec_cli::command::SetConfig::setMaxFileSize(remote_control_host_arg.getValue(), remote_rec_server_service, max_file_size_arg.getValue());
       }
 
       if (error)
@@ -756,7 +756,7 @@ int main(int argc, char** argv)
       }
       else
       {
-        error = eCAL::rec::Error(eCAL::rec::Error::ErrorCode::COMMAND_NOT_AVAILABLE_IN_REMOTE_MODE, description_arg.toString());
+        error = eCAL::rec_cli::command::SetConfig::setDescription(remote_control_host_arg.getValue(), remote_rec_server_service, description_arg.getValue());
       }
 
       if (error)
@@ -787,7 +787,7 @@ int main(int argc, char** argv)
       }
       else
       {
-        error = eCAL::rec::Error(eCAL::rec::Error::ErrorCode::COMMAND_NOT_AVAILABLE_IN_REMOTE_MODE, enable_one_file_per_topic_arg.toString());
+        error = eCAL::rec_cli::command::SetConfig::setOneFilePerTopicEnabled(remote_control_host_arg.getValue(), remote_rec_server_service, enable_one_file_per_topic_arg.getValue());
       }
 
       if (error)
@@ -820,7 +820,7 @@ int main(int argc, char** argv)
       }
       else
       {
-        error = eCAL::rec::Error(eCAL::rec::Error::ErrorCode::COMMAND_NOT_AVAILABLE_IN_REMOTE_MODE, ftp_server_arg.toString());
+        error = eCAL::rec_cli::command::SetConfig::setFtpServer(remote_control_host_arg.getValue(), remote_rec_server_service, ftp_server_arg.getValue());
       }
 
       if (error)
@@ -851,7 +851,7 @@ int main(int argc, char** argv)
       }
       else
       {
-        error = eCAL::rec::Error(eCAL::rec::Error::ErrorCode::COMMAND_NOT_AVAILABLE_IN_REMOTE_MODE, delete_after_upload_arg.toString());
+        error = eCAL::rec_cli::command::SetConfig::setDeleteAfterUpload(remote_control_host_arg.getValue(), remote_rec_server_service, delete_after_upload_arg.getValue());
       }
 
       if (error)

--- a/app/rec/rec_server_cli/src/ecal_rec_server_cli.cpp
+++ b/app/rec/rec_server_cli/src/ecal_rec_server_cli.cpp
@@ -566,11 +566,11 @@ int main(int argc, char** argv)
       eCAL::rec::Error error(eCAL::rec::Error::ErrorCode::GENERIC_ERROR);
       if (rec_server_instance)
       {
-        error = eCAL::rec_cli::command::SetConfig::setPreBuffer(rec_server_instance, pre_buffer_arg.getValue());
+        error = eCAL::rec_cli::command::SetConfig::SetPreBuffer(rec_server_instance, pre_buffer_arg.getValue());
       }
       else
       {
-        error = eCAL::rec_cli::command::SetConfig::setPreBuffer(remote_control_host_arg.getValue(), remote_rec_server_service, pre_buffer_arg.getValue());
+        error = eCAL::rec_cli::command::SetConfig::SetPreBuffer(remote_control_host_arg.getValue(), remote_rec_server_service, pre_buffer_arg.getValue());
       }
 
       if (error)
@@ -597,11 +597,11 @@ int main(int argc, char** argv)
       eCAL::rec::Error error(eCAL::rec::Error::ErrorCode::GENERIC_ERROR);
       if (rec_server_instance)
       {
-        error = eCAL::rec_cli::command::SetConfig::setBlacklist(rec_server_instance, blacklist_arg.getValue());
+        error = eCAL::rec_cli::command::SetConfig::SetBlacklist(rec_server_instance, blacklist_arg.getValue());
       }
       else
       {
-        error = eCAL::rec_cli::command::SetConfig::setBlacklist(remote_control_host_arg.getValue(), remote_rec_server_service, blacklist_arg.getValue());
+        error = eCAL::rec_cli::command::SetConfig::SetBlacklist(remote_control_host_arg.getValue(), remote_rec_server_service, blacklist_arg.getValue());
       }
 
       if (error)
@@ -628,11 +628,11 @@ int main(int argc, char** argv)
       eCAL::rec::Error error(eCAL::rec::Error::ErrorCode::GENERIC_ERROR);
       if (rec_server_instance)
       {
-        error = eCAL::rec_cli::command::SetConfig::setWhitelist(rec_server_instance, whitelist_arg.getValue());
+        error = eCAL::rec_cli::command::SetConfig::SetWhitelist(rec_server_instance, whitelist_arg.getValue());
       }
       else
       {
-        error = eCAL::rec_cli::command::SetConfig::setWhitelist(remote_control_host_arg.getValue(), remote_rec_server_service, whitelist_arg.getValue());
+        error = eCAL::rec_cli::command::SetConfig::SetWhitelist(remote_control_host_arg.getValue(), remote_rec_server_service, whitelist_arg.getValue());
       }
 
       if (error)
@@ -659,11 +659,11 @@ int main(int argc, char** argv)
       eCAL::rec::Error error(eCAL::rec::Error::ErrorCode::GENERIC_ERROR);
       if (rec_server_instance)
       {
-        error = eCAL::rec_cli::command::SetConfig::setMeasRootDir(rec_server_instance, meas_root_dir_arg.getValue());
+        error = eCAL::rec_cli::command::SetConfig::SetMeasRootDir(rec_server_instance, meas_root_dir_arg.getValue());
       }
       else
       {
-        error = eCAL::rec_cli::command::SetConfig::setMeasRootDir(remote_control_host_arg.getValue(), remote_rec_server_service, meas_root_dir_arg.getValue());
+        error = eCAL::rec_cli::command::SetConfig::SetMeasRootDir(remote_control_host_arg.getValue(), remote_rec_server_service, meas_root_dir_arg.getValue());
       }
 
       if (error)
@@ -690,11 +690,11 @@ int main(int argc, char** argv)
       eCAL::rec::Error error(eCAL::rec::Error::ErrorCode::GENERIC_ERROR);
       if (rec_server_instance)
       {
-        error = eCAL::rec_cli::command::SetConfig::setMeasName(rec_server_instance, meas_name_arg.getValue());
+        error = eCAL::rec_cli::command::SetConfig::SetMeasName(rec_server_instance, meas_name_arg.getValue());
       }
       else
       {
-        error = eCAL::rec_cli::command::SetConfig::setMeasName(remote_control_host_arg.getValue(), remote_rec_server_service, meas_name_arg.getValue());
+        error = eCAL::rec_cli::command::SetConfig::SetMeasName(remote_control_host_arg.getValue(), remote_rec_server_service, meas_name_arg.getValue());
       }
 
       if (error)
@@ -721,11 +721,11 @@ int main(int argc, char** argv)
       eCAL::rec::Error error(eCAL::rec::Error::ErrorCode::GENERIC_ERROR);
       if (rec_server_instance)
       {
-        error = eCAL::rec_cli::command::SetConfig::setMaxFileSize(rec_server_instance, max_file_size_arg.getValue());
+        error = eCAL::rec_cli::command::SetConfig::SetMaxFileSize(rec_server_instance, max_file_size_arg.getValue());
       }
       else
       {
-        error = eCAL::rec_cli::command::SetConfig::setMaxFileSize(remote_control_host_arg.getValue(), remote_rec_server_service, max_file_size_arg.getValue());
+        error = eCAL::rec_cli::command::SetConfig::SetMaxFileSize(remote_control_host_arg.getValue(), remote_rec_server_service, max_file_size_arg.getValue());
       }
 
       if (error)
@@ -752,11 +752,11 @@ int main(int argc, char** argv)
       eCAL::rec::Error error(eCAL::rec::Error::ErrorCode::GENERIC_ERROR);
       if (rec_server_instance)
       {
-        error = eCAL::rec_cli::command::SetConfig::setDescription(rec_server_instance, description_arg.getValue());
+        error = eCAL::rec_cli::command::SetConfig::SetDescription(rec_server_instance, description_arg.getValue());
       }
       else
       {
-        error = eCAL::rec_cli::command::SetConfig::setDescription(remote_control_host_arg.getValue(), remote_rec_server_service, description_arg.getValue());
+        error = eCAL::rec_cli::command::SetConfig::SetDescription(remote_control_host_arg.getValue(), remote_rec_server_service, description_arg.getValue());
       }
 
       if (error)
@@ -783,11 +783,11 @@ int main(int argc, char** argv)
       eCAL::rec::Error error(eCAL::rec::Error::ErrorCode::GENERIC_ERROR);
       if (rec_server_instance)
       {
-        error = eCAL::rec_cli::command::SetConfig::setOneFilePerTopicEnabled(rec_server_instance, enable_one_file_per_topic_arg.getValue());
+        error = eCAL::rec_cli::command::SetConfig::SetOneFilePerTopicEnabled(rec_server_instance, enable_one_file_per_topic_arg.getValue());
       }
       else
       {
-        error = eCAL::rec_cli::command::SetConfig::setOneFilePerTopicEnabled(remote_control_host_arg.getValue(), remote_rec_server_service, enable_one_file_per_topic_arg.getValue());
+        error = eCAL::rec_cli::command::SetConfig::SetOneFilePerTopicEnabled(remote_control_host_arg.getValue(), remote_rec_server_service, enable_one_file_per_topic_arg.getValue());
       }
 
       if (error)
@@ -816,11 +816,11 @@ int main(int argc, char** argv)
       eCAL::rec::Error error(eCAL::rec::Error::ErrorCode::GENERIC_ERROR);
       if (rec_server_instance)
       {
-        error = eCAL::rec_cli::command::SetConfig::setFtpServer(rec_server_instance, ftp_server_arg.getValue());
+        error = eCAL::rec_cli::command::SetConfig::SetFtpServer(rec_server_instance, ftp_server_arg.getValue());
       }
       else
       {
-        error = eCAL::rec_cli::command::SetConfig::setFtpServer(remote_control_host_arg.getValue(), remote_rec_server_service, ftp_server_arg.getValue());
+        error = eCAL::rec_cli::command::SetConfig::SetFtpServer(remote_control_host_arg.getValue(), remote_rec_server_service, ftp_server_arg.getValue());
       }
 
       if (error)
@@ -847,11 +847,11 @@ int main(int argc, char** argv)
       eCAL::rec::Error error(eCAL::rec::Error::ErrorCode::GENERIC_ERROR);
       if (rec_server_instance)
       {
-        error = eCAL::rec_cli::command::SetConfig::setDeleteAfterUpload(rec_server_instance, delete_after_upload_arg.getValue());
+        error = eCAL::rec_cli::command::SetConfig::SetDeleteAfterUpload(rec_server_instance, delete_after_upload_arg.getValue());
       }
       else
       {
-        error = eCAL::rec_cli::command::SetConfig::setDeleteAfterUpload(remote_control_host_arg.getValue(), remote_rec_server_service, delete_after_upload_arg.getValue());
+        error = eCAL::rec_cli::command::SetConfig::SetDeleteAfterUpload(remote_control_host_arg.getValue(), remote_rec_server_service, delete_after_upload_arg.getValue());
       }
 
       if (error)

--- a/app/rec/rec_server_cli/src/rec_server_service.cpp
+++ b/app/rec/rec_server_cli/src/rec_server_service.cpp
@@ -368,5 +368,27 @@ namespace eCAL
 
       eCAL::rec_server::proto_helpers::ToProtobuf(config, *response);
     }
+
+    void RecServerService::SetConfig(::google::protobuf::RpcController*                /*controller*/
+                                      , const ::eCAL::pb::rec_server::RecServerConfig* request
+                                      , ::eCAL::pb::rec_server::ServiceResult*         response
+                                      , ::google::protobuf::Closure*                   /*done*/)
+    {
+      eCAL::rec_server::RecServerConfig config = eCAL::rec_server::proto_helpers::FromProtobuf(*request);
+      
+      eCAL::rec::Error error = eCAL::rec::Error::GENERIC_ERROR;
+      error = rec_server_instance_->SetConfig(config);
+
+      if (!error)
+      {
+        response->set_error_code(eCAL::pb::rec_server::ServiceResult::ErrorCode::ServiceResult_ErrorCode_no_error);
+        response->set_info_message("Successfully set config");
+      }
+      else
+      {
+        response->set_error_code(eCAL::pb::rec_server::ServiceResult::ErrorCode::ServiceResult_ErrorCode_error_internal);
+        response->set_info_message(error.ToString());
+      }
+    }
   }
 }

--- a/app/rec/rec_server_cli/src/rec_server_service.cpp
+++ b/app/rec/rec_server_cli/src/rec_server_service.cpp
@@ -374,10 +374,9 @@ namespace eCAL
                                       , ::eCAL::pb::rec_server::ServiceResult*         response
                                       , ::google::protobuf::Closure*                   /*done*/)
     {
-      eCAL::rec_server::RecServerConfig config = eCAL::rec_server::proto_helpers::FromProtobuf(*request);
+      const eCAL::rec_server::RecServerConfig config = eCAL::rec_server::proto_helpers::FromProtobuf(*request);
       
-      eCAL::rec::Error error = eCAL::rec::Error::GENERIC_ERROR;
-      error = rec_server_instance_->SetConfig(config);
+      const eCAL::rec::Error error = rec_server_instance_->SetConfig(config);
 
       if (!error)
       {

--- a/app/rec/rec_server_cli/src/rec_server_service.h
+++ b/app/rec/rec_server_cli/src/rec_server_service.h
@@ -98,6 +98,11 @@ namespace eCAL
                                 , ::eCAL::pb::rec_server::RecServerConfig*      response
                                 , ::google::protobuf::Closure*                  done) override;
 
+      virtual void SetConfig(::google::protobuf::RpcController*                  controller
+                                , const ::eCAL::pb::rec_server::RecServerConfig* request
+                                , ::eCAL::pb::rec_server::ServiceResult*         response
+                                , ::google::protobuf::Closure*                   done) override;
+
     private:
       const std::shared_ptr<eCAL::rec_server::RecServer> rec_server_instance_;
     };

--- a/app/rec/rec_server_core/include/rec_server_core/rec_server.h
+++ b/app/rec/rec_server_core/include/rec_server_core/rec_server.h
@@ -178,6 +178,7 @@ namespace eCAL
     public:
 
       RecServerConfig GetConfig() const;
+      eCAL::rec::Error SetConfig(const RecServerConfig& config);
 
       bool ClearConfig();
       bool SaveConfigToFile(const std::string& path) const;

--- a/app/rec/rec_server_core/include/rec_server_core/rec_server_config.h
+++ b/app/rec/rec_server_core/include/rec_server_core/rec_server_config.h
@@ -63,6 +63,12 @@ namespace eCAL
       std::set<std::string> enabled_addons_;
     };
 
+    inline bool operator==(const ClientConfig& lhs, const ClientConfig& rhs)
+    {
+      return (lhs.host_filter_ == rhs.host_filter_)
+        && (lhs.enabled_addons_ == rhs.enabled_addons_);
+    }
+
     struct RecServerConfig
     {
       RecServerConfig()
@@ -94,4 +100,5 @@ namespace eCAL
       UploadConfig                        upload_config_;
     };
   }
+
 }

--- a/app/rec/rec_server_core/include/rec_server_core/rec_server_config.h
+++ b/app/rec/rec_server_core/include/rec_server_core/rec_server_config.h
@@ -63,12 +63,6 @@ namespace eCAL
       std::set<std::string> enabled_addons_;
     };
 
-    inline bool operator==(const ClientConfig& lhs, const ClientConfig& rhs)
-    {
-      return (lhs.host_filter_ == rhs.host_filter_)
-        && (lhs.enabled_addons_ == rhs.enabled_addons_);
-    }
-
     struct RecServerConfig
     {
       RecServerConfig()
@@ -99,6 +93,58 @@ namespace eCAL
       std::set<std::string>               listed_topics_;
       UploadConfig                        upload_config_;
     };
+
+    ////////////////////////////////////
+    // Operators
+    ////////////////////////////////////
+
+    inline bool operator==(const UploadConfig& lhs, const UploadConfig& rhs)
+    {
+      return  (lhs.type_                == rhs.type_) &&
+              (lhs.host_                == rhs.host_) &&
+              (lhs.port_                == rhs.port_) &&
+              (lhs.username_            == rhs.username_) &&
+              (lhs.password_            == rhs.password_) &&
+              (lhs.root_path_           == rhs.root_path_) &&
+              (lhs.delete_after_upload_ == rhs.delete_after_upload_);
+    }
+
+    inline bool operator==(const ClientConfig& lhs, const ClientConfig& rhs)
+    {
+      return (lhs.host_filter_  == rhs.host_filter_)
+        && (lhs.enabled_addons_ == rhs.enabled_addons_);
+    }
+
+    inline bool operator==(const RecServerConfig& lhs, const RecServerConfig& rhs)
+    {
+      return  (lhs.root_dir_                  == rhs.root_dir_) &&
+              (lhs.meas_name_                 == rhs.meas_name_) &&
+              (lhs.max_file_size_             == rhs.max_file_size_) &&
+              (lhs.one_file_per_topic_        == rhs.one_file_per_topic_) &&
+              (lhs.description_               == rhs.description_) &&
+              (lhs.enabled_clients_config_    == rhs.enabled_clients_config_) &&
+              (lhs.pre_buffer_enabled_        == rhs.pre_buffer_enabled_) &&
+              (lhs.pre_buffer_length_         == rhs.pre_buffer_length_) &&
+              (lhs.built_in_recorder_enabled_ == rhs.built_in_recorder_enabled_) &&
+              (lhs.record_mode_               == rhs.record_mode_) &&
+              (lhs.listed_topics_             == rhs.listed_topics_) &&
+              (lhs.upload_config_             == rhs.upload_config_);
+    }
+
+    inline bool operator!=(const UploadConfig& lhs, const UploadConfig& rhs)
+    {
+      return !(lhs == rhs);
+    }
+
+    inline bool operator!=(const ClientConfig& lhs, const ClientConfig& rhs)
+    {
+      return !(lhs == rhs);
+    }
+
+    inline bool operator!=(const RecServerConfig& lhs, const RecServerConfig& rhs)
+    {
+      return !(lhs == rhs);
+    }
   }
 
 }

--- a/app/rec/rec_server_core/src/config/config.cpp
+++ b/app/rec/rec_server_core/src/config/config.cpp
@@ -109,7 +109,7 @@ namespace eCAL
           if (config_elements.find(v) != config_elements.end())
           {
             // Load config
-            auto error = rec_server.SetConfig(config_v2to4::readConfig(config_elements[v]));
+            const auto error = rec_server.SetConfig(config_v2to4::readConfig(config_elements[v]));
             if (!error && (version != nullptr))
             {
               (*version) = v;

--- a/app/rec/rec_server_core/src/config/config.cpp
+++ b/app/rec/rec_server_core/src/config/config.cpp
@@ -36,29 +36,6 @@ namespace eCAL
   {
     namespace config
     {
-      bool applyConfig(const eCAL::rec_server::RecServerConfig& config, eCAL::rec_server::RecServerImpl& rec_server)
-      {
-        // Set settings that can fail
-        if (!rec_server.SetEnabledRecClients            (config.enabled_clients_config_)
-           || !rec_server.SetUsingBuiltInRecorderEnabled(config.built_in_recorder_enabled_)
-           || !rec_server.SetRecordMode                 (config.record_mode_, config.listed_topics_))
-        {
-          return false;
-        }
-
-        // Set settings that cannot fail
-        rec_server.SetMeasRootDir             (config.root_dir_);
-        rec_server.SetMeasName                (config.meas_name_);
-        rec_server.SetMaxFileSizeMib          (config.max_file_size_);
-        rec_server.SetDescription             (config.description_);
-        rec_server.SetOneFilePerTopicEnabled  (config.one_file_per_topic_);
-        rec_server.SetPreBufferingEnabled     (config.pre_buffer_enabled_);
-        rec_server.SetMaxPreBufferLength      (config.pre_buffer_length_);
-        rec_server.SetUploadConfig            (config.upload_config_);
-
-        return true;
-      }
-
       bool writeConfigToFile(const eCAL::rec_server::RecServerImpl& rec_server, const std::string& path)
       {
         return config_v2to4::writeConfigFile(rec_server, path);
@@ -132,12 +109,12 @@ namespace eCAL
           if (config_elements.find(v) != config_elements.end())
           {
             // Load config
-            bool success = applyConfig(config_v2to4::readConfig(config_elements[v]), rec_server);
-            if (success && (version != nullptr))
+            auto error = rec_server.SetConfig(config_v2to4::readConfig(config_elements[v]));
+            if (!error && (version != nullptr))
             {
               (*version) = v;
             }
-            return success;
+            return !error;
           }
         }
 
@@ -147,24 +124,24 @@ namespace eCAL
           {
             if (version_config_pair.first > NATIVE_CONFIG_VERSION)
             {
-              bool success = applyConfig(config_v2to4::readConfig(version_config_pair.second), rec_server);
-              if (success && (version != nullptr))
+              auto error = rec_server.SetConfig(config_v2to4::readConfig(version_config_pair.second));
+              if (!error && (version != nullptr))
               {
                 (*version) = version_config_pair.first;
               }
-              return success;
+              return !error;
             }
           }
 
           // Load an un-versioned config
           if (config_elements.find(0) != config_elements.end())
           {
-            bool success = applyConfig(config_v2to4::readConfig(config_elements[0]), rec_server);
-            if (success && (version != nullptr))
+            auto error = rec_server.SetConfig(config_v2to4::readConfig(config_elements[0]));
+            if (!error && (version != nullptr))
             {
               (*version) = 0;
             }
-            return success;
+            return !error;
           }
         }
 

--- a/app/rec/rec_server_core/src/config/config.cpp
+++ b/app/rec/rec_server_core/src/config/config.cpp
@@ -124,7 +124,7 @@ namespace eCAL
           {
             if (version_config_pair.first > NATIVE_CONFIG_VERSION)
             {
-              auto error = rec_server.SetConfig(config_v2to4::readConfig(version_config_pair.second));
+              const auto error = rec_server.SetConfig(config_v2to4::readConfig(version_config_pair.second));
               if (!error && (version != nullptr))
               {
                 (*version) = version_config_pair.first;
@@ -136,7 +136,7 @@ namespace eCAL
           // Load an un-versioned config
           if (config_elements.find(0) != config_elements.end())
           {
-            auto error = rec_server.SetConfig(config_v2to4::readConfig(config_elements[0]));
+            const auto error = rec_server.SetConfig(config_v2to4::readConfig(config_elements[0]));
             if (!error && (version != nullptr))
             {
               (*version) = 0;

--- a/app/rec/rec_server_core/src/rec_server.cpp
+++ b/app/rec/rec_server_core/src/rec_server.cpp
@@ -99,7 +99,7 @@ namespace eCAL
     std::string  RecServer::GetMeasRootDir   () const                   { return rec_server_impl_->GetMeasRootDir(); } 
     std::string  RecServer::GetMeasName      () const                   { return rec_server_impl_->GetMeasName(); }
     int64_t      RecServer::GetMaxFileSizeMib() const                   { return rec_server_impl_->GetMaxFileSizeMib(); }
-    bool         RecServer::GetOneFilePerTopicEnabled() const                   { return rec_server_impl_->GetOneFilePerTopicEnabled(); }
+    bool         RecServer::GetOneFilePerTopicEnabled() const           { return rec_server_impl_->GetOneFilePerTopicEnabled(); }
     std::string  RecServer::GetDescription   () const                   { return rec_server_impl_->GetDescription(); }
 
     ////////////////////////////////////
@@ -144,14 +144,16 @@ namespace eCAL
     // Config Save / Load / Get
     ////////////////////////////////////
     
-    RecServerConfig RecServer::GetConfig() const                      { return rec_server_impl_->GetConfig(); }
+    RecServerConfig RecServer::GetConfig() const                         { return rec_server_impl_->GetConfig(); }
+    eCAL::rec::Error RecServer::SetConfig(const RecServerConfig& config) { return rec_server_impl_->SetConfig(config); }
 
-    bool RecServer::ClearConfig       ()                              { return rec_server_impl_->ClearConfig(); }
-    bool RecServer::SaveConfigToFile  (const std::string& path) const { return rec_server_impl_->SaveConfigToFile(path); }
-    bool RecServer::LoadConfigFromFile(const std::string& path)       { return rec_server_impl_->LoadConfigFromFile(path); }
 
-    std::string RecServer::GetLoadedConfigPath() const                { return rec_server_impl_->GetLoadedConfigPath(); }
-    int RecServer::GetLoadedConfigVersion() const                     { return rec_server_impl_->GetLoadedConfigVersion(); }
-    int RecServer::GetNativeConfigVersion() const                     { return rec_server_impl_->GetNativeConfigVersion(); }
+    bool RecServer::ClearConfig       ()                                 { return rec_server_impl_->ClearConfig(); }
+    bool RecServer::SaveConfigToFile  (const std::string& path) const    { return rec_server_impl_->SaveConfigToFile(path); }
+    bool RecServer::LoadConfigFromFile(const std::string& path)          { return rec_server_impl_->LoadConfigFromFile(path); }
+    
+    std::string RecServer::GetLoadedConfigPath() const                   { return rec_server_impl_->GetLoadedConfigPath(); }
+    int RecServer::GetLoadedConfigVersion() const                        { return rec_server_impl_->GetLoadedConfigVersion(); }
+    int RecServer::GetNativeConfigVersion() const                        { return rec_server_impl_->GetNativeConfigVersion(); }
   }
 }

--- a/app/rec/rec_server_core/src/rec_server_impl.cpp
+++ b/app/rec/rec_server_core/src/rec_server_impl.cpp
@@ -1879,6 +1879,61 @@ namespace eCAL
       return config;
     }
 
+    eCAL::rec::Error RecServerImpl::SetConfig(const RecServerConfig& config)
+    {
+      // Set settings that can fail
+      {
+        auto current_enabled_clients_config = GetEnabledRecClients();
+        if (current_enabled_clients_config != config.enabled_clients_config_)
+        {
+          if (recording_)
+            return eCAL::rec::Error(eCAL::rec::Error::CURRENTLY_RECORDING, "Cannot enable / disable rec clients while recording");
+
+          if (!SetEnabledRecClients(config.enabled_clients_config_))
+            return eCAL::rec::Error(eCAL::rec::Error::ErrorCode::GENERIC_ERROR, "Failed enabling / disabling rec clients");
+        }
+      }
+
+      {
+        auto current_built_in_recorder_enabled_ = IsUsingBuiltInRecorderEnabled();
+        if (current_built_in_recorder_enabled_ != config.built_in_recorder_enabled_)
+        {
+          if (recording_)
+            return eCAL::rec::Error(eCAL::rec::Error::CURRENTLY_RECORDING, "Cannot switch between built-in and external local recorder while recording");
+
+          if (!SetUsingBuiltInRecorderEnabled(config.built_in_recorder_enabled_))
+            return eCAL::rec::Error(eCAL::rec::Error::ErrorCode::GENERIC_ERROR, "Failed switch between built-in and external local recorder while recording");
+        }
+      }
+
+      {
+        auto current_record_mode   = GetRecordMode();
+        auto current_listed_topics = GetListedTopics();
+
+        if ((current_record_mode != config.record_mode_)
+          || (current_listed_topics != config.listed_topics_))
+        {
+          if (recording_)
+            return eCAL::rec::Error(eCAL::rec::Error::CURRENTLY_RECORDING, "Cannot set the record mode while recording");
+
+          if (!SetRecordMode(config.record_mode_, config.listed_topics_))
+            return eCAL::rec::Error(eCAL::rec::Error::ErrorCode::GENERIC_ERROR, "Failed setting the record mode");
+        }
+      }
+
+      // Set settings that cannot fail
+      SetMeasRootDir             (config.root_dir_);
+      SetMeasName                (config.meas_name_);
+      SetMaxFileSizeMib          (config.max_file_size_);
+      SetDescription             (config.description_);
+      SetOneFilePerTopicEnabled  (config.one_file_per_topic_);
+      SetPreBufferingEnabled     (config.pre_buffer_enabled_);
+      SetMaxPreBufferLength      (config.pre_buffer_length_);
+      SetUploadConfig            (config.upload_config_);
+
+      return eCAL::rec::Error::OK;
+    }
+
     bool RecServerImpl::ClearConfig()
     {
       if (recording_)

--- a/app/rec/rec_server_core/src/rec_server_impl.cpp
+++ b/app/rec/rec_server_core/src/rec_server_impl.cpp
@@ -1883,7 +1883,7 @@ namespace eCAL
     {
       // Set settings that can fail
       {
-        auto current_enabled_clients_config = GetEnabledRecClients();
+        const auto current_enabled_clients_config = GetEnabledRecClients();
         if (current_enabled_clients_config != config.enabled_clients_config_)
         {
           if (recording_)
@@ -1895,7 +1895,7 @@ namespace eCAL
       }
 
       {
-        auto current_built_in_recorder_enabled_ = IsUsingBuiltInRecorderEnabled();
+        const auto current_built_in_recorder_enabled_ = IsUsingBuiltInRecorderEnabled();
         if (current_built_in_recorder_enabled_ != config.built_in_recorder_enabled_)
         {
           if (recording_)
@@ -1907,8 +1907,8 @@ namespace eCAL
       }
 
       {
-        auto current_record_mode   = GetRecordMode();
-        auto current_listed_topics = GetListedTopics();
+        const auto current_record_mode   = GetRecordMode();
+        const auto current_listed_topics = GetListedTopics();
 
         if ((current_record_mode != config.record_mode_)
           || (current_listed_topics != config.listed_topics_))

--- a/app/rec/rec_server_core/src/rec_server_impl.h
+++ b/app/rec/rec_server_core/src/rec_server_impl.h
@@ -221,6 +221,7 @@ namespace eCAL
     ////////////////////////////////////
     public:
       RecServerConfig GetConfig() const;
+      eCAL::rec::Error SetConfig(const RecServerConfig& config);
 
       bool ClearConfig();
       bool SaveConfigToFile(const std::string& path);

--- a/app/rec/rec_tests/rec_rpc_tests/CMakeLists.txt
+++ b/app/rec/rec_tests/rec_rpc_tests/CMakeLists.txt
@@ -1,0 +1,59 @@
+# ========================= eCAL LICENSE =================================
+#
+# Copyright (C) 2016 - 2019 Continental Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ========================= eCAL LICENSE =================================
+
+project(rec_rpc_tests)
+
+find_package(Threads REQUIRED)
+find_package(GTest REQUIRED)
+
+set(source_files
+  src/rec_cli_test.cpp
+  src/external_ecal_rec.cpp
+  src/external_ecal_rec.h
+)
+
+source_group(
+    TREE
+        ${CMAKE_CURRENT_LIST_DIR}
+    FILES
+        ${source_files}
+)
+
+ecal_add_gtest(${PROJECT_NAME} ${source_files})
+
+target_compile_definitions(${PROJECT_NAME}
+    PRIVATE ECAL_REC_CLI_PATH="$<TARGET_FILE:rec>"
+    PRIVATE ECAL_REC_GUI_PATH="$<TARGET_FILE:rec_gui>"
+)
+
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    eCAL::core
+    Threads::Threads
+    eCAL::rec_server_core
+)
+
+# Depend on the Rec CLI to make sure it is already built
+add_dependencies(${PROJECT_NAME}
+  rec
+  rec_gui
+)
+
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
+
+set_property(TARGET ${PROJECT_NAME} PROPERTY FOLDER app/rec/rec_tests/)

--- a/app/rec/rec_tests/rec_rpc_tests/src/external_ecal_rec.cpp
+++ b/app/rec/rec_tests/rec_rpc_tests/src/external_ecal_rec.cpp
@@ -27,6 +27,7 @@
 
 #include <string>
 #include <iostream>
+#include <thread>
 
 ///////////////////////////////////////////////
 // Constructor, destructor etc.

--- a/app/rec/rec_tests/rec_rpc_tests/src/external_ecal_rec.cpp
+++ b/app/rec/rec_tests/rec_rpc_tests/src/external_ecal_rec.cpp
@@ -1,0 +1,147 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+#include "external_ecal_rec.h"
+
+#include <rec_server_core/proto_helpers.h>
+
+#include <ecal/ecal.h>
+#include <ecal/msg/protobuf/client.h>
+#include <ecal/msg/protobuf/server.h>
+
+#include <string>
+#include <iostream>
+
+///////////////////////////////////////////////
+// Constructor, destructor etc.
+///////////////////////////////////////////////
+
+ExternalEcalRecInstance::ExternalEcalRecInstance(bool gui)
+  : pid(0)
+{
+  ecal_rec_cli_instance_lock.lock();
+
+  eCAL::Initialize({}, "Ecal Rec Tester");
+  
+  remote_rec_server_service = std::make_shared<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>>();
+  remote_rec_server_service->SetHostName(eCAL::Process::GetHostName());
+
+  if (gui)
+  {
+    std::cout << "Starting " << "\"" << ECAL_REC_GUI_PATH << "\"" << std::endl;
+    pid = eCAL::Process::StartProcess(("\"" + std::string(ECAL_REC_GUI_PATH) + "\"").c_str(), "", "", false, eCAL_Process_eStartMode::proc_smode_minimized, false);
+  }
+  else
+  {
+    std::cout << "Starting " << "\"" << ECAL_REC_CLI_PATH << "\"" << std::endl;
+    pid = eCAL::Process::StartProcess(("\"" + std::string(ECAL_REC_CLI_PATH) + "\"").c_str(), "--interactive-dont-exit --no-default", "", false, eCAL_Process_eStartMode::proc_smode_hidden, false);
+  }
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+
+  if (gui)
+  {
+    SetConfigViaRpc(eCAL::rec_server::RecServerConfig());
+  }
+}
+
+
+ExternalEcalRecInstance::~ExternalEcalRecInstance()
+{
+  if (pid > 0)
+    eCAL::Process::StopProcess(pid);
+  eCAL::Finalize();
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  ecal_rec_cli_instance_lock.unlock();
+}
+
+///////////////////////////////////////////////
+// RPC Wrappers
+///////////////////////////////////////////////
+
+eCAL::rec::Error ExternalEcalRecInstance::GetConfigViaRpc(eCAL::rec_server::RecServerConfig& config_output)
+{
+  eCAL::pb::rec_server::RecServerConfig config_pb;
+  
+  {
+    auto error = GetConfigViaRpc(config_pb);
+    if (error)
+    {
+      std::cerr << error.ToString() << std::endl;
+      return error;
+    }
+  }
+
+  eCAL::rec_server::proto_helpers::FromProtobuf(config_pb, config_output);
+
+  return eCAL::rec::Error::OK;
+}
+
+eCAL::rec::Error ExternalEcalRecInstance::GetConfigViaRpc(eCAL::pb::rec_server::RecServerConfig& config_pb_output)
+{
+  eCAL::pb::rec_server::GenericRequest request;
+  eCAL::ServiceResponseVecT            service_response_vec;
+
+  constexpr int timeout_ms = 1000;
+
+  if (remote_rec_server_service->Call("GetConfig", request.SerializeAsString(), timeout_ms, &service_response_vec))
+  {
+    if (service_response_vec.size() > 0)
+    {
+      config_pb_output.ParseFromString(service_response_vec[0].response);
+      return eCAL::rec::Error::ErrorCode::OK;
+    }
+  }
+  return eCAL::rec::Error(eCAL::rec::Error::ErrorCode::REMOTE_HOST_UNAVAILABLE);
+}
+
+
+eCAL::rec::Error ExternalEcalRecInstance::SetConfigViaRpc(const eCAL::rec_server::RecServerConfig& config)
+{
+  return SetConfigViaRpc(eCAL::rec_server::proto_helpers::ToProtobuf(config));
+}
+
+eCAL::rec::Error ExternalEcalRecInstance::SetConfigViaRpc(const eCAL::pb::rec_server::RecServerConfig& config_pb)
+{
+  eCAL::ServiceResponseVecT service_response_vec;
+
+  constexpr int timeout_ms = 1000;
+
+  if (remote_rec_server_service->Call("SetConfig", config_pb.SerializeAsString(), timeout_ms, &service_response_vec))
+  {
+    if (service_response_vec.size() > 0)
+    {
+      eCAL::pb::rec_server::ServiceResult response_pb;
+
+      response_pb.ParseFromString(service_response_vec[0].response);
+
+      if (response_pb.error_code() != eCAL::pb::rec_server::ServiceResult_ErrorCode_no_error)
+      {
+        return eCAL::rec::Error(eCAL::rec::Error::ErrorCode::GENERIC_ERROR, response_pb.info_message());
+      }
+      else
+      {
+        return eCAL::rec::Error::ErrorCode::OK;
+      }
+    }
+  }
+
+  return eCAL::rec::Error(eCAL::rec::Error::ErrorCode::REMOTE_HOST_UNAVAILABLE);
+}

--- a/app/rec/rec_tests/rec_rpc_tests/src/external_ecal_rec.cpp
+++ b/app/rec/rec_tests/rec_rpc_tests/src/external_ecal_rec.cpp
@@ -46,12 +46,12 @@ ExternalEcalRecInstance::ExternalEcalRecInstance(bool gui)
   if (gui)
   {
     std::cout << "Starting " << "\"" << ECAL_REC_GUI_PATH << "\"" << std::endl;
-    pid = eCAL::Process::StartProcess(("\"" + std::string(ECAL_REC_GUI_PATH) + "\"").c_str(), "", "", false, eCAL_Process_eStartMode::proc_smode_minimized, false);
+    pid = eCAL::Process::StartProcess(ECAL_REC_GUI_PATH, "", "", false, eCAL_Process_eStartMode::proc_smode_minimized, false);
   }
   else
   {
     std::cout << "Starting " << "\"" << ECAL_REC_CLI_PATH << "\"" << std::endl;
-    pid = eCAL::Process::StartProcess(("\"" + std::string(ECAL_REC_CLI_PATH) + "\"").c_str(), "--interactive-dont-exit --no-default", "", false, eCAL_Process_eStartMode::proc_smode_hidden, false);
+    pid = eCAL::Process::StartProcess(ECAL_REC_CLI_PATH, "--interactive-dont-exit --no-default", "", false, eCAL_Process_eStartMode::proc_smode_hidden, false);
   }
 
   std::this_thread::sleep_for(std::chrono::milliseconds(1500));

--- a/app/rec/rec_tests/rec_rpc_tests/src/external_ecal_rec.h
+++ b/app/rec/rec_tests/rec_rpc_tests/src/external_ecal_rec.h
@@ -1,0 +1,73 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+#pragma once
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4100 4127 4146 4505 4800 4189 4592) // disable proto warnings 
+#endif
+#include <ecal/msg/protobuf/client.h>
+#include <ecal/app/pb/rec/server_service.pb.h>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+#include <string>
+#include <mutex>
+#include <rec_server_core/rec_server_config.h>
+#include <rec_client_core/rec_error.h>
+
+// Lock preventing multiple instances of this class
+static std::mutex ecal_rec_cli_instance_lock;
+
+class ExternalEcalRecInstance
+{
+///////////////////////////////////////////////
+// Constructor, destructor etc.
+///////////////////////////////////////////////
+public:
+  ExternalEcalRecInstance(bool gui = false);
+
+  // Copy
+  ExternalEcalRecInstance(const ExternalEcalRecInstance&)            = delete;
+  ExternalEcalRecInstance& operator=(const ExternalEcalRecInstance&) = delete;
+
+  // Move
+  ExternalEcalRecInstance& operator=(ExternalEcalRecInstance&&)      = default;
+  ExternalEcalRecInstance(ExternalEcalRecInstance&&)                 = default;
+
+  ~ExternalEcalRecInstance();
+
+///////////////////////////////////////////////
+// RPC Wrappers
+///////////////////////////////////////////////
+public:
+  eCAL::rec::Error GetConfigViaRpc(eCAL::rec_server::RecServerConfig&     config_output);
+  eCAL::rec::Error GetConfigViaRpc(eCAL::pb::rec_server::RecServerConfig& config_pb_output);
+
+  eCAL::rec::Error SetConfigViaRpc(const eCAL::rec_server::RecServerConfig&     config);
+  eCAL::rec::Error SetConfigViaRpc(const eCAL::pb::rec_server::RecServerConfig& config_pb);
+
+///////////////////////////////////////////////
+// Member Variables
+///////////////////////////////////////////////
+private:
+  int pid;
+  std::shared_ptr<eCAL::protobuf::CServiceClient<eCAL::pb::rec_server::EcalRecServerService>> remote_rec_server_service;
+};

--- a/app/rec/rec_tests/rec_rpc_tests/src/rec_cli_test.cpp
+++ b/app/rec/rec_tests/rec_rpc_tests/src/rec_cli_test.cpp
@@ -1,0 +1,196 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+#include <ecal/ecal.h>
+
+#include <string>
+#include <chrono>
+#include <thread>
+#include <cstdint>
+
+#include <gtest/gtest.h>
+
+#include <iostream>
+
+#include "external_ecal_rec.h"
+
+struct TestCase
+{
+  std::string cli_cmdline_remotecontrol;
+  eCAL::rec_server::RecServerConfig expected_config;
+};
+
+std::vector<TestCase> getRpcConfigTestcases()
+{
+  std::vector<TestCase> testcases;
+
+  eCAL::rec_server::RecServerConfig config;
+
+  // --set-client
+  {
+    testcases.emplace_back();
+
+    config.enabled_clients_config_["A"].host_filter_.insert("A");
+
+    testcases.back().cli_cmdline_remotecontrol = "--set-client A:A";
+    testcases.back().expected_config = config;
+  }
+
+  // --set-client
+  {
+    testcases.emplace_back();
+
+    config.enabled_clients_config_["A"].host_filter_.erase("A");
+    config.enabled_clients_config_["A"].host_filter_.insert("B");
+    config.enabled_clients_config_["A"].host_filter_.insert("C");
+    config.enabled_clients_config_["B"];
+
+    testcases.back().cli_cmdline_remotecontrol = "--set-client A:B,C --set-client B";
+    testcases.back().expected_config = config;
+  }
+
+  {
+    testcases.emplace_back();
+
+    config.enabled_clients_config_["A"].enabled_addons_.insert("A1");
+    config.enabled_clients_config_["A"].enabled_addons_.insert("A2");
+
+    config.enabled_clients_config_["B"].enabled_addons_.insert("B1");
+
+    testcases.back().cli_cmdline_remotecontrol = "--set-addons A:A1,A2 --set-addons B:B1";
+    testcases.back().expected_config = config;
+  }
+
+  {
+    testcases.emplace_back();
+
+    config.enabled_clients_config_.erase("B");
+    config.enabled_clients_config_["C"];
+
+    testcases.back().cli_cmdline_remotecontrol = "--remove-client B --set-client C";
+    testcases.back().expected_config = config;
+  }
+
+  {
+    testcases.emplace_back();
+
+    config.listed_topics_.insert("t1");
+    config.listed_topics_.insert("t2");
+    config.listed_topics_.insert("t3");
+    config.record_mode_ = eCAL::rec::RecordMode::Blacklist;
+
+    testcases.back().cli_cmdline_remotecontrol = "--blacklist t1,t2,t3";
+    testcases.back().expected_config = config;
+  }
+
+  {
+    testcases.emplace_back();
+
+    config.listed_topics_.clear();
+    config.listed_topics_.insert("mytopic");
+    config.record_mode_ = eCAL::rec::RecordMode::Whitelist;
+
+    testcases.back().cli_cmdline_remotecontrol = "--whitelist mytopic";
+    testcases.back().expected_config = config;
+  }
+
+  {
+    testcases.emplace_back();
+
+    config.root_dir_      = "root_dir";
+    config.meas_name_     = "my_meas_name";
+    config.max_file_size_ = 1337;
+    config.description_   = "HelloWorld";
+
+    testcases.back().cli_cmdline_remotecontrol = "--meas-root-dir root_dir --meas-name my_meas_name --max-file-size 1337 --description HelloWorld";
+    testcases.back().expected_config = config;
+  }
+
+  {
+    testcases.emplace_back();
+
+    config.one_file_per_topic_ = true;
+
+    testcases.back().cli_cmdline_remotecontrol = "--enable-one-file-per-topic yes";
+    testcases.back().expected_config = config;
+  }
+
+  {
+    testcases.emplace_back();
+
+    config.upload_config_.type_      = eCAL::rec_server::UploadConfig::Type::FTP;
+    config.upload_config_.username_  = "user";
+    config.upload_config_.password_  = "pass";
+    config.upload_config_.host_      = "host";
+    config.upload_config_.port_      = 2121;
+    config.upload_config_.root_path_ = "/ftp/path";
+    config.upload_config_.delete_after_upload_ = true;
+
+    testcases.back().cli_cmdline_remotecontrol = "--ftp-server ftp://user:pass@host:2121/ftp/path --delete-after-upload";
+    testcases.back().expected_config = config;
+  }
+
+  return testcases;
+}
+
+TEST(EcalRecCli, NoDefault)
+{
+  eCAL::rec_server::RecServerConfig config;
+
+  auto rec = ExternalEcalRecInstance();
+
+  EXPECT_EQ(rec.GetConfigViaRpc(config), eCAL::rec::Error::OK);
+  EXPECT_EQ(config, eCAL::rec_server::RecServerConfig());
+}
+
+TEST(EcalRecCli, SetConfigViaRPC)
+{
+  auto test_cases = getRpcConfigTestcases();
+  auto rec = ExternalEcalRecInstance();
+
+  for (const auto& testcase : test_cases)
+  {
+    std::string command_line = ECAL_REC_CLI_PATH + std::string(" --remote-control ") + testcase.cli_cmdline_remotecontrol;
+    std::cout << "Running command line: " << command_line << std::endl;
+
+    system((std::string(ECAL_REC_CLI_PATH) + " --remote-control " + testcase.cli_cmdline_remotecontrol).c_str());
+
+    eCAL::rec_server::RecServerConfig config_result;
+    EXPECT_EQ(rec.GetConfigViaRpc(config_result), eCAL::rec::Error::OK);
+    EXPECT_EQ(config_result, testcase.expected_config);
+  }
+}
+
+TEST(EcalRecGui, SetConfigViaRPC)
+{
+  auto test_cases = getRpcConfigTestcases();
+  auto rec = ExternalEcalRecInstance(true);
+
+  for (const auto& testcase : test_cases)
+  {
+    std::string command_line = ECAL_REC_CLI_PATH + std::string(" --remote-control ") + testcase.cli_cmdline_remotecontrol;
+    std::cout << "Running command line: " << command_line << std::endl;
+
+    system(command_line.c_str());
+
+    eCAL::rec_server::RecServerConfig config_result;
+    EXPECT_EQ(rec.GetConfigViaRpc(config_result), eCAL::rec::Error::OK);
+    EXPECT_EQ(config_result, testcase.expected_config);
+  }
+}


### PR DESCRIPTION
- Added SetConfig RPC Call to Rec GUI and Rec CLI
- Enabled --set-config from command line and setconfig from interactive mode of Rec CLI in Remote control mode
- Added Tests for Rec CLI Remote control mode (command-line version) testing the control of both eCAL Rec CLI and GUI 

Fixes #848