### PR TITLE
Fixed wrong udpcap target in monitor gui

### DIFF
--- a/app/mon/mon_gui/CMakeLists.txt
+++ b/app/mon/mon_gui/CMakeLists.txt
@@ -25,6 +25,10 @@ REQUIRED)
 
 find_package(Protobuf REQUIRED)
 
+if(ECAL_NPCAP_SUPPORT)
+  find_package(udpcap REQUIRED)
+endif(ECAL_NPCAP_SUPPORT)
+
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC OFF) # Reason for being turned off: AutoUIC will prevent VS from detecting changes in .ui files
 set(CMAKE_AUTORCC OFF) # Reason for being turned off: AutoRCC will create an entirely new project in VS which clutters the solution appearance. Additionally, we cannot assign a source group to the generated .cpp files which will clutter the project.

--- a/app/mon/mon_gui/CMakeLists.txt
+++ b/app/mon/mon_gui/CMakeLists.txt
@@ -189,7 +189,7 @@ target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 if(ECAL_NPCAP_SUPPORT)
   add_definitions(-DECAL_NPCAP_SUPPORT)
   target_link_libraries(${PROJECT_NAME}
-    udpcap
+    udpcap::udpcap
   )
 endif(ECAL_NPCAP_SUPPORT)
 


### PR DESCRIPTION
**Pull request type**

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


**What is the current behavior?**
eCAL or rather the monitor gui does not build when ECAL_NPCAP_SUPPORT flag is enabled due to a wrong target name of udpcap.

Issue Number: N/A

**What is the new behavior?**
eCAL Monitor gui builds properly against the correct udpcap target.


**Does this introduce a breaking change?**

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

**Other information**

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
