### PR TITLE
Bugfix: Process name on MacOs should have the length of the read path.

### DIFF
--- a/ecal/core/src/ecal_process.cpp
+++ b/ecal/core/src/ecal_process.cpp
@@ -885,6 +885,7 @@ namespace eCAL
           // Buffer size is too small.
           return "";
         }
+        length = strlen(buf);
 #elif defined(ECAL_OS_QNX)
         size_t length {0};
         // TODO: Find a suitable method on QNX to retrieve current process name


### PR DESCRIPTION
**Pull request type**
Please check the type of change your PR introduces:
- [x] Bugfix

On MacOs the process name does not have the correct length.

@JerryHyun