### PR TITLE
std::map replaced by CExpMap in description gate

### DIFF
--- a/ecal/core/src/ecal_descgate.cpp
+++ b/ecal/core/src/ecal_descgate.cpp
@@ -22,6 +22,8 @@
 **/
 
 #include <ecal/ecal_log.h>
+#include <ecal/ecal_config.h>
+
 #include "ecal_descgate.h"
 #include <assert.h>
 #include <algorithm>
@@ -29,7 +31,11 @@
 
 namespace eCAL
 {
-  CDescGate::CDescGate()  = default;
+  CDescGate::CDescGate() :
+    m_topic_info_map  (std::chrono::milliseconds(Config::GetMonitoringTimeoutMs())),
+    m_service_info_map(std::chrono::milliseconds(Config::GetMonitoringTimeoutMs()))
+  {
+  }
   CDescGate::~CDescGate() = default;
 
   void CDescGate::Create()
@@ -42,30 +48,33 @@ namespace eCAL
 
   void CDescGate::ApplyTopicDescription(const std::string& topic_name_, const std::string& topic_type_, const std::string& topic_desc_, const QualityFlags description_quality_)
   {
-    std::unique_lock<std::shared_timed_mutex> lock(m_topic_info_map_mutex);
-    const auto topic_info_it = m_topic_info_map.find(topic_name_);
+    std::lock_guard<std::mutex> lock(m_topic_info_map.sync);
+    m_topic_info_map.map->remove_deprecated();
+
+    const auto topic_info_it = m_topic_info_map.map->find(topic_name_);
     
     // new element (no need to check anything, just add it)
-    if(topic_info_it == m_topic_info_map.end())
+    if(topic_info_it == m_topic_info_map.map->end())
     {
       // TODO: Maybe we should copy the description from another topic with the same type, if it is empty?
-      STopicInfoQuality topic_info;
+      STopicInfoQuality& topic_info = (*m_topic_info_map.map)[topic_name_];
       topic_info.info.type_name        = topic_type_;
       topic_info.info.type_description = topic_desc_;
       topic_info.description_quality   = description_quality_;
-      m_topic_info_map.emplace(topic_name_, std::move(topic_info));
     }
     else
     {
       // existing type for the same topic name should be equal !!
       // we log the error only one time
-      if(  !topic_info_it->second.type_missmatch_logged
+      STopicInfoQuality& topic_info = (*m_topic_info_map.map)[topic_name_];
+
+      if(  !topic_info.type_missmatch_logged
             && !topic_type_.empty()
-            && !topic_info_it->second.info.type_name.empty()
-            && (topic_info_it->second.info.type_name != topic_type_)
+            && !topic_info.info.type_name.empty()
+            && (topic_info.info.type_name != topic_type_)
         )
       {
-        std::string ttype1 =  topic_info_it->second.info.type_name;
+        std::string ttype1 = topic_info.info.type_name;
         std::string ttype2 = topic_type_;
         std::replace(ttype1.begin(), ttype1.end(), '\0', '?');
         std::replace(ttype1.begin(), ttype1.end(), '\t', '?');
@@ -80,31 +89,31 @@ namespace eCAL
         msg += "\')";
         eCAL::Logging::Log(log_level_warning, msg);
 
-        topic_info_it->second.type_missmatch_logged = true;
+        topic_info.type_missmatch_logged = true;
       }
 
       // existing description for the same topic name should be equal !!
       // we log the warning only one time
-      if ( !topic_info_it->second.type_missmatch_logged
+      if(   !topic_info.type_missmatch_logged
             && !topic_desc_.empty()
-            && !topic_info_it->second.info.type_description.empty()
-            && (topic_info_it->second.info.type_description != topic_desc_)
+            && !topic_info.info.type_description.empty()
+            && (topic_info.info.type_description != topic_desc_)
         )
       {
         std::string msg = "eCAL Pub/Sub description mismatch for topic ";
         msg += topic_name_;
         eCAL::Logging::Log(log_level_warning, msg);
 
-        topic_info_it->second.type_missmatch_logged = true;
+        topic_info.type_missmatch_logged = true;
       }
 
       // Now let's check whether the current information has a higher quality.
       // If it has a higher quality, we overwrite it.
-      if (description_quality_ > topic_info_it->second.description_quality)
+      if (description_quality_ > topic_info.description_quality)
       {
-        topic_info_it->second.info.type_name        = topic_type_;
-        topic_info_it->second.info.type_description = topic_desc_;
-        topic_info_it->second.description_quality   = description_quality_;
+        topic_info.info.type_name        = topic_type_;
+        topic_info.info.type_description = topic_desc_;
+        topic_info.description_quality   = description_quality_;
       }
     }
   }
@@ -112,8 +121,10 @@ namespace eCAL
   void CDescGate::GetTopics(std::map<std::string, Util::STopicInfo>& topic_info_map_)
   {
     topic_info_map_.clear();
-    std::shared_lock<std::shared_timed_mutex> lock(m_topic_info_map_mutex);
-    for (auto& topic_info : m_topic_info_map)
+    std::lock_guard<std::mutex> lock(m_topic_info_map.sync);
+    m_topic_info_map.map->remove_deprecated();
+
+    for (const auto& topic_info : (*m_topic_info_map.map))
     {
       topic_info_map_[topic_info.first] = topic_info.second.info;
     }
@@ -123,23 +134,23 @@ namespace eCAL
   {
     if(topic_name_.empty()) return(false);
 
-    std::shared_lock<std::shared_timed_mutex> lock(m_topic_info_map_mutex);
-    const auto topic_info_it = m_topic_info_map.find(topic_name_);
+    std::lock_guard<std::mutex> lock(m_topic_info_map.sync);
+    const auto topic_info_it = m_topic_info_map.map->find(topic_name_);
 
-    if(topic_info_it == m_topic_info_map.end()) return(false);
-    topic_type_ = topic_info_it->second.info.type_name;
+    if(topic_info_it == m_topic_info_map.map->end()) return(false);
+    topic_type_ = (*topic_info_it).second.info.type_name;
     return(true);
   }
 
   bool CDescGate::GetTopicDescription(const std::string& topic_name_, std::string& topic_desc_)
   {
-    if(topic_name_.empty()) return(false);
+    if (topic_name_.empty()) return(false);
 
-    std::shared_lock<std::shared_timed_mutex> lock(m_topic_info_map_mutex);
-    const auto topic_info_it = m_topic_info_map.find(topic_name_);
+    std::lock_guard<std::mutex> lock(m_topic_info_map.sync);
+    const auto topic_info_it = m_topic_info_map.map->find(topic_name_);
 
-    if(topic_info_it == m_topic_info_map.end()) return(false);
-    topic_desc_ = topic_info_it->second.info.type_description;
+    if (topic_info_it == m_topic_info_map.map->end()) return(false);
+    topic_desc_ = (*topic_info_it).second.info.type_description;
     return(true);
   }
   
@@ -153,29 +164,30 @@ namespace eCAL
   {
     std::tuple<std::string, std::string> service_method_tuple = std::make_tuple(service_name_, method_name_);
 
-    std::shared_lock<std::shared_timed_mutex> lock(m_service_info_map_mutex);
-    auto service_info_map_it = m_service_info_map.find(service_method_tuple);
-    if (service_info_map_it == m_service_info_map.end())
+    std::lock_guard<std::mutex> lock(m_service_info_map.sync);
+    m_service_info_map.map->remove_deprecated();
+
+    auto service_info_map_it = m_service_info_map.map->find(service_method_tuple);
+    if (service_info_map_it == m_service_info_map.map->end())
     {
-      SServiceMethodInfoQuality service_info;
+      SServiceMethodInfoQuality& service_info = (*m_service_info_map.map)[service_method_tuple];
       service_info.info.request_type_name         = req_type_name_;
       service_info.info.request_type_description  = req_type_desc_;
       service_info.info.response_type_name        = resp_type_name_;
       service_info.info.response_type_description = resp_type_desc_;
       service_info.info_quality                   = info_quality_;
-
-      m_service_info_map[service_method_tuple] = std::move(service_info);
     }
     else
     {
       // do we need to check consistency ?
-      if (info_quality_ > service_info_map_it->second.info_quality)
+      SServiceMethodInfoQuality& service_info = (*m_service_info_map.map)[service_method_tuple];
+      if (info_quality_ > service_info.info_quality)
       {
-        service_info_map_it->second.info.request_type_name         = req_type_name_;
-        service_info_map_it->second.info.request_type_description  = req_type_desc_;
-        service_info_map_it->second.info.response_type_name        = resp_type_name_;
-        service_info_map_it->second.info.response_type_description = resp_type_desc_;
-        service_info_map_it->second.info_quality                   = info_quality_;
+        service_info.info.request_type_name         = req_type_name_;
+        service_info.info.request_type_description  = req_type_desc_;
+        service_info.info.response_type_name        = resp_type_name_;
+        service_info.info.response_type_description = resp_type_desc_;
+        service_info.info_quality                   = info_quality_;
       }
     }
   }
@@ -183,8 +195,10 @@ namespace eCAL
   void CDescGate::GetServices(std::map<std::tuple<std::string, std::string>, Util::SServiceMethodInfo>& service_info_map_)
   {
     service_info_map_.clear();
-    std::shared_lock<std::shared_timed_mutex> lock(m_service_info_map_mutex);
-    for (auto& service_info : m_service_info_map)
+    std::lock_guard<std::mutex> lock(m_service_info_map.sync);
+    m_service_info_map.map->remove_deprecated();
+
+    for (const auto& service_info : (*m_service_info_map.map))
     {
       service_info_map_[service_info.first] = service_info.second.info;
     }
@@ -194,14 +208,12 @@ namespace eCAL
   {
     std::tuple<std::string, std::string> service_method_tuple = std::make_tuple(service_name_, method_name_);
 
-    std::shared_lock<std::shared_timed_mutex> lock(m_service_info_map_mutex);
-    auto service_info_map_it = m_service_info_map.find(service_method_tuple);
+    std::lock_guard<std::mutex> lock(m_service_info_map.sync);
+    auto service_info_map_it = m_service_info_map.map->find(service_method_tuple);
 
-    if (service_info_map_it == m_service_info_map.end()) return false;
-
-    req_type_name_  = service_info_map_it->second.info.request_type_name;
-    resp_type_name_ = service_info_map_it->second.info.response_type_name;
-
+    if (service_info_map_it == m_service_info_map.map->end()) return false;
+    req_type_name_  = (*service_info_map_it).second.info.request_type_name;
+    resp_type_name_ = (*service_info_map_it).second.info.response_type_name;
     return true;
   }
 
@@ -209,14 +221,12 @@ namespace eCAL
   {
     std::tuple<std::string, std::string> service_method_tuple = std::make_tuple(service_name_, method_name_);
 
-    std::shared_lock<std::shared_timed_mutex> lock(m_service_info_map_mutex);
-    auto service_info_map_it = m_service_info_map.find(service_method_tuple);
+    std::lock_guard<std::mutex> lock(m_service_info_map.sync);
+    auto service_info_map_it = m_service_info_map.map->find(service_method_tuple);
 
-    if (service_info_map_it == m_service_info_map.end()) return false;
-    
-    req_type_desc_  = service_info_map_it->second.info.request_type_description;
-    resp_type_desc_ = service_info_map_it->second.info.response_type_description;
-
+    if (service_info_map_it == m_service_info_map.map->end()) return false;
+    req_type_desc_  = (*service_info_map_it).second.info.request_type_description;
+    resp_type_desc_ = (*service_info_map_it).second.info.response_type_description;
     return true;
   }
 };

--- a/ecal/core/src/mon/ecal_monitoring_impl.cpp
+++ b/ecal/core/src/mon/ecal_monitoring_impl.cpp
@@ -544,7 +544,7 @@ namespace eCAL
 
     // iterate map
     m_process_map.map->remove_deprecated();
-    for (auto process : (*m_process_map.map))
+    for (const auto& process : (*m_process_map.map))
     {
       // add host
       eCAL::pb::Process* pMonProcs = monitoring_.add_processes();
@@ -618,7 +618,7 @@ namespace eCAL
 
     // iterate map
     m_server_map.map->remove_deprecated();
-    for (auto service : (*m_server_map.map))
+    for (const auto& service : (*m_server_map.map))
     {
       // add host
       eCAL::pb::Service* pMonService = monitoring_.add_services();
@@ -668,7 +668,7 @@ namespace eCAL
 
     // iterate map
     m_client_map.map->remove_deprecated();
-    for (auto service : (*m_client_map.map))
+    for (const auto& service : (*m_client_map.map))
     {
       // add host
       eCAL::pb::Client* pMonClient = monitoring_.add_clients();
@@ -703,7 +703,7 @@ namespace eCAL
 
     // iterate map
     map_.map->remove_deprecated();
-    for (auto topic : (*map_.map))
+    for (const auto& topic : (*map_.map))
     {
       // add topic
       eCAL::pb::Topic* pMonTopic = monitoring_.add_topics();


### PR DESCRIPTION
**Pull request type**

Please check the type of change your PR introduces:
- [X] Bugfix

**What is the current behavior?**
Internal maps in description gate never expire.

**What is the new behavior?**
std::map replaced by CExpMap with expiration "monitoring timeout" (default = 5s).
