### PR TITLE
Feature/size limited memfile names

### DIFF
--- a/ecal/core/CMakeLists.txt
+++ b/ecal/core/CMakeLists.txt
@@ -87,6 +87,7 @@ if(NOT ECAL_LAYER_ICEORYX)
       src/io/ecal_memfile_broadcast.cpp
       src/io/ecal_memfile_broadcast_reader.cpp
       src/io/ecal_memfile_broadcast_writer.cpp
+      src/io/ecal_memfile_naming.cpp      
       src/io/ecal_memfile_pool.cpp
       src/io/ecal_memfile_sync.cpp
       src/io/ecal_named_mutex.cpp
@@ -219,6 +220,7 @@ if(NOT ECAL_LAYER_ICEORYX)
       src/io/ecal_memfile_broadcast_writer.h
       src/io/ecal_memfile_db.h
       src/io/ecal_memfile_info.h
+      src/io/ecal_memfile_naming.h
       src/io/ecal_memfile_os.h
       src/io/ecal_memfile_pool.h
       src/io/ecal_memfile_sync.h

--- a/ecal/core/src/io/ecal_memfile_naming.cpp
+++ b/ecal/core/src/io/ecal_memfile_naming.cpp
@@ -9,19 +9,14 @@ namespace eCAL
   {
     std::string BuildMemFileName(const std::string& base_name_, const std::chrono::time_point<std::chrono::steady_clock>& time_point)
     {
-      std::string mfile_name(base_name_);
       std::stringstream out;
-      out << mfile_name << "_" << std::chrono::duration_cast<std::chrono::microseconds>(time_point.time_since_epoch()).count();
-      mfile_name = out.str();
 
-      // replace all '\\' and '/' to '_'
-      std::replace(mfile_name.begin(), mfile_name.end(), '\\', '_');
-      std::replace(mfile_name.begin(), mfile_name.end(), '/', '_');
+      size_t hash = std::hash<std::string>()(base_name_ + std::to_string(time_point.time_since_epoch().count()));
+      uint32_t compressed_hash = static_cast<uint32_t>(hash);
 
-      // append "_shm" for debugging purposes
-      mfile_name += "_shm";
+      out << "ecal_" << std::hex << compressed_hash;
 
-      return mfile_name;
+      return out.str();
     }
   }
 }

--- a/ecal/core/src/io/ecal_memfile_naming.cpp
+++ b/ecal/core/src/io/ecal_memfile_naming.cpp
@@ -1,20 +1,41 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
 #include <io/ecal_memfile_naming.h>
 
-#include <sstream>
+#include <cstdint>
+#include <limits>
 #include <random>
+#include <sstream>
 
 namespace eCAL
 {
   namespace memfile
   {
 
-    std::string BuildRandomMemFileName()
+    std::string BuildRandomMemFileName(const std::string& base_name)
     {
       static std::random_device rd;
-      static std::uniform_int_distribution<uint32_t> dist(0, UINT32_MAX);
+      static std::uniform_int_distribution<uint32_t> dist(0, std::numeric_limits<uint32_t>::max());
 
       std::stringstream out;
-      out << "ecal_" << std::hex << dist(rd);
+      out << base_name << std::hex << dist(rd);
 
       return out.str();
     }

--- a/ecal/core/src/io/ecal_memfile_naming.cpp
+++ b/ecal/core/src/io/ecal_memfile_naming.cpp
@@ -1,0 +1,27 @@
+#include <io/ecal_memfile_naming.h>
+
+#include <sstream>
+#include <algorithm>
+
+namespace eCAL
+{
+  namespace memfile
+  {
+    std::string BuildMemFileName(const std::string& base_name_, const std::chrono::time_point<std::chrono::steady_clock>& time_point)
+    {
+      std::string mfile_name(base_name_);
+      std::stringstream out;
+      out << mfile_name << "_" << std::chrono::duration_cast<std::chrono::microseconds>(time_point.time_since_epoch()).count();
+      mfile_name = out.str();
+
+      // replace all '\\' and '/' to '_'
+      std::replace(mfile_name.begin(), mfile_name.end(), '\\', '_');
+      std::replace(mfile_name.begin(), mfile_name.end(), '/', '_');
+
+      // append "_shm" for debugging purposes
+      mfile_name += "_shm";
+
+      return mfile_name;
+    }
+  }
+}

--- a/ecal/core/src/io/ecal_memfile_naming.cpp
+++ b/ecal/core/src/io/ecal_memfile_naming.cpp
@@ -1,20 +1,20 @@
 #include <io/ecal_memfile_naming.h>
 
 #include <sstream>
-#include <algorithm>
+#include <random>
 
 namespace eCAL
 {
   namespace memfile
   {
-    std::string BuildMemFileName(const std::string& base_name_, const std::chrono::time_point<std::chrono::steady_clock>& time_point)
+
+    std::string BuildRandomMemFileName()
     {
+      static std::random_device rd;
+      static std::uniform_int_distribution<uint32_t> dist(0, UINT32_MAX);
+
       std::stringstream out;
-
-      size_t hash = std::hash<std::string>()(base_name_ + std::to_string(time_point.time_since_epoch().count()));
-      uint32_t compressed_hash = static_cast<uint32_t>(hash);
-
-      out << "ecal_" << std::hex << compressed_hash;
+      out << "ecal_" << std::hex << dist(rd);
 
       return out.str();
     }

--- a/ecal/core/src/io/ecal_memfile_naming.h
+++ b/ecal/core/src/io/ecal_memfile_naming.h
@@ -29,6 +29,6 @@ namespace eCAL
 {
   namespace memfile
   {
-    std::string BuildRandomMemFileName();
+    std::string BuildRandomMemFileName(const std::string& base_name);
   }
 }

--- a/ecal/core/src/io/ecal_memfile_naming.h
+++ b/ecal/core/src/io/ecal_memfile_naming.h
@@ -1,0 +1,36 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+/**
+ * @brief  helper functionality to determine names of memory files / semaphores / ...
+**/
+
+#pragma once
+#include <string>
+#include <chrono>
+
+namespace eCAL
+{
+  namespace memfile
+  {
+
+    std::string BuildMemFileName(const std::string& base_name_, const std::chrono::time_point<std::chrono::steady_clock>& time_point);
+
+  }
+}

--- a/ecal/core/src/io/ecal_memfile_naming.h
+++ b/ecal/core/src/io/ecal_memfile_naming.h
@@ -29,8 +29,6 @@ namespace eCAL
 {
   namespace memfile
   {
-
-    std::string BuildMemFileName(const std::string& base_name_, const std::chrono::time_point<std::chrono::steady_clock>& time_point);
-
+    std::string BuildRandomMemFileName();
   }
 }

--- a/ecal/core/src/io/ecal_memfile_sync.cpp
+++ b/ecal/core/src/io/ecal_memfile_sync.cpp
@@ -232,7 +232,7 @@ namespace eCAL
 
     // build unique memory file name
     m_base_name = base_name_;
-    m_memfile_name = eCAL::memfile::BuildRandomMemFileName();
+    m_memfile_name = eCAL::memfile::BuildRandomMemFileName(base_name_);
 
     // create new memory file object
     // with additional space for SMemFileHeader

--- a/ecal/core/src/io/ecal_memfile_sync.cpp
+++ b/ecal/core/src/io/ecal_memfile_sync.cpp
@@ -25,6 +25,7 @@
 #include <ecal/ecal_log.h>
 
 #include "ecal_memfile_header.h"
+#include "ecal_memfile_naming.h"
 #include "ecal_memfile_sync.h"
 
 #include <algorithm>
@@ -231,7 +232,7 @@ namespace eCAL
 
     // build unique memory file name
     m_base_name = base_name_;
-    m_memfile_name = BuildMemFileName(m_base_name);
+    m_memfile_name = eCAL::memfile::BuildMemFileName(m_base_name, std::chrono::steady_clock::now());
 
     // create new memory file object
     // with additional space for SMemFileHeader
@@ -315,23 +316,6 @@ namespace eCAL
     }
 
     return true;
-  }
-
-  std::string CSyncMemoryFile::BuildMemFileName(const std::string base_name_)
-  {
-    std::string mfile_name(base_name_);
-    std::stringstream out;
-    out << mfile_name << "_" << std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
-    mfile_name = out.str();
-
-    // replace all '\\' and '/' to '_'
-    std::replace(mfile_name.begin(), mfile_name.end(), '\\', '_');
-    std::replace(mfile_name.begin(), mfile_name.end(), '/', '_');
-
-    // append "_shm" for debugging purposes
-    mfile_name += "_shm";
-
-    return mfile_name;
   }
 
   void CSyncMemoryFile::SyncContent()

--- a/ecal/core/src/io/ecal_memfile_sync.cpp
+++ b/ecal/core/src/io/ecal_memfile_sync.cpp
@@ -232,7 +232,7 @@ namespace eCAL
 
     // build unique memory file name
     m_base_name = base_name_;
-    m_memfile_name = eCAL::memfile::BuildMemFileName(m_base_name, std::chrono::steady_clock::now());
+    m_memfile_name = eCAL::memfile::BuildRandomMemFileName();
 
     // create new memory file object
     // with additional space for SMemFileHeader

--- a/ecal/core/src/io/ecal_memfile_sync.cpp
+++ b/ecal/core/src/io/ecal_memfile_sync.cpp
@@ -221,7 +221,7 @@ namespace eCAL
     return written;
   }
 
-  std::string CSyncMemoryFile::GetName()
+  std::string CSyncMemoryFile::GetName() const
   {
     return m_memfile_name;
   }

--- a/ecal/core/src/io/ecal_memfile_sync.h
+++ b/ecal/core/src/io/ecal_memfile_sync.h
@@ -54,7 +54,7 @@ namespace eCAL
     bool CheckSize(size_t size_);
     bool Write(const SWriterData& data_);
 
-    std::string GetName();
+    std::string GetName() const;
 
   protected:
     bool Create(const std::string& base_name_, size_t size_);

--- a/ecal/core/src/io/ecal_memfile_sync.h
+++ b/ecal/core/src/io/ecal_memfile_sync.h
@@ -61,8 +61,6 @@ namespace eCAL
     bool Destroy();
     bool Recreate(size_t size_);
 
-    std::string BuildMemFileName(const std::string base_name_);
-
     void SyncContent();
     void DisconnectAll();
 

--- a/ecal/core/src/readwrite/ecal_writer_shm.cpp
+++ b/ecal/core/src/readwrite/ecal_writer_shm.cpp
@@ -40,7 +40,7 @@
 
 namespace eCAL
 {
-  std::string CDataWriterSHM::m_memfile_base_name = "ecal_";
+  const std::string CDataWriterSHM::m_memfile_base_name = "ecal_";
 
   CDataWriterSHM::CDataWriterSHM()
   {

--- a/ecal/core/src/readwrite/ecal_writer_shm.cpp
+++ b/ecal/core/src/readwrite/ecal_writer_shm.cpp
@@ -40,6 +40,8 @@
 
 namespace eCAL
 {
+  std::string CDataWriterSHM::m_memfile_base_name = "ecal_";
+
   CDataWriterSHM::CDataWriterSHM()
   {
   }
@@ -84,7 +86,7 @@ namespace eCAL
     // create the files
     for (size_t num(0); num < m_buffer_count; ++num)
     {
-      auto sync_memfile = std::make_shared<CSyncMemoryFile>(topic_name_, 0, m_memory_file_attr);
+      auto sync_memfile = std::make_shared<CSyncMemoryFile>(m_memfile_base_name, 0, m_memory_file_attr);
       m_memory_file_vec.push_back(sync_memfile);
     }
 
@@ -145,7 +147,7 @@ namespace eCAL
       // increase buffer count
       while (m_memory_file_vec.size() < m_buffer_count)
       {
-        auto sync_memfile = std::make_shared<CSyncMemoryFile>(m_topic_name, data_.len, m_memory_file_attr);
+        auto sync_memfile = std::make_shared<CSyncMemoryFile>(m_memfile_base_name, data_.len, m_memory_file_attr);
         m_memory_file_vec.push_back(sync_memfile);
       }
       // decrease buffer count

--- a/ecal/core/src/readwrite/ecal_writer_shm.h
+++ b/ecal/core/src/readwrite/ecal_writer_shm.h
@@ -59,5 +59,6 @@ namespace eCAL
     size_t                                        m_buffer_count = 1;
     SSyncMemoryFileAttr                           m_memory_file_attr;
     std::vector<std::shared_ptr<CSyncMemoryFile>> m_memory_file_vec;
+    static std::string                            m_memfile_base_name;
   };
 }

--- a/ecal/core/src/readwrite/ecal_writer_shm.h
+++ b/ecal/core/src/readwrite/ecal_writer_shm.h
@@ -59,6 +59,6 @@ namespace eCAL
     size_t                                        m_buffer_count = 1;
     SSyncMemoryFileAttr                           m_memory_file_attr;
     std::vector<std::shared_ptr<CSyncMemoryFile>> m_memory_file_vec;
-    static std::string                            m_memfile_base_name;
+    static const std::string                      m_memfile_base_name;
   };
 }

--- a/testing/ecal/io_memfile_test/CMakeLists.txt
+++ b/testing/ecal/io_memfile_test/CMakeLists.txt
@@ -23,9 +23,11 @@ find_package(GTest REQUIRED)
 
 set(memfile_test_src
     src/memfile_test.cpp
+    src/memfile_naming_test.cpp
     ../../../ecal/core/src/io/ecal_memfile.cpp
     ../../../ecal/core/src/io/ecal_memfile_db.cpp
     ../../../ecal/core/src/io/ecal_named_mutex.cpp
+    ../../../ecal/core/src/io/ecal_memfile_naming.cpp
 )
 
 if(UNIX)

--- a/testing/ecal/io_memfile_test/src/memfile_naming_test.cpp
+++ b/testing/ecal/io_memfile_test/src/memfile_naming_test.cpp
@@ -32,10 +32,9 @@ TEST(IO, MemfileNaming)
 {
   std::chrono::steady_clock::time_point timepoint{};
 
-  std::string memfile_name_1{ eCAL::memfile::BuildMemFileName("person", timepoint) };
-  std::string memfile_name_2{ eCAL::memfile::BuildMemFileName("ecal", timepoint) };
+  std::string memfile_name_1{ eCAL::memfile::BuildRandomMemFileName() };
+  std::string memfile_name_2{ eCAL::memfile::BuildRandomMemFileName() };
 
-  EXPECT_EQ(memfile_name_1, "ecal_61573470");
-  EXPECT_EQ(memfile_name_2, "ecal_bc263994");
+  EXPECT_NE(memfile_name_1, memfile_name_2);
 
 }

--- a/testing/ecal/io_memfile_test/src/memfile_naming_test.cpp
+++ b/testing/ecal/io_memfile_test/src/memfile_naming_test.cpp
@@ -32,9 +32,10 @@ TEST(IO, MemfileNaming)
 {
   std::chrono::steady_clock::time_point timepoint{};
 
-  std::string memfile_name_1{ eCAL::memfile::BuildRandomMemFileName() };
-  std::string memfile_name_2{ eCAL::memfile::BuildRandomMemFileName() };
+  std::string memfile_name_1{ eCAL::memfile::BuildRandomMemFileName("test_")};
+  std::string memfile_name_2{ eCAL::memfile::BuildRandomMemFileName("test_")};
 
+  EXPECT_EQ(memfile_name_1.size(), 13);
   EXPECT_NE(memfile_name_1, memfile_name_2);
 
 }

--- a/testing/ecal/io_memfile_test/src/memfile_naming_test.cpp
+++ b/testing/ecal/io_memfile_test/src/memfile_naming_test.cpp
@@ -35,7 +35,7 @@ TEST(IO, MemfileNaming)
   std::string memfile_name_1{ eCAL::memfile::BuildRandomMemFileName("test_")};
   std::string memfile_name_2{ eCAL::memfile::BuildRandomMemFileName("test_")};
 
-  EXPECT_EQ(memfile_name_1.size(), 13);
+  EXPECT_LE(memfile_name_1.size(), 13);
   EXPECT_NE(memfile_name_1, memfile_name_2);
 
 }

--- a/testing/ecal/io_memfile_test/src/memfile_naming_test.cpp
+++ b/testing/ecal/io_memfile_test/src/memfile_naming_test.cpp
@@ -1,0 +1,41 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+#include "io/ecal_memfile_naming.h"
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <iostream>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+
+TEST(IO, MemfileNaming)
+{
+  std::chrono::steady_clock::time_point timepoint{};
+
+  std::string memfile_name_1{ eCAL::memfile::BuildMemFileName("person", timepoint) };
+  std::string memfile_name_2{ eCAL::memfile::BuildMemFileName("ecal", timepoint) };
+
+  EXPECT_EQ(memfile_name_1, "ecal_61573470");
+  EXPECT_EQ(memfile_name_2, "ecal_bc263994");
+
+}


### PR DESCRIPTION
**Pull request type**

With this PR, ecal memory files / events will be limited to max 29 characters

`ecal_<topic&time_hash>` as a base name, and then possibly `_ack` as well as process specific events for synchronization.

```
ecal_        5 char
<hash>       8 char
_            1 char
<PID>    max 7 char
_ack         4 char
_evt         4 char
```

This totally works and communication works fine, there is no kind of incompatibility.

However, we should reiterate on what really makes sense here.
After all we want to avoid collisions. To avoid collisions, all we really need for the filename would be the creation time, it's not even necessary to include the topic name.

Also if we think about possibly taking out the shared memory as a separate library, we'd probably want to keep being able to set a file name, and not have the library compute some random hashes.