### PR TITLE
Feature/out of order messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -477,6 +477,7 @@ endif(NOT ECAL_LAYER_ICEORYX)
   add_subdirectory(testing/ecal/pubsub_proto_test)
   add_subdirectory(testing/ecal/pubsub_test)
   add_subdirectory(testing/ecal/topic2mcast_test)
+  add_subdirectory(testing/distributed/message_out_of_order)
   
   # ------------------------------------------------------
   # test apps

--- a/ecal/core/cfg/ecal.ini
+++ b/ecal/core/cfg/ecal.ini
@@ -163,7 +163,7 @@ share_tdesc               = 1
 timeout                   = 5000
 filter_excl               = __.*
 filter_incl               =
-filter_log_con            = error, fatal
+filter_log_con            = error, fatal, warning
 filter_log_file           =
 filter_log_udp            = info, warning, error, fatal
 

--- a/ecal/core/src/readwrite/ecal_reader.cpp
+++ b/ecal/core/src/readwrite/ecal_reader.cpp
@@ -435,7 +435,7 @@ namespace eCAL
     //  - a dropped message
     //  - an out of order message
     //  - a multiple sent message
-    if (CheckMessageClock(tid_, clock_) == false)
+    if (!CheckMessageClock(tid_, clock_))
     {
       // we will not process that message
       return(0);

--- a/ecal/core/src/readwrite/ecal_reader.h
+++ b/ecal/core/src/readwrite/ecal_reader.h
@@ -107,7 +107,7 @@ namespace eCAL
     bool DoRegister(const bool force_);
     void Connect(const std::string& tid_, const std::string& ttype_, const std::string& tdesc_);
     void Disconnect();
-    void CheckCounter(const std::string& tid_, long long counter_);
+    bool CheckMessageClock(const std::string& tid_, long long current_clock_);
 
     std::string                               m_host_name;
     int                                       m_host_id;

--- a/testing/distributed/message_out_of_order/CMakeLists.txt
+++ b/testing/distributed/message_out_of_order/CMakeLists.txt
@@ -16,22 +16,20 @@
 #
 # ========================= eCAL LICENSE =================================
 
-project(test_pubsub)
+project(message_out_of_order)
 
 find_package(Threads REQUIRED)
-find_package(GTest REQUIRED)
 
-set(pubsub_test_src
-  src/pubsub_test.cpp
-  src/pubsub_receive_test.cpp
-  src/out_of_order_messages_test.cpp
-)
+add_executable(message_out_of_order_publisher publisher.cpp)
+add_executable(message_out_of_order_lazy_subscriber lazy_subscriber.cpp)
+add_executable(message_out_of_order_crazy_subscriber crazy_subscriber.cpp)
 
-ecal_add_gtest(${PROJECT_NAME} ${pubsub_test_src})
-target_link_libraries(${PROJECT_NAME}
-  PRIVATE
-    eCAL::core
-    Threads::Threads)
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
-ecal_install_gtest(${PROJECT_NAME})
-set_property(TARGET ${PROJECT_NAME} PROPERTY FOLDER testing/ecal/pubsub)
+foreach(executable message_out_of_order_publisher message_out_of_order_lazy_subscriber message_out_of_order_crazy_subscriber)
+  target_link_libraries(${executable}
+    PRIVATE
+      eCAL::core
+      Threads::Threads)
+  target_compile_features(${executable} PRIVATE cxx_std_14)
+  set_property(TARGET ${executable} PROPERTY FOLDER testing/distributed)
+endforeach()
+

--- a/testing/distributed/message_out_of_order/crazy_subscriber.cpp
+++ b/testing/distributed/message_out_of_order/crazy_subscriber.cpp
@@ -1,0 +1,29 @@
+#include <ecal/ecal.h>
+#include <ecal/msg/string/subscriber.h>
+#include <thread>
+#include <iostream>
+
+void OnReceiveCrazy(const char* topic_name_, const std::string& msg_, long long time_, long long clock_, long long id_)
+{
+  static long long last_clock = 0;
+  if (clock_ < last_clock)
+  {
+    std::cout << "Received old data clock_ " << clock_ << " < " << last_clock << std::endl;
+   }
+  last_clock = clock_;
+}
+
+int main()
+{
+  eCAL::Initialize(0, nullptr, "Receive Crazy");
+
+  eCAL::string::CSubscriber<std::string> sub_crazy("foo");
+  sub_crazy.AddReceiveCallback(OnReceiveCrazy);
+
+  while (eCAL::Ok())
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+
+  eCAL::Finalize();
+}

--- a/testing/distributed/message_out_of_order/lazy_subscriber.cpp
+++ b/testing/distributed/message_out_of_order/lazy_subscriber.cpp
@@ -6,6 +6,12 @@
 void OnReceiveLazy(const char* topic_name_, const std::string& msg_, long long time_, long long clock_, long long id_)
 {
   std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  static long long last_clock = 0;
+  if (clock_ < last_clock)
+  {
+    std::cout << "Received old data clock_ " << clock_ << " < " << last_clock << std::endl;
+  }
+  last_clock = clock_;
 }
 
 int main()

--- a/testing/distributed/message_out_of_order/lazy_subscriber.cpp
+++ b/testing/distributed/message_out_of_order/lazy_subscriber.cpp
@@ -1,0 +1,24 @@
+#include <ecal/ecal.h>
+#include <ecal/msg/string/subscriber.h>
+#include <thread>
+#include <iostream>
+
+void OnReceiveLazy(const char* topic_name_, const std::string& msg_, long long time_, long long clock_, long long id_)
+{
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+}
+
+int main()
+{
+  eCAL::Initialize(0, nullptr, "Receive Lazy");
+
+  eCAL::string::CSubscriber<std::string> sub_lazy("foo");
+  sub_lazy.AddReceiveCallback(OnReceiveLazy);
+
+  while (eCAL::Ok())
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+
+  eCAL::Finalize();
+}

--- a/testing/distributed/message_out_of_order/publisher.cpp
+++ b/testing/distributed/message_out_of_order/publisher.cpp
@@ -7,6 +7,7 @@ int main()
   eCAL::Initialize(0, nullptr, "Quick Publisher");
 
   eCAL::string::CPublisher<std::string> pub("foo");
+  pub.ShmSetBufferCount(2);
 
   while (eCAL::Ok())
   {

--- a/testing/distributed/message_out_of_order/publisher.cpp
+++ b/testing/distributed/message_out_of_order/publisher.cpp
@@ -1,0 +1,18 @@
+#include <ecal/ecal.h>
+#include <ecal/msg/string/publisher.h>
+#include <thread>
+
+int main()
+{
+  eCAL::Initialize(0, nullptr, "Quick Publisher");
+
+  eCAL::string::CPublisher<std::string> pub("foo");
+
+  while (eCAL::Ok())
+  {
+    pub.Send("Hello World");
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+
+  eCAL::Finalize();
+}

--- a/testing/ecal/pubsub_test/src/out_of_order_messages_test.cpp
+++ b/testing/ecal/pubsub_test/src/out_of_order_messages_test.cpp
@@ -1,0 +1,104 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+#include <ecal/ecal.h>
+#include <ecal/msg/string/publisher.h>
+#include <ecal/msg/string/subscriber.h>
+#include <algorithm>
+#include <atomic>
+#include <thread>
+#include <vector>
+#include <gtest/gtest.h>
+
+namespace {
+  // subscriber callback function
+  void OnReceiveLazy(const char* topic_name_, const std::string& msg_, long long time_, long long clock_, long long id_)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  }
+
+  void OnReceiveCrazy(const char* topic_name_, const std::string& msg_, long long time_, long long clock_, long long id_)
+  {
+    static long long last_clock = 0;
+    EXPECT_LE(last_clock, clock_);
+    last_clock = clock_;
+  }
+}
+
+
+TEST(Core, OutOfOrderMessages)
+{
+  // initialize eCAL API
+  EXPECT_EQ(0, eCAL::Initialize(0, nullptr, "callback destruction"));
+
+  // enable loop back communication in the same thread
+  eCAL::Util::EnableLoopback(true);
+
+  // start publishing thread
+  eCAL::string::CPublisher<std::string> pub("foo");
+  eCAL::string::CSubscriber<std::string> sub_lazy("foo");
+  sub_lazy.AddReceiveCallback(OnReceiveLazy);
+  eCAL::string::CSubscriber<std::string> sub_crazy("foo");
+  sub_crazy.AddReceiveCallback(OnReceiveCrazy);
+
+
+  std::atomic<bool> pub_stop(false);
+  std::thread pub_t([&]() {
+    while (!pub_stop)
+    {
+      pub.Send("Hello World");
+      // some kind of busy waiting....
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    });
+
+  std::atomic<bool> sub_lazy_stop(false);
+  std::thread sub_lazy_t([&]() {
+    while (!sub_lazy_stop)
+    {
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    });
+
+  std::atomic<bool> sub_crazy_stop(false);
+  std::thread sub_crazy_t([&]() {
+    while (!sub_crazy_stop)
+    {
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    });
+  
+  // let them work together
+  std::this_thread::sleep_for(std::chrono::seconds(10));
+
+  // stop publishing thread
+  pub_stop = true;
+  pub_t.join();
+
+  sub_lazy_stop = true;
+  sub_lazy_t.join();
+
+  sub_crazy_stop = true;
+  sub_crazy_t.join();
+
+  // finalize eCAL API
+  // without destroying any pub / sub
+  EXPECT_EQ(0, eCAL::Finalize());
+
+}


### PR DESCRIPTION
**Pull request type**

Please check the type of change your PR introduces:
- [X] Bugfix

**What is the current behavior?**
See #1005.

Issue Number: #1005

**What is the new behavior?**
Out of order messages will be ignored and finally interpreted and logged as dropped message. Out of order message should be prevented by the transport layer itself. The current fix is on DataReader level and handling all incoming message for a certain subscriber.
The 3 "message_out_of_order" tests should be removed or cleaned up before merging this ..

**Does this introduce a breaking change?**

- [ ] Yes
- [X] No
