### PR TITLE
memfile observer pool and receive buffer cleanup

### DIFF
--- a/ecal/core/src/ecal_def.h
+++ b/ecal/core/src/ecal_def.h
@@ -126,7 +126,7 @@
 
 /* timeout for create / open a memory file using mutex lock in ms */
 #define PUB_MEMFILE_CREATE_TO                        200
-#define PUB_MEMFILE_OPEN_TO                           50
+#define PUB_MEMFILE_OPEN_TO                          200
 
 /* timeout for memory read acknowledge signal from data reader in ms */
 #define PUB_MEMFILE_ACK_TO                            0   /* ms */

--- a/ecal/core/src/io/ecal_memfile_pool.cpp
+++ b/ecal/core/src/io/ecal_memfile_pool.cpp
@@ -25,6 +25,8 @@
 #include "ecal_def.h"
 #include "ecal_memfile_pool.h"
 
+#include <ecal/ecal_process.h>
+
 #include <chrono>
 
 namespace eCAL
@@ -147,6 +149,9 @@ namespace eCAL
     // internal clock sample update checking
     uint64_t last_sample_clock(0);
 
+    // buffer to store memory file content
+    std::vector<char> receive_buffer;
+
     // runs as long as there is no timeout and no external stop request
     while((m_timeout_read < timeout_) && !m_do_stop)
     {
@@ -175,7 +180,7 @@ namespace eCAL
           else
           {
             // clear receive buffer
-            m_ecal_buffer.clear();
+            receive_buffer.clear();
 
             bool zero_copy_allowed = mfile_hdr.options.zero_copy != 0;
             bool post_process_buffer(false);
@@ -215,8 +220,8 @@ namespace eCAL
               }
               else
               {
-                m_ecal_buffer.resize((size_t)mfile_hdr.data_size);
-                m_memfile.Read(m_ecal_buffer.data(), (size_t)mfile_hdr.data_size, mfile_hdr.hdr_size);
+                receive_buffer.resize((size_t)mfile_hdr.data_size);
+                m_memfile.Read(receive_buffer.data(), (size_t)mfile_hdr.data_size, mfile_hdr.hdr_size);
                 post_process_buffer = true;
               }
             }
@@ -231,7 +236,7 @@ namespace eCAL
             if (post_process_buffer)
             {
               // add sample to data reader (and call user callback function)
-              if (m_data_callback) m_data_callback(topic_name_, topic_id_, m_ecal_buffer.data(), m_ecal_buffer.size(), (long long)mfile_hdr.id, (long long)mfile_hdr.clock, (long long)mfile_hdr.time, (size_t)mfile_hdr.hash);
+              if (m_data_callback) m_data_callback(topic_name_, topic_id_, receive_buffer.data(), receive_buffer.size(), (long long)mfile_hdr.id, (long long)mfile_hdr.clock, (long long)mfile_hdr.time, (size_t)mfile_hdr.hash);
             }
 
             // send acknowledge event
@@ -295,7 +300,8 @@ namespace eCAL
   // CMemFileThreadPool
   ////////////////////////////////////////
   CMemFileThreadPool::CMemFileThreadPool() :
-  m_created(false)
+  m_created(false),
+  m_do_cleanup(false)
   {
   }
 
@@ -304,12 +310,21 @@ namespace eCAL
   void CMemFileThreadPool::Create()
   {
     if(m_created) return;
+
+    // start cleanup thread
+    m_do_cleanup = true;
+    m_cleanup_thread = std::thread(&CMemFileThreadPool::CleanupPoolThread, this);
+
     m_created = true;
   }
 
   void CMemFileThreadPool::Destroy()
   {
     if(!m_created) return;
+
+    // stop cleanup thread
+    m_do_cleanup = false;
+    if (m_cleanup_thread.joinable()) m_cleanup_thread.join();
 
     // lock pool
     std::lock_guard<std::mutex> lock(m_observer_pool_sync);
@@ -327,9 +342,6 @@ namespace eCAL
   {
     if(!m_created)            return(false);
     if(memfile_name_.empty()) return(false);
-
-    // remove outdated observers
-    //CleanupPool();
 
     // lock pool
     std::lock_guard<std::mutex> lock(m_observer_pool_sync);
@@ -366,6 +378,16 @@ namespace eCAL
       Logging::Log(log_level_debug2, std::string("CMemFileThreadPool::ObserveFile " + memfile_name_ + " added"));
 #endif
       return(true);
+    }
+  }
+
+  void CMemFileThreadPool::CleanupPoolThread()
+  {
+    while (m_do_cleanup)
+    {
+      // cleanup outdated observers every 100 ms
+      CleanupPool();
+      Process::SleepMS(100);
     }
   }
 

--- a/ecal/core/src/io/ecal_memfile_pool.h
+++ b/ecal/core/src/io/ecal_memfile_pool.h
@@ -30,6 +30,7 @@
 #include "ecal_memfile_header.h"
 
 #include <atomic>
+#include <condition_variable>
 #include <functional>
 #include <map>
 #include <memory>
@@ -99,6 +100,8 @@ namespace eCAL
     std::map<std::string, std::shared_ptr<CMemFileObserver>>  m_observer_pool;
 
     std::atomic<bool>                                         m_do_cleanup;
+    std::condition_variable                                   m_do_cleanup_cv;
+    std::mutex                                                m_do_cleanup_mtx;
     std::thread                                               m_cleanup_thread;
   };
 }

--- a/ecal/core/src/io/ecal_memfile_pool.h
+++ b/ecal/core/src/io/ecal_memfile_pool.h
@@ -74,7 +74,6 @@ namespace eCAL
     EventHandleT            m_event_snd;
     EventHandleT            m_event_ack;
     CMemoryFile             m_memfile;
-    std::vector<char>       m_ecal_buffer;
   };
 
   ////////////////////////////////////////
@@ -92,10 +91,14 @@ namespace eCAL
     bool ObserveFile(const std::string& memfile_name_, const std::string& memfile_event_, const std::string& topic_name_, const std::string& topic_id_, int timeout_observation_ms, const MemFileDataCallbackT& callback_);
 
   protected:
+    void CleanupPoolThread();
     void CleanupPool();
 
     std::atomic<bool>                                         m_created;
     std::mutex                                                m_observer_pool_sync;
     std::map<std::string, std::shared_ptr<CMemFileObserver>>  m_observer_pool;
+
+    std::atomic<bool>                                         m_do_cleanup;
+    std::thread                                               m_cleanup_thread;
   };
 }

--- a/samples/cpp/datarate/datarate_snd/src/datarate_snd.cpp
+++ b/samples/cpp/datarate/datarate_snd/src/datarate_snd.cpp
@@ -31,16 +31,18 @@ int main(int argc, char **argv)
 {
   // parse command line
   TCLAP::CmdLine cmd("datarate_snd");
-  TCLAP::ValueArg<std::string> arg_topic_name(   "t", "topic_name",   "Topic name to publish.",           false, "topic", "string" );
-  TCLAP::ValueArg<int>         arg_size(         "s", "size",         "Message size in MB.",              false, 8,       "int"    );
-  TCLAP::ValueArg<int>         arg_sleep(        "d", "delay",        "Delay between publication in ms.", false, 1,       "int"    );
-  TCLAP::SwitchArg             arg_zero_copy(    "z", "zero_copy",    "Zero copy mode on/off."                                     );
-  TCLAP::ValueArg<int>         arg_buffer_count( "b", "buffer_count", "Number of memory file buffers.",   false, 1,       "int"    );
+  TCLAP::ValueArg<std::string> arg_topic_name       ("t", "topic_name",       "Topic name to publish.",                  false, "topic", "string");
+  TCLAP::ValueArg<int>         arg_size             ("s", "size",             "Message size in MB.",                     false,       8,    "int");
+  TCLAP::ValueArg<int>         arg_sleep            ("d", "delay",            "Delay between publication in ms.",        false,       1,    "int");
+  TCLAP::SwitchArg             arg_zero_copy        ("z", "zero_copy",        "Zero copy mode on/off."                                           );
+  TCLAP::ValueArg<int>         arg_buffer_count     ("b", "buffer_count",     "Number of memory file buffers.",          false,       1,    "int");
+  TCLAP::ValueArg<int>         arg_acknowledge_time ("a", "acknowledge_time", "Handshake acknowledgement timout in ms.", false,       0,    "int");
   cmd.add(arg_topic_name);
   cmd.add(arg_size);
   cmd.add(arg_sleep);
   cmd.add(arg_zero_copy);
   cmd.add(arg_buffer_count);
+  cmd.add(arg_acknowledge_time);
   cmd.parse(argc, argv);
   
   // get parameters
@@ -49,13 +51,15 @@ int main(int argc, char **argv)
   int         sleep(arg_sleep.getValue());
   bool        zero_copy(arg_zero_copy.getValue());
   int         buffer_count(arg_buffer_count.getValue());
+  int         acknowledge_time(arg_acknowledge_time.getValue());
 
   // log parameter
-  std::cout << "Topic name     = " << topic_name << std::endl;
-  std::cout << "Message size   = " << size << " MByte" << std::endl;
-  std::cout << "Sleep time     = " << sleep << " ms" << std::endl;
-  std::cout << "Zero copy mode = " << zero_copy << std::endl;
-  std::cout << "Buffer count   = " << buffer_count << std::endl;
+  std::cout << "Topic name           = " << topic_name                   << std::endl;
+  std::cout << "Message size         = " << size             << " MByte" << std::endl;
+  std::cout << "Sleep time           = " << sleep            << " ms"    << std::endl;
+  std::cout << "Zero copy mode       = " << zero_copy                    << std::endl;
+  std::cout << "Buffer count         = " << buffer_count                 << std::endl;
+  std::cout << "Acknowledgement time = " << acknowledge_time << " ms"    << std::endl;
 
   // initialize eCAL API
   eCAL::Initialize(argc, argv, "datarate_snd");
@@ -78,13 +82,16 @@ int main(int argc, char **argv)
   // set buffering
   pub.ShmSetBufferCount(buffer_count);
 
+  // set handshake acknowledgement timeout [ms]
+  pub.ShmSetAcknowledgeTimeout(acknowledge_time);
+
   // send updates
   while(eCAL::Ok())
   {
     // send content
     pub.Send(send_s);
     // sleep
-    std::this_thread::sleep_for(std::chrono::milliseconds(sleep));
+    if(sleep > 0) std::this_thread::sleep_for(std::chrono::milliseconds(sleep));
   }
 
   // destroy publisher


### PR DESCRIPTION
**Pull request type**

Please check the type of change your PR introduces:
- [X] Bugfix

**What is the current behavior?**
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
* For every observed memory file a separate thread is checking for updates (`CMemFileObserver::Observer`). When a memory file is outdated the observing thread ends without deallocating the `CMemFileObserver` internal receive buffer buffer variable `m_ecal_buffer` (renamed to `receive_buffer`).
* All `CMemFileObserver` are organized in a central map inside `CMemFileThreadPool`. Outdated/stopped observer entities are not removed from the global `CMemFileThreadPool::m_observer_pool` map.

Issue Number: #1021

**What is the new behavior?**
* The memory file content receive buffer is now defined inside the scope of the `CMemFileObserver::Observe` function and will be freed when observation is stopped/outdated.
* A new, additional eCAL global thread is cleaning up the `CMemFileThreadPool::m_observer_pool` map periodically.

**Does this introduce a breaking change?**

- [ ] Yes
- [X] No
