### PR TITLE
additional configurable logic to handle out of order messages

### DIFF
--- a/ecal/core/cfg/ecal.ini
+++ b/ecal/core/cfg/ecal.ini
@@ -182,9 +182,13 @@ filter_excl               = ^eCALSysClient$|^eCALSysGUI$|^eCALSys$
 ; shm_monitoring_domain       = ecal_monitoring    Domain name for shared memory based monitoring/registration
 ; shm_monitoring_queue_size   = 1024               Queue size of monitoring/registration events
 ; network_monitoring_disabled = false              Disable distribution of monitoring/registration information via network (default)
+;
+; drop_out_of_order_messages  = false              Enable dropping of payload messages that arrive out of order
 ; --------------------------------------------------
 [experimental]
 shm_monitoring_enabled      = false
 shm_monitoring_domain       = ecal_monitoring
 shm_monitoring_queue_size   = 1024
 network_monitoring_disabled = false
+
+drop_out_of_order_messages  = false

--- a/ecal/core/cfg/ecal.ini
+++ b/ecal/core/cfg/ecal.ini
@@ -163,7 +163,7 @@ share_tdesc               = 1
 timeout                   = 5000
 filter_excl               = __.*
 filter_incl               =
-filter_log_con            = error, fatal
+filter_log_con            = error, fatal, warning
 filter_log_file           =
 filter_log_udp            = info, warning, error, fatal
 

--- a/ecal/core/include/ecal/ecal_config.h
+++ b/ecal/core/include/ecal/ecal_config.h
@@ -127,6 +127,7 @@ namespace eCAL
       ECAL_API bool              IsNetworkMonitoringDisabled        ();
       ECAL_API size_t            GetShmMonitoringQueueSize          ();
       ECAL_API std::string       GetShmMonitoringDomain             ();
+      ECAL_API bool              GetDropOutOfOrderMessages          ();
     }
   }
 }

--- a/ecal/core/src/ecal_config.cpp
+++ b/ecal/core/src/ecal_config.cpp
@@ -187,6 +187,7 @@ namespace eCAL
       ECAL_API bool              IsNetworkMonitoringDisabled        () { return eCALPAR(EXP, NETWORK_MONITORING_DISABLED); }
       ECAL_API size_t            GetShmMonitoringQueueSize          () { return static_cast<size_t>(eCALPAR(EXP, SHM_MONITORING_QUEUE_SIZE)); }
       ECAL_API std::string       GetShmMonitoringDomain             () { return eCALPAR(EXP, SHM_MONITORING_DOMAIN);}
+      ECAL_API bool              GetDropOutOfOrderMessages          () { return eCALPAR(EXP, DROP_OUT_OF_ORDER_MESSAGES); }
     }
   }
 }

--- a/ecal/core/src/ecal_def.h
+++ b/ecal/core/src/ecal_def.h
@@ -188,3 +188,5 @@
 /* memory file access timeout */
 #define EXP_MEMFILE_ACCESS_TIMEOUT                  100
 
+/* enable dropping of payload messages that arrive out of order */
+#define EXP_DROP_OUT_OF_ORDER_MESSAGES              false

--- a/ecal/core/src/ecal_def_ini.h
+++ b/ecal/core/src/ecal_def_ini.h
@@ -128,3 +128,4 @@
 #define  EXP_NETWORK_MONITORING_DISABLED_S   "network_monitoring_disabled"
 #define  EXP_SHM_MONITORING_QUEUE_SIZE_S     "shm_monitoring_queue_size"
 #define  EXP_SHM_MONITORING_DOMAIN_S         "shm_monitoring_domain"
+#define  EXP_DROP_OUT_OF_ORDER_MESSAGES_S    "drop_out_of_order_messages"

--- a/ecal/core/src/readwrite/ecal_reader.cpp
+++ b/ecal/core/src/readwrite/ecal_reader.cpp
@@ -430,8 +430,16 @@ namespace eCAL
       if (m_id_set.find(id_) == m_id_set.end()) return(0);
     }
 
-    // check message dropping
-    CheckCounter(tid_, clock_);
+    // check the current message clock
+    // if the function returns false we detected
+    //  - a dropped message
+    //  - an out of order message
+    //  - a multiple sent message
+    if (!CheckMessageClock(tid_, clock_))
+    {
+      // we will not process that message
+      return(0);
+    }
 
 #ifndef NDEBUG
     // log it
@@ -702,17 +710,51 @@ namespace eCAL
     }
   }
 
-  void CDataReader::CheckCounter(const std::string& tid_, long long counter_)
+  bool CDataReader::CheckMessageClock(const std::string& tid_, long long current_clock_)
   {
     auto iter = m_writer_counter_map.find(tid_);
-    if (iter != m_writer_counter_map.end())
+    
+    // initial entry
+    if (iter == m_writer_counter_map.end())
     {
-      long long counter_last = iter->second;
-      long long drops = counter_ - counter_last;
-      if (drops > 1)
+      m_writer_counter_map[tid_] = current_clock_;
+      return true;
+    }
+    // clock entry exists
+    else
+    {
+      // calculate difference
+      long long last_clock = iter->second;
+      long long clock_difference = current_clock_ - last_clock;
+
+      // this is perfect, the next message arrived
+      if (clock_difference == 1)
+      {
+        // update the internal clock counter
+        iter->second = current_clock_;
+
+        // process it
+        return true;
+      }
+
+      // that should never happen, maybe there is a publisher
+      // sending parallel on multiple layers ?
+      // we ignore this message duplicate
+      if (clock_difference == 0)
+      {
+        // do not update the internal clock counter
+
+        // do not process it
+        return false;
+      }
+
+      // that means we miss at least one message
+      // -> we have a "message drop"
+      if (clock_difference > 1)
       {
 #if 0
-        std::string msg = std::to_string(counter_-counter_last) + " Messages lost ! ";
+        // we log this
+        std::string msg = std::to_string(counter_ - counter_last) + " Messages lost ! ";
         msg += "(Unit: \'";
         msg += Process::GetUnitName();
         msg += "@";
@@ -722,23 +764,69 @@ namespace eCAL
         msg += "\')";
         Logging::Log(log_level_warning, msg);
 #endif
+        // we fire the message drop event
         auto citer = m_event_callback_map.find(sub_event_dropped);
         if (citer != m_event_callback_map.end())
         {
           SSubEventCallbackData data;
-          data.type  = sub_event_dropped;
-          data.time  = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
-          data.clock = drops;
+          data.type = sub_event_dropped;
+          data.time = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
+          data.clock = current_clock_;
           (citer->second)(m_topic_name.c_str(), &data);
         }
-        m_message_drops += drops;
+        // increase the drop counter
+        m_message_drops += clock_difference;
+
+        // update the internal clock counter
+        iter->second = current_clock_;
+
+        // process it
+        return true;
       }
-      iter->second = counter_;
+
+      // a negative clock difference may happen if a publisher
+      // is using a shm ringbuffer and messages arrive in the wrong order
+      if (clock_difference < 0)
+      {
+        // we log this first
+        std::string msg = "Message received in wrong order ! ";
+        msg += "(Unit: \'";
+        msg += Process::GetUnitName();
+        msg += "@";
+        msg += Process::GetHostName();
+        msg += "\' | Subscriber: \'";
+        msg += m_topic_name;
+        msg += "\')";
+        Logging::Log(log_level_warning, msg);
+
+        // -----------------------------------
+        // drop messages in the wrong order
+        // -----------------------------------
+        if (eCAL::Config::Experimental::GetDropOutOfOrderMessages())
+        {
+          // do not update the internal clock counter
+
+          // there is no need to fire the drop event, because
+          // this event has been fired with the message before
+
+          // do not process it
+          return false;
+        }
+        // -----------------------------------
+        // process messages in the wrong order
+        // -----------------------------------
+        else
+        {
+          // do not update the internal clock counter
+
+          // process it
+          return true;
+        }
+      }
     }
-    else
-    {
-      m_writer_counter_map[tid_] = counter_;
-    }
+
+    // should never be reached
+    return false;
   }
     
   void CDataReader::RefreshRegistration()

--- a/ecal/core/src/readwrite/ecal_reader.cpp
+++ b/ecal/core/src/readwrite/ecal_reader.cpp
@@ -788,17 +788,6 @@ namespace eCAL
       // is using a shm ringbuffer and messages arrive in the wrong order
       if (clock_difference < 0)
       {
-        // we log this first
-        std::string msg = "Message received in wrong order ! ";
-        msg += "(Unit: \'";
-        msg += Process::GetUnitName();
-        msg += "@";
-        msg += Process::GetHostName();
-        msg += "\' | Subscriber: \'";
-        msg += m_topic_name;
-        msg += "\')";
-        Logging::Log(log_level_warning, msg);
-
         // -----------------------------------
         // drop messages in the wrong order
         // -----------------------------------
@@ -818,6 +807,13 @@ namespace eCAL
         else
         {
           // do not update the internal clock counter
+
+          // but we log this
+          std::string msg = "Subscriber: \'";
+          msg += m_topic_name;
+          msg += "\'";
+          msg += " received a message in the wrong order";
+          Logging::Log(log_level_warning, msg);
 
           // process it
           return true;

--- a/ecal/core/src/readwrite/ecal_reader.h
+++ b/ecal/core/src/readwrite/ecal_reader.h
@@ -107,7 +107,7 @@ namespace eCAL
     bool DoRegister(const bool force_);
     void Connect(const std::string& tid_, const std::string& ttype_, const std::string& tdesc_);
     void Disconnect();
-    void CheckCounter(const std::string& tid_, long long counter_);
+    bool CheckMessageClock(const std::string& tid_, long long current_clock_);
 
     std::string                               m_host_name;
     int                                       m_host_id;

--- a/samples/cpp/performance/performance_rec_cb/src/performance_rec_cb.cpp
+++ b/samples/cpp/performance/performance_rec_cb/src/performance_rec_cb.cpp
@@ -35,11 +35,12 @@ long long                             g_bytes(0);
 void PrintStatistic(const std::string& topic_name_, const std::chrono::duration<double>& diff_time_, const size_t size_, long long& bytes_, long long& msgs_)
 {
     std::stringstream out;
-    out << "Topic Name:            " << topic_name_                                    << std::endl;
+    out << "Topic Name:            " << topic_name_                                               << std::endl;
     out << "Message size (kByte):  " << (unsigned int)(size_  / 1024                            ) << std::endl;
     out << "kByte/s:               " << (unsigned int)(bytes_ / 1024        / diff_time_.count()) << std::endl;
     out << "MByte/s:               " << (unsigned int)(bytes_ / 1024 / 1024 / diff_time_.count()) << std::endl;
     out << "Messages/s:            " << (unsigned int)(msgs_                / diff_time_.count()) << std::endl;
+    out << "Latency (us):          " << (diff_time_.count() / msgs_) * 1000 * 1000                << std::endl;
     std::cout << out.str() << std::endl;
     msgs_  = 0;
     bytes_ = 0;


### PR DESCRIPTION
**Pull request type**

- [X] Feature

**What is the current behavior?**
Messages may arrive out of order under certain conditions. This is not handled currently.

Issue Number: #986

**What is the new behavior?**
Based on a new, experimental configuration flag `drop_out_of_order_messages` the eCAL core can handle out of order messages in 2 different ways:
1. ignore order and forward the message to the matching subscriber (issue will logged as warning)
2. ignore the message, interrupt the forwarding

The default behavior is 1.

**Does this introduce a breaking change?**

- [X] No
