### PR TITLE
bugfix/wrong-topic-id-used-in-local-layer-registration

### DIFF
--- a/ecal/core/src/pubsub/ecal_subgate.cpp
+++ b/ecal/core/src/pubsub/ecal_subgate.cpp
@@ -265,7 +265,7 @@ namespace eCAL
         // REMOVE ME IN ECAL6
         // ----------------------------------------------------------------------
 
-        iter->second->ApplyLocLayerParameter(process_id, tlayer.type(), writer_par);
+        iter->second->ApplyLocLayerParameter(process_id, topic_id, tlayer.type(), writer_par);
       }
       // inform for local publisher connection
       iter->second->ApplyLocPublication(process_id, topic_id, topic_type, topic_desc);

--- a/ecal/core/src/readwrite/ecal_reader.cpp
+++ b/ecal/core/src/readwrite/ecal_reader.cpp
@@ -598,7 +598,7 @@ namespace eCAL
     m_ext_published = true;
   }
 
-  void CDataReader::ApplyLocLayerParameter(const std::string& process_id_, eCAL::pb::eTLayerType type_, const std::string& parameter_)
+  void CDataReader::ApplyLocLayerParameter(const std::string& process_id_, const std::string& topic_id_, eCAL::pb::eTLayerType type_, const std::string& parameter_)
   {
     // process only for shm and tcp layer
     switch (type_)
@@ -615,7 +615,7 @@ namespace eCAL
     par.host_name  = m_host_name;
     par.process_id = process_id_;
     par.topic_name = m_topic_name;
-    par.topic_id   = m_topic_id;
+    par.topic_id   = topic_id_;
     par.parameter  = parameter_;
 
     switch (type_)

--- a/ecal/core/src/readwrite/ecal_reader.h
+++ b/ecal/core/src/readwrite/ecal_reader.h
@@ -77,8 +77,8 @@ namespace eCAL
     void ApplyLocPublication(const std::string& process_id_, const std::string& tid_, const std::string& ttype_, const std::string& tdesc_);
     void ApplyExtPublication(const std::string& host_name_, const std::string& tid_, const std::string& ttype_, const std::string& tdesc_);
 
-    void ApplyLocLayerParameter(const std::string& process_id_, eCAL::pb::eTLayerType type_, const std::string& parameter_);
-    void ApplyExtLayerParameter(const std::string& host_name_,  eCAL::pb::eTLayerType type_, const std::string& parameter_);
+    void ApplyLocLayerParameter(const std::string& process_id_, const std::string& topic_id_, eCAL::pb::eTLayerType type_, const std::string& parameter_);
+    void ApplyExtLayerParameter(const std::string& host_name_, eCAL::pb::eTLayerType type_, const std::string& parameter_);
 
     std::string Dump(const std::string& indent_ = "");
 


### PR DESCRIPTION
**Pull request type**

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix

**What is the current behavior?**
Subscriber receive clocks are stored in a map that handles all publisher connection. This receive clock map is using topic id's as key to differ between multiple publisher connections, writing on the same subscriber. In the case of a N:1 pub/sub SHM connection, the wrong topic id was used (the id from the subscriber itself, not from the sending publisher).

**What is the new behavior?**
Topic id from source topic (publisher) is use as key for the internal subscriber message clock counter map.

**Does this introduce a breaking change?**

- [X] No
