### PR TITLE
We implement one and only one SEND method for the publishers.

### DIFF
--- a/ecal/core/include/ecal/ecal_publisher.h
+++ b/ecal/core/include/ecal/ecal_publisher.h
@@ -314,7 +314,7 @@ namespace eCAL
      *
      * @return  Number of bytes sent. 
     **/
-    size_t Send(const void* const buf_, size_t len_, long long time_ = DEFAULT_TIME_ARGUMENT) const;
+    size_t Send(const void* buf_, size_t len_, long long time_ = DEFAULT_TIME_ARGUMENT) const;
 
     /**
      * @brief Send a message to all subscribers synchronized with acknowledge timeout (see also ShmSetAcknowledgeTimeout).

--- a/ecal/core/include/ecal/ecal_publisher.h
+++ b/ecal/core/include/ecal/ecal_publisher.h
@@ -66,6 +66,10 @@ namespace eCAL
   class ECAL_API CPublisher
   {
   public:
+
+    static constexpr long long DEFAULT_TIME_ARGUMENT        = -1;
+    static constexpr long long DEFAULT_ACKNOWLEDGE_ARGUMENT = -1;
+
     /**
      * @brief Constructor. 
     **/
@@ -310,7 +314,7 @@ namespace eCAL
      *
      * @return  Number of bytes sent. 
     **/
-    size_t Send(const void* const buf_, size_t len_, long long time_ = -1) const;
+    size_t Send(const void* const buf_, size_t len_, long long time_ = DEFAULT_TIME_ARGUMENT) const;
 
     /**
      * @brief Send a message to all subscribers synchronized with acknowledge timeout (see also ShmSetAcknowledgeTimeout).
@@ -352,9 +356,9 @@ namespace eCAL
      *
      * @return  Number of bytes sent.
     **/
-    size_t Send(const std::string& s_, long long time_ = -1) const
+    size_t Send(const std::string& s_, long long time_ = DEFAULT_TIME_ARGUMENT) const
     {
-      return(Send(s_.data(), s_.size(), time_));
+      return(Send(s_.data(), s_.size(), time_, DEFAULT_ACKNOWLEDGE_ARGUMENT));
     }
 
     /**

--- a/ecal/core/include/ecal/msg/publisher.h
+++ b/ecal/core/include/ecal/msg/publisher.h
@@ -116,36 +116,9 @@ namespace eCAL
      *
      * @return  Number of bytes sent. 
     **/
-    size_t Send(const T& msg_, long long time_ = -1)
+    size_t Send(const T& msg_, long long time_ = eCAL::CPublisher::DEFAULT_TIME_ARGUMENT)
     {
-      // this is an optimization ...
-      // if there is no subscription we do not waste time for
-      // serialization but we send an empty payload
-      // to still do some statistics like message clock
-      // counting and frequency calculation for the monitoring layer
-      if (!IsSubscribed())
-      {
-        return(CPublisher::Send(nullptr, 0));
-      }
-
-      // if we have a subscription allocate memory for the
-      // binary stream, serialize the message into the
-      // buffer and finally send it with a binary publisher
-      size_t size = GetSize(msg_);
-      if(size > 0)
-      {
-        m_buffer.resize(size);
-        if(Serialize(msg_, &m_buffer[0], m_buffer.size()))
-        {
-          return(CPublisher::Send(&m_buffer[0], size, time_));
-        }
-      }
-      else
-      {
-        // send a zero payload length message to trigger the subscriber side
-        return(CPublisher::Send(nullptr, 0, time_));
-      }
-      return(0);
+      return Send(msg_, time_, eCAL::CPublisher::DEFAULT_ACKNOWLEDGE_ARGUMENT);
     }
 
     /**
@@ -161,13 +134,19 @@ namespace eCAL
     **/
     size_t Send(const T& msg_, long long time_, long long acknowledge_timeout_ms_)
     {
-      // see CMsgPublisher::Send
+      // this is an optimization ...
+      // if there is no subscription we do not waste time for
+      // serialization but we send an empty payload
+      // to still do some statistics like message clock
+      // counting and frequency calculation for the monitoring layer
       if (!IsSubscribed())
       {
-        return(CPublisher::Send(nullptr, 0));
+        return(CPublisher::Send(nullptr, 0, time_, acknowledge_timeout_ms_));
       }
 
-      // see CMsgPublisher::Send
+      // if we have a subscription allocate memory for the
+      // binary stream, serialize the message into the
+      // buffer and finally send it with a binary publisher
       size_t size = GetSize(msg_);
       if (size > 0)
       {


### PR DESCRIPTION
**Pull request type**

Implement only one send function, to make the rest of the send logic trivial.
