### PR TITLE
clang-tidy fixes in ecal/core/src/ecal_util.cpp

### DIFF
--- a/ecal/core/src/ecal_util.cpp
+++ b/ecal/core/src/ecal_util.cpp
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,7 +21,6 @@
  * @brief  eCAL utility functions
 **/
 
-#include <ecal/ecal_os.h>
 #include <ecal/ecal_core.h>
 
 #include "ecal_def.h"
@@ -31,11 +30,7 @@
 #include "pubsub/ecal_pubgate.h"
 #include "mon/ecal_monitoring_def.h"
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <cstdlib>
 #include <iostream>
-#include <list>
 #include <string>
 
 #ifdef ECAL_OS_WINDOWS
@@ -47,7 +42,7 @@ namespace eCAL
   /**
    * @brief Return the eCAL process state.
    *
-   * @return  True if eCAL is in proper state. 
+   * @return  True if eCAL is in proper state.
   **/
   bool Ok()
   {
@@ -59,14 +54,15 @@ namespace eCAL
     // take monitoring snapshot
     static eCAL::pb::Monitoring GetMonitoring()
     {
-      if (!eCAL::IsInitialized(eCAL::Init::Monitoring))
+      if (eCAL::IsInitialized(eCAL::Init::Monitoring) == 0)
       {
         eCAL::Initialize(0, nullptr, "", eCAL::Init::Monitoring);
         eCAL::Process::SleepMS(1000);
       }
 
       eCAL::pb::Monitoring monitoring;
-      if (eCAL::g_monitoring()) eCAL::g_monitoring()->GetMonitoring(monitoring);
+      if (eCAL::g_monitoring() != nullptr)
+        eCAL::g_monitoring()->GetMonitoring(monitoring);
 
       return(monitoring);
     }
@@ -82,10 +78,9 @@ namespace eCAL
       std::string          host_name  = eCAL::Process::GetHostName();
 
       std::vector<int> proc_id_list;
-      for (int i = 0; i < monitoring.processes().size(); i++)
+      for (const auto& process : monitoring.processes())
       {
-        const eCAL::pb::Process& process = monitoring.processes(i);
-        std::string pname = process.pname();
+        const std::string& pname = process.pname();
         if ((pname == process_name_)
           && (process.hname() == host_name)
           )
@@ -126,10 +121,9 @@ namespace eCAL
       std::string          host_name  = eCAL::Process::GetHostName();
 
       std::vector<int> proc_id_list;
-      for (int i = 0; i < monitoring.processes().size(); i++)
+      for (const auto& process : monitoring.processes())
       {
-        const eCAL::pb::Process& process = monitoring.processes(i);
-        std::string uname = process.uname();
+        const std::string& uname = process.uname();
         if  ((uname != "eCALMon")
           && (uname != "eCALRPCService")
           && (uname != "eCALParam")
@@ -162,10 +156,9 @@ namespace eCAL
       std::string          host_name  = eCAL::Process::GetHostName();
 
       std::vector<int> proc_id_list;
-      for (int i = 0; i < monitoring.processes().size(); i++)
+      for (const auto& process : monitoring.processes())
       {
-        const eCAL::pb::Process& process = monitoring.processes(i);
-        std::string uname = process.uname();
+        const std::string& uname = process.uname();
         if (((uname == "eCALMon")
           || (uname == "eCALParam")
           || (uname == "eCALPlay")
@@ -198,7 +191,8 @@ namespace eCAL
     **/
     void EnableLoopback(bool state_)
     {
-      if (g_registration_receiver()) g_registration_receiver()->EnableLoopback(state_);
+      if (g_registration_receiver() != nullptr)
+        g_registration_receiver()->EnableLoopback(state_);
     }
 
     /**
@@ -209,7 +203,8 @@ namespace eCAL
     **/
     void PubShareType(bool state_)
     {
-      if (g_pubgate()) g_pubgate()->ShareType(state_);
+      if (g_pubgate() != nullptr)
+        g_pubgate()->ShareType(state_);
     }
 
     /**
@@ -220,7 +215,8 @@ namespace eCAL
     **/
     void PubShareDescription(bool state_)
     {
-      if (g_pubgate()) g_pubgate()->ShareDescription(state_);
+      if (g_pubgate() != nullptr)
+        g_pubgate()->ShareDescription(state_);
     }
 
     /**
@@ -231,7 +227,7 @@ namespace eCAL
     **/
     void GetTopics(std::unordered_map<std::string, STopicInfo>& topic_info_map_)
     {
-      if (!g_descgate()) return;
+      if (g_descgate() == nullptr) return;
       g_descgate()->GetTopics(topic_info_map_);
     }
 
@@ -242,7 +238,7 @@ namespace eCAL
     **/
     void GetTopicNames(std::vector<std::string>& topic_names_)
     {
-      if (!g_descgate()) return;
+      if (g_descgate() == nullptr) return;
       g_descgate()->GetTopicNames(topic_names_);
     }
 
@@ -256,7 +252,7 @@ namespace eCAL
     **/
     bool GetTopicTypeName(const std::string& topic_name_, std::string& topic_type_)
     {
-      if (!g_descgate()) return(false);
+      if (g_descgate() == nullptr) return(false);
       return(g_descgate()->GetTopicTypeName(topic_name_, topic_type_));
     }
 
@@ -299,7 +295,8 @@ namespace eCAL
     **/
     bool GetTopicDescription(const std::string& topic_name_, std::string& topic_desc_)
     {
-      if (!g_descgate()) return(false);
+      if (g_descgate() == nullptr)
+        return(false);
       return(g_descgate()->GetTopicDescription(topic_name_, topic_desc_));
     }
 
@@ -340,7 +337,8 @@ namespace eCAL
     **/
     void GetServices(std::map<std::tuple<std::string, std::string>, Util::SServiceMethodInfo>& service_info_map_)
     {
-      if (!g_descgate()) return;
+      if (g_descgate() == nullptr)
+        return;
       g_descgate()->GetServices(service_info_map_);
     }
 
@@ -351,7 +349,8 @@ namespace eCAL
     **/
     void GetServiceNames(std::vector<std::tuple<std::string, std::string>>& service_method_names_)
     {
-      if (!g_descgate()) return;
+      if (g_descgate() == nullptr)
+        return;
       g_descgate()->GetServiceNames(service_method_names_);
     }
 
@@ -367,7 +366,8 @@ namespace eCAL
     **/
     bool GetServiceTypeNames(const std::string& service_name_, const std::string& method_name_, std::string& req_type_, std::string& resp_type_)
     {
-      if (!g_descgate()) return(false);
+      if (g_descgate() == nullptr)
+        return(false);
       return(g_descgate()->GetServiceTypeNames(service_name_, method_name_, req_type_, resp_type_));
     }
 
@@ -383,7 +383,8 @@ namespace eCAL
     **/
     bool GetServiceDescription(const std::string& service_name_, const std::string& method_name_, std::string& req_desc_, std::string& resp_desc_)
     {
-      if (!g_descgate()) return(false);
+      if (g_descgate() == nullptr)
+        return(false);
       return(g_descgate()->GetServiceDescription(service_name_, method_name_, req_desc_, resp_desc_));
     }
   }

--- a/ecal/core/src/ecal_util.cpp
+++ b/ecal/core/src/ecal_util.cpp
@@ -227,7 +227,8 @@ namespace eCAL
     **/
     void GetTopics(std::unordered_map<std::string, STopicInfo>& topic_info_map_)
     {
-      if (g_descgate() == nullptr) return;
+      if (g_descgate() == nullptr)
+        return;
       g_descgate()->GetTopics(topic_info_map_);
     }
 
@@ -238,7 +239,8 @@ namespace eCAL
     **/
     void GetTopicNames(std::vector<std::string>& topic_names_)
     {
-      if (g_descgate() == nullptr) return;
+      if (g_descgate() == nullptr)
+        return;
       g_descgate()->GetTopicNames(topic_names_);
     }
 
@@ -252,7 +254,8 @@ namespace eCAL
     **/
     bool GetTopicTypeName(const std::string& topic_name_, std::string& topic_type_)
     {
-      if (g_descgate() == nullptr) return(false);
+      if (g_descgate() == nullptr)
+        return(false);
       return(g_descgate()->GetTopicTypeName(topic_name_, topic_type_));
     }
 


### PR DESCRIPTION
Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


Fixed some minor clang-tidy warnings in the file `ecal/core/src/ecal_util.cpp` in the easiest possible way. Also replaced looping over `RepeatedPtrField` variables with range based for loops. **No functional changes.**

Not sure how to test it, though. `test_core` is passing, but I'm not sure whether it's testing any of the changed functions.