### PR TITLE
Feature/shared ptr datawriter

### DIFF
--- a/ecal/core/include/ecal/ecal_publisher.h
+++ b/ecal/core/include/ecal/ecal_publisher.h
@@ -30,6 +30,7 @@
 #include <ecal/ecal_tlayer.h>
 
 #include <chrono>
+#include <memory>
 #include <string>
 
 namespace eCAL
@@ -63,17 +64,17 @@ namespace eCAL
    *            size_t snd_len = pub.Send(send_s);
    * @endcode
   **/
-  class ECAL_API CPublisher
+  class CPublisher
   {
   public:
 
-    static constexpr long long DEFAULT_TIME_ARGUMENT        = -1;
-    static constexpr long long DEFAULT_ACKNOWLEDGE_ARGUMENT = -1;
+    ECAL_API static constexpr long long DEFAULT_TIME_ARGUMENT        = -1;
+    ECAL_API static constexpr long long DEFAULT_ACKNOWLEDGE_ARGUMENT = -1;
 
     /**
      * @brief Constructor. 
     **/
-    CPublisher();
+    ECAL_API CPublisher();
 
     /**
      * @brief Constructor. 
@@ -82,32 +83,32 @@ namespace eCAL
      * @param topic_type_   Type name (optional). 
      * @param topic_desc_   Type description (optional). 
     **/
-    CPublisher(const std::string& topic_name_, const std::string& topic_type_ = "", const std::string& topic_desc_ = "");
+    ECAL_API CPublisher(const std::string& topic_name_, const std::string& topic_type_ = "", const std::string& topic_desc_ = "");
 
     /**
      * @brief Destructor. 
     **/
-    virtual ~CPublisher();
+    ECAL_API virtual ~CPublisher();
 
     /**
      * @brief CPublishers are non-copyable
     **/
-    CPublisher(const CPublisher&) = delete;
+    ECAL_API CPublisher(const CPublisher&) = delete;
 
     /**
      * @brief CPublishers are non-copyable
     **/
-    CPublisher& operator=(const CPublisher&) = delete;
+    ECAL_API CPublisher& operator=(const CPublisher&) = delete;
 
     /**
      * @brief CPublishers are move-enabled
     **/
-    CPublisher(CPublisher&& rhs) noexcept;
+    ECAL_API CPublisher(CPublisher&& rhs) noexcept;
 
     /**
      * @brief CPublishers are move-enabled
     **/
-    CPublisher& operator=(CPublisher&& rhs) noexcept;
+    ECAL_API CPublisher& operator=(CPublisher&& rhs) noexcept;
 
     /**
      * @brief Creates this object. 
@@ -118,14 +119,14 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails. 
     **/
-    bool Create(const std::string& topic_name_, const std::string& topic_type_ = "", const std::string& topic_desc_ = "");
+    ECAL_API bool Create(const std::string& topic_name_, const std::string& topic_type_ = "", const std::string& topic_desc_ = "");
 
     /**
      * @brief Destroys this object. 
      *
      * @return  True if it succeeds, false if it fails. 
     **/
-    bool Destroy();
+    ECAL_API bool Destroy();
 
     /**
      * @brief Setup topic type name.
@@ -134,7 +135,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails.
     **/
-    bool SetTypeName(const std::string& topic_type_name_);
+    ECAL_API bool SetTypeName(const std::string& topic_type_name_);
 
     /**
      * @brief Setup topic description. 
@@ -143,7 +144,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails. 
     **/
-    bool SetDescription(const std::string& topic_desc_);
+    ECAL_API bool SetDescription(const std::string& topic_desc_);
 
     /**
      * @brief Sets publisher attribute. 
@@ -154,7 +155,7 @@ namespace eCAL
      * @return  True if it succeeds, false if it fails. 
      * @experimental
     **/
-    bool SetAttribute(const std::string& attr_name_, const std::string& attr_value_);
+    ECAL_API bool SetAttribute(const std::string& attr_name_, const std::string& attr_value_);
 
     /**
      * @brief Removes publisher attribute. 
@@ -164,7 +165,7 @@ namespace eCAL
      * @return  True if it succeeds, false if it fails.
      * @experimental
     **/
-    bool ClearAttribute(const std::string& attr_name_);
+    ECAL_API bool ClearAttribute(const std::string& attr_name_);
 
     /**
      * @brief Share topic type.
@@ -173,7 +174,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails.
     **/
-    bool ShareType(bool state_ = true);
+    ECAL_API bool ShareType(bool state_ = true);
 
     /**
      * @brief Share topic description.
@@ -182,7 +183,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails.
     **/
-    bool ShareDescription(bool state_ = true);
+    ECAL_API bool ShareDescription(bool state_ = true);
 
     /**
      * @brief Set publisher quality of service attributes.
@@ -191,14 +192,14 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails.
     **/
-    bool SetQOS(const QOS::SWriterQOS& qos_);
+    ECAL_API bool SetQOS(const QOS::SWriterQOS& qos_);
 
     /**
      * @brief Get current publisher quality of service attributes.
      *
      * @return  Quality of service attributes.
     **/
-    QOS::SWriterQOS GetQOS();
+    ECAL_API QOS::SWriterQOS GetQOS();
 
     /**
      * @brief Set publisher send mode for specific transport layer. 
@@ -208,7 +209,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails. 
     **/
-    bool SetLayerMode(TLayer::eTransportLayer layer_, TLayer::eSendMode mode_);
+    ECAL_API bool SetLayerMode(TLayer::eTransportLayer layer_, TLayer::eSendMode mode_);
 
     /**
      * @brief Set publisher maximum transmit bandwidth for the udp layer.
@@ -217,7 +218,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails.
     **/
-    bool SetMaxBandwidthUDP(long bandwidth_);
+    ECAL_API bool SetMaxBandwidthUDP(long bandwidth_);
 
     /**
      * @brief Set publisher maximum number of used shared memory buffers.
@@ -226,7 +227,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails.
     **/
-    bool ShmSetBufferCount(long buffering_);
+    ECAL_API bool ShmSetBufferCount(long buffering_);
 
     /**
      * @brief Enable zero copy shared memory transport mode.
@@ -255,7 +256,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails.
     **/
-    bool ShmEnableZeroCopy(bool state_);
+    ECAL_API bool ShmEnableZeroCopy(bool state_);
 
     /**
      * @brief Force connected subscribers to send acknowledge event after processing the message and 
@@ -277,7 +278,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails.
     **/
-    bool ShmSetAcknowledgeTimeout(long long acknowledge_timeout_ms_);
+    ECAL_API bool ShmSetAcknowledgeTimeout(long long acknowledge_timeout_ms_);
 
     /**
      * @brief Force connected subscribers to send acknowledge event after processing the message and
@@ -303,7 +304,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails.
     **/
-    bool SetID(long long id_);
+    ECAL_API bool SetID(long long id_);
 
     /**
      * @brief Send a message to all subscribers. 
@@ -314,7 +315,7 @@ namespace eCAL
      *
      * @return  Number of bytes sent. 
     **/
-    size_t Send(const void* buf_, size_t len_, long long time_ = DEFAULT_TIME_ARGUMENT) const;
+    ECAL_API size_t Send(const void* buf_, size_t len_, long long time_ = DEFAULT_TIME_ARGUMENT) const;
 
     /**
      * @brief Send a message to all subscribers synchronized with acknowledge timeout (see also ShmSetAcknowledgeTimeout).
@@ -328,7 +329,7 @@ namespace eCAL
      *
      * @return  Number of bytes sent.
     **/
-    size_t Send(const void* const buf_, size_t len_, long long time_, long long acknowledge_timeout_ms_) const;
+    ECAL_API size_t Send(const void* const buf_, size_t len_, long long time_, long long acknowledge_timeout_ms_) const;
 
     /**
      * @brief Send a message to all subscribers synchronized with acknowledge timeout (see also ShmSetAcknowledgeTimeout).
@@ -343,7 +344,7 @@ namespace eCAL
      * @return  Number of bytes sent.
     **/
     [[deprecated]]
-    size_t SendSynchronized(const void* const buf_, size_t len_, long long time_, long long acknowledge_timeout_ms_) const
+    ECAL_API size_t SendSynchronized(const void* const buf_, size_t len_, long long time_, long long acknowledge_timeout_ms_) const
     {
       return Send(buf_, len_, time_, acknowledge_timeout_ms_);
     }
@@ -356,7 +357,7 @@ namespace eCAL
      *
      * @return  Number of bytes sent.
     **/
-    size_t Send(const std::string& s_, long long time_ = DEFAULT_TIME_ARGUMENT) const
+    ECAL_API size_t Send(const std::string& s_, long long time_ = DEFAULT_TIME_ARGUMENT) const
     {
       return(Send(s_.data(), s_.size(), time_, DEFAULT_ACKNOWLEDGE_ARGUMENT));
     }
@@ -370,7 +371,7 @@ namespace eCAL
      *
      * @return  Number of bytes sent.
     **/
-    size_t Send(const std::string& s_, long long time_, long long acknowledge_timeout_ms_) const
+    ECAL_API size_t Send(const std::string& s_, long long time_, long long acknowledge_timeout_ms_) const
     {
       return(Send(s_.data(), s_.size(), time_, acknowledge_timeout_ms_));
     }
@@ -383,7 +384,7 @@ namespace eCAL
      *
      * @return  True if succeeded, false if not.
     **/
-    bool AddEventCallback(eCAL_Publisher_Event type_, PubEventCallbackT callback_);
+    ECAL_API bool AddEventCallback(eCAL_Publisher_Event type_, PubEventCallbackT callback_);
 
     /**
      * @brief Remove callback function for publisher events.
@@ -392,49 +393,49 @@ namespace eCAL
      *
      * @return  True if succeeded, false if not.
     **/
-    bool RemEventCallback(eCAL_Publisher_Event type_);
+    ECAL_API bool RemEventCallback(eCAL_Publisher_Event type_);
 
     /**
      * @brief Query if the publisher is created. 
      *
      * @return  True if created, false if not. 
     **/
-    bool IsCreated() const {return(m_created);}
+    ECAL_API bool IsCreated() const {return(m_created);}
 
     /**
      * @brief Query if the publisher is subscribed. 
      *
      * @return  true if subscribed, false if not. 
     **/
-    bool IsSubscribed() const;
+    ECAL_API bool IsSubscribed() const;
 
     /**
      * @brief Query the number of subscribers. 
      *
      * @return  Number of subscribers. 
     **/
-    size_t GetSubscriberCount() const;
+    ECAL_API size_t GetSubscriberCount() const;
 
     /**
      * @brief Gets name of the connected topic. 
      *
      * @return  The topic name. 
     **/
-    std::string GetTopicName() const;
+    ECAL_API std::string GetTopicName() const;
 
     /**
      * @brief Gets type of the connected topic. 
      *
      * @return  The type name. 
     **/
-    std::string GetTypeName() const;
+    ECAL_API std::string GetTypeName() const;
 
     /**
      * @brief Gets description of the connected topic. 
      *
      * @return  The description. 
     **/
-    std::string GetDescription() const;
+    ECAL_API std::string GetDescription() const;
 
     /**
      * @brief Dump the whole class state into a string. 
@@ -443,7 +444,7 @@ namespace eCAL
      *
      * @return  The dump string. 
     **/
-    std::string Dump(const std::string& indent_ = "") const;
+    ECAL_API std::string Dump(const std::string& indent_ = "") const;
 
   protected:
     void InitializeQOS();
@@ -451,7 +452,7 @@ namespace eCAL
     bool ApplyTopicToDescGate(const std::string& topic_name_, const std::string& topic_type_, const std::string& topic_desc_);
 
     // class members
-    CDataWriter*                     m_datawriter;
+    std::shared_ptr<CDataWriter>     m_datawriter;
     struct ECAL_API QOS::SWriterQOS  m_qos;
     struct ECAL_API TLayer::STLayer  m_tlayer;
     long long                        m_id;

--- a/ecal/core/include/ecal/ecal_subscriber.h
+++ b/ecal/core/include/ecal/ecal_subscriber.h
@@ -28,6 +28,7 @@
 #include <ecal/ecal_callback.h>
 #include <ecal/ecal_qos.h>
 
+#include <memory>
 #include <set>
 #include <string>
 
@@ -78,13 +79,13 @@ namespace eCAL
    * @endcode
   **/
 
-  class ECAL_API CSubscriber
+  class CSubscriber
   {
   public:
     /**
      * @brief Constructor. 
     **/
-    CSubscriber();
+    ECAL_API CSubscriber();
 
     /**
      * @brief Constructor. 
@@ -93,32 +94,32 @@ namespace eCAL
      * @param topic_type_   Type name (optional for type checking).
      * @param topic_desc_   Type description (optional for description checking).
      **/
-    CSubscriber(const std::string& topic_name_, const std::string& topic_type_ = "", const std::string& topic_desc_ = "");
+    ECAL_API CSubscriber(const std::string& topic_name_, const std::string& topic_type_ = "", const std::string& topic_desc_ = "");
 
     /**
      * @brief Destructor. 
     **/
-    virtual ~CSubscriber();
+    ECAL_API virtual ~CSubscriber();
 
     /**
      * @brief CSubscribers are non-copyable
     **/
-    CSubscriber(const CSubscriber&) = delete;
+    ECAL_API CSubscriber(const CSubscriber&) = delete;
 
     /**
      * @brief CSubscribers are non-copyable
     **/
-    CSubscriber& operator=(const CSubscriber&) = delete;
+    ECAL_API CSubscriber& operator=(const CSubscriber&) = delete;
 
     /**
      * @brief CSubscribers are move-enabled
     **/
-    CSubscriber(CSubscriber&& rhs) noexcept;
+    ECAL_API CSubscriber(CSubscriber&& rhs) noexcept;
 
     /**
      * @brief CSubscribers are move-enabled
     **/
-    CSubscriber& operator=(CSubscriber&& rhs) noexcept;
+    ECAL_API CSubscriber& operator=(CSubscriber&& rhs) noexcept;
 
     /**
      * @brief Creates this object. 
@@ -129,14 +130,14 @@ namespace eCAL
      *
      * @return  true if it succeeds, false if it fails. 
     **/
-    bool Create(const std::string& topic_name_, const std::string& topic_type_ = "", const std::string& topic_desc_ = "");
+    ECAL_API bool Create(const std::string& topic_name_, const std::string& topic_type_ = "", const std::string& topic_desc_ = "");
 
     /**
      * @brief Destroys this object. 
      *
      * @return  true if it succeeds, false if it fails. 
     **/
-    bool Destroy();
+    ECAL_API bool Destroy();
 
     /**
      * @brief Set subscriber quality of service attributes.
@@ -145,14 +146,14 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails.
     **/
-    bool SetQOS(const QOS::SReaderQOS& qos_);
+    ECAL_API bool SetQOS(const QOS::SReaderQOS& qos_);
 
     /**
      * @brief Get current subscriber quality of service attributes.
      *
      * @return  Quality of service attributes.
     **/
-    QOS::SReaderQOS GetQOS();
+    ECAL_API QOS::SReaderQOS GetQOS();
 
     /**
      * @brief Set a set of id's to prefiltering topics (see CPublisher::SetID).
@@ -161,7 +162,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails.
     **/
-    bool SetID(const std::set<long long>& id_set_);
+    ECAL_API bool SetID(const std::set<long long>& id_set_);
 
     /**
      * @brief Sets subscriber attribute. 
@@ -172,7 +173,7 @@ namespace eCAL
      * @return  True if it succeeds, false if it fails. 
      * @experimental
     **/
-    bool SetAttribute(const std::string& attr_name_, const std::string& attr_value_);
+    ECAL_API bool SetAttribute(const std::string& attr_name_, const std::string& attr_value_);
 
     /**
      * @brief Removes subscriber attribute. 
@@ -182,7 +183,7 @@ namespace eCAL
      * @return  True if it succeeds, false if it fails.
      * @experimental
     **/
-    bool ClearAttribute(const std::string& attr_name_);
+    ECAL_API bool ClearAttribute(const std::string& attr_name_);
 
     /**
      * @brief Receive a message from the publisher. 
@@ -194,7 +195,7 @@ namespace eCAL
      * @return  Length of received buffer. 
     **/
     [[deprecated]]
-    size_t Receive(std::string& buf_, long long* time_ = nullptr, int rcv_timeout_ = 0) const;
+    ECAL_API size_t Receive(std::string& buf_, long long* time_ = nullptr, int rcv_timeout_ = 0) const;
 
     /**
      * @brief Receive a message from the publisher (able to process zero length buffer).
@@ -205,7 +206,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails.
     **/
-    bool ReceiveBuffer(std::string& buf_, long long* time_ = nullptr, int rcv_timeout_ = 0) const;
+    ECAL_API bool ReceiveBuffer(std::string& buf_, long long* time_ = nullptr, int rcv_timeout_ = 0) const;
 
     /**
      * @brief Add callback function for incoming receives. 
@@ -214,14 +215,14 @@ namespace eCAL
      *
      * @return  True if succeeded, false if not. 
     **/
-    bool AddReceiveCallback(ReceiveCallbackT callback_);
+    ECAL_API bool AddReceiveCallback(ReceiveCallbackT callback_);
 
     /**
      * @brief Remove callback function for incoming receives. 
      *
      * @return  True if succeeded, false if not. 
     **/
-    bool RemReceiveCallback();
+    ECAL_API bool RemReceiveCallback();
 
     /**
      * @brief Add callback function for subscriber events.
@@ -231,7 +232,7 @@ namespace eCAL
      *
      * @return  True if succeeded, false if not.
     **/
-    bool AddEventCallback(eCAL_Subscriber_Event type_, SubEventCallbackT callback_);
+    ECAL_API bool AddEventCallback(eCAL_Subscriber_Event type_, SubEventCallbackT callback_);
 
     /**
      * @brief Remove callback function for subscriber events.
@@ -240,42 +241,42 @@ namespace eCAL
      *
      * @return  True if succeeded, false if not.
     **/
-    bool RemEventCallback(eCAL_Subscriber_Event type_);
+    ECAL_API bool RemEventCallback(eCAL_Subscriber_Event type_);
 
     /**
      * @brief Query if this object is created. 
      *
      * @return  true if created, false if not. 
     **/
-    bool IsCreated() const {return(m_created);}
+    ECAL_API bool IsCreated() const {return(m_created);}
 
     /**
      * @brief Query the number of publishers. 
      *
      * @return  Number of publishers. 
     **/
-    size_t GetPublisherCount() const;
+    ECAL_API size_t GetPublisherCount() const;
 
     /**
      * @brief Gets name of the connected topic. 
      *
      * @return  The topic name. 
     **/
-    std::string GetTopicName() const;
+    ECAL_API std::string GetTopicName() const;
 
     /**
      * @brief Gets type of the connected topic. 
      *
      * @return  The type name. 
     **/
-    std::string GetTypeName() const;
+    ECAL_API std::string GetTypeName() const;
 
     /**
      * @brief Gets description of the connected topic. 
      *
      * @return  The description. 
     **/
-    std::string GetDescription() const;
+    ECAL_API std::string GetDescription() const;
 
     /**
      * @brief Set the timeout parameter for triggering
@@ -285,7 +286,7 @@ namespace eCAL
      *
      * @return  True if succeeded, false if not.
     **/
-    bool SetTimeout(int timeout_);
+    ECAL_API bool SetTimeout(int timeout_);
 
     /**
      * @brief Dump the whole class state into a string. 
@@ -294,14 +295,14 @@ namespace eCAL
      *
      * @return  The dump sting. 
     **/
-    std::string Dump(const std::string& indent_ = "") const;
+    ECAL_API std::string Dump(const std::string& indent_ = "") const;
 
   protected:
     void InitializeQOS();
     bool ApplyTopicToDescGate(const std::string& topic_name_, const std::string& topic_type_, const std::string& topic_desc_);
 
     // class members
-    CDataReader*                     m_datareader;
+    std::shared_ptr<CDataReader>     m_datareader;
     struct ECAL_API QOS::SReaderQOS  m_qos;
     bool                             m_created;
     bool                             m_initialized;

--- a/ecal/core/src/pubsub/ecal_pubgate.cpp
+++ b/ecal/core/src/pubsub/ecal_pubgate.cpp
@@ -79,18 +79,18 @@ namespace eCAL
     m_share_desc = state_;
   }
 
-  bool CPubGate::Register(const std::string& topic_name_, CDataWriter* datawriter_)
+  bool CPubGate::Register(const std::string& topic_name_, std::shared_ptr<CDataWriter> datawriter_)
   {
     if(!m_created) return(false);
 
     // register writer and multicast group
     std::unique_lock<std::shared_timed_mutex> lock(m_topic_name_datawriter_sync);
-    m_topic_name_datawriter_map.emplace(std::pair<std::string, CDataWriter*>(topic_name_, datawriter_));
+    m_topic_name_datawriter_map.emplace(std::pair<std::string, std::shared_ptr<CDataWriter>>(topic_name_, datawriter_));
 
     return(true);
   }
 
-  bool CPubGate::Unregister(const std::string& topic_name_, CDataWriter* datawriter_)
+  bool CPubGate::Unregister(const std::string& topic_name_, std::shared_ptr<CDataWriter> datawriter_)
   {
     if(!m_created) return(false);
     bool ret_state = false;

--- a/ecal/core/src/pubsub/ecal_pubgate.h
+++ b/ecal/core/src/pubsub/ecal_pubgate.h
@@ -49,8 +49,8 @@ namespace eCAL
     void ShareDescription(bool state_);
     bool DescriptionShared() { return m_share_desc; };
 
-    bool Register(const std::string& topic_name_, CDataWriter* datawriter_);
-    bool Unregister(const std::string& topic_name_, CDataWriter* datawriter_);
+    bool Register(const std::string& topic_name_, std::shared_ptr<CDataWriter> datawriter_);
+    bool Unregister(const std::string& topic_name_, std::shared_ptr<CDataWriter> datawriter_);
 
     void ApplyLocSubRegistration(const eCAL::pb::Sample& ecal_sample_);
     void ApplyExtSubRegistration(const eCAL::pb::Sample& ecal_sample_);
@@ -64,7 +64,7 @@ namespace eCAL
     bool                      m_share_type;
     bool                      m_share_desc;
 
-    typedef std::multimap<std::string, CDataWriter*> TopicNameDataWriterMapT;
+    typedef std::multimap<std::string, std::shared_ptr<CDataWriter>> TopicNameDataWriterMapT;
     std::shared_timed_mutex   m_topic_name_datawriter_sync;
     TopicNameDataWriterMapT   m_topic_name_datawriter_map;
   };

--- a/ecal/core/src/pubsub/ecal_publisher.cpp
+++ b/ecal/core/src/pubsub/ecal_publisher.cpp
@@ -126,7 +126,7 @@ namespace eCAL
     if (m_tlayer.sm_inproc  == TLayer::smode_none) m_tlayer.sm_inproc = Config::GetPublisherInprocMode();
 
     // create data writer
-    m_datawriter = new CDataWriter();
+    m_datawriter = std::make_shared<CDataWriter>();
     // set qos
     m_datawriter->SetQOS(m_qos);
     // set transport layer
@@ -176,8 +176,7 @@ namespace eCAL
 #endif
 
     // free datawriter
-    delete m_datawriter;
-    m_datawriter = nullptr;
+    m_datawriter.reset();
 
     // we made it :-)
     m_created = false;

--- a/ecal/core/src/pubsub/ecal_subgate.cpp
+++ b/ecal/core/src/pubsub/ecal_subgate.cpp
@@ -93,18 +93,18 @@ namespace eCAL
     m_created = false;
   }
 
-  bool CSubGate::Register(const std::string& topic_name_, CDataReader* datareader_)
+  bool CSubGate::Register(const std::string& topic_name_, std::shared_ptr<CDataReader> datareader_)
   {
     if(!m_created) return(false);
 
     // register reader
     std::unique_lock<std::shared_timed_mutex> lock(m_topic_name_datareader_sync);
-    m_topic_name_datareader_map.emplace(std::pair<std::string, CDataReader*>(topic_name_, datareader_));
+    m_topic_name_datareader_map.emplace(std::pair<std::string, std::shared_ptr<CDataReader>>(topic_name_, datareader_));
 
     return(true);
   }
 
-  bool CSubGate::Unregister(const std::string& topic_name_, CDataReader* datareader_)
+  bool CSubGate::Unregister(const std::string& topic_name_, std::shared_ptr<CDataReader> datareader_)
   {
     if(!m_created) return(false);
     bool ret_state = false;

--- a/ecal/core/src/pubsub/ecal_subgate.h
+++ b/ecal/core/src/pubsub/ecal_subgate.h
@@ -43,8 +43,8 @@ namespace eCAL
     void Create();
     void Destroy();
 
-    bool Register(const std::string& topic_name_, CDataReader* datareader_);
-    bool Unregister(const std::string& topic_name_, CDataReader* datareader_);
+    bool Register(const std::string& topic_name_, std::shared_ptr<CDataReader> datareader_);
+    bool Unregister(const std::string& topic_name_, std::shared_ptr<CDataReader> datareader_);
 
     bool HasSample(const std::string& sample_name_);
     size_t ApplySample(const eCAL::pb::Sample& ecal_sample_, eCAL::pb::eTLayerType layer_);
@@ -62,7 +62,7 @@ namespace eCAL
     static std::atomic<bool> m_created;
 
     // database data reader
-    typedef std::unordered_multimap<std::string, CDataReader*> TopicNameDataReaderMapT;
+    typedef std::unordered_multimap<std::string, std::shared_ptr<CDataReader>> TopicNameDataReaderMapT;
     std::shared_timed_mutex  m_topic_name_datareader_sync;
     TopicNameDataReaderMapT  m_topic_name_datareader_map;
 

--- a/ecal/core/src/pubsub/ecal_subscriber.cpp
+++ b/ecal/core/src/pubsub/ecal_subscriber.cpp
@@ -100,7 +100,7 @@ namespace eCAL
     }
 
     // create data reader
-    m_datareader = new CDataReader;
+    m_datareader = std::make_shared<CDataReader>();
     // set qos
     m_datareader->SetQOS(m_qos);
     // create it
@@ -148,9 +148,8 @@ namespace eCAL
     m_datareader->Destroy();
 
     // free datareader
-    delete m_datareader;
-    m_datareader = nullptr;
-
+    m_datareader.reset();
+    
     // we made it :-)
     m_created = false;
 

--- a/testing/ecal/pubsub_test/src/pubsub_test.cpp
+++ b/testing/ecal/pubsub_test/src/pubsub_test.cpp
@@ -20,6 +20,7 @@
 #include <ecal/ecal.h>
 
 #include <atomic>
+#include <thread>
 
 #include <gtest/gtest.h>
 
@@ -763,7 +764,7 @@ TEST(IO, DestroyInCallback)
   eCAL::string::CSubscriber<std::string> sub_destroy("destroy");
   std::atomic<bool> destroyed(false);
 
-  auto destroy_lambda = [&sub_foo, &destroyed](const char* /*topic_*/, const std::string& msg, long long /*time_*/, long long /*clock_*/, long long /*id_*/) {
+  auto destroy_lambda = [&sub_foo, &destroyed](const char* /*topic_*/, const std::string& /*msg*/, long long /*time_*/, long long /*clock_*/, long long /*id_*/) {
     std::cout << "Receive destroy command" << std::endl;
     sub_foo.Destroy();
     destroyed = true;
@@ -771,7 +772,7 @@ TEST(IO, DestroyInCallback)
   };
   sub_destroy.AddReceiveCallback(destroy_lambda);
 
-  auto receive_lambda = [](const char* /*topic_*/, const std::string& msg, long long /*time_*/, long long /*clock_*/, long long /*id_*/) {
+  auto receive_lambda = [](const char* /*topic_*/, const std::string& /*msg*/, long long /*time_*/, long long /*clock_*/, long long /*id_*/) {
     std::cout << "Hello" << std::endl;
   };
   sub_foo.AddReceiveCallback(receive_lambda);

--- a/testing/ecal/pubsub_test/src/pubsub_test.cpp
+++ b/testing/ecal/pubsub_test/src/pubsub_test.cpp
@@ -744,3 +744,63 @@ TEST(IO, ZeroPayloadMessageTCP)
   eCAL::Finalize();
 }
 #endif
+
+#include <ecal/msg/string/publisher.h>
+#include <ecal/msg/string/subscriber.h>
+TEST(IO, DestroyInCallback)
+{
+  // initialize eCAL API
+  eCAL::Initialize(0, nullptr, "New Publisher in Callback");
+
+  // enable loop back communication in the same thread
+  eCAL::Util::EnableLoopback(true);
+
+  // start publishing thread
+  eCAL::string::CPublisher<std::string> pub_foo("foo");
+  eCAL::string::CSubscriber<std::string> sub_foo("foo");
+
+  eCAL::string::CPublisher<std::string> pub_destroy("destroy");
+  eCAL::string::CSubscriber<std::string> sub_destroy("destroy");
+  std::atomic<bool> destroyed(false);
+
+  auto destroy_lambda = [&sub_foo, &destroyed](const char* /*topic_*/, const std::string& msg, long long /*time_*/, long long /*clock_*/, long long /*id_*/) {
+    std::cout << "Receive destroy command" << std::endl;
+    sub_foo.Destroy();
+    destroyed = true;
+    std::cout << "Finnished destroying" << std::endl;
+  };
+  sub_destroy.AddReceiveCallback(destroy_lambda);
+
+  auto receive_lambda = [](const char* /*topic_*/, const std::string& msg, long long /*time_*/, long long /*clock_*/, long long /*id_*/) {
+    std::cout << "Hello" << std::endl;
+  };
+  sub_foo.AddReceiveCallback(receive_lambda);
+
+  // sleep for 2 seconds, registration should be good!
+  std::this_thread::sleep_for(std::chrono::seconds(5));
+
+  std::thread pub_foo_t([&pub_foo, &destroyed]() {
+    while (!destroyed)
+    {
+      pub_foo.Send("Hello World");
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    std::cout << "Stopped sending foo" << std::endl;
+    });
+
+  std::thread pub_destroy_t([&pub_destroy]() {
+    // sleep for a second, then send the destroy command
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+    std::cout << "Sending destroy message" << std::endl;
+    pub_destroy.Send("Destroy");
+    std::cout << "Done sending destroy message" << std::endl;
+    });
+
+
+  pub_foo_t.join();
+  pub_destroy_t.join();
+
+  // finalize eCAL API
+  // without destroying any pub / sub
+  eCAL::Finalize();
+}


### PR DESCRIPTION
#1073 

Please check the type of change your PR introduces:
- [x] Bugfix

**What is the current behavior?**
You cannot call `destroy()` from a callback.
To change this: 

- First 2 commits: use shared_ptrs for Datareaders. It kind of introduces an incompatibility, e.g. protected members are not exported from the dll any more (should we care making them private?)
- Copy the datareaders to a vector before applying samples. Works with other Subscribers. However, trying to destroy the subscriber on which the callback is registered, creates a segfault :( 

(`CDataREader` holds a lock to `m_receive_callback_sync` in `AddSample` and tries to reaquire it in `RemReceiveCallback`.

**Does this introduce a breaking change?**

- [x] Yes
- [ ] No

