### PR TITLE
Measurement: Prepare mcap support by introducing measurement base class.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,6 +371,7 @@ if(HAS_HDF5)
   add_subdirectory(contrib/ecalhdf5)
   add_subdirectory(contrib/message)
 endif()
+add_subdirectory(contrib/measurement/base)
 
 # --------------------------------------------------------
 # ecal core python binding

--- a/app/meas_cutter/src/measurement_exporter.cpp
+++ b/app/meas_cutter/src/measurement_exporter.cpp
@@ -27,7 +27,7 @@ MeasurementExporter::MeasurementExporter():
 void MeasurementExporter::setPath(const std::string& path, const std::string& base_name, const size_t& max_size_per_file)
 {
   _output_path = EcalUtils::Filesystem::CleanPath(path + EcalUtils::Filesystem::NativeSeparator(EcalUtils::Filesystem::OsStyle::Current) + eCALMeasCutterUtils::kDefaultFolderOutput, EcalUtils::Filesystem::OsStyle::Current);
-  if (!_writer->Open(_output_path, eCAL::eh5::eAccessType::CREATE))
+  if (!_writer->Open(_output_path, eCAL::measurement::base::CREATE))
   {
     throw ExporterException("Unable to create HDF5 protobuf output path " + path + ".");
   }

--- a/app/meas_cutter/src/measurement_exporter.h
+++ b/app/meas_cutter/src/measurement_exporter.h
@@ -42,9 +42,9 @@ public:
   std::string getOutputPath();
 
 private:
-  std::unique_ptr<eCAL::eh5::HDF5Meas> _writer;
-  std::string                          _current_channel_name;
-  std::string                          _output_path;
+  std::unique_ptr<eCAL::measurement::base::Measurement> _writer;
+  std::string                                           _current_channel_name;
+  std::string                                           _output_path;
 };
 
 class ExporterException : public std::exception

--- a/app/meas_cutter/src/measurement_importer.cpp
+++ b/app/meas_cutter/src/measurement_importer.cpp
@@ -79,7 +79,7 @@ void MeasurementImporter::openChannel(const std::string& channel_name)
   _current_opened_channel_data._channel_info.description = _reader->GetChannelDescription(channel_name);
   _current_opened_channel_data._channel_info.name = channel_name;
 
-  eCAL::eh5::EntryInfoSet entry_info_set;
+  eCAL::measurement::base::EntryInfoSet entry_info_set;
   _reader->GetEntriesInfo(channel_name, entry_info_set);
 
   for (const auto& entry_info : entry_info_set)

--- a/app/meas_cutter/src/measurement_importer.h
+++ b/app/meas_cutter/src/measurement_importer.h
@@ -53,10 +53,10 @@ public:
 private:
   bool                                 isEcalMeasFile(const std::string& path);
   bool                                 isProtoChannel(const std::string& channel_type);
-  std::unique_ptr<eCAL::eh5::HDF5Meas> _reader;
-  eCALMeasCutterUtils::ChannelData     _current_opened_channel_data;
-  std::string                          _loaded_path;
-  eCALMeasCutterUtils::ChannelNameSet  _channel_names;
+  std::unique_ptr<eCAL::measurement::base::Measurement> _reader;
+  eCALMeasCutterUtils::ChannelData                      _current_opened_channel_data;
+  std::string                                           _loaded_path;
+  eCALMeasCutterUtils::ChannelNameSet                   _channel_names;
 };
 
 class ImporterException : public std::exception

--- a/app/meas_cutter/src/utils.h
+++ b/app/meas_cutter/src/utils.h
@@ -339,6 +339,6 @@ namespace eCALMeasCutterUtils
   {
     ChannelInfo _channel_info;
     TimestampSet _timestamps;
-    std::unordered_map<Timestamp, eCAL::measurement::base::SEntryInfo> _timestamp_entry_info_map;
+    std::unordered_map<Timestamp, eCAL::measurement::base::EntryInfo> _timestamp_entry_info_map;
   };
 }

--- a/app/meas_cutter/src/utils.h
+++ b/app/meas_cutter/src/utils.h
@@ -339,6 +339,6 @@ namespace eCALMeasCutterUtils
   {
     ChannelInfo _channel_info;
     TimestampSet _timestamps;
-    std::unordered_map<Timestamp, eCAL::eh5::SEntryInfo> _timestamp_entry_info_map;
+    std::unordered_map<Timestamp, eCAL::measurement::base::SEntryInfo> _timestamp_entry_info_map;
   };
 }

--- a/app/play/play_core/src/ecal_play.cpp
+++ b/app/play/play_core/src/ecal_play.cpp
@@ -58,7 +58,7 @@ bool EcalPlay::LoadMeasurement(const std::string& path)
 {
   EcalPlayLogger::Instance()->info("Loading measurement...");
 
-  std::shared_ptr<eCAL::eh5::HDF5Meas> measurement(std::make_shared<eCAL::eh5::HDF5Meas>());
+  std::shared_ptr<eCAL::measurement::base::Measurement> measurement(std::make_shared<eCAL::eh5::HDF5Meas>());
 
   std::string meas_dir;               // The directory of the measurement
   std::string path_to_load;           // The actual path we load the measurement from. May be a directory or a .hdf5 file
@@ -129,7 +129,7 @@ bool EcalPlay::LoadMeasurement(const std::string& path)
 void EcalPlay::CloseMeasurement()
 {
   description_ = "";
-  play_thread_->SetMeasurement(std::shared_ptr<eCAL::eh5::HDF5Meas>(nullptr));
+  play_thread_->SetMeasurement(std::shared_ptr<eCAL::measurement::base::Measurement>(nullptr));
   measurement_path_ = "";
   clearScenariosPath();
   channel_mapping_path_ = "";

--- a/app/play/play_core/src/measurement_container.cpp
+++ b/app/play/play_core/src/measurement_container.cpp
@@ -23,7 +23,7 @@
 #include <math.h>
 #include <stdlib.h>
 
-MeasurementContainer::MeasurementContainer(std::shared_ptr<eCAL::eh5::HDF5Meas> hdf5_meas, const std::string& meas_dir, bool use_receive_timestamp)
+MeasurementContainer::MeasurementContainer(std::shared_ptr<eCAL::measurement::base::Measurement> hdf5_meas, const std::string& meas_dir, bool use_receive_timestamp)
   : hdf5_meas_             (hdf5_meas)
   , meas_dir_              (meas_dir)
   , use_receive_timestamp_ (use_receive_timestamp)
@@ -48,7 +48,7 @@ void MeasurementContainer::CreateFrameTable()
   auto channel_names = hdf5_meas_->GetChannelNames();
   for (auto& channel_name : channel_names)
   {
-    eCAL::eh5::EntryInfoSet entry_info_set;
+    eCAL::measurement::base::EntryInfoSet entry_info_set;
     if (hdf5_meas_->GetEntriesInfo(channel_name, entry_info_set))
     {
       for (auto& entry_info : entry_info_set)
@@ -83,7 +83,7 @@ void MeasurementContainer::CalculateEstimatedSizeForChannels()
   auto channel_names = hdf5_meas_->GetChannelNames();
   for (auto& channel_name : channel_names)
   {
-    eCAL::eh5::EntryInfoSet entry_info_set;
+    eCAL::measurement::base::EntryInfoSet entry_info_set;
     if (hdf5_meas_->GetEntriesInfo(channel_name, entry_info_set))
     {
       auto size = entry_info_set.size();
@@ -451,7 +451,7 @@ std::map<std::string, ContinuityReport> MeasurementContainer::CreateContinuityRe
   auto channel_names = hdf5_meas_->GetChannelNames();
   for (auto& channel_name : channel_names)
   {
-    eCAL::eh5::EntryInfoSet entry_info_set;
+    eCAL::measurement::base::EntryInfoSet entry_info_set;
     if (hdf5_meas_->GetEntriesInfo(channel_name, entry_info_set))
     {
 

--- a/app/play/play_core/src/measurement_container.h
+++ b/app/play/play_core/src/measurement_container.h
@@ -31,7 +31,7 @@
 class MeasurementContainer
 {
 public:
-  MeasurementContainer(std::shared_ptr<eCAL::eh5::HDF5Meas> hdf5_meas, const std::string& meas_dir = "", bool use_receive_timestamp = true);
+  MeasurementContainer(std::shared_ptr<eCAL::measurement::base::Measurement> hdf5_meas, const std::string& meas_dir = "", bool use_receive_timestamp = true);
   ~MeasurementContainer();
 
   void CreatePublishers();
@@ -108,9 +108,9 @@ private:
     PublisherInfo*                     publisher_info_;
   };
 
-  std::shared_ptr<eCAL::eh5::HDF5Meas>    hdf5_meas_;
-  std::string                             meas_dir_;
-  bool                                    use_receive_timestamp_;
+  std::shared_ptr<eCAL::measurement::base::Measurement> hdf5_meas_;
+  std::string                                           meas_dir_;
+  bool                                                  use_receive_timestamp_;
 
   std::vector<MeasurementFrame>           frame_table_;
   std::map<std::string, size_t>           total_estimated_channel_size_map_;

--- a/app/play/play_core/src/play_thread.cpp
+++ b/app/play/play_core/src/play_thread.cpp
@@ -576,7 +576,7 @@ void PlayThread::LogChannelMapping(const std::map<std::string, std::string>& cha
 //// Measurement                                                            ////
 ////////////////////////////////////////////////////////////////////////////////
 
-void PlayThread::SetMeasurement(std::shared_ptr<eCAL::measurement::base::Measurement> measurement, const std::string& path)
+void PlayThread::SetMeasurement(const std::shared_ptr<eCAL::measurement::base::Measurement>& measurement, const std::string& path)
 {
   std::unique_ptr<MeasurementContainer> new_measurment_container;
 

--- a/app/play/play_core/src/play_thread.cpp
+++ b/app/play/play_core/src/play_thread.cpp
@@ -576,7 +576,7 @@ void PlayThread::LogChannelMapping(const std::map<std::string, std::string>& cha
 //// Measurement                                                            ////
 ////////////////////////////////////////////////////////////////////////////////
 
-void PlayThread::SetMeasurement(std::shared_ptr<eCAL::eh5::HDF5Meas> measurement, const std::string& path)
+void PlayThread::SetMeasurement(std::shared_ptr<eCAL::measurement::base::Measurement> measurement, const std::string& path)
 {
   std::unique_ptr<MeasurementContainer> new_measurment_container;
 

--- a/app/play/play_core/src/play_thread.h
+++ b/app/play/play_core/src/play_thread.h
@@ -80,7 +80,7 @@ public:
    * @param measurement    The new measurement
    * @param path           The (optional) path from where the measurement was loaded
    */
-  void SetMeasurement(std::shared_ptr<eCAL::eh5::HDF5Meas> measurement, const std::string& path = "");
+  void SetMeasurement(std::shared_ptr<eCAL::measurement::base::Measurement> measurement, const std::string& path = "");
 
   /**
    * @brief Returns whether a measurement has successfully been loaded

--- a/app/play/play_core/src/play_thread.h
+++ b/app/play/play_core/src/play_thread.h
@@ -80,7 +80,7 @@ public:
    * @param measurement    The new measurement
    * @param path           The (optional) path from where the measurement was loaded
    */
-  void SetMeasurement(std::shared_ptr<eCAL::measurement::base::Measurement> measurement, const std::string& path = "");
+  void SetMeasurement(const std::shared_ptr<eCAL::measurement::base::Measurement>& measurement, const std::string& path = "");
 
   /**
    * @brief Returns whether a measurement has successfully been loaded

--- a/app/rec/rec_client_core/src/job/hdf5_writer_thread.cpp
+++ b/app/rec/rec_client_core/src/job/hdf5_writer_thread.cpp
@@ -264,7 +264,7 @@ namespace eCAL
 #endif // NDEBUG
       std::unique_lock<decltype(hdf5_writer_mutex_)> hdf5_writer_lock(hdf5_writer_mutex_);
 
-      if (hdf5_writer_->Open(hdf5_dir, eCAL::eh5::eAccessType::CREATE))
+      if (hdf5_writer_->Open(hdf5_dir, eCAL::measurement::base::eAccessType::CREATE))
       {
 #ifndef NDEBUG
         EcalRecLogger::Instance()->debug("Hdf5WriterThread::Open(): Successfully opened HDF5-Writer with path \"" + hdf5_dir + "\"");

--- a/app/rec/rec_client_core/src/job/hdf5_writer_thread.cpp
+++ b/app/rec/rec_client_core/src/job/hdf5_writer_thread.cpp
@@ -264,7 +264,7 @@ namespace eCAL
 #endif // NDEBUG
       std::unique_lock<decltype(hdf5_writer_mutex_)> hdf5_writer_lock(hdf5_writer_mutex_);
 
-      if (hdf5_writer_->Open(hdf5_dir, eCAL::measurement::base::eAccessType::CREATE))
+      if (hdf5_writer_->Open(hdf5_dir, eCAL::measurement::base::AccessType::CREATE))
       {
 #ifndef NDEBUG
         EcalRecLogger::Instance()->debug("Hdf5WriterThread::Open(): Successfully opened HDF5-Writer with path \"" + hdf5_dir + "\"");

--- a/app/rec/rec_client_core/src/job/hdf5_writer_thread.h
+++ b/app/rec/rec_client_core/src/job/hdf5_writer_thread.h
@@ -93,8 +93,8 @@ namespace eCAL
       bool                                  new_topic_info_map_available_;      /**< Telling that a new topic info map has been set from the outside. */
       mutable RecHdf5JobStatus              last_status_;
 
-      mutable std::mutex                   hdf5_writer_mutex_;
-      std::unique_ptr<eCAL::eh5::HDF5Meas> hdf5_writer_;
+      mutable std::mutex                                    hdf5_writer_mutex_;
+      std::unique_ptr<eCAL::measurement::base::Measurement> hdf5_writer_;
 
 
       std::atomic<bool> flushing_;

--- a/contrib/ecalhdf5/CMakeLists.txt
+++ b/contrib/ecalhdf5/CMakeLists.txt
@@ -85,6 +85,7 @@ target_link_libraries(${PROJECT_NAME}
 
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_14)
 
+target_link_libraries(${PROJECT_NAME} PUBLIC eCAL::measurement_base)
 if (${ECAL_LINK_HDF5_SHARED})
   if (TARGET hdf5::hdf5-shared)
     target_link_libraries(${PROJECT_NAME} PRIVATE

--- a/contrib/ecalhdf5/include/ecal/measurement/imeasurement.h
+++ b/contrib/ecalhdf5/include/ecal/measurement/imeasurement.h
@@ -35,14 +35,14 @@ namespace eCAL
     class IBinaryChannel
     {
     public:
-      IBinaryChannel(std::shared_ptr<eh5::HDF5Meas> meas_, std::string name_)
+      IBinaryChannel(std::shared_ptr<base::Measurement> meas_, std::string name_)
         : channel_name(name_)
         , meas(meas_)
       {
         meas->GetEntriesInfo(channel_name, entry_infos);
       }
 
-      virtual BinaryFrame operator[](const eh5::SEntryInfo& entry)
+      virtual BinaryFrame operator[](const base::SEntryInfo& entry)
       {
         size_t message_size;
         meas->GetEntryDataSize(entry.ID, message_size);
@@ -64,7 +64,7 @@ namespace eCAL
           , m_entry_iterator(owner_.entry_infos.begin())
         {};
 
-        iterator(IBinaryChannel& owner_, const eh5::EntryInfoSet::iterator& it)
+        iterator(IBinaryChannel& owner_, const measurement::base::EntryInfoSet::iterator& it)
           : m_owner(owner_)
           , m_entry_iterator(it)
         {};
@@ -96,7 +96,7 @@ namespace eCAL
         bool operator!=(const iterator& rhs) const { return !(operator==(rhs)); };
       private:
         IBinaryChannel& m_owner;
-        eh5::EntryInfoSet::iterator m_entry_iterator;
+        measurement::base::EntryInfoSet::iterator m_entry_iterator;
         mutable std::string m_msg;
       };
 
@@ -115,8 +115,8 @@ namespace eCAL
 
     private:
       const std::string channel_name;
-      std::shared_ptr<eh5::HDF5Meas> meas;
-      mutable eh5::EntryInfoSet entry_infos;
+      std::shared_ptr<base::Measurement> meas;
+      mutable base::EntryInfoSet entry_infos;
       mutable std::string data;
     };
 
@@ -125,7 +125,7 @@ namespace eCAL
     class IChannel
     {
     public:
-      IChannel(std::shared_ptr<eh5::HDF5Meas> meas_, std::string name_)
+      IChannel(std::shared_ptr<base::Measurement> meas_, std::string name_)
         : binary_channel(meas_, name_)
       {
       }
@@ -134,7 +134,7 @@ namespace eCAL
       bool operator!=(const IChannel& rhs) const { return !(operator==(rhs)); }
 
       //virtual Entry<T> operator[](unsigned long long timestamp);
-      virtual Frame<T> operator[](const eh5::SEntryInfo& entry)
+      virtual Frame<T> operator[](const base::SEntryInfo& entry)
       {
         auto binary_entry = binary_channel[entry];
         eCAL::message::Deserialize(binary_entry.message, message);
@@ -225,11 +225,11 @@ namespace eCAL
       IChannel<T> Get(const std::string& channel) const;
 
     private:
-      std::shared_ptr<eh5::HDF5Meas> meas;
+      std::shared_ptr<base::Measurement> meas;
     };
 
     inline IMeasurement::IMeasurement(const std::string& path)
-      : meas{ std::make_shared<eh5::HDF5Meas>(path, eh5::RDONLY) }
+      : meas{ std::make_shared<eh5::HDF5Meas>(path, eCAL::measurement::base::RDONLY) }
     {
     }
 

--- a/contrib/ecalhdf5/include/ecal/measurement/imeasurement.h
+++ b/contrib/ecalhdf5/include/ecal/measurement/imeasurement.h
@@ -42,7 +42,7 @@ namespace eCAL
         meas->GetEntriesInfo(channel_name, entry_infos);
       }
 
-      virtual BinaryFrame operator[](const base::SEntryInfo& entry)
+      virtual BinaryFrame operator[](const base::EntryInfo& entry)
       {
         size_t message_size;
         meas->GetEntryDataSize(entry.ID, message_size);
@@ -134,7 +134,7 @@ namespace eCAL
       bool operator!=(const IChannel& rhs) const { return !(operator==(rhs)); }
 
       //virtual Entry<T> operator[](unsigned long long timestamp);
-      virtual Frame<T> operator[](const base::SEntryInfo& entry)
+      virtual Frame<T> operator[](const base::EntryInfo& entry)
       {
         auto binary_entry = binary_channel[entry];
         eCAL::message::Deserialize(binary_entry.message, message);

--- a/contrib/ecalhdf5/include/ecal/measurement/omeasurement.h
+++ b/contrib/ecalhdf5/include/ecal/measurement/omeasurement.h
@@ -34,7 +34,7 @@ namespace eCAL
     class OBinaryChannel
     {
     public:
-      OBinaryChannel(std::shared_ptr<eh5::HDF5Meas> meas_, const std::string& name_)
+      OBinaryChannel(std::shared_ptr<base::Measurement> meas_, const std::string& name_)
         : channel_name(name_)
         , meas(meas_)
         , SenderID(0)
@@ -61,7 +61,7 @@ namespace eCAL
 
     private:
       const std::string channel_name;
-      std::shared_ptr<eh5::HDF5Meas> meas;
+      std::shared_ptr<base::Measurement> meas;
 
       long long SenderID;
       long long clock;
@@ -72,7 +72,7 @@ namespace eCAL
     class OChannel
     {
     public:
-      OChannel(std::shared_ptr<eh5::HDF5Meas> meas_, std::string name_)
+      OChannel(std::shared_ptr<base::Measurement> meas_, std::string name_)
         : binary_channel(meas_, name_)
       {
       }
@@ -113,13 +113,13 @@ namespace eCAL
       OChannel<T> Create(const std::string& channel) const;
 
     private:
-      std::shared_ptr<eh5::HDF5Meas> meas;
+      std::shared_ptr<base::Measurement> meas;
     };
 
 
 
     inline OMeasurement::OMeasurement(const std::string& base_path_, const std::string& measurement_name_)
-      : meas{ std::make_shared<eh5::HDF5Meas>(base_path_, eh5::CREATE) }
+      : meas{ std::make_shared<eh5::HDF5Meas>(base_path_, base::CREATE) }
     {
       meas->SetFileBaseName(measurement_name_);
     }

--- a/contrib/ecalhdf5/include/ecalhdf5/eh5_meas.h
+++ b/contrib/ecalhdf5/include/ecalhdf5/eh5_meas.h
@@ -100,7 +100,7 @@ namespace eCAL
        * @return         true if output (eAccessType::CREATE) measurement directory structure can be accessed/created, false otherwise.
        *                 true if input (eAccessType::RDONLY) measurement/file path was opened, false otherwise.
       **/
-      bool Open(const std::string& path, measurement::base::AccessType access = measurement::base::AccessType::RDONLY);
+      bool Open(const std::string& path, measurement::base::AccessType access = measurement::base::AccessType::RDONLY) override;
 
       /**
        * @brief Close file

--- a/contrib/ecalhdf5/include/ecalhdf5/eh5_meas.h
+++ b/contrib/ecalhdf5/include/ecalhdf5/eh5_meas.h
@@ -56,7 +56,7 @@ namespace eCAL
        * @param access   Access type
        *
       **/
-      explicit HDF5Meas(const std::string& path, measurement::base::eAccessType access = measurement::base::eAccessType::RDONLY);
+      explicit HDF5Meas(const std::string& path, measurement::base::AccessType access = measurement::base::AccessType::RDONLY);
 
       /**
        * @brief Destructor
@@ -100,7 +100,7 @@ namespace eCAL
        * @return         true if output (eAccessType::CREATE) measurement directory structure can be accessed/created, false otherwise.
        *                 true if input (eAccessType::RDONLY) measurement/file path was opened, false otherwise.
       **/
-      bool Open(const std::string& path, measurement::base::eAccessType access = measurement::base::eAccessType::RDONLY);
+      bool Open(const std::string& path, measurement::base::AccessType access = measurement::base::AccessType::RDONLY);
 
       /**
        * @brief Close file

--- a/contrib/ecalhdf5/include/ecalhdf5/eh5_types.h
+++ b/contrib/ecalhdf5/include/ecalhdf5/eh5_types.h
@@ -44,10 +44,10 @@ namespace eCAL
     //!< @endcond
 
     // Remove @eCAL6 -> backwards compatibility with old interface!
-    using SEntryInfo = eCAL::measurement::base::SEntryInfo;
+    using SEntryInfo = eCAL::measurement::base::EntryInfo;
     using EntryInfoSet = eCAL::measurement::base::EntryInfoSet;
     using EntryInfoVect = eCAL::measurement::base::EntryInfoVect;
-    using eAccessType = eCAL::measurement::base::eAccessType;
+    using eAccessType = eCAL::measurement::base::AccessType;
     using eCAL::measurement::base::RDONLY;
     using eCAL::measurement::base::CREATE;
   }  // namespace eh5

--- a/contrib/ecalhdf5/include/ecalhdf5/eh5_types.h
+++ b/contrib/ecalhdf5/include/ecalhdf5/eh5_types.h
@@ -28,6 +28,8 @@
 #include <string>
 #include <vector>
 
+#include <ecal/measurement/base/types.h>
+
 namespace eCAL
 {
   namespace eh5
@@ -41,57 +43,12 @@ namespace eCAL
     const std::string kChnAttrTitle       ("Channels");
     //!< @endcond
 
-    /**
-     * @brief Info struct for a single measurement entry
-    **/
-    struct SEntryInfo
-    {
-      long long RcvTimestamp;   //!< Receive time stamp
-      long long ID;             //!< Channel ID
-      long long SndClock;       //!< Send clock
-      long long SndTimestamp;   //!< Send time stamp
-      long long SndID;          //!< Send ID
-
-      //!< @cond
-      SEntryInfo() : RcvTimestamp(0), ID(0), SndClock(0), SndTimestamp(0), SndID(0) {}
-
-      SEntryInfo(long long rcv_timestamp, long long id) : RcvTimestamp(rcv_timestamp), ID(id), SndClock(0), SndTimestamp(0), SndID(0) {}
-
-      SEntryInfo(long long rcv_timestamp, long long id, long long snd_clock) : RcvTimestamp(rcv_timestamp), ID(id), SndClock(snd_clock), SndTimestamp(0), SndID(0) {}
-
-      SEntryInfo(long long rcv_timestamp, long long id, long long snd_clock, long long snd_timestamp) : RcvTimestamp(rcv_timestamp), ID(id), SndClock(snd_clock), SndTimestamp(snd_timestamp), SndID(0) {}
-
-      SEntryInfo(long long rcv_timestamp, long long id, long long snd_clock, long long snd_timestamp, long long snd_id) : RcvTimestamp(rcv_timestamp), ID(id), SndClock(snd_clock), SndTimestamp(snd_timestamp), SndID(snd_id) {}
-
-      bool operator==(const SEntryInfo& other) const
-      {
-        return (ID == other.ID && SndTimestamp == other.SndTimestamp && RcvTimestamp == other.RcvTimestamp && SndClock == other.SndClock && SndID == other.SndID);
-      }
-
-      bool operator<(const SEntryInfo& other) const
-      {
-        return (RcvTimestamp < other.RcvTimestamp);
-      }
-      //!< @endcond
-    };
-
-    /**
-     * @brief eCAL HDF5 entries (as set container)
-    **/
-    typedef std::set<SEntryInfo>    EntryInfoSet;
-
-    /**
-     * @brief eCAL HDF5 entries (as vector container)
-    **/
-    typedef std::vector<SEntryInfo> EntryInfoVect;
-
-    /**
-     * @brief eCAL HDF5 measurement access type
-    **/
-    enum eAccessType
-    {
-      RDONLY,
-      CREATE
-    };
+    // Remove @eCAL6 -> backwards compatibility with old interface!
+    using SEntryInfo = eCAL::measurement::base::SEntryInfo;
+    using EntryInfoSet = eCAL::measurement::base::EntryInfoSet;
+    using EntryInfoVect = eCAL::measurement::base::EntryInfoVect;
+    using eAccessType = eCAL::measurement::base::eAccessType;
+    using eCAL::measurement::base::RDONLY;
+    using eCAL::measurement::base::CREATE;
   }  // namespace eh5
 }  // namespace eCAL

--- a/contrib/measurement/base/CMakeLists.txt
+++ b/contrib/measurement/base/CMakeLists.txt
@@ -1,0 +1,39 @@
+# ========================= eCAL LICENSE =================================
+#
+# Copyright (C) 2016 - 2019 Continental Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ========================= eCAL LICENSE =================================
+
+project(measurement_base)
+
+set(ecal_message_header
+    include/ecal/measurement/base/measurement.h
+)
+
+add_library(${PROJECT_NAME} INTERFACE)
+add_library(eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+
+target_include_directories(${PROJECT_NAME} INTERFACE 
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
+ecal_install_library(${PROJECT_NAME})
+
+install(DIRECTORY
+   "include/" DESTINATION "${INSTALL_INCLUDE_DIR}" COMPONENT sdk
+)
+
+

--- a/contrib/measurement/base/include/ecal/measurement/base/measurement.h
+++ b/contrib/measurement/base/include/ecal/measurement/base/measurement.h
@@ -38,7 +38,7 @@ namespace eCAL
     namespace base
     {
     /**
-     * @brief eCAL HDF5 measurement API
+     * @brief eCAL measurement API
     **/
     class Measurement
     {
@@ -47,15 +47,6 @@ namespace eCAL
        * @brief Constructor
       **/
       Measurement() = default;
-
-      /**
-       * @brief Constructor
-       *
-       * @param path     Input file path / measurement directory path (see meas directory structure description bellow, in Open method).
-       * @param access   Access type
-       *
-      **/
-      //explicit Measurement(const std::string& path, eAccessType access = eAccessType::RDONLY);
 
       /**
        * @brief Destructor
@@ -85,21 +76,21 @@ namespace eCAL
        *                  - hosts directories:                                  |_Host1 (e.g.: CARPC01)
        *                                                                        |_Host2 (e.g.: CARPC02)
        *
-       *                 File path as input (eAccessType::RDONLY):
+       *                 File path as input (AccessType::RDONLY):
        *                  - root directory (e.g.: M:\measurement_directory\measurement01) in this case all hosts subdirectories will be iterated,
        *                  - host directory (e.g.: M:\measurement_directory\measurement01\CARPC01),
        *                  - file path, path to file from measurement (e.g.: M:\measurement_directory\measurement01\CARPC01\meas01_05.hdf5).
        *
-       *                 File path as output (eAccessType::CREATE):
+       *                 File path as output (AccessType::CREATE):
        *                  - full path to  measurement directory (recommended with host name) (e.g.: M:\measurement_directory\measurement01\CARPC01),
        *                  - to set the name of the actual hdf5 file use SetFileBaseName method.
        *
        * @param access   Access type
        *
-       * @return         true if output (eAccessType::CREATE) measurement directory structure can be accessed/created, false otherwise.
-       *                 true if input (eAccessType::RDONLY) measurement/file path was opened, false otherwise.
+       * @return         true if output (AccessType::CREATE) measurement directory structure can be accessed/created, false otherwise.
+       *                 true if input (AccessType::RDONLY) measurement/file path was opened, false otherwise.
       **/
-      virtual bool Open(const std::string& path, eAccessType access = eAccessType::RDONLY)  = 0;
+      virtual bool Open(const std::string& path, AccessType access = AccessType::RDONLY)  = 0;
 
       /**
        * @brief Close file

--- a/contrib/measurement/base/include/ecal/measurement/base/measurement.h
+++ b/contrib/measurement/base/include/ecal/measurement/base/measurement.h
@@ -18,8 +18,8 @@
 */
 
 /**
- * @file   eh5_meas.h
- * @brief  eCALHDF5 measurement class
+ * @file   measurement.h
+ * @brief  Base class for low level measurement oprations
 **/
 
 #pragma once
@@ -29,25 +29,24 @@
 #include <string>
 #include <memory>
 
-#include "eh5_types.h"
-#include <ecal/measurement/base/measurement.h>
+#include <ecal/measurement/base/types.h>
 
 namespace eCAL
 {
-  namespace eh5
+  namespace measurement
   {
-    class HDF5MeasImpl;
-
+    namespace base
+    {
     /**
      * @brief eCAL HDF5 measurement API
     **/
-    class HDF5Meas : public eCAL::measurement::base::Measurement
+    class Measurement
     {
     public:
       /**
        * @brief Constructor
       **/
-      HDF5Meas();
+      Measurement() = default;
 
       /**
        * @brief Constructor
@@ -56,24 +55,24 @@ namespace eCAL
        * @param access   Access type
        *
       **/
-      explicit HDF5Meas(const std::string& path, measurement::base::eAccessType access = measurement::base::eAccessType::RDONLY);
+      //explicit Measurement(const std::string& path, eAccessType access = eAccessType::RDONLY);
 
       /**
        * @brief Destructor
       **/
-      ~HDF5Meas() override;
+      virtual ~Measurement() = default;
 
       /**
        * @brief Copy operator
       **/
-      HDF5Meas(const HDF5Meas& other) = delete;
-      HDF5Meas& operator=(const HDF5Meas& other) = delete;
+      Measurement(const Measurement& other) = delete;
+      Measurement& operator=(const Measurement& other) = delete;
 
       /**
       * @brief Move operator
       **/
-      HDF5Meas(HDF5Meas&&) = default;
-      HDF5Meas& operator=(HDF5Meas&&) = default;
+      Measurement(Measurement&&) = default;
+      Measurement& operator=(Measurement&&) = default;
 
       /**
        * @brief Open file
@@ -100,42 +99,42 @@ namespace eCAL
        * @return         true if output (eAccessType::CREATE) measurement directory structure can be accessed/created, false otherwise.
        *                 true if input (eAccessType::RDONLY) measurement/file path was opened, false otherwise.
       **/
-      bool Open(const std::string& path, measurement::base::eAccessType access = measurement::base::eAccessType::RDONLY);
+      virtual bool Open(const std::string& path, eAccessType access = eAccessType::RDONLY)  = 0;
 
       /**
        * @brief Close file
        *
        * @return         true if succeeds, false if it fails
       **/
-      bool Close() override;
+      virtual bool Close()  = 0;
 
       /**
        * @brief Checks if file/measurement is ok
        *
        * @return  true if meas can be opened(read) or location is accessible(write), false otherwise
       **/
-      bool IsOk() const override;
+      virtual bool IsOk() const  = 0;
 
       /**
        * @brief Get the File Type Version of the current opened file
        *
        * @return       file version
       **/
-      std::string GetFileVersion() const override;
+      virtual std::string GetFileVersion() const = 0;
 
       /**
        * @brief Gets maximum allowed size for an individual file
        *
        * @return       maximum size in MB
       **/
-      size_t GetMaxSizePerFile() const override;
+      virtual size_t GetMaxSizePerFile() const = 0;
 
       /**
        * @brief Sets maximum allowed size for an individual file
        *
        * @param size   maximum size in MB
       **/
-      void SetMaxSizePerFile(size_t size) override;
+      virtual void SetMaxSizePerFile(size_t size) = 0;
 
       /**
       * @brief Whether each Channel shall be writte in its own file
@@ -146,7 +145,7 @@ namespace eCAL
       * 
       * @return true, if one file per channel is enabled
       */
-      bool IsOneFilePerChannelEnabled() const override;
+      virtual bool IsOneFilePerChannelEnabled() const = 0;
 
       /**
       * @brief Enable / disable the creation of one individual file per channel
@@ -157,14 +156,14 @@ namespace eCAL
       * 
       * @param enabled   Whether one file shall be created per channel
       */
-      void SetOneFilePerChannelEnabled(bool enabled) override;
+      virtual void SetOneFilePerChannelEnabled(bool enabled) = 0;
 
       /**
        * @brief Get the available channel names of the current opened file / measurement
        *
        * @return       channel names
       **/
-      std::set<std::string> GetChannelNames() const override;
+      virtual std::set<std::string> GetChannelNames() const = 0;
 
       /**
        * @brief Check if channel exists in measurement
@@ -173,7 +172,7 @@ namespace eCAL
        *
        * @return       true if exists, false otherwise
       **/
-      bool HasChannel(const std::string& channel_name) const override;
+      virtual bool HasChannel(const std::string& channel_name) const = 0;
 
       /**
        * @brief Get the channel description for the given channel
@@ -182,7 +181,7 @@ namespace eCAL
        *
        * @return              channel description
       **/
-      std::string GetChannelDescription(const std::string& channel_name) const override;
+      virtual std::string GetChannelDescription(const std::string& channel_name) const = 0;
 
       /**
        * @brief Set description of the given channel
@@ -190,7 +189,7 @@ namespace eCAL
        * @param channel_name    channel name
        * @param description     description of the channel
       **/
-      void SetChannelDescription(const std::string& channel_name, const std::string& description) override;
+      virtual void SetChannelDescription(const std::string& channel_name, const std::string& description) = 0;
 
       /**
        * @brief Gets the channel type of the given channel
@@ -199,7 +198,7 @@ namespace eCAL
        *
        * @return              channel type
       **/
-      std::string GetChannelType(const std::string& channel_name) const override;
+      virtual std::string GetChannelType(const std::string& channel_name) const = 0;
 
       /**
        * @brief Set type of the given channel
@@ -207,7 +206,7 @@ namespace eCAL
        * @param channel_name  channel name
        * @param type          type of the channel
       **/
-      void SetChannelType(const std::string& channel_name, const std::string& type) override;
+      virtual void SetChannelType(const std::string& channel_name, const std::string& type) = 0;
 
       /**
        * @brief Gets minimum timestamp for specified channel
@@ -216,7 +215,7 @@ namespace eCAL
        *
        * @return                minimum timestamp value
       **/
-      long long GetMinTimestamp(const std::string& channel_name) const override;
+      virtual long long GetMinTimestamp(const std::string& channel_name) const = 0;
 
       /**
        * @brief Gets maximum timestamp for specified channel
@@ -225,7 +224,7 @@ namespace eCAL
        *
        * @return                maximum timestamp value
       **/
-      long long GetMaxTimestamp(const std::string& channel_name) const override;
+      virtual long long GetMaxTimestamp(const std::string& channel_name) const = 0;
 
       /**
        * @brief Gets the header info for all data entries for the given channel
@@ -236,7 +235,7 @@ namespace eCAL
        *
        * @return                    true if succeeds, false if it fails
       **/
-      bool GetEntriesInfo(const std::string& channel_name, measurement::base::EntryInfoSet& entries) const override;
+      virtual bool GetEntriesInfo(const std::string& channel_name, EntryInfoSet& entries) const = 0;
 
       /**
        * @brief Gets the header info for data entries for the given channel included in given time range (begin->end)
@@ -249,7 +248,7 @@ namespace eCAL
        *
        * @return                   true if succeeds, false if it fails
       **/
-      bool GetEntriesInfoRange(const std::string& channel_name, long long begin, long long end, measurement::base::EntryInfoSet& entries) const override;
+      virtual bool GetEntriesInfoRange(const std::string& channel_name, long long begin, long long end, EntryInfoSet& entries) const = 0;
 
       /**
        * @brief Gets data size of a specific entry
@@ -259,7 +258,7 @@ namespace eCAL
        *
        * @return                 true if succeeds, false if it fails
       **/
-      bool GetEntryDataSize(long long entry_id, size_t& size) const override;
+      virtual bool GetEntryDataSize(long long entry_id, size_t& size) const = 0;
 
       /**
        * @brief Gets data from a specific entry
@@ -269,14 +268,14 @@ namespace eCAL
        *
        * @return                 true if succeeds, false if it fails
       **/
-      bool GetEntryData(long long entry_id, void* data) const override;
+      virtual bool GetEntryData(long long entry_id, void* data) const = 0;
 
       /**
        * @brief Set measurement file base name (desired name for the actual hdf5 files that will be created)
        *
        * @param base_name        Name of the hdf5 files that will be created.
       **/
-      void SetFileBaseName(const std::string& base_name) override;
+      virtual void SetFileBaseName(const std::string& base_name) = 0;
 
       /**
        * @brief Add entry to file
@@ -291,22 +290,25 @@ namespace eCAL
        *
        * @return              true if succeeds, false if it fails
       **/
-      bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const std::string& channel_name, long long id, long long clock) override;
+      virtual bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const std::string& channel_name, long long id, long long clock) = 0;
+
+      /**
+       * @brief Callback function type for pre file split notification
+      **/
+      typedef std::function<void(void)> CallbackFunction;
 
       /**
        * @brief Connect callback for pre file split notification
        *
        * @param cb   callback function
       **/
-      void ConnectPreSplitCallback(CallbackFunction cb) override;
+      virtual void ConnectPreSplitCallback(CallbackFunction cb) = 0;
 
       /**
        * @brief Disconnect pre file split callback
       **/
-      void DisconnectPreSplitCallback() override;
-
-     private:
-      std::unique_ptr<HDF5MeasImpl> hdf_meas_impl_;
+      virtual void DisconnectPreSplitCallback() = 0;
     };
+    }
   }  // namespace eh5
 }  // namespace eCAL

--- a/contrib/measurement/base/include/ecal/measurement/base/types.h
+++ b/contrib/measurement/base/include/ecal/measurement/base/types.h
@@ -1,0 +1,88 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+/**
+ * @file   types.h
+ * @brief  Type definitions for low level measurement access
+**/
+
+#pragma once 
+
+namespace eCAL
+{
+  namespace measurement
+  {
+    namespace base
+    {
+      /**
+       * @brief Info struct for a single measurement entry
+      **/
+      struct SEntryInfo
+      {
+        long long RcvTimestamp;   //!< Receive time stamp
+        long long ID;             //!< Channel ID
+        long long SndClock;       //!< Send clock
+        long long SndTimestamp;   //!< Send time stamp
+        long long SndID;          //!< Send ID
+
+        //!< @cond
+        SEntryInfo() : RcvTimestamp(0), ID(0), SndClock(0), SndTimestamp(0), SndID(0) {}
+
+        SEntryInfo(long long rcv_timestamp, long long id) : RcvTimestamp(rcv_timestamp), ID(id), SndClock(0), SndTimestamp(0), SndID(0) {}
+
+        SEntryInfo(long long rcv_timestamp, long long id, long long snd_clock) : RcvTimestamp(rcv_timestamp), ID(id), SndClock(snd_clock), SndTimestamp(0), SndID(0) {}
+
+        SEntryInfo(long long rcv_timestamp, long long id, long long snd_clock, long long snd_timestamp) : RcvTimestamp(rcv_timestamp), ID(id), SndClock(snd_clock), SndTimestamp(snd_timestamp), SndID(0) {}
+
+        SEntryInfo(long long rcv_timestamp, long long id, long long snd_clock, long long snd_timestamp, long long snd_id) : RcvTimestamp(rcv_timestamp), ID(id), SndClock(snd_clock), SndTimestamp(snd_timestamp), SndID(snd_id) {}
+
+        bool operator==(const SEntryInfo& other) const
+        {
+          return (ID == other.ID && SndTimestamp == other.SndTimestamp && RcvTimestamp == other.RcvTimestamp && SndClock == other.SndClock && SndID == other.SndID);
+        }
+
+        bool operator<(const SEntryInfo& other) const
+        {
+          return (RcvTimestamp < other.RcvTimestamp);
+        }
+        //!< @endcond
+      };
+
+      /**
+       * @brief eCAL HDF5 entries (as set container)
+      **/
+      typedef std::set<SEntryInfo>    EntryInfoSet;
+
+      /**
+       * @brief eCAL HDF5 entries (as vector container)
+      **/
+      typedef std::vector<SEntryInfo> EntryInfoVect;
+
+      /**
+       * @brief eCAL Measurement Access types
+      **/
+      enum eAccessType
+      {
+        RDONLY,
+        CREATE
+      };
+
+    }
+  }
+}

--- a/contrib/measurement/base/include/ecal/measurement/base/types.h
+++ b/contrib/measurement/base/include/ecal/measurement/base/types.h
@@ -33,7 +33,7 @@ namespace eCAL
       /**
        * @brief Info struct for a single measurement entry
       **/
-      struct SEntryInfo
+      struct EntryInfo
       {
         long long RcvTimestamp;   //!< Receive time stamp
         long long ID;             //!< Channel ID
@@ -42,22 +42,22 @@ namespace eCAL
         long long SndID;          //!< Send ID
 
         //!< @cond
-        SEntryInfo() : RcvTimestamp(0), ID(0), SndClock(0), SndTimestamp(0), SndID(0) {}
+        EntryInfo() : RcvTimestamp(0), ID(0), SndClock(0), SndTimestamp(0), SndID(0) {}
 
-        SEntryInfo(long long rcv_timestamp, long long id) : RcvTimestamp(rcv_timestamp), ID(id), SndClock(0), SndTimestamp(0), SndID(0) {}
+        EntryInfo(long long rcv_timestamp, long long id) : RcvTimestamp(rcv_timestamp), ID(id), SndClock(0), SndTimestamp(0), SndID(0) {}
 
-        SEntryInfo(long long rcv_timestamp, long long id, long long snd_clock) : RcvTimestamp(rcv_timestamp), ID(id), SndClock(snd_clock), SndTimestamp(0), SndID(0) {}
+        EntryInfo(long long rcv_timestamp, long long id, long long snd_clock) : RcvTimestamp(rcv_timestamp), ID(id), SndClock(snd_clock), SndTimestamp(0), SndID(0) {}
 
-        SEntryInfo(long long rcv_timestamp, long long id, long long snd_clock, long long snd_timestamp) : RcvTimestamp(rcv_timestamp), ID(id), SndClock(snd_clock), SndTimestamp(snd_timestamp), SndID(0) {}
+        EntryInfo(long long rcv_timestamp, long long id, long long snd_clock, long long snd_timestamp) : RcvTimestamp(rcv_timestamp), ID(id), SndClock(snd_clock), SndTimestamp(snd_timestamp), SndID(0) {}
 
-        SEntryInfo(long long rcv_timestamp, long long id, long long snd_clock, long long snd_timestamp, long long snd_id) : RcvTimestamp(rcv_timestamp), ID(id), SndClock(snd_clock), SndTimestamp(snd_timestamp), SndID(snd_id) {}
+        EntryInfo(long long rcv_timestamp, long long id, long long snd_clock, long long snd_timestamp, long long snd_id) : RcvTimestamp(rcv_timestamp), ID(id), SndClock(snd_clock), SndTimestamp(snd_timestamp), SndID(snd_id) {}
 
-        bool operator==(const SEntryInfo& other) const
+        bool operator==(const EntryInfo& other) const
         {
           return (ID == other.ID && SndTimestamp == other.SndTimestamp && RcvTimestamp == other.RcvTimestamp && SndClock == other.SndClock && SndID == other.SndID);
         }
 
-        bool operator<(const SEntryInfo& other) const
+        bool operator<(const EntryInfo& other) const
         {
           return (RcvTimestamp < other.RcvTimestamp);
         }
@@ -67,17 +67,17 @@ namespace eCAL
       /**
        * @brief eCAL HDF5 entries (as set container)
       **/
-      typedef std::set<SEntryInfo>    EntryInfoSet;
+      typedef std::set<EntryInfo>    EntryInfoSet;
 
       /**
        * @brief eCAL HDF5 entries (as vector container)
       **/
-      typedef std::vector<SEntryInfo> EntryInfoVect;
+      typedef std::vector<EntryInfo> EntryInfoVect;
 
       /**
        * @brief eCAL Measurement Access types
       **/
-      enum eAccessType
+      enum AccessType
       {
         RDONLY,
         CREATE

--- a/contrib/measurement/base/include/ecal/measurement/base/types.h
+++ b/contrib/measurement/base/include/ecal/measurement/base/types.h
@@ -24,6 +24,9 @@
 
 #pragma once 
 
+#include <set>
+#include <vector>
+
 namespace eCAL
 {
   namespace measurement
@@ -67,12 +70,12 @@ namespace eCAL
       /**
        * @brief eCAL HDF5 entries (as set container)
       **/
-      typedef std::set<EntryInfo>    EntryInfoSet;
+      using EntryInfoSet = std::set<EntryInfo>;
 
       /**
        * @brief eCAL HDF5 entries (as vector container)
       **/
-      typedef std::vector<EntryInfo> EntryInfoVect;
+      using EntryInfoVect = std::vector<EntryInfo>;
 
       /**
        * @brief eCAL Measurement Access types

--- a/lang/python/ecalhdf5/src/ecalhdf5_wrap.cxx
+++ b/lang/python/ecalhdf5/src/ecalhdf5_wrap.cxx
@@ -107,11 +107,11 @@ static PyObject* Meas_Open(Meas *self, PyObject *args)
   switch (access)
   {
   case 0:
-    open_meas = self->hdf5_meas->Open(path, eCAL::measurement::base::eAccessType::RDONLY);
+    open_meas = self->hdf5_meas->Open(path, eCAL::measurement::base::AccessType::RDONLY);
     break;
 
   case 1:
-    open_meas = self->hdf5_meas->Open(path, eCAL::measurement::base::eAccessType::CREATE);
+    open_meas = self->hdf5_meas->Open(path, eCAL::measurement::base::AccessType::CREATE);
     break;
 
   default:

--- a/lang/python/ecalhdf5/src/ecalhdf5_wrap.cxx
+++ b/lang/python/ecalhdf5/src/ecalhdf5_wrap.cxx
@@ -39,7 +39,7 @@
 typedef struct
 {
   PyObject_HEAD
-  eCAL::eh5::HDF5Meas *hdf5_meas;
+  eCAL::measurement::base::Measurement *hdf5_meas;
 } Meas;
 
 /****************************************/
@@ -107,11 +107,11 @@ static PyObject* Meas_Open(Meas *self, PyObject *args)
   switch (access)
   {
   case 0:
-    open_meas = self->hdf5_meas->Open(path, eCAL::eh5::eAccessType::RDONLY);
+    open_meas = self->hdf5_meas->Open(path, eCAL::measurement::base::eAccessType::RDONLY);
     break;
 
   case 1:
-    open_meas = self->hdf5_meas->Open(path, eCAL::eh5::eAccessType::CREATE);
+    open_meas = self->hdf5_meas->Open(path, eCAL::measurement::base::eAccessType::CREATE);
     break;
 
   default:
@@ -279,7 +279,7 @@ static PyObject* Meas_GetEntriesInfo(Meas *self, PyObject *args)
   if (!PyArg_ParseTuple(args, "s", &channel_name))
     return nullptr;
 
-  eCAL::eh5::EntryInfoSet entries;
+  eCAL::measurement::base::EntryInfoSet entries;
   self->hdf5_meas->GetEntriesInfo(channel_name, entries);
   PyObject* entries_info = PyList_New(0);
 
@@ -327,7 +327,7 @@ static PyObject* Meas_GetEntriesInfoRange(Meas *self, PyObject *args)
   if (!PyArg_ParseTuple(args, "sLL", &channel_name, &begin, &end))
     return nullptr;
 
-  eCAL::eh5::EntryInfoSet entries;
+  eCAL::measurement::base::EntryInfoSet entries;
   self->hdf5_meas->GetEntriesInfoRange(channel_name, begin, end, entries);
   PyObject* entries_info = PyList_New(0);
 


### PR DESCRIPTION
**Pull request type**
- [x] Feature

This introduces a common base class `eCAL::measurement::base::Measurement` that allows to write measurements in a polymorphic way, thus allowing to exchange the actual writer implementation.
All occurences (except in test cases) now use the base class for pointers, and instantiating then `eh5::eCALMeas`.
Behavior should be 100% identical.

Part of #1076 .

**Does this introduce a breaking change?**
- [ ] Yes
- [x] No
The implementation is **fully** compatible and does not break API for anyone wishing to use `eh5::eCALMeas` directly. 


**Other information**

Please review with regard to:
- Class naming
- CMake target naming
- Folder / include path structure
