### PR TITLE
Feature/ecal meas reader writer 3

### DIFF
--- a/app/meas_cutter/src/measurement_exporter.cpp
+++ b/app/meas_cutter/src/measurement_exporter.cpp
@@ -20,14 +20,14 @@
 #include "measurement_exporter.h"
 
 MeasurementExporter::MeasurementExporter():
-  _writer(new eCAL::eh5::HDF5Meas)
+  _writer(new eCAL::eh5::Writer)
 {
 }
 
 void MeasurementExporter::setPath(const std::string& path, const std::string& base_name, const size_t& max_size_per_file)
 {
   _output_path = EcalUtils::Filesystem::CleanPath(path + EcalUtils::Filesystem::NativeSeparator(EcalUtils::Filesystem::OsStyle::Current) + eCALMeasCutterUtils::kDefaultFolderOutput, EcalUtils::Filesystem::OsStyle::Current);
-  if (!_writer->Open(_output_path, eCAL::measurement::base::CREATE))
+  if (!_writer->Open(_output_path))
   {
     throw ExporterException("Unable to create HDF5 protobuf output path " + path + ".");
   }

--- a/app/meas_cutter/src/measurement_exporter.h
+++ b/app/meas_cutter/src/measurement_exporter.h
@@ -22,7 +22,7 @@
 #include <unordered_map>
 #include <map>
 
-#include <ecalhdf5/eh5_meas.h>
+#include <ecalhdf5/eh5_writer.h>
 #include <ecal_utils/filesystem.h>
 #include "utils.h"
 
@@ -42,7 +42,7 @@ public:
   std::string getOutputPath();
 
 private:
-  std::unique_ptr<eCAL::measurement::base::Measurement> _writer;
+  std::unique_ptr<eCAL::measurement::base::Writer>      _writer;
   std::string                                           _current_channel_name;
   std::string                                           _output_path;
 };

--- a/app/meas_cutter/src/measurement_importer.cpp
+++ b/app/meas_cutter/src/measurement_importer.cpp
@@ -20,7 +20,7 @@
 #include "measurement_importer.h"
 
 MeasurementImporter::MeasurementImporter() :
-  _reader(new eCAL::eh5::HDF5Meas),
+  _reader(new eCAL::eh5::Reader),
   _current_opened_channel_data()
 {
 }

--- a/app/meas_cutter/src/measurement_importer.h
+++ b/app/meas_cutter/src/measurement_importer.h
@@ -26,6 +26,7 @@
 
 #include <ecal_utils/filesystem.h>
 #include <ecalhdf5/eh5_meas.h>
+#include <ecalhdf5/eh5_reader.h>
 
 #include "utils.h"
 
@@ -53,7 +54,7 @@ public:
 private:
   bool                                 isEcalMeasFile(const std::string& path);
   bool                                 isProtoChannel(const std::string& channel_type);
-  std::unique_ptr<eCAL::measurement::base::Measurement> _reader;
+  std::unique_ptr<eCAL::measurement::base::Reader>      _reader;
   eCALMeasCutterUtils::ChannelData                      _current_opened_channel_data;
   std::string                                           _loaded_path;
   eCALMeasCutterUtils::ChannelNameSet                   _channel_names;

--- a/app/play/play_core/src/ecal_play.cpp
+++ b/app/play/play_core/src/ecal_play.cpp
@@ -27,7 +27,7 @@
 
 #include "ecal_play_logger.h"
 #include "play_thread.h"
-#include "ecalhdf5/eh5_meas.h"
+#include "ecalhdf5/eh5_reader.h"
 
 #include <ecal_utils/string.h>
 #include <ecal_utils/filesystem.h>
@@ -58,7 +58,7 @@ bool EcalPlay::LoadMeasurement(const std::string& path)
 {
   EcalPlayLogger::Instance()->info("Loading measurement...");
 
-  std::shared_ptr<eCAL::measurement::base::Measurement> measurement(std::make_shared<eCAL::eh5::HDF5Meas>());
+  std::shared_ptr<eCAL::measurement::base::Reader> measurement(std::make_shared<eCAL::eh5::Reader>());
 
   std::string meas_dir;               // The directory of the measurement
   std::string path_to_load;           // The actual path we load the measurement from. May be a directory or a .hdf5 file
@@ -129,7 +129,7 @@ bool EcalPlay::LoadMeasurement(const std::string& path)
 void EcalPlay::CloseMeasurement()
 {
   description_ = "";
-  play_thread_->SetMeasurement(std::shared_ptr<eCAL::measurement::base::Measurement>(nullptr));
+  play_thread_->SetMeasurement(std::shared_ptr<eCAL::measurement::base::Reader>(nullptr));
   measurement_path_ = "";
   clearScenariosPath();
   channel_mapping_path_ = "";

--- a/app/play/play_core/src/measurement_container.cpp
+++ b/app/play/play_core/src/measurement_container.cpp
@@ -18,12 +18,13 @@
 */
 
 #include "measurement_container.h"
+#include <ecalhdf5/eh5_meas.h>
 
 #include <algorithm>
 #include <math.h>
 #include <stdlib.h>
 
-MeasurementContainer::MeasurementContainer(std::shared_ptr<eCAL::measurement::base::Measurement> hdf5_meas, const std::string& meas_dir, bool use_receive_timestamp)
+MeasurementContainer::MeasurementContainer(std::shared_ptr<eCAL::measurement::base::Reader> hdf5_meas, const std::string& meas_dir, bool use_receive_timestamp)
   : hdf5_meas_             (hdf5_meas)
   , meas_dir_              (meas_dir)
   , use_receive_timestamp_ (use_receive_timestamp)

--- a/app/play/play_core/src/measurement_container.h
+++ b/app/play/play_core/src/measurement_container.h
@@ -24,14 +24,14 @@
 #include <memory>
 
 #include <ecal/ecal.h>
-#include <ecalhdf5/eh5_meas.h>
+#include <ecal/measurement/base/reader.h>
 
 #include "continuity_report.h"
 
 class MeasurementContainer
 {
 public:
-  MeasurementContainer(std::shared_ptr<eCAL::measurement::base::Measurement> hdf5_meas, const std::string& meas_dir = "", bool use_receive_timestamp = true);
+  MeasurementContainer(std::shared_ptr<eCAL::measurement::base::Reader> hdf5_meas, const std::string& meas_dir = "", bool use_receive_timestamp = true);
   ~MeasurementContainer();
 
   void CreatePublishers();
@@ -108,7 +108,7 @@ private:
     PublisherInfo*                     publisher_info_;
   };
 
-  std::shared_ptr<eCAL::measurement::base::Measurement> hdf5_meas_;
+  std::shared_ptr<eCAL::measurement::base::Reader>      hdf5_meas_;
   std::string                                           meas_dir_;
   bool                                                  use_receive_timestamp_;
 

--- a/app/play/play_core/src/play_thread.cpp
+++ b/app/play/play_core/src/play_thread.cpp
@@ -576,7 +576,7 @@ void PlayThread::LogChannelMapping(const std::map<std::string, std::string>& cha
 //// Measurement                                                            ////
 ////////////////////////////////////////////////////////////////////////////////
 
-void PlayThread::SetMeasurement(const std::shared_ptr<eCAL::measurement::base::Measurement>& measurement, const std::string& path)
+void PlayThread::SetMeasurement(const std::shared_ptr<eCAL::measurement::base::Reader>& measurement, const std::string& path)
 {
   std::unique_ptr<MeasurementContainer> new_measurment_container;
 

--- a/app/play/play_core/src/play_thread.h
+++ b/app/play/play_core/src/play_thread.h
@@ -80,7 +80,7 @@ public:
    * @param measurement    The new measurement
    * @param path           The (optional) path from where the measurement was loaded
    */
-  void SetMeasurement(const std::shared_ptr<eCAL::measurement::base::Measurement>& measurement, const std::string& path = "");
+  void SetMeasurement(const std::shared_ptr<eCAL::measurement::base::Reader>& measurement, const std::string& path = "");
 
   /**
    * @brief Returns whether a measurement has successfully been loaded

--- a/app/rec/rec_client_core/src/job/hdf5_writer_thread.cpp
+++ b/app/rec/rec_client_core/src/job/hdf5_writer_thread.cpp
@@ -18,6 +18,7 @@
 */
 
 #include "hdf5_writer_thread.h"
+#include <ecalhdf5/eh5_writer.h>
 
 #include "rec_client_core/ecal_rec_logger.h"
 
@@ -41,7 +42,7 @@ namespace eCAL
       , new_topic_info_map_available_(true)
       , flushing_                    (false)
     {
-      hdf5_writer_ = std::make_unique<eCAL::eh5::HDF5Meas>();
+      hdf5_writer_ = std::make_unique<eCAL::eh5::Writer>();
     }
 
     Hdf5WriterThread::~Hdf5WriterThread()
@@ -264,7 +265,7 @@ namespace eCAL
 #endif // NDEBUG
       std::unique_lock<decltype(hdf5_writer_mutex_)> hdf5_writer_lock(hdf5_writer_mutex_);
 
-      if (hdf5_writer_->Open(hdf5_dir, eCAL::measurement::base::AccessType::CREATE))
+      if (hdf5_writer_->Open(hdf5_dir))
       {
 #ifndef NDEBUG
         EcalRecLogger::Instance()->debug("Hdf5WriterThread::Open(): Successfully opened HDF5-Writer with path \"" + hdf5_dir + "\"");

--- a/app/rec/rec_client_core/src/job/hdf5_writer_thread.h
+++ b/app/rec/rec_client_core/src/job/hdf5_writer_thread.h
@@ -20,7 +20,7 @@
 #pragma once
 #include <ThreadingUtils/InterruptibleThread.h>
 
-#include <ecalhdf5/eh5_meas.h>
+#include <ecal/measurement/base/writer.h>
 
 #include <mutex>
 #include <deque>
@@ -94,7 +94,7 @@ namespace eCAL
       mutable RecHdf5JobStatus              last_status_;
 
       mutable std::mutex                                    hdf5_writer_mutex_;
-      std::unique_ptr<eCAL::measurement::base::Measurement> hdf5_writer_;
+      std::unique_ptr<eCAL::measurement::base::Writer>      hdf5_writer_;
 
 
       std::atomic<bool> flushing_;

--- a/contrib/ecalhdf5/CMakeLists.txt
+++ b/contrib/ecalhdf5/CMakeLists.txt
@@ -57,6 +57,7 @@ set(ecalhdf5_header_base
     include/ecalhdf5/eh5_meas.h
     include/ecalhdf5/eh5_reader.h
     include/ecalhdf5/eh5_types.h
+    include/ecalhdf5/eh5_writer.h
 )
 
 ecal_add_library(${PROJECT_NAME} ${ecalhdf5_src} ${ecalhdf5_header_base})

--- a/contrib/ecalhdf5/CMakeLists.txt
+++ b/contrib/ecalhdf5/CMakeLists.txt
@@ -55,7 +55,8 @@ set(ecalhdf5_header_base
     include/ecal/measurement/omeasurement.h
     include/ecalhdf5/eh5_defs.h
     include/ecalhdf5/eh5_meas.h
-    include/ecalhdf5/eh5_types.h   
+    include/ecalhdf5/eh5_reader.h
+    include/ecalhdf5/eh5_types.h
 )
 
 ecal_add_library(${PROJECT_NAME} ${ecalhdf5_src} ${ecalhdf5_header_base})

--- a/contrib/ecalhdf5/include/ecal/measurement/imeasurement.h
+++ b/contrib/ecalhdf5/include/ecal/measurement/imeasurement.h
@@ -25,7 +25,7 @@
 #include <utility>
 #include <stdexcept>
 
-#include <ecalhdf5/eh5_meas.h>
+#include <ecalhdf5/eh5_reader.h>
 #include <ecal/measurement/measurement.h>
 
 namespace eCAL
@@ -35,7 +35,7 @@ namespace eCAL
     class IBinaryChannel
     {
     public:
-      IBinaryChannel(std::shared_ptr<base::Measurement> meas_, std::string name_)
+      IBinaryChannel(std::shared_ptr<base::Reader> meas_, std::string name_)
         : channel_name(name_)
         , meas(meas_)
       {
@@ -115,7 +115,7 @@ namespace eCAL
 
     private:
       const std::string channel_name;
-      std::shared_ptr<base::Measurement> meas;
+      std::shared_ptr<base::Reader> meas;
       mutable base::EntryInfoSet entry_infos;
       mutable std::string data;
     };
@@ -125,7 +125,7 @@ namespace eCAL
     class IChannel
     {
     public:
-      IChannel(std::shared_ptr<base::Measurement> meas_, std::string name_)
+      IChannel(std::shared_ptr<base::Reader> meas_, std::string name_)
         : binary_channel(meas_, name_)
       {
       }
@@ -225,11 +225,11 @@ namespace eCAL
       IChannel<T> Get(const std::string& channel) const;
 
     private:
-      std::shared_ptr<base::Measurement> meas;
+      std::shared_ptr<base::Reader> meas;
     };
 
     inline IMeasurement::IMeasurement(const std::string& path)
-      : meas{ std::make_shared<eh5::HDF5Meas>(path, eCAL::measurement::base::RDONLY) }
+      : meas{ std::make_shared<eh5::Reader>(path) }
     {
     }
 

--- a/contrib/ecalhdf5/include/ecal/measurement/omeasurement.h
+++ b/contrib/ecalhdf5/include/ecal/measurement/omeasurement.h
@@ -24,7 +24,7 @@
 #include <string>
 #include <utility>
 
-#include <ecalhdf5/eh5_meas.h>
+#include <ecalhdf5/eh5_writer.h>
 #include <ecal/measurement/measurement.h>
 
 namespace eCAL
@@ -34,7 +34,7 @@ namespace eCAL
     class OBinaryChannel
     {
     public:
-      OBinaryChannel(std::shared_ptr<base::Measurement> meas_, const std::string& name_)
+      OBinaryChannel(std::shared_ptr<base::Writer> meas_, const std::string& name_)
         : channel_name(name_)
         , meas(meas_)
         , SenderID(0)
@@ -61,7 +61,7 @@ namespace eCAL
 
     private:
       const std::string channel_name;
-      std::shared_ptr<base::Measurement> meas;
+      std::shared_ptr<base::Writer> meas;
 
       long long SenderID;
       long long clock;
@@ -72,7 +72,7 @@ namespace eCAL
     class OChannel
     {
     public:
-      OChannel(std::shared_ptr<base::Measurement> meas_, std::string name_)
+      OChannel(std::shared_ptr<base::Writer> meas_, std::string name_)
         : binary_channel(meas_, name_)
       {
       }
@@ -113,13 +113,13 @@ namespace eCAL
       OChannel<T> Create(const std::string& channel) const;
 
     private:
-      std::shared_ptr<base::Measurement> meas;
+      std::shared_ptr<base::Writer> meas;
     };
 
 
 
     inline OMeasurement::OMeasurement(const std::string& base_path_, const std::string& measurement_name_)
-      : meas{ std::make_shared<eh5::HDF5Meas>(base_path_, base::CREATE) }
+      : meas{ std::make_shared<eh5::Writer>(base_path_) }
     {
       meas->SetFileBaseName(measurement_name_);
     }

--- a/contrib/ecalhdf5/include/ecalhdf5/eh5_reader.h
+++ b/contrib/ecalhdf5/include/ecalhdf5/eh5_reader.h
@@ -1,0 +1,211 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+/**
+ * @file   eh5_meas.h
+ * @brief  eCALHDF5 measurement class
+**/
+
+#pragma once
+
+#include "eh5_meas.h"
+#include <ecal/measurement/base/reader.h>
+
+namespace eCAL
+{
+  namespace eh5
+  {
+ 
+    /**
+ * @brief eCAL Reader API
+**/
+    class Reader : public measurement::base::Reader
+    {
+    public:
+      /**
+       * @brief Constructor
+      **/
+      Reader() = default;
+
+      /**
+       * @brief Constructor
+       * 
+       * @param path     Input file path / measurement directory path (see meas directory structure description bellow, in Open method).
+       * @param access   Access type
+       *
+      **/
+      explicit Reader(const std::string& path) : measurement(path, eAccessType::RDONLY){};
+      
+      /**
+       * @brief Open file
+       *
+       * @param path     Input file path / Reader directory path.
+       *
+       *                 Default Reader directory structure:
+       *                  - root directory e.g.: M:\Reader_directory\Reader01
+       *                  - documents directory:                                |_doc
+       *                  - hosts directories:                                  |_Host1 (e.g.: CARPC01)
+       *                                                                        |_Host2 (e.g.: CARPC02)
+       *
+       *                 File path as input (AccessType::RDONLY):
+       *                  - root directory (e.g.: M:\Reader_directory\Reader01) in this case all hosts subdirectories will be iterated,
+       *                  - host directory (e.g.: M:\Reader_directory\Reader01\CARPC01),
+       *                  - file path, path to file from Reader (e.g.: M:\Reader_directory\Reader01\CARPC01\meas01_05.hdf5).
+       *
+       *
+       * @param access   Access type
+       *
+       * @return         true if input (AccessType::RDONLY) Reader/file path was opened, false otherwise.
+      **/
+       bool Open(const std::string& path) override {
+         return measurement.Open(path, eAccessType::RDONLY);
+       }
+
+      /**
+       * @brief Close file
+       *
+       * @return         true if succeeds, false if it fails
+      **/
+       bool Close() override { return measurement.Close(); }
+
+      /**
+       * @brief Checks if file/Reader is ok
+       *
+       * @return  true if meas can be opened(read) false otherwise
+      **/
+       bool IsOk() const override { return measurement.IsOk(); }
+
+      /**
+       * @brief Get the File Type Version of the current opened file
+       *
+       * @return       file version
+      **/
+       std::string GetFileVersion() const override { return measurement.GetFileVersion(); }
+
+      /**
+       * @brief Gets maximum allowed size for an individual file
+       *
+       * @return       maximum size in MB
+      **/
+      /* size_t GetMaxSizePerFile() const override {}*/
+
+      /**
+       * @brief Get the available channel names of the current opened file / Reader
+       *
+       * @return       channel names
+      **/
+       std::set<std::string> GetChannelNames() const override { return measurement.GetChannelNames(); }
+
+      /**
+       * @brief Check if channel exists in Reader
+       *
+       * @param channel_name   name of the channel
+       *
+       * @return       true if exists, false otherwise
+      **/
+       bool HasChannel(const std::string& channel_name) const override { return measurement.HasChannel(channel_name);  }
+
+      /**
+       * @brief Get the channel description for the given channel
+       *
+       * @param channel_name  channel name
+       *
+       * @return              channel description
+      **/
+       std::string GetChannelDescription(const std::string& channel_name) const override { return measurement.GetChannelDescription(channel_name); }
+
+      /**
+       * @brief Gets the channel type of the given channel
+       *
+       * @param channel_name  channel name
+       *
+       * @return              channel type
+      **/
+       std::string GetChannelType(const std::string& channel_name) const override { return measurement.GetChannelType(channel_name); }
+
+      /**
+       * @brief Gets minimum timestamp for specified channel
+       *
+       * @param channel_name    channel name
+       *
+       * @return                minimum timestamp value
+      **/
+       long long GetMinTimestamp(const std::string& channel_name) const override { return measurement.GetMinTimestamp(channel_name); }
+
+      /**
+       * @brief Gets maximum timestamp for specified channel
+       *
+       * @param channel_name    channel name
+       *
+       * @return                maximum timestamp value
+      **/
+       long long GetMaxTimestamp(const std::string& channel_name) const override { return measurement.GetMaxTimestamp(channel_name); }
+
+      /**
+       * @brief Gets the header info for all data entries for the given channel
+       *        Header = timestamp + entry id
+       *
+       * @param [in]  channel_name  channel name
+       * @param [out] entries       header info for all data entries
+       *
+       * @return                    true if succeeds, false if it fails
+      **/
+       bool GetEntriesInfo(const std::string& channel_name, EntryInfoSet& entries) const override { return measurement.GetEntriesInfo(channel_name, entries); }
+
+      /**
+       * @brief Gets the header info for data entries for the given channel included in given time range (begin->end)
+       *        Header = timestamp + entry id
+       *
+       * @param [in]  channel_name channel name
+       * @param [in]  begin        time range begin timestamp
+       * @param [in]  end          time range end timestamp
+       * @param [out] entries      header info for data entries in given range
+       *
+       * @return                   true if succeeds, false if it fails
+      **/
+       bool GetEntriesInfoRange(const std::string& channel_name, long long begin, long long end, EntryInfoSet& entries) const override { return measurement.GetEntriesInfoRange(channel_name, begin, end, entries); }
+
+      /**
+       * @brief Gets data size of a specific entry
+       *
+       * @param [in]  entry_id   Entry ID
+       * @param [out] size       Entry data size
+       *
+       * @return                 true if succeeds, false if it fails
+      **/
+       bool GetEntryDataSize(long long entry_id, size_t& size) const override { return measurement.GetEntryDataSize(entry_id, size); }
+
+      /**
+       * @brief Gets data from a specific entry
+       *
+       * @param [in]  entry_id   Entry ID
+       * @param [out] data       Entry data
+       *
+       * @return                 true if succeeds, false if it fails
+      **/
+       bool GetEntryData(long long entry_id, void* data) const override { return measurement.GetEntryData(entry_id, data); }
+
+    private:
+      HDF5Meas measurement;
+
+    };
+
+
+  }  // namespace eh5
+}  // namespace eCAL

--- a/contrib/ecalhdf5/include/ecalhdf5/eh5_writer.h
+++ b/contrib/ecalhdf5/include/ecalhdf5/eh5_writer.h
@@ -1,0 +1,196 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+/**
+ * @file   measurement.h
+ * @brief  Base class for low level measurement oprations
+**/
+
+#pragma once
+
+#include <functional>
+#include <set>
+#include <string>
+#include <memory>
+
+#include <ecal/measurement/base/writer.h>
+#include <ecalhdf5/eh5_meas.h>
+
+namespace eCAL
+{
+  namespace eh5
+  {
+      /**
+       * @brief eCAL measurement API
+      **/
+      class Writer : public measurement::base::Writer
+      {
+      public:
+        /**
+         * @brief Constructor
+        **/
+        Writer() = default;
+
+        /**
+         * @brief Constructor
+        **/
+        Writer(const std::string& path) : measurement(path, eAccessType::CREATE) {}
+
+        /**
+         * @brief Destructor
+        **/
+        virtual ~Writer() = default;
+
+        /**
+         * @brief Copy operator
+        **/
+        Writer(const Writer& other) = delete;
+        Writer& operator=(const Writer& other) = delete;
+
+        /**
+        * @brief Move operator
+        **/
+        Writer(Writer&&) = default;
+        Writer& operator=(Writer&&) = default;
+
+        /**
+         * @brief Open file
+         *
+         * @param path     Input file path / measurement directory path.
+         *
+         *                 Default measurement directory structure:
+         *                  - root directory e.g.: M:\measurement_directory\measurement01
+         *                  - documents directory:                                |_doc
+         *                  - hosts directories:                                  |_Host1 (e.g.: CARPC01)
+         *                                                                        |_Host2 (e.g.: CARPC02)
+         *
+         *                 File path as input (AccessType::RDONLY):
+         *                  - root directory (e.g.: M:\measurement_directory\measurement01) in this case all hosts subdirectories will be iterated,
+         *                  - host directory (e.g.: M:\measurement_directory\measurement01\CARPC01),
+         *                  - file path, path to file from measurement (e.g.: M:\measurement_directory\measurement01\CARPC01\meas01_05.hdf5).
+         *
+         *                 File path as output (AccessType::CREATE):
+         *                  - full path to  measurement directory (recommended with host name) (e.g.: M:\measurement_directory\measurement01\CARPC01),
+         *                  - to set the name of the actual hdf5 file use SetFileBaseName method.
+         *
+         * @param access   Access type
+         *
+         * @return         true if output (AccessType::CREATE) measurement directory structure can be accessed/created, false otherwise.
+         *                 true if input (AccessType::RDONLY) measurement/file path was opened, false otherwise.
+        **/
+        bool Open(const std::string& path) override { return measurement.Open(path, eAccessType::CREATE); }
+
+        /**
+         * @brief Close file
+         *
+         * @return         true if succeeds, false if it fails
+        **/
+        bool Close() override { return measurement.Close(); }
+
+        /**
+         * @brief Checks if file/measurement is ok
+         *
+         * @return  true if meas can be opened(read) or location is accessible(write), false otherwise
+        **/
+        bool IsOk() const override { return measurement.IsOk(); }
+
+        /**
+         * @brief Gets maximum allowed size for an individual file
+         *
+         * @return       maximum size in MB
+        **/
+        size_t GetMaxSizePerFile() const override { return measurement.GetMaxSizePerFile(); }
+
+        /**
+         * @brief Sets maximum allowed size for an individual file
+         *
+         * @param size   maximum size in MB
+        **/
+        void SetMaxSizePerFile(size_t size) override { return measurement.SetMaxSizePerFile(size); }
+
+        /**
+        * @brief Whether each Channel shall be writte in its own file
+        *
+        * When enabled, data is clustered by channel and each channel is written
+        * to its own file. The filenames will consist of the basename and the
+        * channel name.
+        *
+        * @return true, if one file per channel is enabled
+        */
+        bool IsOneFilePerChannelEnabled() const override { return measurement.IsOneFilePerChannelEnabled(); }
+
+        /**
+        * @brief Enable / disable the creation of one individual file per channel
+        *
+        * When enabled, data is clustered by channel and each channel is written
+        * to its own file. The filenames will consist of the basename and the
+        * channel name.
+        *
+        * @param enabled   Whether one file shall be created per channel
+        */
+        void SetOneFilePerChannelEnabled(bool enabled) override { return measurement.SetOneFilePerChannelEnabled(enabled); }
+
+        /**
+         * @brief Set description of the given channel
+         *
+         * @param channel_name    channel name
+         * @param description     description of the channel
+        **/
+        void SetChannelDescription(const std::string& channel_name, const std::string& description) override { return measurement.SetChannelDescription(channel_name, description); }
+
+        /**
+         * @brief Set type of the given channel
+         *
+         * @param channel_name  channel name
+         * @param type          type of the channel
+        **/
+        void SetChannelType(const std::string& channel_name, const std::string& type) override { return measurement.SetChannelType(channel_name, type); }
+
+        /**
+         * @brief Set measurement file base name (desired name for the actual hdf5 files that will be created)
+         *
+         * @param base_name        Name of the hdf5 files that will be created.
+        **/
+        void SetFileBaseName(const std::string& base_name) { return measurement.SetFileBaseName(base_name); }
+
+        /**
+         * @brief Add entry to file
+         *
+         * @param data           data to be added
+         * @param size           size of the data
+         * @param snd_timestamp  send time stamp
+         * @param rcv_timestamp  receive time stamp
+         * @param channel_name   channel name
+         * @param id             message id
+         * @param clock          message clock
+         *
+         * @return              true if succeeds, false if it fails
+        **/
+        bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const std::string& channel_name, long long id, long long clock) override
+        {
+          return measurement.AddEntryToFile(data, size, snd_timestamp, rcv_timestamp, channel_name, id, clock);
+        }
+
+        private:
+          HDF5Meas measurement;
+
+      };
+
+  }  // namespace eh5
+}  // namespace eCAL

--- a/contrib/measurement/base/include/ecal/measurement/base/reader.h
+++ b/contrib/measurement/base/include/ecal/measurement/base/reader.h
@@ -1,0 +1,218 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+/**
+ * @file   Reader.h
+ * @brief  Base class for low level Reader oprations
+**/
+
+#pragma once
+
+#include <functional>
+#include <set>
+#include <string>
+#include <memory>
+
+#include <ecal/measurement/base/types.h>
+
+namespace eCAL
+{
+  namespace measurement
+  {
+    namespace base
+    {
+      /**
+       * @brief eCAL Reader API
+      **/
+      class Reader
+      {
+      public:
+        /**
+         * @brief Constructor
+        **/
+        Reader() = default;
+
+        /**
+         * @brief Destructor
+        **/
+        virtual ~Reader() = default;
+
+        /**
+         * @brief Copy operator
+        **/
+        Reader(const Reader& other) = delete;
+        Reader& operator=(const Reader& other) = delete;
+
+        /**
+        * @brief Move operator
+        **/
+        Reader(Reader&&) = default;
+        Reader& operator=(Reader&&) = default;
+
+        /**
+         * @brief Open file
+         *
+         * @param path     Input file path / Reader directory path.
+         *
+         *                 Default Reader directory structure:
+         *                  - root directory e.g.: M:\Reader_directory\Reader01
+         *                  - documents directory:                                |_doc
+         *                  - hosts directories:                                  |_Host1 (e.g.: CARPC01)
+         *                                                                        |_Host2 (e.g.: CARPC02)
+         *
+         *                 File path as input (AccessType::RDONLY):
+         *                  - root directory (e.g.: M:\Reader_directory\Reader01) in this case all hosts subdirectories will be iterated,
+         *                  - host directory (e.g.: M:\Reader_directory\Reader01\CARPC01),
+         *                  - file path, path to file from Reader (e.g.: M:\Reader_directory\Reader01\CARPC01\meas01_05.hdf5).
+         *
+         *
+         * @param access   Access type
+         *
+         * @return         true if input (AccessType::RDONLY) Reader/file path was opened, false otherwise.
+        **/
+        virtual bool Open(const std::string& path) = 0;
+
+        /**
+         * @brief Close file
+         *
+         * @return         true if succeeds, false if it fails
+        **/
+        virtual bool Close() = 0;
+
+        /**
+         * @brief Checks if file/Reader is ok
+         *
+         * @return  true if meas can be opened(read) false otherwise
+        **/
+        virtual bool IsOk() const = 0;
+
+        /**
+         * @brief Get the File Type Version of the current opened file
+         *
+         * @return       file version
+        **/
+        virtual std::string GetFileVersion() const = 0;
+
+        /**
+         * @brief Gets maximum allowed size for an individual file
+         *
+         * @return       maximum size in MB
+        **/
+        /*virtual size_t GetMaxSizePerFile() const = 0;*/
+
+        /**
+         * @brief Get the available channel names of the current opened file / Reader
+         *
+         * @return       channel names
+        **/
+        virtual std::set<std::string> GetChannelNames() const = 0;
+
+        /**
+         * @brief Check if channel exists in Reader
+         *
+         * @param channel_name   name of the channel
+         *
+         * @return       true if exists, false otherwise
+        **/
+        virtual bool HasChannel(const std::string& channel_name) const = 0;
+
+        /**
+         * @brief Get the channel description for the given channel
+         *
+         * @param channel_name  channel name
+         *
+         * @return              channel description
+        **/
+        virtual std::string GetChannelDescription(const std::string& channel_name) const = 0;
+
+        /**
+         * @brief Gets the channel type of the given channel
+         *
+         * @param channel_name  channel name
+         *
+         * @return              channel type
+        **/
+        virtual std::string GetChannelType(const std::string& channel_name) const = 0;
+
+        /**
+         * @brief Gets minimum timestamp for specified channel
+         *
+         * @param channel_name    channel name
+         *
+         * @return                minimum timestamp value
+        **/
+        virtual long long GetMinTimestamp(const std::string& channel_name) const = 0;
+
+        /**
+         * @brief Gets maximum timestamp for specified channel
+         *
+         * @param channel_name    channel name
+         *
+         * @return                maximum timestamp value
+        **/
+        virtual long long GetMaxTimestamp(const std::string& channel_name) const = 0;
+
+        /**
+         * @brief Gets the header info for all data entries for the given channel
+         *        Header = timestamp + entry id
+         *
+         * @param [in]  channel_name  channel name
+         * @param [out] entries       header info for all data entries
+         *
+         * @return                    true if succeeds, false if it fails
+        **/
+        virtual bool GetEntriesInfo(const std::string& channel_name, EntryInfoSet& entries) const = 0;
+
+        /**
+         * @brief Gets the header info for data entries for the given channel included in given time range (begin->end)
+         *        Header = timestamp + entry id
+         *
+         * @param [in]  channel_name channel name
+         * @param [in]  begin        time range begin timestamp
+         * @param [in]  end          time range end timestamp
+         * @param [out] entries      header info for data entries in given range
+         *
+         * @return                   true if succeeds, false if it fails
+        **/
+        virtual bool GetEntriesInfoRange(const std::string& channel_name, long long begin, long long end, EntryInfoSet& entries) const = 0;
+
+        /**
+         * @brief Gets data size of a specific entry
+         *
+         * @param [in]  entry_id   Entry ID
+         * @param [out] size       Entry data size
+         *
+         * @return                 true if succeeds, false if it fails
+        **/
+        virtual bool GetEntryDataSize(long long entry_id, size_t& size) const = 0;
+
+        /**
+         * @brief Gets data from a specific entry
+         *
+         * @param [in]  entry_id   Entry ID
+         * @param [out] data       Entry data
+         *
+         * @return                 true if succeeds, false if it fails
+        **/
+        virtual bool GetEntryData(long long entry_id, void* data) const = 0;
+
+      };
+    }
+  }  // namespace eh5
+}  // namespace eCAL

--- a/contrib/measurement/base/include/ecal/measurement/base/writer.h
+++ b/contrib/measurement/base/include/ecal/measurement/base/writer.h
@@ -1,0 +1,186 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+/**
+ * @file   measurement.h
+ * @brief  Base class for low level measurement oprations
+**/
+
+#pragma once
+
+#include <functional>
+#include <set>
+#include <string>
+#include <memory>
+
+#include <ecal/measurement/base/types.h>
+
+namespace eCAL
+{
+  namespace measurement
+  {
+    namespace base
+    {
+      /**
+       * @brief eCAL measurement API
+      **/
+      class Writer
+      {
+      public:
+        /**
+         * @brief Constructor
+        **/
+        Writer() = default;
+
+        /**
+         * @brief Destructor
+        **/
+        virtual ~Writer() = default;
+
+        /**
+         * @brief Copy operator
+        **/
+        Writer(const Writer& other) = delete;
+        Writer& operator=(const Writer& other) = delete;
+
+        /**
+        * @brief Move operator
+        **/
+        Writer(Writer&&) = default;
+        Writer& operator=(Writer&&) = default;
+
+        /**
+         * @brief Open file
+         *
+         * @param path     Input file path / measurement directory path.
+         *
+         *                 Default measurement directory structure:
+         *                  - root directory e.g.: M:\measurement_directory\measurement01
+         *                  - documents directory:                                |_doc
+         *                  - hosts directories:                                  |_Host1 (e.g.: CARPC01)
+         *                                                                        |_Host2 (e.g.: CARPC02)
+         *
+         *                 File path as input (AccessType::RDONLY):
+         *                  - root directory (e.g.: M:\measurement_directory\measurement01) in this case all hosts subdirectories will be iterated,
+         *                  - host directory (e.g.: M:\measurement_directory\measurement01\CARPC01),
+         *                  - file path, path to file from measurement (e.g.: M:\measurement_directory\measurement01\CARPC01\meas01_05.hdf5).
+         *
+         *                 File path as output (AccessType::CREATE):
+         *                  - full path to  measurement directory (recommended with host name) (e.g.: M:\measurement_directory\measurement01\CARPC01),
+         *                  - to set the name of the actual hdf5 file use SetFileBaseName method.
+         *
+         * @param access   Access type
+         *
+         * @return         true if output (AccessType::CREATE) measurement directory structure can be accessed/created, false otherwise.
+         *                 true if input (AccessType::RDONLY) measurement/file path was opened, false otherwise.
+        **/
+        virtual bool Open(const std::string& path) = 0;
+
+        /**
+         * @brief Close file
+         *
+         * @return         true if succeeds, false if it fails
+        **/
+        virtual bool Close() = 0;
+
+        /**
+         * @brief Checks if file/measurement is ok
+         *
+         * @return  true if meas can be opened(read) or location is accessible(write), false otherwise
+        **/
+        virtual bool IsOk() const = 0;
+
+        /**
+         * @brief Gets maximum allowed size for an individual file
+         *
+         * @return       maximum size in MB
+        **/
+        virtual size_t GetMaxSizePerFile() const = 0;
+
+        /**
+         * @brief Sets maximum allowed size for an individual file
+         *
+         * @param size   maximum size in MB
+        **/
+        virtual void SetMaxSizePerFile(size_t size) = 0;
+
+        /**
+        * @brief Whether each Channel shall be writte in its own file
+        *
+        * When enabled, data is clustered by channel and each channel is written
+        * to its own file. The filenames will consist of the basename and the
+        * channel name.
+        *
+        * @return true, if one file per channel is enabled
+        */
+        virtual bool IsOneFilePerChannelEnabled() const = 0;
+
+        /**
+        * @brief Enable / disable the creation of one individual file per channel
+        *
+        * When enabled, data is clustered by channel and each channel is written
+        * to its own file. The filenames will consist of the basename and the
+        * channel name.
+        *
+        * @param enabled   Whether one file shall be created per channel
+        */
+        virtual void SetOneFilePerChannelEnabled(bool enabled) = 0;
+
+        /**
+         * @brief Set description of the given channel
+         *
+         * @param channel_name    channel name
+         * @param description     description of the channel
+        **/
+        virtual void SetChannelDescription(const std::string& channel_name, const std::string& description) = 0;
+
+        /**
+         * @brief Set type of the given channel
+         *
+         * @param channel_name  channel name
+         * @param type          type of the channel
+        **/
+        virtual void SetChannelType(const std::string& channel_name, const std::string& type) = 0;
+
+        /**
+         * @brief Set measurement file base name (desired name for the actual hdf5 files that will be created)
+         *
+         * @param base_name        Name of the hdf5 files that will be created.
+        **/
+        virtual void SetFileBaseName(const std::string& base_name) = 0;
+
+        /**
+         * @brief Add entry to file
+         *
+         * @param data           data to be added
+         * @param size           size of the data
+         * @param snd_timestamp  send time stamp
+         * @param rcv_timestamp  receive time stamp
+         * @param channel_name   channel name
+         * @param id             message id
+         * @param clock          message clock
+         *
+         * @return              true if succeeds, false if it fails
+        **/
+        virtual bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const std::string& channel_name, long long id, long long clock) = 0;
+        
+      };
+    }
+  }  // namespace eh5
+}  // namespace eCAL


### PR DESCRIPTION
Please check the type of change your PR introduces:
- [x] Refactoring (no functional changes, no api changes)

Issue Number: #1076 

Split Measurement interface into reader / writer interface, to be used by all internal applications making use of the measurement API. (Except for now the Python API - reading / writing mcap there might not be supported right away by the 5.12 release).