### PR TITLE
feature/true-zero-copy-7

### DIFF
--- a/ecal/core/CMakeLists.txt
+++ b/ecal/core/CMakeLists.txt
@@ -322,6 +322,7 @@ set(ecal_header_cmn
     include/ecal/ecal_monitoring_entity.h
     include/ecal/ecal_monitoring_struct.h
     include/ecal/ecal_os.h
+    include/ecal/ecal_payload_writer.h
     include/ecal/ecal_process.h
     include/ecal/ecal_process_mode.h
     include/ecal/ecal_process_severity.h

--- a/ecal/core/include/ecal/ecal_payload_writer.h
+++ b/ecal/core/include/ecal/ecal_payload_writer.h
@@ -1,0 +1,83 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+/**
+ * @file   ecal_payload_writer.h
+ * @brief  eCAL payload writer base class
+**/
+
+#pragma once
+
+#include <cstddef>
+#include <cstring>
+
+namespace eCAL
+{
+  // base payload writer class to allow zero copy memory operations
+  // 
+  // the `Write`and `Update` calls may operate on the target memory file directly (zero copy mode)
+  class CPayloadWriter
+  {
+  public:
+    CPayloadWriter() = default;
+    virtual ~CPayloadWriter() = default;
+
+    CPayloadWriter(const CPayloadWriter &) = default;
+    CPayloadWriter(CPayloadWriter &&) = default;
+
+    CPayloadWriter& operator=(const CPayloadWriter &) = default;
+    CPayloadWriter& operator=(CPayloadWriter &&) = default;
+
+    // the provisioned memory is uninitialized ->
+    // perform a full write operation
+    virtual bool Write(void* buffer_, size_t size_) = 0;
+
+    // the provisioned memory is initialized and contains the data from the last write operation ->
+    // perform a partial write operation or just modify a few bytes here
+    //
+    // by default this operation will just call `Write`
+    virtual bool Update(void* buffer_, size_t size_) { return Write(buffer_, size_); };
+
+    // provide the size of the required memory (eCAL needs to allocate for you).
+    virtual size_t GetSize() = 0;
+  };
+
+  // payload writer class that wraps classic (void*, size_t) interface
+  class CBufferPayloadWriter : public CPayloadWriter
+  {
+  public:
+    CBufferPayloadWriter(const void* const buffer_, size_t size_) : m_buffer(buffer_), m_size(size_) {};
+
+    // make a dump memory copy
+    bool Write (void* buffer_, size_t size_) override {
+      if (size_ < m_size)      return false;
+      if (m_buffer == nullptr) return false;
+      if (m_size == 0)         return false;
+      memcpy(buffer_, m_buffer, m_size);
+      return true;
+    }
+
+    // size of the memory that needs to be copied
+    size_t GetSize() override { return m_size; };
+  
+  private:
+    const void* m_buffer = nullptr;
+    size_t      m_size   = 0;
+  };
+}

--- a/ecal/core/include/ecal/ecal_payload_writer.h
+++ b/ecal/core/include/ecal/ecal_payload_writer.h
@@ -66,6 +66,7 @@ namespace eCAL
 
     // make a dump memory copy
     bool Write (void* buffer_, size_t size_) override {
+      if (buffer_ == nullptr)  return false;
       if (size_ < m_size)      return false;
       if (m_buffer == nullptr) return false;
       if (m_size == 0)         return false;

--- a/ecal/core/include/ecal/ecal_publisher.h
+++ b/ecal/core/include/ecal/ecal_publisher.h
@@ -26,6 +26,7 @@
 
 #include <ecal/ecal_os.h>
 #include <ecal/ecal_callback.h>
+#include <ecal/ecal_payload_writer.h>
 #include <ecal/ecal_qos.h>
 #include <ecal/ecal_tlayer.h>
 
@@ -317,6 +318,16 @@ namespace eCAL
     size_t Send(const void* buf_, size_t len_, long long time_ = DEFAULT_TIME_ARGUMENT) const;
 
     /**
+     * @brief Send a message to all subscribers.
+     *
+     * @param payload_  Payload.
+     * @param time_     Send time (-1 = use eCAL system time in us, default = -1).
+     *
+     * @return  Number of bytes sent.
+    **/
+    size_t Send(CPayloadWriter& payload_, long long time_ = -1) const;
+
+    /**
      * @brief Send a message to all subscribers synchronized with acknowledge timeout (see also ShmSetAcknowledgeTimeout).
      * 
      * This synchronized mode is currently implemented for local interprocess communication (shm-ecal layer) only.
@@ -328,7 +339,7 @@ namespace eCAL
      *
      * @return  Number of bytes sent.
     **/
-    size_t Send(const void* const buf_, size_t len_, long long time_, long long acknowledge_timeout_ms_) const;
+    size_t Send(const void* buf_, size_t len_, long long time_, long long acknowledge_timeout_ms_) const;
 
     /**
      * @brief Send a message to all subscribers synchronized with acknowledge timeout (see also ShmSetAcknowledgeTimeout).
@@ -347,6 +358,19 @@ namespace eCAL
     {
       return Send(buf_, len_, time_, acknowledge_timeout_ms_);
     }
+
+    /**
+     * @brief Send a message to all subscribers synchronized with acknowledge timeout (see also ShmSetAcknowledgeTimeout).
+     *
+     * This synchronized mode is currently implemented for local interprocess communication (shm-ecal layer) only.
+     *
+     * @param payload_                 Payload.
+     * @param time_                    Send time (-1 = use eCAL system time in us).
+     * @param acknowledge_timeout_ms_  Maximum time to wait for all subscribers acknowledge feedback in ms (buffer received and processed).
+     *
+     * @return  Number of bytes sent.
+    **/
+    size_t Send(CPayloadWriter& payload_, long long time_, long long acknowledge_timeout_ms_) const;
 
     /**
      * @brief Send a message to all subscribers.

--- a/ecal/core/include/ecal/ecal_publisher.h
+++ b/ecal/core/include/ecal/ecal_publisher.h
@@ -325,7 +325,7 @@ namespace eCAL
      *
      * @return  Number of bytes sent.
     **/
-    size_t Send(CPayloadWriter& payload_, long long time_ = -1) const;
+    size_t Send(CPayloadWriter& payload_, long long time_ = DEFAULT_TIME_ARGUMENT) const;
 
     /**
      * @brief Send a message to all subscribers synchronized with acknowledge timeout (see also ShmSetAcknowledgeTimeout).

--- a/ecal/core/include/ecal/msg/protobuf/publisher.h
+++ b/ecal/core/include/ecal/msg/protobuf/publisher.h
@@ -52,13 +52,46 @@ namespace eCAL
      *
     **/
     template <typename T>
-    class CPublisher : public CMsgPublisher<T>
+    class CPublisher : public eCAL::CPublisher
     {
+      class CPayload : public eCAL::CPayloadWriter
+      {
+      public:
+        CPayload(const google::protobuf::Message& message_) :
+          message(message_) {};
+
+        ~CPayload() override = default;
+
+        CPayload(const CPayload&) = default;
+        CPayload(CPayload&&) noexcept = default;
+
+        CPayload& operator=(const CPayload&) = delete;
+        CPayload& operator=(CPayload&&) noexcept = delete;
+
+        bool Write(void* buf_, size_t len_) override
+        {
+          return message.SerializeToArray(buf_, (int)len_);
+        }
+
+        size_t GetSize() override {
+          size_t size(0);
+#if GOOGLE_PROTOBUF_VERSION >= 3001000
+          size = (size_t)message.ByteSizeLong();
+#else
+          size = (size_t)message.ByteSize();
+#endif
+          return(size);
+          };
+
+      private:
+        const google::protobuf::Message& message;
+      };
+
     public:
       /**
        * @brief  Constructor.
       **/
-      CPublisher() : CMsgPublisher<T>()
+      CPublisher() : eCAL::CPublisher()
       {
       }
 
@@ -70,7 +103,7 @@ namespace eCAL
 
       // call the function via its class becase it's a virtual function that is called in constructor/destructor,-
       // where the vtable is not created yet or it's destructed.
-      CPublisher(const std::string& topic_name_) : CMsgPublisher<T>(topic_name_, CPublisher::GetTypeName(), CPublisher::GetDescription())
+      CPublisher(const std::string& topic_name_) : eCAL::CPublisher(topic_name_, CPublisher::GetTypeName(), CPublisher::GetDescription())
       {
       }
 
@@ -103,15 +136,39 @@ namespace eCAL
       **/
       bool Create(const std::string& topic_name_)
       {
-        return(CMsgPublisher<T>::Create(topic_name_, GetTypeName(), GetDescription()));
+        return(eCAL::CPublisher::Create(topic_name_, GetTypeName(), GetDescription()));
       }
+
+      size_t Send(const T& msg_, long long time_ = -1)
+      {
+        return Send(msg_, time_, -1);
+      }
+
+      /**
+       * @brief Send a serialized message to all subscribers synchronized with acknowledge timeout (see also ShmSetAcknowledgeTimeout).
+       *
+       * This synchronized mode is currently implemented for local interprocess communication (shm-ecal layer) only.
+       *
+       * @param msg_                     The message object.
+       * @param time_                    Time stamp.
+       * @param acknowledge_timeout_ms_  Maximum time to wait for all subscribers acknowledge feedback in ms (buffer received and processed).
+       *
+       * @return  Number of bytes sent.
+      **/
+      size_t Send(const T& msg_, long long time_, long long acknowledge_timeout_ms_)
+      {
+        CPayload payload{ msg_ };
+        eCAL::CPublisher::Send(payload, time_, acknowledge_timeout_ms_);
+        return(0);
+      }
+
 
       /**
        * @brief  Get type name of the protobuf message.
        *
        * @return  Type name.
       **/
-      std::string GetTypeName() const override
+      std::string GetTypeName() const
       {
         static T msg;
         return("proto:" + msg.GetTypeName());
@@ -123,42 +180,10 @@ namespace eCAL
        *
        * @return  Description string.
       **/
-      std::string GetDescription() const override
+      std::string GetDescription() const
       {
         static T msg;
         return(protobuf::GetProtoMessageDescription(msg));
-      }
-
-      /**
-       * @brief  Get size for serialized message object.
-       *
-       * @param msg_  The message object.
-       *
-       * @return  Message size.
-      **/
-      size_t GetSize(const T& msg_) const override
-      {
-        size_t size(0);
-#if GOOGLE_PROTOBUF_VERSION >= 3001000
-        size = (size_t)msg_.ByteSizeLong();
-#else
-        size = (size_t)msg_.ByteSize();
-#endif
-        return(size);
-      }
-
-      /**
-       * @brief  Serialize the message object into a preallocated char buffer.
-       *
-       * @param       msg_     The message object.
-       * @param [out] buffer_  Target buffer.
-       * @param       size_    Target buffer size.
-       *
-       * @return  True if it succeeds, false if it fails.
-      **/
-      bool Serialize(const T& msg_, char* buffer_, size_t size_) const override
-      {
-        return(msg_.SerializeToArray((void*)buffer_, (int)size_));
       }
 
     };

--- a/ecal/core/include/ecal/msg/protobuf/publisher.h
+++ b/ecal/core/include/ecal/msg/protobuf/publisher.h
@@ -70,15 +70,15 @@ namespace eCAL
 
         bool Write(void* buf_, size_t len_) override
         {
-          return message.SerializeToArray(buf_, (int)len_);
+          return message.SerializeToArray(buf_, static_cast<int>(len_));
         }
 
         size_t GetSize() override {
           size_t size(0);
 #if GOOGLE_PROTOBUF_VERSION >= 3001000
-          size = (size_t)message.ByteSizeLong();
+          size = static_cast<size_t>(message.ByteSizeLong());
 #else
-          size = (size_t)message.ByteSize();
+          size = static_cast<size_t>(message.ByteSize());
 #endif
           return(size);
           };
@@ -113,14 +113,19 @@ namespace eCAL
       CPublisher(const CPublisher&) = delete;
 
       /**
-      * @brief  Copy Constructor is not available.
-      **/
-      CPublisher& operator=(const CPublisher&) = delete;
-
-      /**
       * @brief  Move Constructor
       **/
       CPublisher(CPublisher&&) = default;
+
+      /**
+      * @brief  Destructor.
+      **/
+      ~CPublisher() override = default;
+
+      /**
+      * @brief  Copy assignment is not available.
+      **/
+      CPublisher& operator=(const CPublisher&) = delete;
 
       /**
       * @brief  Move assignment

--- a/ecal/core/src/io/ecal_memfile.cpp
+++ b/ecal/core/src/io/ecal_memfile.cpp
@@ -173,8 +173,9 @@ namespace eCAL
     m_memfile_mutex.Destroy();
 
     // reset states
-    m_created      = false;
-    m_access_state = access_state::closed;
+    m_created             = false;
+    m_payload_initialized = false;
+    m_access_state        = access_state::closed;
     m_name.clear();
 
     // reset header and info

--- a/ecal/core/src/io/ecal_memfile.cpp
+++ b/ecal/core/src/io/ecal_memfile.cpp
@@ -42,8 +42,9 @@ namespace eCAL
 
   CMemoryFile::CMemoryFile() :
     m_created(false),
-    m_access_state(access_state::closed),
-    m_name("")
+    m_auto_sanitizing(false),
+    m_payload_initialized(false),
+    m_access_state(access_state::closed)
   {
   }
 
@@ -72,8 +73,9 @@ namespace eCAL
       Destroy(create_);
 
       // reset states
-      m_created      = false;
-      m_access_state = access_state::closed;
+      m_created             = false;
+      m_payload_initialized = false;
+      m_access_state        = access_state::closed;
       m_name.clear();
 
       // reset header and info
@@ -110,7 +112,7 @@ namespace eCAL
       // for performance reasons only apply consistency check if it is explicitly set
       if(m_memfile_mutex.Lock(PUB_MEMFILE_CREATE_TO))
       {
-        if (m_memfile_info.mem_address)
+        if (m_memfile_info.mem_address != nullptr)
         {
           SInternalHeader* header = reinterpret_cast<SInternalHeader*>(m_memfile_info.mem_address);
 
@@ -217,7 +219,7 @@ namespace eCAL
     if (m_access_state != access_state::read_access)         return(0);
     if (len_ == 0)                                           return(0);
     if (len_ > static_cast<size_t>(m_header.cur_data_size))  return(0);
-    if (!m_memfile_info.mem_address)                         return(0);
+    if (m_memfile_info.mem_address == nullptr)               return(0);
 
     // return read address
     buf_ = static_cast<char*>(m_memfile_info.mem_address) + m_header.int_hdr_size;
@@ -227,10 +229,10 @@ namespace eCAL
 
   size_t CMemoryFile::Read(void* buf_, const size_t len_, const size_t offset_)
   {
-    if (!buf_) return(0);
+    if (buf_ == nullptr) return(0);
 
     const void* rbuf(nullptr);
-    if (GetReadAddress(rbuf, len_ + offset_))
+    if (GetReadAddress(rbuf, len_ + offset_) != 0u)
     {
       // copy from read buffer with offset
       memcpy(buf_, static_cast<const char*>(rbuf) + offset_, len_);
@@ -278,7 +280,7 @@ namespace eCAL
     if (m_access_state != access_state::write_access)        return(0);
     if (len_ == 0)                                           return(0);
     if (len_ > static_cast<size_t>(m_header.max_data_size))  return(0);
-    if (!m_memfile_info.mem_address)                         return(0);
+    if (m_memfile_info.mem_address == nullptr)               return(0);
 
     // update m_header and write into memory file header
     m_header.cur_data_size = (unsigned long)(len_);
@@ -291,13 +293,13 @@ namespace eCAL
     return(len_);
   }
 
-  size_t CMemoryFile::Write(const void* buf_, const size_t len_, const size_t offset_)
+  size_t CMemoryFile::WriteBuffer(const void* buf_, const size_t len_, const size_t offset_)
   {
-    if (!m_created) return(0);
-    if (!buf_)      return(0);
+    if (!m_created)      return(0);
+    if (buf_ == nullptr) return(0);
 
     void* wbuf(nullptr);
-    if (GetWriteAddress(wbuf, len_ + offset_))
+    if (GetWriteAddress(wbuf, len_ + offset_) != 0u)
     {
       // copy to write buffer
       memcpy(static_cast<char*>(wbuf) + offset_, buf_, len_);
@@ -311,10 +313,49 @@ namespace eCAL
     }
   }
 
+  size_t CMemoryFile::WritePayload(CPayloadWriter& payload_, const size_t len_, const size_t offset_)
+  {
+    if (!m_created) return(0);
+
+    void* wbuf(nullptr);
+    if (GetWriteAddress(wbuf, len_ + offset_) != 0u)
+    {
+      // (re)write complete buffer
+      if (!m_payload_initialized)
+      {
+        bool const success = payload_.Write(static_cast<char*>(wbuf) + offset_, len_);
+        if (!success)
+        {
+          printf("Could not write payload content to the memory file (CPayload::Write returned false): %s.\n\n", m_name.c_str());
+        }
+        else
+        {
+          m_payload_initialized = true;
+        }
+      }
+      else
+      {
+        // apply update to write buffer
+        bool const success = payload_.Update(static_cast<char*>(wbuf) + offset_, len_);
+        if (!success)
+        {
+          printf("Could not write payload content to the memory file (CPayload::Update returned false): %s.\n\n", m_name.c_str());
+        }
+      }
+
+      // return number of written bytes
+      return(len_);
+    }
+    else
+    {
+      return(0);
+    }
+  }
+
   bool CMemoryFile::GetAccess(int timeout_)
   {
-    if (!m_created)                  return(false);
-    if (!m_memfile_info.mem_address) return(false);
+    if (!m_created)                            return(false);
+    if (m_memfile_info.mem_address == nullptr) return(false);
 
     // lock mutex
     if(!m_memfile_mutex.Lock(timeout_))
@@ -336,13 +377,13 @@ namespace eCAL
     memcpy(&m_header, m_memfile_info.mem_address, std::min(sizeof(SInternalHeader), static_cast<std::size_t>(m_header.int_hdr_size)));
 
     // check size again
-    size_t len = static_cast<size_t>(m_header.int_hdr_size) + static_cast<size_t>(m_header.max_data_size);
+    size_t const len = static_cast<size_t>(m_header.int_hdr_size) + static_cast<size_t>(m_header.max_data_size);
     if (len > m_memfile_info.size)
     {
       // check file size and update memory file map
       memfile::db::CheckFileSize(m_name, len, m_memfile_info);
 
-      // check size again and give up if it is still to small
+      // check size again and give up if it is still too small
       if (len > m_memfile_info.size)
       {
         // unlock mutex

--- a/ecal/core/src/io/ecal_memfile.h
+++ b/ecal/core/src/io/ecal_memfile.h
@@ -27,6 +27,8 @@
 #include <array>
 #include <cstdint>
 
+#include <ecal/ecal_payload_writer.h>
+
 #include "ecal_memfile_info.h"
 #include "ecal_named_mutex.h"
 
@@ -140,7 +142,18 @@ namespace eCAL
      *
      * @return         Number of bytes copied to the memory file.
     **/
-    size_t Write(const void* buf_, const size_t len_, const size_t offset_);
+    size_t WriteBuffer(const void* buf_, size_t len_, size_t offset_);
+
+    /**
+     * @brief Apply payload on the memory file.
+     *
+     * @param payload_  The payload.
+     * @param len_      The number of bytes to write.
+     * @param offset_   The offset for writing the data.
+     *
+     * @return          Number of bytes access (len if succeeded otherwise zero).
+    **/
+    size_t WritePayload(CPayloadWriter& payload_, size_t len_, size_t offset_);
 
     /**
      * @brief Maximum data size of the whole memory file.
@@ -201,6 +214,7 @@ namespace eCAL
     };
     bool            m_created;
     bool            m_auto_sanitizing;
+    bool            m_payload_initialized;
     access_state    m_access_state;
     std::string     m_name;
     SInternalHeader m_header;

--- a/ecal/core/src/io/ecal_memfile_broadcast_writer.cpp
+++ b/ecal/core/src/io/ecal_memfile_broadcast_writer.cpp
@@ -72,7 +72,7 @@ namespace eCAL
 
     if (m_payload_memfile->GetWriteAccess(EXP_MEMFILE_ACCESS_TIMEOUT))
     {
-      m_payload_memfile->Write(data, size, 0);
+      m_payload_memfile->WriteBuffer(data, size, 0);
       m_payload_memfile->ReleaseWriteAccess();
       m_memfile_broadcast->SendEvent(m_event_id, eMemfileBroadcastEventType::EVENT_UPDATED);
 

--- a/ecal/core/src/io/ecal_memfile_sync.cpp
+++ b/ecal/core/src/io/ecal_memfile_sync.cpp
@@ -28,7 +28,6 @@
 #include "ecal_memfile_naming.h"
 #include "ecal_memfile_sync.h"
 
-#include <algorithm>
 #include <chrono>
 #include <sstream>
 
@@ -50,17 +49,17 @@ namespace eCAL
   {
     if (!m_created) return false;
 
-    // a local subscriber is registering with it's process id
+    // a local subscriber is registering with its process id
     //   we have to open the send update event and the acknowledge event
     //   we have ONE memory file per publisher and 1 or 2 events per memory file
 
     // the event names
-    std::string event_snd_name = m_memfile_name + "_" + process_id_;
-    std::string event_ack_name = m_memfile_name + "_" + process_id_ + "_ack";
+    std::string const event_snd_name = m_memfile_name + "_" + process_id_;
+    std::string const event_ack_name = m_memfile_name + "_" + process_id_ + "_ack";
 
     // check for existing process
-    std::lock_guard<std::mutex> lock(m_event_handle_map_sync);
-    EventHandleMapT::iterator iter = m_event_handle_map.find(process_id_);
+    std::lock_guard<std::mutex> const lock(m_event_handle_map_sync);
+    EventHandleMapT::iterator const iter = m_event_handle_map.find(process_id_);
 
     // add a new process id and create the sync and acknowledge event
     if (iter == m_event_handle_map.end())
@@ -92,11 +91,11 @@ namespace eCAL
     // we close the associated sync events and
     // remove them from the event handle map
 
-    std::lock_guard<std::mutex> lock(m_event_handle_map_sync);
-    EventHandleMapT::const_iterator iter = m_event_handle_map.find(process_id_);
+    std::lock_guard<std::mutex> const lock(m_event_handle_map_sync);
+    EventHandleMapT::const_iterator const iter = m_event_handle_map.find(process_id_);
     if (iter != m_event_handle_map.end())
     {
-      SEventHandlePair event_pair = iter->second;
+      SEventHandlePair const event_pair = iter->second;
       gCloseEvent(event_pair.event_snd);
       gCloseEvent(event_pair.event_ack);
       m_event_handle_map.erase(iter);
@@ -110,15 +109,15 @@ namespace eCAL
   {
     if (!m_created) return false;
 
-    // we recreate a memory file if the file size is to small
-    bool file_to_small = m_memfile.MaxDataSize() < (sizeof(SMemFileHeader) + size_);
+    // we recreate a memory file if the file size is too small
+    bool const file_to_small = m_memfile.MaxDataSize() < (sizeof(SMemFileHeader) + size_);
     if (file_to_small)
     {
 #ifndef NDEBUG
       Logging::Log(log_level_debug4, m_base_name + "::CSyncMemoryFile::CheckSize - RECREATE");
 #endif
       // estimate size of memory file
-      size_t memfile_size = sizeof(SMemFileHeader) + size_ + static_cast<size_t>((static_cast<float>(m_attr.reserve) / 100.0f) * static_cast<float>(size_));
+      size_t const memfile_size = sizeof(SMemFileHeader) + size_ + static_cast<size_t>((static_cast<float>(m_attr.reserve) / 100.0f) * static_cast<float>(size_));
 
       // recreate the file
       if (!Recreate(memfile_size)) return false;
@@ -130,7 +129,7 @@ namespace eCAL
     return false;
   }
 
-  bool CSyncMemoryFile::Write(const SWriterData& data_)
+  bool CSyncMemoryFile::Write(CPayloadWriter& payload_, const SWriterAttr& data_)
   {
     if (!m_created)
     {
@@ -162,7 +161,7 @@ namespace eCAL
     // set zero copy
     memfile_hdr.options.zero_copy = static_cast<unsigned char>(data_.zero_copy);
     // set acknowledge timeout
-    memfile_hdr.ack_timout_ms        = static_cast<int64_t>(data_.acknowledge_timeout_ms);
+    memfile_hdr.ack_timout_ms     = static_cast<int64_t>(data_.acknowledge_timeout_ms);
 
     // acquire write access
     bool write_access = m_memfile.GetWriteAccess(static_cast<int>(m_attr.timeout_open_ms));
@@ -193,12 +192,12 @@ namespace eCAL
     size_t wbytes(0);
 
     // write the user file header
-    written &= m_memfile.Write(&memfile_hdr, memfile_hdr.hdr_size, wbytes) > 0;
+    written &= m_memfile.WriteBuffer(&memfile_hdr, memfile_hdr.hdr_size, wbytes) > 0;
     wbytes += memfile_hdr.hdr_size;
     // write the buffer
     if (data_.len > 0)
     {
-      written &= m_memfile.Write(data_.buf, data_.len, wbytes) > 0;
+      written &= m_memfile.WritePayload(payload_, data_.len, wbytes) > 0;
     }
     // release write access
     m_memfile.ReleaseWriteAccess();
@@ -254,7 +253,7 @@ namespace eCAL
     // initialize memory file with empty header
     struct SMemFileHeader memfile_hdr;
     m_memfile.GetWriteAccess(static_cast<int>(m_attr.timeout_open_ms));
-    m_memfile.Write(&memfile_hdr, memfile_hdr.hdr_size, 0);
+    m_memfile.WriteBuffer(&memfile_hdr, memfile_hdr.hdr_size, 0);
     m_memfile.ReleaseWriteAccess();
 
     // it's created
@@ -296,7 +295,7 @@ namespace eCAL
     // collect id's of the currently connected processes
     std::vector<std::string> process_id_list;
     {
-      std::lock_guard<std::mutex> lock(m_event_handle_map_sync);
+      std::lock_guard<std::mutex> const lock(m_event_handle_map_sync);
       for (const auto& event_handle : m_event_handle_map)
       {
         process_id_list.push_back(event_handle.first);
@@ -325,7 +324,7 @@ namespace eCAL
     // fire the publisher events
     // connected subscribers will read the content from the memory file
 
-    std::lock_guard<std::mutex> lock(m_event_handle_map_sync);
+    std::lock_guard<std::mutex> const lock(m_event_handle_map_sync);
 
     // "eat" old acknowledge events :)
     if (m_attr.timeout_ack_ms != 0)
@@ -378,7 +377,7 @@ namespace eCAL
 
   void CSyncMemoryFile::DisconnectAll()
   {
-    std::lock_guard<std::mutex> lock(m_event_handle_map_sync);
+    std::lock_guard<std::mutex> const lock(m_event_handle_map_sync);
 
     // fire acknowledge events, to unlock blocking send function
     for (const auto& event_handle : m_event_handle_map)

--- a/ecal/core/src/io/ecal_memfile_sync.h
+++ b/ecal/core/src/io/ecal_memfile_sync.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <ecal/ecal_eventhandle.h>
+#include <ecal/ecal_payload_writer.h>
 
 #include "readwrite/ecal_writer_data.h"
 #include "ecal_memfile.h"
@@ -52,7 +53,7 @@ namespace eCAL
     bool Disconnect(const std::string& process_id_);
 
     bool CheckSize(size_t size_);
-    bool Write(const SWriterData& data_);
+    bool Write(CPayloadWriter& payload_, const SWriterAttr& data_);
 
     std::string GetName() const;
 

--- a/ecal/core/src/pubsub/ecal_publisher.cpp
+++ b/ecal/core/src/pubsub/ecal_publisher.cpp
@@ -25,16 +25,14 @@
 #include <ecal/ecal_tlayer.h>
 #include <ecal/ecal_config.h>
 
-#include "ecal_def.h"
 #include "ecal_config_reader_hlp.h"
 #include "ecal_globals.h"
-#include "ecal_pubgate.h"
-#include "ecal_registration_provider.h"
 
 #include "readwrite/ecal_writer.h"
 
 #include <sstream>
 #include <iostream>
+#include <utility>
 
 namespace eCAL
 {
@@ -50,6 +48,7 @@ namespace eCAL
 
   CPublisher::CPublisher(const std::string& topic_name_, const std::string& topic_type_ /* = "" */, const std::string& topic_desc_ /* = "" */) :
                 m_datawriter(nullptr),
+                m_id(0),
                 m_created(false),
                 m_initialized(false)
   {
@@ -68,7 +67,7 @@ namespace eCAL
    * @brief CPublisher are move-enabled
   **/
   CPublisher::CPublisher(CPublisher&& rhs) noexcept :
-                m_datawriter(std::move(rhs.m_datawriter)),
+                m_datawriter(rhs.m_datawriter),
                 m_qos(rhs.m_qos),
                 m_id(rhs.m_id),
                 m_created(rhs.m_created),
@@ -86,7 +85,7 @@ namespace eCAL
   **/
   CPublisher& CPublisher::operator=(CPublisher&& rhs) noexcept
   {
-    m_datawriter = std::move(rhs.m_datawriter);
+    m_datawriter = rhs.m_datawriter;
 
     m_qos             = rhs.m_qos;
     m_id              = rhs.m_id;
@@ -103,12 +102,12 @@ namespace eCAL
 
   bool CPublisher::Create(const std::string& topic_name_, const std::string& topic_type_ /* = "" */, const std::string& topic_desc_ /* = "" */)
   {
-    if(m_created)               return(false);
-    if(topic_name_.size() == 0) return(false);
-    if(!g_globals())            return(false);
+    if(m_created)              return(false);
+    if(topic_name_.empty())    return(false);
+    if(g_globals() == nullptr) return(false);
 
     // initialize globals
-    if (!g_globals()->IsInitialized(Init::Publisher))
+    if (g_globals()->IsInitialized(Init::Publisher) == 0)
     {
       g_globals()->Initialize(Init::Publisher);
       m_initialized = true;
@@ -118,7 +117,7 @@ namespace eCAL
     // if layer API was not accessed before creation of this class
     // the layer mode will be initialized by the global config
     // this can not be done in the constructor because a publisher is allowed
-    // to construct befor eCAL::Initialize and so global config is not
+    // to construct before eCAL::Initialize and so global config is not
     // existing while construction
     if (m_tlayer.sm_udp_mc  == TLayer::smode_none) m_tlayer.sm_udp_mc = Config::GetPublisherUdpMulticastMode();
     if (m_tlayer.sm_shm     == TLayer::smode_none) m_tlayer.sm_shm    = Config::GetPublisherShmMode();
@@ -161,15 +160,15 @@ namespace eCAL
 
   bool CPublisher::Destroy()
   {
-    if(!m_created)   return(false);
-    if(!g_globals()) return(false);
+    if(!m_created)             return(false);
+    if(g_globals() == nullptr) return(false);
 
     // destroy data writer
     m_datawriter->Destroy();
 
     // unregister data writer
-    if(g_pubgate())               g_pubgate()->Unregister(m_datawriter->GetTopicName(), m_datawriter);
-    if(g_registration_provider()) g_registration_provider()->UnregisterTopic(m_datawriter->GetTopicName(), m_datawriter->GetTopicID());
+    if(g_pubgate() != nullptr)               g_pubgate()->Unregister(m_datawriter->GetTopicName(), m_datawriter);
+    if(g_registration_provider() != nullptr) g_registration_provider()->UnregisterTopic(m_datawriter->GetTopicName(), m_datawriter->GetTopicID());
 #ifndef NDEBUG
     // log it
     if (g_log()) g_log()->Log(log_level_debug1, std::string(m_datawriter->GetTopicName() + "::CPublisher::Destroy"));
@@ -195,7 +194,7 @@ namespace eCAL
 
   bool CPublisher::SetTypeName(const std::string& topic_type_name_)
   {
-    if (!m_datawriter) return false;
+    if (m_datawriter == nullptr) return false;
 
     // register to description gateway for type / description checking
     const std::string topic_desc = m_datawriter->GetDescription();
@@ -206,7 +205,7 @@ namespace eCAL
 
   bool CPublisher::SetDescription(const std::string& topic_desc_)
   {
-    if(!m_datawriter) return false;
+    if(m_datawriter == nullptr) return false;
 
     // register to description gateway for type / description checking
     const std::string topic_type = m_datawriter->GetTypeName();
@@ -217,26 +216,26 @@ namespace eCAL
 
   bool CPublisher::SetAttribute(const std::string& attr_name_, const std::string& attr_value_)
   {
-    if(!m_datawriter) return false;
+    if(m_datawriter == nullptr) return false;
     return m_datawriter->SetAttribute(attr_name_, attr_value_);
   }
 
   bool CPublisher::ClearAttribute(const std::string& attr_name_)
   {
-    if(!m_datawriter) return false;
+    if(m_datawriter == nullptr) return false;
     return m_datawriter->ClearAttribute(attr_name_);
   }
 
   bool CPublisher::ShareType(bool state_ /*= true*/)
   {
-    if (!m_datawriter) return false;
+    if (m_datawriter == nullptr) return false;
     m_datawriter->ShareType(state_);
     return true;
   }
 
   bool CPublisher::ShareDescription(bool state_ /*= true*/)
   {
-    if (!m_datawriter) return false;
+    if (m_datawriter == nullptr) return false;
     m_datawriter->ShareDescription(state_);
     return true;
   }
@@ -322,80 +321,93 @@ namespace eCAL
 
   size_t CPublisher::Send(const void* const buf_, size_t len_, long long time_, long long acknowledge_timeout_ms_) const
   {
-    if (!m_created) return(0);
+    CBufferPayloadWriter payload{ buf_, len_ };
+    return Send(payload, time_, acknowledge_timeout_ms_);
+  }
 
-    // in an optimization case the
-    // publisher can send an empty package
-    // or we do not have any subscription at all
-    // then the data writer will only do some statistics
-    // for the monitoring layer and return
-    if (!IsSubscribed())
-    {
-      m_datawriter->RefreshSendCounter();
-      return(len_);
-    }
+  // @Rex, do we even need this function? I guess so for convenience...
+  size_t CPublisher::Send(CPayloadWriter& payload_, long long time_) const
+  {
+    return Send(payload_, time_, DEFAULT_ACKNOWLEDGE_ARGUMENT);
+  }
+  
+  size_t CPublisher::Send(CPayloadWriter& payload_, long long time_, long long acknowledge_timeout_ms_) const
+  {
+     if (!m_created) return(0);
 
-    long long current_acknowledge_timeout_ms{ 0 };
-    // set new acknowledge timeout
-    if (acknowledge_timeout_ms_ != DEFAULT_ACKNOWLEDGE_ARGUMENT)
-    {
-      current_acknowledge_timeout_ms = m_datawriter->ShmGetAcknowledgeTimeout();
-      m_datawriter->ShmSetAcknowledgeTimeout(static_cast<long long>(acknowledge_timeout_ms_));
-    }
+     // in an optimization case the
+     // publisher can send an empty package
+     // or we do not have any subscription at all
+     // then the data writer will only do some statistics
+     // for the monitoring layer and return
+     if (!IsSubscribed())
+     {
+       m_datawriter->RefreshSendCounter();
+       return(payload_.GetSize());
+     }
 
-    // send content via data writer layer
-    long long write_time = (time_ == DEFAULT_TIME_ARGUMENT) ? eCAL::Time::GetMicroSeconds() : time_;
-    bool sent = m_datawriter->Write(buf_, len_, write_time, m_id);
+     long long current_acknowledge_timeout_ms{ 0 };
+     // set new acknowledge timeout
+     if (acknowledge_timeout_ms_ != DEFAULT_ACKNOWLEDGE_ARGUMENT)
+     {
+       current_acknowledge_timeout_ms = m_datawriter->ShmGetAcknowledgeTimeout();
+       m_datawriter->ShmSetAcknowledgeTimeout(static_cast<long long>(acknowledge_timeout_ms_));
+     }
 
-    if (acknowledge_timeout_ms_ != DEFAULT_ACKNOWLEDGE_ARGUMENT)
-    {
-      // reset acknowledge timeout
-      m_datawriter->ShmSetAcknowledgeTimeout(current_acknowledge_timeout_ms);
-    }
+     // send content via data writer layer
+     long long const write_time = (time_ == DEFAULT_TIME_ARGUMENT) ? eCAL::Time::GetMicroSeconds() : time_;
+     bool const sent = m_datawriter->Write(payload_, write_time, m_id);
 
-    return sent ? len_ : 0;
+     if (acknowledge_timeout_ms_ != DEFAULT_ACKNOWLEDGE_ARGUMENT)
+     {
+       // reset acknowledge timeout
+       m_datawriter->ShmSetAcknowledgeTimeout(current_acknowledge_timeout_ms);
+     }
+
+     //@Rex we have to call GetSize() again. Can't we return this from the Write call?
+     return sent ? payload_.GetSize() : 0;
   }
 
   bool CPublisher::AddEventCallback(eCAL_Publisher_Event type_, PubEventCallbackT callback_)
   {
-    if (!m_datawriter) return(false);
+    if (m_datawriter == nullptr) return(false);
     RemEventCallback(type_);
-    return(m_datawriter->AddEventCallback(type_, callback_));
+    return(m_datawriter->AddEventCallback(type_, std::move(callback_)));
   }
 
   bool CPublisher::RemEventCallback(eCAL_Publisher_Event type_)
   {
-    if (!m_datawriter) return(false);
+    if (m_datawriter == nullptr) return(false);
     return(m_datawriter->RemEventCallback(type_));
   }
 
   bool CPublisher::IsSubscribed() const
   {
-    if(!m_datawriter) return(false);
+    if(m_datawriter == nullptr) return(false);
     return(m_datawriter->IsSubscribed());
   }
 
   size_t CPublisher::GetSubscriberCount() const
   {
-    if(!m_datawriter) return(0);
+    if(m_datawriter == nullptr) return(0);
     return(m_datawriter->GetSubscriberCount());
   }
 
   std::string CPublisher::GetTopicName() const
   {
-    if(!m_datawriter) return("");
+    if(m_datawriter == nullptr) return("");
     return(m_datawriter->GetTopicName());
   }
 
   std::string CPublisher::GetTypeName() const
   {
-    if(!m_datawriter) return("");
+    if(m_datawriter == nullptr) return("");
     return(m_datawriter->GetTypeName());
   }
 
   std::string CPublisher::GetDescription() const
   {
-    if(!m_datawriter) return("");
+    if(m_datawriter == nullptr) return("");
     return(m_datawriter->GetDescription());
   }
 
@@ -411,7 +423,7 @@ namespace eCAL
 
   bool CPublisher::ApplyTopicToDescGate(const std::string& topic_name_, const std::string& topic_type_, const std::string& topic_desc_)
   {
-    if (g_descgate())
+    if (g_descgate() != nullptr)
     {
       // Calculate the quality of the current info
       ::eCAL::CDescGate::QualityFlags quality = ::eCAL::CDescGate::QualityFlags::NO_QUALITY;
@@ -436,7 +448,7 @@ namespace eCAL
     out << indent_ << " class CPublisher"      << std::endl;
     out << indent_ << "----------------------" << std::endl;
     out << indent_ << "m_created:            " << m_created << std::endl;
-    if(m_datawriter && m_datawriter->IsCreated()) out << indent_ << m_datawriter->Dump("    ");
+    if((m_datawriter != nullptr) && m_datawriter->IsCreated()) out << indent_ << m_datawriter->Dump("    ");
     out << std::endl;
 
     return(out.str());

--- a/ecal/core/src/pubsub/ecal_publisher.cpp
+++ b/ecal/core/src/pubsub/ecal_publisher.cpp
@@ -356,7 +356,7 @@ namespace eCAL
 
      // send content via data writer layer
      long long const write_time = (time_ == DEFAULT_TIME_ARGUMENT) ? eCAL::Time::GetMicroSeconds() : time_;
-     bool const sent = m_datawriter->Write(payload_, write_time, m_id);
+     const size_t written_bytes = m_datawriter->Write(payload_, write_time, m_id);
 
      if (acknowledge_timeout_ms_ != DEFAULT_ACKNOWLEDGE_ARGUMENT)
      {
@@ -364,8 +364,8 @@ namespace eCAL
        m_datawriter->ShmSetAcknowledgeTimeout(current_acknowledge_timeout_ms);
      }
 
-     //@Rex we have to call GetSize() again. Can't we return this from the Write call?
-     return sent ? payload_.GetSize() : 0;
+     // return number of bytes written
+     return written_bytes;
   }
 
   bool CPublisher::AddEventCallback(eCAL_Publisher_Event type_, PubEventCallbackT callback_)

--- a/ecal/core/src/readwrite/ecal_reader.h
+++ b/ecal/core/src/readwrite/ecal_reader.h
@@ -40,6 +40,7 @@
 #include <mutex>
 #include <atomic>
 #include <set>
+#include <queue>
 
 #include <string>
 #include <unordered_map>
@@ -139,8 +140,7 @@ namespace eCAL
     std::atomic<int>                          m_receive_timeout;
     std::atomic<int>                          m_receive_time;
 
-    typedef Util::CExpMap<size_t, size_t>     SampleHashMapT;
-    SampleHashMapT                            m_sample_hash;
+    std::deque<size_t>                        m_sample_hash_queue;
 
     std::mutex                                m_event_callback_map_sync;
     typedef std::map<eCAL_Subscriber_Event, SubEventCallbackT> EventCallbackMapT;

--- a/ecal/core/src/readwrite/ecal_writer.cpp
+++ b/ecal/core/src/readwrite/ecal_writer.cpp
@@ -23,17 +23,19 @@
 
 #include <ecal/ecal.h>
 #include <ecal/ecal_config.h>
+#include <ecal/ecal_payload_writer.h>
 
 #include "ecal_def.h"
 #include "ecal_config_reader_hlp.h"
 
 #include "ecal_registration_provider.h"
 #include "ecal_registration_receiver.h"
-#include "pubsub/ecal_pubgate.h"
 
 #include "ecal_writer.h"
 #include "ecal_writer_base.h"
 #include "ecal_process.h"
+
+#include "pubsub/ecal_pubgate.h"
 
 #include <sstream>
 #include <chrono>
@@ -53,8 +55,8 @@ namespace std
   public:
     size_t operator()(const SSndHash &h) const
     {
-      size_t h1 = std::hash<std::string>()(h.topic_id);
-      size_t h2 = std::hash<long long>()(h.snd_clock);
+      const size_t h1 = std::hash<std::string>()(h.topic_id);
+      const size_t h2 = std::hash<long long>()(h.snd_clock);
       return h1 ^ (h2 << 1);
     }
   };
@@ -75,25 +77,21 @@ namespace eCAL
     m_id(0),
     m_clock(0),
     m_clock_old(0),
-    m_snd_time(),
     m_freq(0),
     m_bandwidth_max_udp(NET_BANDWIDTH_MAX_UDP),
     m_loc_subscribed(false),
     m_ext_subscribed(false),
-    m_use_udp_mc(Config::GetPublisherUdpMulticastMode()),
-    m_use_udp_mc_confirmed(false),
-    m_use_shm(Config::GetPublisherShmMode()),
-    m_use_shm_confirmed(false),
-    m_use_tcp(Config::GetPublisherTcpMode()),
-    m_use_tcp_confirmed(false),
-    m_use_inproc(Config::GetPublisherInprocMode()),
-    m_use_inproc_confirmed(false),
     m_use_ttype(true),
     m_use_tdesc(true),
     m_share_ttype(-1),
     m_share_tdesc(-1),
     m_created(false)
   {
+    // initialize layer modes with configuration settings
+    m_writer.udp_mc_mode.requested = Config::GetPublisherUdpMulticastMode();
+    m_writer.shm_mode.requested    = Config::GetPublisherShmMode();
+    m_writer.tcp_mode.requested    = Config::GetPublisherTcpMode();
+    m_writer.inproc_mode.requested = Config::GetPublisherInprocMode();
   }
 
   CDataWriter::~CDataWriter()
@@ -106,14 +104,14 @@ namespace eCAL
     if (m_created) return(false);
 
     // set defaults
-    m_topic_name              = topic_name_;
+    m_topic_name             = topic_name_;
     m_topic_id.clear();
-    m_topic_type              = topic_type_;
-    m_topic_desc              = topic_desc_;
-    m_id                      = 0;
-    m_clock                   = 0;
-    m_clock_old               = 0;
-    m_snd_time                = std::chrono::steady_clock::time_point();
+    m_topic_type             = topic_type_;
+    m_topic_desc             = topic_desc_;
+    m_id                     = 0;
+    m_clock                  = 0;
+    m_clock_old              = 0;
+    m_snd_time               = std::chrono::steady_clock::time_point();
     m_freq                   = 0;
     m_bandwidth_max_udp      = Config::GetMaxUdpBandwidthBytesPerSecond();
     m_buffering_shm          = Config::GetMemfileBufferCount();
@@ -129,7 +127,7 @@ namespace eCAL
     m_topic_id = counter.str();
 
     // set registration expiration
-    std::chrono::milliseconds registration_timeout(Config::GetRegistrationTimeoutMs());
+    const std::chrono::milliseconds registration_timeout(Config::GetRegistrationTimeoutMs());
     m_loc_sub_map.set_expiration(registration_timeout);
     m_ext_sub_map.set_expiration(registration_timeout);
 
@@ -146,16 +144,16 @@ namespace eCAL
     m_created = true;
 
     // create udp multicast layer
-    SetUseUdpMC(m_use_udp_mc);
+    SetUseUdpMC(m_writer.udp_mc_mode.requested);
 
     // create shm layer
-    SetUseShm(m_use_shm);
+    SetUseShm(m_writer.shm_mode.requested);
 
     // create tcp layer
-    SetUseTcp(m_use_tcp);
+    SetUseTcp(m_writer.tcp_mode.requested);
 
     // create inproc layer
-    SetUseInProc(m_use_inproc);
+    SetUseInProc(m_writer.inproc_mode.requested);
 
 #ifndef NDEBUG
     // log it
@@ -175,13 +173,13 @@ namespace eCAL
 #endif
 
     // destroy udp multicast writer
-    m_writer_udp_mc.Destroy();
+    m_writer.udp_mc.Destroy();
 
     // destroy memory file writer
-    m_writer_shm.Destroy();
+    m_writer.shm.Destroy();
 
     // destroy inproc writer
-    m_writer_inproc.Destroy();
+    m_writer.inproc.Destroy();
 
     // reset defaults
     m_id                     = 0;
@@ -197,14 +195,14 @@ namespace eCAL
 
     // reset subscriber maps
     {
-      std::lock_guard<std::mutex> lock(m_sub_map_sync);
+      const std::lock_guard<std::mutex> lock(m_sub_map_sync);
       m_loc_sub_map.clear();
       m_ext_sub_map.clear();
     }
 
     // reset event callback map
     {
-      std::lock_guard<std::mutex> lock(m_event_callback_map_sync);
+      const std::lock_guard<std::mutex> lock(m_event_callback_map_sync);
       m_event_callback_map.clear();
     }
 
@@ -215,7 +213,7 @@ namespace eCAL
 
   bool CDataWriter::SetTypeName(const std::string& topic_type_name_)
   {
-    bool force = m_topic_type != topic_type_name_;
+    const bool force = m_topic_type != topic_type_name_;
     m_topic_type = topic_type_name_;
 
 #ifndef NDEBUG
@@ -231,7 +229,7 @@ namespace eCAL
 
   bool CDataWriter::SetDescription(const std::string& topic_desc_)
   {
-    bool force = m_topic_desc != topic_desc_;
+    const bool force = m_topic_desc != topic_desc_;
     m_topic_desc = topic_desc_;
 
 #ifndef NDEBUG
@@ -249,7 +247,7 @@ namespace eCAL
   {
     auto current_val = m_attr.find(attr_name_);
 
-    bool force = current_val == m_attr.end() || current_val->second != attr_value_;
+    const bool force = current_val == m_attr.end() || current_val->second != attr_value_;
     m_attr[attr_name_] = attr_value_;
 
 #ifndef NDEBUG
@@ -308,7 +306,7 @@ namespace eCAL
   {
     m_qos = qos_;
     bool ret = true;
-    ret &= m_writer_shm.SetQOS(qos_);
+    ret &= m_writer.shm.SetQOS(qos_);
     return ret;
   }
 
@@ -365,7 +363,7 @@ namespace eCAL
     return true;
   }
 
-  long long CDataWriter::ShmGetAcknowledgeTimeout()
+  long long CDataWriter::ShmGetAcknowledgeTimeout() const
   {
     return m_acknowledge_timeout_ms;
   }
@@ -376,12 +374,12 @@ namespace eCAL
 
     // store event callback
     {
-      std::lock_guard<std::mutex> lock(m_event_callback_map_sync);
+      const std::lock_guard<std::mutex> lock(m_event_callback_map_sync);
 #ifndef NDEBUG
       // log it
       Logging::Log(log_level_debug2, m_topic_name + "::CDataWriter::AddEventCallback");
 #endif
-      m_event_callback_map[type_] = callback_;
+      m_event_callback_map[type_] = std::move(callback_);
     }
 
     return(true);
@@ -393,7 +391,7 @@ namespace eCAL
 
     // reset event callback
     {
-      std::lock_guard<std::mutex> lock(m_event_callback_map_sync);
+      const std::lock_guard<std::mutex> lock(m_event_callback_map_sync);
 #ifndef NDEBUG
       // log it
       Logging::Log(log_level_debug2, m_topic_name + "::CDataWriter::RemEventCallback");
@@ -404,147 +402,44 @@ namespace eCAL
     return(true);
   }
 
-  bool CDataWriter::Write(const void* const buf_, size_t len_, long long time_, long long id_)
+  bool CDataWriter::Write(CPayloadWriter& payload_, long long time_, long long id_)
   {
-    // store id
-    m_id = id_;
+    // check writer modes
+    if (!CheckWriterModes())
+    {
+      // incompatible writer configurations
+      return false;
+    }
 
-    // handle write counters
-    RefreshSendCounter();
+    // get payload buffer size (one time, to avoid multiple computations)
+    const size_t payload_buf_size(payload_.GetSize());
 
-    // calculate unique send hash
-    std::hash<SSndHash> hf;
-    size_t snd_hash = hf(SSndHash(m_topic_id, m_clock));
+    // can we do a zero copy write ?
+    bool const allow_zero_copy =
+          m_zero_copy                       // zero copy mode activated by user
+      &&  m_writer.shm_mode.activated       // shm layer active
+      && !m_writer.inproc_mode.activated    // all other layers not active
+      && !m_writer.udp_mc_mode.activated
+      && !m_writer.tcp_mode.activated;
 
-    // increase overall sum send
-    g_process_wbytes_sum += len_;
+    // create a payload copy for all layer
+    m_payload_buffer.clear();
+    if (!allow_zero_copy)
+    {
+      m_payload_buffer.resize(payload_buf_size);
+      payload_.Write(m_payload_buffer.data(), m_payload_buffer.size());
+    }
 
-    // store size for monitoring
-    m_topic_size = len_;
+    // prepare counter and internal states
+    const size_t snd_hash = PrepareWrite(id_, payload_buf_size);
 
     // did we write anything
     bool written(false);
 
-    // check send modes
-    TLayer::eSendMode use_udp_mc(m_use_udp_mc);
-    TLayer::eSendMode use_shm(m_use_shm);
-    TLayer::eSendMode use_tcp(m_use_tcp);
-    TLayer::eSendMode use_inproc(m_use_inproc);
-    if ( (use_udp_mc == TLayer::smode_off)
-      && (use_shm    == TLayer::smode_off)
-      && (use_tcp    == TLayer::smode_off)
-      && (use_inproc == TLayer::smode_off)
-      )
-    {
-      // failsafe default mode if
-      // nothing is activated
-      use_udp_mc = TLayer::smode_auto;
-      use_shm    = TLayer::smode_auto;
-    }
-
-    // if we do not have loopback
-    // enabled we can switch off
-    // inner process communication
-    if (g_registration_receiver() && !g_registration_receiver()->LoopBackEnabled())
-    {
-      use_inproc = TLayer::smode_off;
-    }
-    
-    // shared memory transport is on and
-    // inner process transport is on
-    // let's check if there is a need for
-    // shared memory because of external
-    // process subscription, if not
-    // let's switch it off
-    if  ((use_shm    != TLayer::smode_off)
-      && (use_inproc != TLayer::smode_off)
-      )
-    {
-      if (!IsExtSubscribed())
-      {
-        // we have no external subscriptions,
-        // but we have local ones (otherwise we would have
-        // no subscriptions and this is checked with !IsSubscribed())
-        // so let's check if all local subscriptions are 
-        // "inner process only", that means
-        // they have all our process id
-        if (IsInternalSubscribedOnly())
-        {
-          // we can switch shared memory layer off
-          // it's all subscribed in our process
-          use_shm = TLayer::smode_off;
-        }
-      }
-    }
-
-    if ( (use_tcp    == TLayer::smode_auto)
-      && (use_udp_mc == TLayer::smode_auto)
-      )
-    {
-      Logging::Log(log_level_error, m_topic_name + "::CDataWriter::Send: TCP layer and UDP layer are both set to auto mode - Publication failed !");
-      return 0;
-    }
-
     ////////////////////////////////////////////////////////////////////////////
-    // LAYER 1 : INPROC
+    // LAYER 1 : SHM
     ////////////////////////////////////////////////////////////////////////////
-    if  ((use_inproc == TLayer::smode_auto)
-      || (use_inproc == TLayer::smode_on)
-      )
-    {
-#ifndef NDEBUG
-      // log it
-      Logging::Log(log_level_debug3, m_topic_name + "::CDataWriter::Send::INPROC");
-#endif
-
-      // send it
-      bool inproc_sent(false);
-      {
-        // fill writer data
-        struct SWriterData wdata;
-        wdata.buf   = buf_;
-        wdata.len   = len_;
-        wdata.id    = m_id;
-        wdata.clock = m_clock;
-        wdata.hash  = snd_hash;
-        wdata.time  = time_;
-
-        // prepare send
-        if (m_writer_inproc.PrepareWrite(wdata))
-        {
-          // register new to update listening subscribers and rematch
-          DoRegister(true);
-          Process::SleepMS(5);
-        }
-
-        // send
-        inproc_sent = m_writer_inproc.Write(wdata);
-        m_use_inproc_confirmed = true;
-      }
-      written |= inproc_sent;
-
-#ifndef NDEBUG
-      // log it
-      if (inproc_sent)
-      {
-        Logging::Log(log_level_debug3, m_topic_name + "::CDataWriter::Send::INPROC - SUCCESS");
-      }
-      else
-      {
-        // if "m_writer_inproc.Send" returns 0 it's not a fault, the inner process writer may have no
-        // subscription and so it will return 0 written bytes
-        // the other layers will write their bytes in any case on the specific layer
-        // so we will not handle this as an error
-      }
-#endif
-    }
-
-    ////////////////////////////////////////////////////////////////////////////
-    // LAYER 2 : SHM
-    ////////////////////////////////////////////////////////////////////////////
-    if (((use_shm == TLayer::smode_auto) && m_loc_subscribed)
-      || (use_shm == TLayer::smode_on)
-      )
+    if (m_writer.shm_mode.activated)
     {
 #ifndef NDEBUG
       // log it
@@ -555,28 +450,40 @@ namespace eCAL
       bool shm_sent(false);
       {
         // fill writer data
-        struct SWriterData wdata;
-        wdata.buf                    = buf_;
-        wdata.len                    = len_;
-        wdata.id                     = m_id;
-        wdata.clock                  = m_clock;
-        wdata.hash                   = snd_hash;
-        wdata.time                   = time_;
-        wdata.buffering              = m_buffering_shm;
-        wdata.zero_copy              = m_zero_copy;
-        wdata.acknowledge_timeout_ms = m_acknowledge_timeout_ms;
+        struct SWriterAttr wattr;
+        wattr.len                    = payload_buf_size;
+        wattr.id                     = m_id;
+        wattr.clock                  = m_clock;
+        wattr.hash                   = snd_hash;
+        wattr.time                   = time_;
+        wattr.buffering              = m_buffering_shm;
+        wattr.zero_copy              = m_zero_copy;
+        wattr.acknowledge_timeout_ms = m_acknowledge_timeout_ms;
 
         // prepare send
-        if (m_writer_shm.PrepareWrite(wdata))
+        if (m_writer.shm.PrepareWrite(wattr))
         {
           // register new to update listening subscribers and rematch
           DoRegister(true);
           Process::SleepMS(5);
         }
 
-        // send
-        shm_sent = m_writer_shm.Write(wdata);
-        m_use_shm_confirmed = true;
+        // we are the only active layer, and we support zero copy -> we do a zero copy write via payload
+        if (allow_zero_copy)
+        {
+          // write to shm layer (write content into the opened memory file without additional copy)
+          shm_sent = m_writer.shm.Write(payload_, wattr);
+        }
+        // multiple layer are active -> we make a copy and use that one
+        else
+        {
+          // wrap the buffer into a payload object
+          CBufferPayloadWriter payload_buf(m_payload_buffer.data(), m_payload_buffer.size());
+          // write to shm layer (write content into the opened memory file without additional copy)
+          shm_sent = m_writer.shm.Write(payload_buf, wattr);
+        }
+
+        m_writer.shm_mode.confirmed = true;
       }
       written |= shm_sent;
 
@@ -594,11 +501,60 @@ namespace eCAL
     }
 
     ////////////////////////////////////////////////////////////////////////////
+    // LAYER 2 : INPROC
+    ////////////////////////////////////////////////////////////////////////////
+    if (m_writer.inproc_mode.activated)
+    {
+#ifndef NDEBUG
+      // log it
+      Logging::Log(log_level_debug3, m_topic_name + "::CDataWriter::Send::INPROC");
+#endif
+
+      // send it
+      bool inproc_sent(false);
+      {
+        // fill writer data
+        struct SWriterAttr wdata;
+        wdata.len   = payload_buf_size;
+        wdata.id    = m_id;
+        wdata.clock = m_clock;
+        wdata.hash  = snd_hash;
+        wdata.time  = time_;
+
+        // prepare send
+        if (m_writer.inproc.PrepareWrite(wdata))
+        {
+          // register new to update listening subscribers and rematch
+          DoRegister(true);
+          Process::SleepMS(5);
+        }
+
+        // write to inproc layer
+        inproc_sent = m_writer.inproc.Write(m_payload_buffer.data(), wdata);
+        m_writer.inproc_mode.confirmed = true;
+      }
+      written |= inproc_sent;
+
+#ifndef NDEBUG
+      // log it
+      if (inproc_sent)
+      {
+        Logging::Log(log_level_debug3, m_topic_name + "::CDataWriter::Send::INPROC - SUCCESS");
+      }
+      else
+      {
+        // if "m_m_writer.inproc.Send" returns 0 it's not a fault, the inner process writer may have no
+        // subscription and so it will return 0 written bytes
+        // the other layers will write their bytes in any case on the specific layer,
+        // so we will not handle this as an error
+      }
+#endif
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
     // LAYER 3 : UDP (MC)
     ////////////////////////////////////////////////////////////////////////////
-    if (((use_udp_mc == TLayer::smode_auto) && m_ext_subscribed)
-      || (use_udp_mc == TLayer::smode_on)
-      )
+    if (m_writer.udp_mc_mode.activated)
     {
 #ifndef NDEBUG
       // log it
@@ -610,30 +566,29 @@ namespace eCAL
       {
         // if shared memory layer for local communication is switched off
         // we activate udp message loopback to communicate with local processes too
-        bool loopback = use_shm == TLayer::smode_off;
+        const bool loopback = m_writer.shm_mode.requested == TLayer::smode_off;
 
         // fill writer data
-        struct SWriterData wdata;
-        wdata.buf       = buf_;
-        wdata.len       = len_;
-        wdata.id        = m_id;
-        wdata.clock     = m_clock;
-        wdata.hash      = snd_hash;
-        wdata.time      = time_;
-        wdata.bandwidth = m_bandwidth_max_udp;
-        wdata.loopback  = loopback;
+        struct SWriterAttr wattr;
+        wattr.len       = payload_buf_size;
+        wattr.id        = m_id;
+        wattr.clock     = m_clock;
+        wattr.hash      = snd_hash;
+        wattr.time      = time_;
+        wattr.bandwidth = m_bandwidth_max_udp;
+        wattr.loopback  = loopback;
 
         // prepare send
-        if (m_writer_udp_mc.PrepareWrite(wdata))
+        if (m_writer.udp_mc.PrepareWrite(wattr))
         {
           // register new to update listening subscribers and rematch
           DoRegister(true);
           Process::SleepMS(5);
         }
 
-        // send
-        udp_mc_sent = m_writer_udp_mc.Write(wdata);
-        m_use_udp_mc_confirmed = true;
+        // write to udp multicast layer
+        udp_mc_sent = m_writer.udp_mc.Write(m_payload_buffer.data(), wattr);
+        m_writer.udp_mc_mode.confirmed = true;
       }
       written |= udp_mc_sent;
 
@@ -653,9 +608,7 @@ namespace eCAL
     ////////////////////////////////////////////////////////////////////////////
     // LAYER 4 : TCP
     ////////////////////////////////////////////////////////////////////////////
-    if (((use_tcp == TLayer::smode_auto) && m_ext_subscribed)
-      || (use_tcp == TLayer::smode_on)
-      )
+    if (m_writer.tcp_mode.activated)
     {
 #ifndef NDEBUG
       // log it
@@ -666,18 +619,17 @@ namespace eCAL
       bool tcp_sent(false);
       {
         // fill writer data
-        struct SWriterData wdata;
-        wdata.buf       = buf_;
-        wdata.len       = len_;
-        wdata.id        = m_id;
-        wdata.clock     = m_clock;
-        wdata.hash      = snd_hash;
-        wdata.time      = time_;
-        wdata.buffering = 0;
+        struct SWriterAttr wattr;
+        wattr.len       = payload_buf_size;
+        wattr.id        = m_id;
+        wattr.clock     = m_clock;
+        wattr.hash      = snd_hash;
+        wattr.time      = time_;
+        wattr.buffering = 0;
 
-        // send
-        tcp_sent = m_writer_tcp.Write(wdata);
-        m_use_tcp_confirmed = true;
+        // write to tcp layer
+        tcp_sent = m_writer.tcp.Write(m_payload_buffer.data(), wattr);
+        m_writer.tcp_mode.confirmed = true;
   }
       written |= tcp_sent;
 
@@ -702,14 +654,14 @@ namespace eCAL
   {
     Connect(tid_, ttype_, tdesc_);
     {
-      std::lock_guard<std::mutex> lock(m_sub_map_sync);
+      const std::lock_guard<std::mutex> lock(m_sub_map_sync);
       m_loc_sub_map[process_id_] = true;
     }
     m_loc_subscribed = true;
 
     // add a new local subscription
-    m_writer_udp_mc.AddLocConnection (process_id_, reader_par_);
-    m_writer_shm.AddLocConnection    (process_id_, reader_par_);
+    m_writer.udp_mc.AddLocConnection (process_id_, reader_par_);
+    m_writer.shm.AddLocConnection    (process_id_, reader_par_);
 
 #ifndef NDEBUG
     // log it
@@ -720,8 +672,8 @@ namespace eCAL
   void CDataWriter::RemoveLocSubscription(const std::string& process_id_)
   {
     // remove a local subscription
-    m_writer_udp_mc.RemLocConnection (process_id_);
-    m_writer_shm.RemLocConnection    (process_id_);
+    m_writer.udp_mc.RemLocConnection (process_id_);
+    m_writer.shm.RemLocConnection    (process_id_);
 
 #ifndef NDEBUG
     // log it
@@ -733,14 +685,14 @@ namespace eCAL
   {
     Connect(tid_, ttype_, tdesc_);
     {
-      std::lock_guard<std::mutex> lock(m_sub_map_sync);
+      const std::lock_guard<std::mutex> lock(m_sub_map_sync);
       m_ext_sub_map[host_name_] = true;
     }
     m_ext_subscribed = true;
 
     // add a new external subscription
-    m_writer_udp_mc.AddExtConnection (host_name_, process_id_, reader_par_);
-    m_writer_shm.AddExtConnection    (host_name_, process_id_, reader_par_);
+    m_writer.udp_mc.AddExtConnection (host_name_, process_id_, reader_par_);
+    m_writer.shm.AddExtConnection    (host_name_, process_id_, reader_par_);
 
 #ifndef NDEBUG
     // log it
@@ -751,8 +703,8 @@ namespace eCAL
   void CDataWriter::RemoveExtSubscription(const std::string& host_name_, const std::string& process_id_)
   {
     // remove external subscription
-    m_writer_udp_mc.RemExtConnection (host_name_, process_id_);
-    m_writer_shm.RemExtConnection    (host_name_, process_id_);
+    m_writer.udp_mc.RemExtConnection (host_name_, process_id_);
+    m_writer.shm.RemExtConnection    (host_name_, process_id_);
   }
 
   void CDataWriter::RefreshRegistration()
@@ -789,9 +741,9 @@ namespace eCAL
     DoRegister(false);
 
     // check connection timeouts
-    std::shared_ptr<std::list<std::string>> loc_timeouts = std::make_shared<std::list<std::string>>();
+    const std::shared_ptr<std::list<std::string>> loc_timeouts = std::make_shared<std::list<std::string>>();
     {
-      std::lock_guard<std::mutex> lock(m_sub_map_sync);
+      const std::lock_guard<std::mutex> lock(m_sub_map_sync);
       m_loc_sub_map.remove_deprecated(loc_timeouts.get());
       m_ext_sub_map.remove_deprecated();
 
@@ -799,9 +751,9 @@ namespace eCAL
       m_ext_subscribed = !m_ext_sub_map.empty();
     }
 
-    for(auto loc_sub : *loc_timeouts)
+    for(const auto& loc_sub : *loc_timeouts)
     {
-      m_writer_shm.RemLocConnection(loc_sub);
+      m_writer.shm.RemLocConnection(loc_sub);
     }
 
     if (!m_loc_subscribed && !m_ext_subscribed)
@@ -848,12 +800,12 @@ namespace eCAL
     if (m_topic_name.empty()) return(false);
 
     // check share modes
-    bool share_ttype(m_use_ttype && g_pubgate() && g_pubgate()->TypeShared());
+    bool share_ttype(m_use_ttype && (g_pubgate() != nullptr) && g_pubgate()->TypeShared());
     if (m_share_ttype != -1)
     {
       share_ttype = m_share_ttype == 1;
     }
-    bool share_tdesc(m_use_tdesc && g_pubgate() && g_pubgate()->DescriptionShared());
+    bool share_tdesc(m_use_tdesc && (g_pubgate() != nullptr) && g_pubgate()->DescriptionShared());
     if (m_share_tdesc != -1)
     {
       share_tdesc = m_share_tdesc == 1;
@@ -862,7 +814,7 @@ namespace eCAL
     // create command parameter
     eCAL::pb::Sample ecal_reg_sample;
     ecal_reg_sample.set_cmd_type(eCAL::pb::bct_reg_publisher);
-    auto ecal_reg_sample_mutable_topic = ecal_reg_sample.mutable_topic();
+    auto *ecal_reg_sample_mutable_topic = ecal_reg_sample.mutable_topic();
     ecal_reg_sample_mutable_topic->set_hname(m_host_name);
     ecal_reg_sample_mutable_topic->set_hid(m_host_id);
     ecal_reg_sample_mutable_topic->set_tname(m_topic_name);
@@ -873,19 +825,19 @@ namespace eCAL
     ecal_reg_sample_mutable_topic->set_tsize(google::protobuf::int32(m_topic_size));
     // udp multicast layer
     {
-      auto udp_tlayer = ecal_reg_sample_mutable_topic->add_tlayer();
+      auto *udp_tlayer = ecal_reg_sample_mutable_topic->add_tlayer();
       udp_tlayer->set_type(eCAL::pb::tl_ecal_udp_mc);
       udp_tlayer->set_version(1);
-      udp_tlayer->set_confirmed(m_use_udp_mc_confirmed);
-      udp_tlayer->mutable_par_layer()->ParseFromString(m_writer_udp_mc.GetConnectionParameter());
+      udp_tlayer->set_confirmed(m_writer.udp_mc_mode.confirmed);
+      udp_tlayer->mutable_par_layer()->ParseFromString(m_writer.udp_mc.GetConnectionParameter());
     }
     // shm layer
     {
-      auto shm_tlayer = ecal_reg_sample_mutable_topic->add_tlayer();
+      auto *shm_tlayer = ecal_reg_sample_mutable_topic->add_tlayer();
       shm_tlayer->set_type(eCAL::pb::tl_ecal_shm);
       shm_tlayer->set_version(1);
-      shm_tlayer->set_confirmed(m_use_shm_confirmed);
-      std::string par_layer_s = m_writer_shm.GetConnectionParameter();
+      shm_tlayer->set_confirmed(m_writer.shm_mode.confirmed);
+      const std::string par_layer_s = m_writer.shm.GetConnectionParameter();
       shm_tlayer->mutable_par_layer()->ParseFromString(par_layer_s);
 
       // ----------------------------------------------------------------------
@@ -909,19 +861,19 @@ namespace eCAL
     }
     // tcp layer
     {
-      auto tcp_tlayer = ecal_reg_sample_mutable_topic->add_tlayer();
+      auto *tcp_tlayer = ecal_reg_sample_mutable_topic->add_tlayer();
       tcp_tlayer->set_type(eCAL::pb::tl_ecal_tcp);
       tcp_tlayer->set_version(1);
-      tcp_tlayer->set_confirmed(m_use_tcp_confirmed);
-      tcp_tlayer->mutable_par_layer()->ParseFromString(m_writer_tcp.GetConnectionParameter());
+      tcp_tlayer->set_confirmed(m_writer.tcp_mode.confirmed);
+      tcp_tlayer->mutable_par_layer()->ParseFromString(m_writer.tcp.GetConnectionParameter());
     }
     // inproc layer
     {
-      auto inproc_tlayer = ecal_reg_sample_mutable_topic->add_tlayer();
+      auto *inproc_tlayer = ecal_reg_sample_mutable_topic->add_tlayer();
       inproc_tlayer->set_type(eCAL::pb::tl_inproc);
       inproc_tlayer->set_version(1);
-      inproc_tlayer->set_confirmed(m_use_inproc_confirmed);
-      inproc_tlayer->mutable_par_layer()->ParseFromString(m_writer_inproc.GetConnectionParameter());
+      inproc_tlayer->set_confirmed(m_writer.inproc_mode.confirmed);
+      inproc_tlayer->mutable_par_layer()->ParseFromString(m_writer.inproc.GetConnectionParameter());
     }
     ecal_reg_sample_mutable_topic->set_pid(m_pid);
     ecal_reg_sample_mutable_topic->set_pname(m_pname);
@@ -933,7 +885,7 @@ namespace eCAL
     size_t loc_connections(0);
     size_t ext_connections(0);
     {
-      std::lock_guard<std::mutex> lock(m_sub_map_sync);
+      const std::lock_guard<std::mutex> lock(m_sub_map_sync);
       loc_connections = m_loc_sub_map.size();
       ext_connections = m_ext_sub_map.size();
     }
@@ -967,7 +919,7 @@ namespace eCAL
     }
 
     // register publisher
-    if (g_registration_provider()) g_registration_provider()->RegisterTopic(m_topic_name, m_topic_id, ecal_reg_sample, force_);
+    if (g_registration_provider() != nullptr) g_registration_provider()->RegisterTopic(m_topic_name, m_topic_id, ecal_reg_sample, force_);
 
 #ifndef NDEBUG
     // log it
@@ -1028,24 +980,24 @@ namespace eCAL
 
   bool CDataWriter::SetUseUdpMC(TLayer::eSendMode mode_)
   {
-    m_use_udp_mc = mode_;
+    m_writer.udp_mc_mode.requested = mode_;
     if (!m_created) return true;
 
     // log send mode
-    LogSendMode(m_use_udp_mc, m_topic_name + "::CDataWriter::Create::UDP_MC_SENDMODE::");
+    LogSendMode(mode_, m_topic_name + "::CDataWriter::Create::UDP_MC_SENDMODE::");
 
-    switch (m_use_udp_mc)
+    switch (mode_)
     {
     case TLayer::eSendMode::smode_auto:
     case TLayer::eSendMode::smode_on:
-      m_writer_udp_mc.Create(m_host_name, m_topic_name, m_topic_id);
+      m_writer.udp_mc.Create(m_host_name, m_topic_name, m_topic_id);
 #ifndef NDEBUG
       Logging::Log(log_level_debug4, m_topic_name + "::CDataWriter::Create::UDP_MC_WRITER");
 #endif
       break;
     case TLayer::eSendMode::smode_none:
     case TLayer::eSendMode::smode_off:
-      m_writer_udp_mc.Destroy();
+      m_writer.udp_mc.Destroy();
       break;
     }
 
@@ -1054,24 +1006,24 @@ namespace eCAL
 
   bool CDataWriter::SetUseShm(TLayer::eSendMode mode_)
   {
-    m_use_shm = mode_;
+    m_writer.shm_mode.requested = mode_;
     if (!m_created) return true;
 
     // log send mode
-    LogSendMode(m_use_shm, m_topic_name + "::CDataWriter::Create::SHM_SENDMODE::");
+    LogSendMode(mode_, m_topic_name + "::CDataWriter::Create::SHM_SENDMODE::");
 
-    switch (m_use_shm)
+    switch (mode_)
     {
     case TLayer::eSendMode::smode_auto:
     case TLayer::eSendMode::smode_on:
-      m_writer_shm.Create(m_host_name, m_topic_name, m_topic_id);
+      m_writer.shm.Create(m_host_name, m_topic_name, m_topic_id);
 #ifndef NDEBUG
       Logging::Log(log_level_debug4, m_topic_name + "::CDataWriter::Create::SHM_WRITER");
 #endif
       break;
     case TLayer::eSendMode::smode_none:
     case TLayer::eSendMode::smode_off:
-      m_writer_shm.Destroy();
+      m_writer.shm.Destroy();
       break;
     }
 
@@ -1080,24 +1032,24 @@ namespace eCAL
 
   bool CDataWriter::SetUseTcp(TLayer::eSendMode mode_)
   {
-    m_use_tcp = mode_;
+    m_writer.tcp_mode.requested = mode_;
     if (!m_created) return true;
 
     // log send mode
-    LogSendMode(m_use_tcp, m_topic_name + "::CDataWriter::Create::TCP_SENDMODE::");
+    LogSendMode(mode_, m_topic_name + "::CDataWriter::Create::TCP_SENDMODE::");
 
-    switch (m_use_tcp)
+    switch (mode_)
     {
     case TLayer::eSendMode::smode_auto:
     case TLayer::eSendMode::smode_on:
-      m_writer_tcp.Create(m_host_name, m_topic_name, m_topic_id);
+      m_writer.tcp.Create(m_host_name, m_topic_name, m_topic_id);
 #ifndef NDEBUG
       Logging::Log(log_level_debug4, m_topic_name + "::CDataWriter::Create::TCP_WRITER");
 #endif
       break;
     case TLayer::eSendMode::smode_none:
     case TLayer::eSendMode::smode_off:
-      m_writer_tcp.Destroy();
+      m_writer.tcp.Destroy();
       break;
     }
 
@@ -1106,34 +1058,156 @@ namespace eCAL
 
   bool CDataWriter::SetUseInProc(TLayer::eSendMode mode_)
   {
-    m_use_inproc = mode_;
+    m_writer.inproc_mode.requested = mode_;
     if (!m_created) return true;
 
     // log send mode
-    LogSendMode(m_use_inproc, m_topic_name + "::CDataWriter::Create::INPROC_SENDMODE::");
+    LogSendMode(mode_, m_topic_name + "::CDataWriter::Create::INPROC_SENDMODE::");
 
-    switch (m_use_inproc)
+    switch (mode_)
     {
     case TLayer::eSendMode::smode_auto:
     case TLayer::eSendMode::smode_on:
-      m_writer_inproc.Create(m_host_name, m_topic_name, m_topic_id);
+      m_writer.inproc.Create(m_host_name, m_topic_name, m_topic_id);
 #ifndef NDEBUG
       Logging::Log(log_level_debug4, m_topic_name + "::CDataWriter::Create::INPROC_WRITER");
 #endif
       break;
     default:
-      m_writer_inproc.Destroy();
+      m_writer.inproc.Destroy();
       break;
     }
 
     return(true);
   }
 
+  bool CDataWriter::CheckWriterModes()
+  {
+    if ( (m_writer.udp_mc_mode.requested == TLayer::smode_off)
+      && (m_writer.shm_mode.requested    == TLayer::smode_off)
+      && (m_writer.tcp_mode.requested    == TLayer::smode_off)
+      && (m_writer.inproc_mode.requested == TLayer::smode_off)
+      )
+    {
+      // failsafe default mode if
+      // nothing is activated
+      m_writer.udp_mc_mode.requested = TLayer::smode_auto;
+      m_writer.shm_mode.requested    = TLayer::smode_auto;
+    }
+
+    // if we do not have loopback
+    // enabled we can switch off
+    // inner process communication
+    if ((g_registration_receiver() != nullptr) && !g_registration_receiver()->LoopBackEnabled())
+    {
+      m_writer.inproc_mode.requested = TLayer::smode_off;
+    }
+
+    // shared memory transport is on and
+    // inner process transport is on
+    // let's check if there is a need for
+    // shared memory because of external
+    // process subscription, if not
+    // let's switch it off
+    if ( (m_writer.shm_mode.requested    != TLayer::smode_off)
+      && (m_writer.inproc_mode.requested != TLayer::smode_off)
+      )
+    {
+      if (!IsExtSubscribed())
+      {
+        // we have no external subscriptions,
+        // but we have local ones (otherwise we would have
+        // no subscriptions and this is checked with !IsSubscribed())
+        // so let's check if all local subscriptions are 
+        // "inner process only", that means
+        // they have all our process id
+        if (IsInternalSubscribedOnly())
+        {
+          // we can switch shared memory layer off
+          // it's all subscribed in our process
+          m_writer.shm_mode.requested = TLayer::smode_off;
+        }
+      }
+    }
+
+    if ( (m_writer.tcp_mode.requested    == TLayer::smode_auto)
+      && (m_writer.udp_mc_mode.requested == TLayer::smode_auto)
+      )
+    {
+      Logging::Log(log_level_error, m_topic_name + "::CDataWriter::Send: TCP layer and UDP layer are both set to auto mode - Publication failed !");
+      return false;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // UDP (MC)
+    ////////////////////////////////////////////////////////////////////////////
+    if (((m_writer.udp_mc_mode.requested == TLayer::smode_auto) && m_ext_subscribed)
+      || (m_writer.udp_mc_mode.requested == TLayer::smode_on)
+      )
+    {
+      m_writer.udp_mc_mode.activated = true;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // SHM
+    ////////////////////////////////////////////////////////////////////////////
+    if (((m_writer.shm_mode.requested == TLayer::smode_auto) && m_loc_subscribed)
+      || (m_writer.shm_mode.requested == TLayer::smode_on)
+      )
+    {
+      m_writer.shm_mode.activated = true;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // TCP
+    ////////////////////////////////////////////////////////////////////////////
+    if (((m_writer.tcp_mode.requested == TLayer::smode_auto) && m_ext_subscribed)
+      || (m_writer.tcp_mode.requested == TLayer::smode_on)
+      )
+    {
+      m_writer.tcp_mode.activated = true;
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // INPROC
+    ////////////////////////////////////////////////////////////////////////////
+    if ( (m_writer.inproc_mode.requested == TLayer::smode_auto)
+      || (m_writer.inproc_mode.requested == TLayer::smode_on)
+      )
+    {
+      m_writer.inproc_mode.activated = true;
+    }
+
+    return true;
+  }
+
+  size_t CDataWriter::PrepareWrite(long long id_, size_t len_)
+  {
+    // store id
+    m_id = id_;
+
+    // handle write counters
+    RefreshSendCounter();
+
+    // calculate unique send hash
+    std::hash<SSndHash> const hf;
+    const size_t snd_hash = hf(SSndHash(m_topic_id, m_clock));
+
+    // increase overall sum send
+    g_process_wbytes_sum += len_;
+
+    // store size for monitoring
+    m_topic_size = len_;
+
+    // return the hash for the write action
+    return snd_hash;
+  }
+
   bool CDataWriter::IsInternalSubscribedOnly()
   {
-    std::string process_id = Process::GetProcessIDAsString();
+    const std::string process_id = Process::GetProcessIDAsString();
     bool is_internal_only(true);
-    std::lock_guard<std::mutex> lock(m_sub_map_sync);
+    const std::lock_guard<std::mutex> lock(m_sub_map_sync);
     for (auto sub : m_loc_sub_map)
     {
       if (sub.first != process_id)

--- a/ecal/core/src/readwrite/ecal_writer.cpp
+++ b/ecal/core/src/readwrite/ecal_writer.cpp
@@ -402,7 +402,7 @@ namespace eCAL
     return(true);
   }
 
-  bool CDataWriter::Write(CPayloadWriter& payload_, long long time_, long long id_)
+  size_t CDataWriter::Write(CPayloadWriter& payload_, long long time_, long long id_)
   {
     // check writer modes
     if (!CheckWriterModes())
@@ -647,7 +647,8 @@ namespace eCAL
     }
 
     // return success
-    return(written);
+    if (written) return payload_buf_size;
+    else         return 0;
   }
 
   void CDataWriter::ApplyLocSubscription(const std::string& process_id_, const std::string& tid_, const std::string& ttype_, const std::string& tdesc_, const std::string& reader_par_)

--- a/ecal/core/src/readwrite/ecal_writer.h
+++ b/ecal/core/src/readwrite/ecal_writer.h
@@ -75,7 +75,7 @@ namespace eCAL
     bool AddEventCallback(eCAL_Publisher_Event type_, PubEventCallbackT callback_);
     bool RemEventCallback(eCAL_Publisher_Event type_);
 
-    bool Write(CPayloadWriter& payload_, long long time_, long long id_);
+    size_t Write(CPayloadWriter& payload_, long long time_, long long id_);
 
     void ApplyLocSubscription(const std::string& process_id_, const std::string& tid_, const std::string& ttype_, const std::string& tdesc_, const std::string& reader_par_);
     void RemoveLocSubscription(const std::string & process_id_);

--- a/ecal/core/src/readwrite/ecal_writer.h
+++ b/ecal/core/src/readwrite/ecal_writer.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <ecal/ecal_callback.h>
+#include <ecal/ecal_payload_writer.h>
 #include <ecal/ecal_tlayer.h>
 
 #include "ecal_def.h"
@@ -38,6 +39,7 @@
 #include <string>
 #include <atomic>
 #include <map>
+#include <vector>
 
 namespace eCAL
 {
@@ -68,12 +70,12 @@ namespace eCAL
     bool ShmEnableZeroCopy(bool state_);
 
     bool ShmSetAcknowledgeTimeout(long long acknowledge_timeout_ms_);
-    long long  ShmGetAcknowledgeTimeout();
+    long long  ShmGetAcknowledgeTimeout() const;
 
     bool AddEventCallback(eCAL_Publisher_Event type_, PubEventCallbackT callback_);
     bool RemEventCallback(eCAL_Publisher_Event type_);
 
-    bool Write(const void* const buf_, size_t len_, long long time_, long long id_);
+    bool Write(CPayloadWriter& payload_, long long time_, long long id_);
 
     void ApplyLocSubscription(const std::string& process_id_, const std::string& tid_, const std::string& ttype_, const std::string& tdesc_, const std::string& reader_par_);
     void RemoveLocSubscription(const std::string & process_id_);
@@ -91,7 +93,7 @@ namespace eCAL
     bool IsExtSubscribed() const {return(m_ext_subscribed);}
     size_t GetSubscriberCount() const
     {
-      std::lock_guard<std::mutex> lock(m_sub_map_sync);
+      std::lock_guard<std::mutex> const lock(m_sub_map_sync);
       return(m_loc_sub_map.size() + m_ext_sub_map.size());
     }
 
@@ -112,8 +114,9 @@ namespace eCAL
     bool SetUseTcp(TLayer::eSendMode mode_);
     bool SetUseInProc(TLayer::eSendMode mode_);
 
+    bool CheckWriterModes();
+    size_t PrepareWrite(long long id_, size_t len_);
     bool IsInternalSubscribedOnly();
-
     void LogSendMode(TLayer::eSendMode smode_, const std::string & base_msg_);
 
     std::string                        m_host_name;
@@ -133,14 +136,16 @@ namespace eCAL
     bool               m_zero_copy;
     long long          m_acknowledge_timeout_ms;
 
+    std::vector<char>  m_payload_buffer;
+
     std::atomic<bool>  m_connected;
-    typedef Util::CExpMap<std::string, bool> ConnectedMapT;
-    mutable std::mutex  m_sub_map_sync;
+    using ConnectedMapT = Util::CExpMap<std::string, bool>;
+    mutable std::mutex m_sub_map_sync;
     ConnectedMapT      m_loc_sub_map;
     ConnectedMapT      m_ext_sub_map;
 
     std::mutex         m_event_callback_map_sync;
-    typedef std::map<eCAL_Publisher_Event, PubEventCallbackT> EventCallbackMapT;
+    using EventCallbackMapT = std::map<eCAL_Publisher_Event, PubEventCallbackT>;
     EventCallbackMapT  m_event_callback_map;
 
     long long          m_id;
@@ -154,21 +159,28 @@ namespace eCAL
     std::atomic<bool>  m_loc_subscribed;
     std::atomic<bool>  m_ext_subscribed;
 
-    TLayer::eSendMode  m_use_udp_mc;
-    CDataWriterUdpMC   m_writer_udp_mc;
-    bool               m_use_udp_mc_confirmed;
+    struct SWriter
+    {
+      struct SWriterMode
+      {
+        TLayer::eSendMode requested = TLayer::smode_off;
+        bool              activated = false;
+        bool              confirmed = false;
+      };
 
-    TLayer::eSendMode  m_use_shm;
-    CDataWriterSHM     m_writer_shm;
-    bool               m_use_shm_confirmed;
+      SWriterMode        udp_mc_mode;
+      CDataWriterUdpMC   udp_mc;
 
-    TLayer::eSendMode  m_use_tcp;
-    CDataWriterTCP     m_writer_tcp;
-    bool               m_use_tcp_confirmed;
+      SWriterMode        shm_mode;
+      CDataWriterSHM     shm;
 
-    TLayer::eSendMode  m_use_inproc;
-    CDataWriterInProc  m_writer_inproc;
-    bool               m_use_inproc_confirmed;
+      SWriterMode        tcp_mode;
+      CDataWriterTCP     tcp;
+
+      SWriterMode        inproc_mode;
+      CDataWriterInProc  inproc;
+    };
+    SWriter            m_writer;
 
     bool               m_use_ttype;
     bool               m_use_tdesc;

--- a/ecal/core/src/readwrite/ecal_writer_base.h
+++ b/ecal/core/src/readwrite/ecal_writer_base.h
@@ -38,7 +38,7 @@ namespace eCAL
   {
   public:
     CDataWriterBase() : m_created(false) {};
-    virtual ~CDataWriterBase() {};
+    virtual ~CDataWriterBase() = default;
 
     virtual SWriterInfo GetInfo() = 0;
 
@@ -58,7 +58,7 @@ namespace eCAL
 
     virtual bool PrepareWrite(const SWriterAttr& /*attr_*/) { return false; };
     virtual bool Write(CPayloadWriter& /*payload_*/, const SWriterAttr& /*attr_*/) { return false; };
-    virtual bool Write(const void* const /*buf_*/, const SWriterAttr& /*attr_*/) { return false; };
+    virtual bool Write(const void* /*buf_*/, const SWriterAttr& /*attr_*/) { return false; };
 
   protected:
     std::string        m_host_name;

--- a/ecal/core/src/readwrite/ecal_writer_base.h
+++ b/ecal/core/src/readwrite/ecal_writer_base.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <ecal/ecal_payload_writer.h>
 #include <ecal/ecal_qos.h>
 
 #include "ecal_writer_data.h"
@@ -55,8 +56,9 @@ namespace eCAL
 
     virtual std::string GetConnectionParameter() { return ""; };
 
-    virtual bool PrepareWrite(const SWriterData& /*data_*/) { return false; };
-    virtual bool Write(const SWriterData& data_) = 0;
+    virtual bool PrepareWrite(const SWriterAttr& /*attr_*/) { return false; };
+    virtual bool Write(CPayloadWriter& /*payload_*/, const SWriterAttr& /*attr_*/) { return false; };
+    virtual bool Write(const void* const /*buf_*/, const SWriterAttr& /*attr_*/) { return false; };
 
   protected:
     std::string        m_host_name;

--- a/ecal/core/src/readwrite/ecal_writer_data.h
+++ b/ecal/core/src/readwrite/ecal_writer_data.h
@@ -27,9 +27,8 @@
 
 namespace eCAL
 {
-  struct SWriterData
+  struct SWriterAttr
   {
-    const void*  buf                    = nullptr;
     size_t       len                    = 0;
     long long    id                     = 0;
     long long    clock                  = 0;

--- a/ecal/core/src/readwrite/ecal_writer_inproc.cpp
+++ b/ecal/core/src/readwrite/ecal_writer_inproc.cpp
@@ -76,7 +76,7 @@ namespace eCAL
   /////////////////////////////////////////////////////////////////
   // apply the data straight to the subscriber gate
   /////////////////////////////////////////////////////////////////
-  bool CDataWriterInProc::Write(const SWriterData& data_)
+  bool CDataWriterInProc::Write(const void* const buf_, const SWriterAttr& attr_)
   {
     if (!m_created)   return(false);
     if (!g_subgate()) return(false);
@@ -89,7 +89,7 @@ namespace eCAL
     // send it
     // no need to interpret return value 0 as error
     // maybe no one is subscribing in the current process
-    size_t sent = g_subgate()->ApplySample(m_topic_name, m_topic_id, static_cast<const char*>(data_.buf), data_.len, data_.id, data_.clock, data_.time, data_.hash, eCAL::pb::tl_inproc);
+    size_t sent = g_subgate()->ApplySample(m_topic_name, m_topic_id, static_cast<const char*>(buf_), attr_.len, attr_.id, attr_.clock, attr_.time, attr_.hash, eCAL::pb::tl_inproc);
 
     return (sent != 0);
   }

--- a/ecal/core/src/readwrite/ecal_writer_inproc.h
+++ b/ecal/core/src/readwrite/ecal_writer_inproc.h
@@ -53,7 +53,7 @@ namespace eCAL
     // so, mark it as final to ensure that no derived classes override it.
     bool Destroy() final;
 
-    bool Write(const void* const buf_, const SWriterAttr& attr_) override;
+    bool Write(const void* buf_, const SWriterAttr& attr_) override;
 
   protected:
   };

--- a/ecal/core/src/readwrite/ecal_writer_inproc.h
+++ b/ecal/core/src/readwrite/ecal_writer_inproc.h
@@ -44,16 +44,16 @@ namespace eCAL
   class CDataWriterInProc : public CDataWriterBase
   {
   public:
-    ~CDataWriterInProc();
+    ~CDataWriterInProc() override;
 
     SWriterInfo GetInfo() override;
 
     bool Create(const std::string& host_name_, const std::string& topic_name_, const std::string & topic_id_) override;
     // this virtual function is called during construction/destruction,
     // so, mark it as final to ensure that no derived classes override it.
-    bool Destroy() final override;
+    bool Destroy() final;
 
-    bool Write(const SWriterData& data_) override;
+    bool Write(const void* const buf_, const SWriterAttr& attr_) override;
 
   protected:
   };

--- a/ecal/core/src/readwrite/ecal_writer_shm.cpp
+++ b/ecal/core/src/readwrite/ecal_writer_shm.cpp
@@ -42,10 +42,6 @@ namespace eCAL
 {
   const std::string CDataWriterSHM::m_memfile_base_name = "ecal_";
 
-  CDataWriterSHM::CDataWriterSHM()
-  {
-  }
-  
   CDataWriterSHM::~CDataWriterSHM()
   {
     Destroy();
@@ -110,20 +106,20 @@ namespace eCAL
     return true;
   }
 
-  bool CDataWriterSHM::PrepareWrite(const SWriterData& data_)
+  bool CDataWriterSHM::PrepareWrite(const SWriterAttr& attr_)
   {
     if (!m_created)     return false;
-    if (data_.len == 0) return false;
+    if (attr_.len == 0) return false;
 
     // false signals no rematching / exchanging of
     // connection parameters needed
     bool ret_state(false);
 
     // check number of requested memory file buffer
-    if (data_.buffering != m_buffer_count)
+    if (attr_.buffering != m_buffer_count)
     {
       // store new size and flag change
-      m_buffer_count = data_.buffering;
+      m_buffer_count = attr_.buffering;
       ret_state |= true;
 
       // ----------------------------------------------------------------------
@@ -147,7 +143,7 @@ namespace eCAL
       // increase buffer count
       while (m_memory_file_vec.size() < m_buffer_count)
       {
-        auto sync_memfile = std::make_shared<CSyncMemoryFile>(m_memfile_base_name, data_.len, m_memory_file_attr);
+        auto sync_memfile = std::make_shared<CSyncMemoryFile>(m_memfile_base_name, attr_.len, m_memory_file_attr);
         m_memory_file_vec.push_back(sync_memfile);
       }
       // decrease buffer count
@@ -161,17 +157,17 @@ namespace eCAL
     m_write_idx %= m_memory_file_vec.size();
       
     // check size and reserve new if needed
-    ret_state |= m_memory_file_vec[m_write_idx]->CheckSize(data_.len);
+    ret_state |= m_memory_file_vec[m_write_idx]->CheckSize(attr_.len);
 
     return ret_state;
   }
 
-  bool CDataWriterSHM::Write(const SWriterData& data_)
+  bool CDataWriterSHM::Write(CPayloadWriter& payload_, const SWriterAttr& attr_)
   {
-    if (!m_created) return 0;
+    if (!m_created) return false;
 
     // write content
-    bool sent = m_memory_file_vec[m_write_idx]->Write(data_);
+    bool const sent = m_memory_file_vec[m_write_idx]->Write(payload_, attr_);
 
     // and increment file index
     m_write_idx++;

--- a/ecal/core/src/readwrite/ecal_writer_shm.h
+++ b/ecal/core/src/readwrite/ecal_writer_shm.h
@@ -34,20 +34,21 @@ namespace eCAL
   class CDataWriterSHM : public CDataWriterBase
   {
   public:
-    CDataWriterSHM();
-    ~CDataWriterSHM();
+    CDataWriterSHM() = default;
+    ~CDataWriterSHM() override;
 
     SWriterInfo GetInfo() override;
 
     bool Create(const std::string& host_name_, const std::string& topic_name_, const std::string & topic_id_) override;
     // this virtual function is called during construction/destruction,
     // so, mark it as final to ensure that no derived classes override it.
-    bool Destroy() final override;
+    bool Destroy() final;
 
     bool SetQOS(const QOS::SWriterQOS& qos_) override;
 
-    bool PrepareWrite(const SWriterData& data_) override;
-    bool Write(const SWriterData& data_) override;
+    bool PrepareWrite(const SWriterAttr& attr_) override;
+
+    bool Write(CPayloadWriter& payload_, const SWriterAttr& attr_) override;
 
     bool AddLocConnection(const std::string& process_id_, const std::string& conn_par_) override;
     bool RemLocConnection(const std::string& process_id_) override;

--- a/ecal/core/src/readwrite/ecal_writer_tcp.cpp
+++ b/ecal/core/src/readwrite/ecal_writer_tcp.cpp
@@ -104,7 +104,7 @@ namespace eCAL
     return true;
   }
 
-  bool CDataWriterTCP::Write(const SWriterData& data_)
+  bool CDataWriterTCP::Write(const void* const buf_, const SWriterAttr& attr_)
   {
     if (!m_publisher) return false;
 
@@ -116,11 +116,11 @@ namespace eCAL
 
     // append payload header (without payload)
     auto ecal_sample_mutable_content = m_ecal_header.mutable_content();
-    ecal_sample_mutable_content->set_id(data_.id);
-    ecal_sample_mutable_content->set_clock(data_.clock);
-    ecal_sample_mutable_content->set_time(data_.time);
-    ecal_sample_mutable_content->set_hash(data_.hash);
-    ecal_sample_mutable_content->set_size((google::protobuf::int32)data_.len);
+    ecal_sample_mutable_content->set_id(attr_.id);
+    ecal_sample_mutable_content->set_clock(attr_.clock);
+    ecal_sample_mutable_content->set_time(attr_.time);
+    ecal_sample_mutable_content->set_hash(attr_.hash);
+    ecal_sample_mutable_content->set_size((google::protobuf::int32)attr_.len);
 
     // Initialize the padding with 1 element. It just must not be empty right now.
     m_ecal_header.set_padding(std::string("a"));
@@ -176,7 +176,7 @@ namespace eCAL
     // push header data
     send_vec.emplace_back(std::pair<const char* const, const size_t>(m_header_buffer.data(), m_header_buffer.size()));
     // push payload data
-    send_vec.emplace_back(std::pair<const char* const, const size_t>(static_cast<const char*>(data_.buf), data_.len));
+    send_vec.emplace_back(std::pair<const char* const, const size_t>(static_cast<const char*>(buf_), attr_.len));
 
     // send it
     bool success = m_publisher->send(send_vec);

--- a/ecal/core/src/readwrite/ecal_writer_tcp.h
+++ b/ecal/core/src/readwrite/ecal_writer_tcp.h
@@ -56,7 +56,7 @@ namespace eCAL
     // so, mark it as final to ensure that no derived classes override it.
     bool Destroy() final;
 
-    bool Write(const void* const buf_, const SWriterAttr& attr_) override;
+    bool Write(const void* buf_, const SWriterAttr& attr_) override;
 
     std::string GetConnectionParameter() override;
 

--- a/ecal/core/src/readwrite/ecal_writer_tcp.h
+++ b/ecal/core/src/readwrite/ecal_writer_tcp.h
@@ -47,27 +47,27 @@ namespace eCAL
   {
   public:
     CDataWriterTCP();
-    ~CDataWriterTCP();
+    ~CDataWriterTCP() override;
 
     SWriterInfo GetInfo() override;
 
     bool Create(const std::string& host_name_, const std::string& topic_name_, const std::string & topic_id_) override;
     // this virtual function is called during construction/destruction,
     // so, mark it as final to ensure that no derived classes override it.
-    bool Destroy() final override;
+    bool Destroy() final;
 
-    bool Write(const SWriterData& data_) override;
+    bool Write(const void* const buf_, const SWriterAttr& attr_) override;
 
     std::string GetConnectionParameter() override;
 
   private:
-    static std::mutex                       g_tcp_writer_executor_mtx;
+    static std::mutex                            g_tcp_writer_executor_mtx;
     static std::shared_ptr<tcp_pubsub::Executor> g_tcp_writer_executor;
 
     std::shared_ptr<tcp_pubsub::Publisher>       m_publisher;
-    uint16_t                                m_port;
+    uint16_t                                     m_port;
 
-    eCAL::pb::Sample                        m_ecal_header;
-    std::vector<char>                       m_header_buffer;
+    eCAL::pb::Sample                             m_ecal_header;
+    std::vector<char>                            m_header_buffer;
   };
 }

--- a/ecal/core/src/readwrite/ecal_writer_udp_mc.cpp
+++ b/ecal/core/src/readwrite/ecal_writer_udp_mc.cpp
@@ -97,7 +97,7 @@ namespace eCAL
     return true;
   }
 
-  bool CDataWriterUdpMC::Write(const SWriterData& data_)
+  bool CDataWriterUdpMC::Write(const void* const buf_, const SWriterAttr& attr_)
   {
     if (!m_created) return false;
 
@@ -116,22 +116,22 @@ namespace eCAL
 
     // append content
     auto ecal_sample_mutable_content = m_ecal_sample.mutable_content();
-    ecal_sample_mutable_content->set_id(data_.id);
-    ecal_sample_mutable_content->set_clock(data_.clock);
-    ecal_sample_mutable_content->set_time(data_.time);
-    ecal_sample_mutable_content->set_hash(data_.hash);
-    ecal_sample_mutable_content->set_size((google::protobuf::int32)data_.len);
-    ecal_sample_mutable_content->set_payload(data_.buf, data_.len);
+    ecal_sample_mutable_content->set_id(attr_.id);
+    ecal_sample_mutable_content->set_clock(attr_.clock);
+    ecal_sample_mutable_content->set_time(attr_.time);
+    ecal_sample_mutable_content->set_hash(attr_.hash);
+    ecal_sample_mutable_content->set_size((google::protobuf::int32)attr_.len);
+    ecal_sample_mutable_content->set_payload(buf_, attr_.len);
 
     // send it
     size_t sent = 0;
-    if (data_.loopback)
+    if (attr_.loopback)
     {
-      sent = eCAL::SendSample(&m_sample_snd_loopback, m_ecal_sample.topic().tname(), m_ecal_sample, m_udp_ipaddr, data_.bandwidth);
+      sent = eCAL::SendSample(&m_sample_snd_loopback, m_ecal_sample.topic().tname(), m_ecal_sample, m_udp_ipaddr, attr_.bandwidth);
     }
     else
     {
-      sent = eCAL::SendSample(&m_sample_snd_no_loopback, m_ecal_sample.topic().tname(), m_ecal_sample, m_udp_ipaddr, data_.bandwidth);
+      sent = eCAL::SendSample(&m_sample_snd_no_loopback, m_ecal_sample.topic().tname(), m_ecal_sample, m_udp_ipaddr, attr_.bandwidth);
     }
 
     // log it

--- a/ecal/core/src/readwrite/ecal_writer_udp_mc.h
+++ b/ecal/core/src/readwrite/ecal_writer_udp_mc.h
@@ -52,7 +52,7 @@ namespace eCAL
     // so, mark it as final to ensure that no derived classes override it.
     bool Destroy() final;
 
-    bool Write(const void* const buf_, const SWriterAttr& attr_) override;
+    bool Write(const void* buf_, const SWriterAttr& attr_) override;
 
   protected:
     std::string       m_udp_ipaddr;

--- a/ecal/core/src/readwrite/ecal_writer_udp_mc.h
+++ b/ecal/core/src/readwrite/ecal_writer_udp_mc.h
@@ -43,22 +43,22 @@ namespace eCAL
   class CDataWriterUdpMC : public CDataWriterBase
   {
   public:
-    ~CDataWriterUdpMC();
+    ~CDataWriterUdpMC() override;
 
     SWriterInfo GetInfo() override;
 
     bool Create(const std::string& host_name_, const std::string& topic_name_, const std::string & topic_id_) override;
     // this virtual function is called during construction/destruction,
     // so, mark it as final to ensure that no derived classes override it.
-    bool Destroy() final override;
+    bool Destroy() final;
 
-    bool Write(const SWriterData& data_) override;
+    bool Write(const void* const buf_, const SWriterAttr& attr_) override;
 
   protected:
-    std::string     m_udp_ipaddr;
+    std::string       m_udp_ipaddr;
     eCAL::pb::Sample  m_ecal_sample;
 
-    CUDPSender      m_sample_snd_loopback;
-    CUDPSender      m_sample_snd_no_loopback;
+    CUDPSender        m_sample_snd_loopback;
+    CUDPSender        m_sample_snd_no_loopback;
   };
 }

--- a/samples/cpp/benchmarks/latency_snd/src/binary_payload_writer.h
+++ b/samples/cpp/benchmarks/latency_snd/src/binary_payload_writer.h
@@ -1,0 +1,55 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+#pragma once
+
+#include <ecal/ecal_payload_writer.h>
+#include <cstring>
+
+// a binary payload
+class CBinaryPayload : public eCAL::CPayloadWriter
+{
+public:
+  CBinaryPayload(size_t size_) : size(size_) {}
+
+  bool Write(void* buf_, size_t len_) override
+  {
+    // write complete content to the shared memory file
+    if (len_ < size) return false;
+    memset(buf_, 42, size);
+    return true;
+  };
+
+  bool Update(void* buf_, size_t len_) override
+  {
+    // update content of the shared memory file
+    if (len_ < size) return false;
+    size_t const write_idx((clock % 1024) % len_);
+    char   const write_chr(clock % 10 + 48);
+    static_cast<char*>(buf_)[write_idx] = write_chr;
+    clock++;
+    return true;
+  };
+
+  size_t GetSize() override { return size; };
+
+private:
+  size_t size  = 0;
+  int    clock = 0;
+};

--- a/samples/cpp/benchmarks/latency_snd/src/latency_snd.cpp
+++ b/samples/cpp/benchmarks/latency_snd/src/latency_snd.cpp
@@ -24,6 +24,8 @@
 #include <thread>
 #include <tclap/CmdLine.h>
 
+#include "binary_payload_writer.h"
+
 // warmup runs not to measure
 const int warmups(100);
 
@@ -57,19 +59,19 @@ void do_run(const int runs, int snd_size /*kB*/, int mem_buffer, bool zero_copy)
   pub.ShmEnableZeroCopy(zero_copy);
 
   // prepare send buffer
-  std::vector<char> snd_array(snd_size * 1024);
+  CBinaryPayload payload(snd_size * 1024);
 
   // let them match
   std::this_thread::sleep_for(std::chrono::milliseconds(2000));
 
   // add some extra loops for warmup :-)
   int run(0);
-  for (run = 0; run < runs+warmups; ++run)
+  for (; run < runs+warmups; ++run)
   {
     // get microseconds
     auto snd_time  = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
     // send message (with receive timeout 100 ms)
-    pub.Send(snd_array.data(), snd_array.size(), snd_time, 100 /*ms*/);
+    pub.Send(payload, snd_time, 100 /*ms*/);
   }
 
   // log test

--- a/samples/cpp/benchmarks/performance_snd/src/binary_payload_writer.h
+++ b/samples/cpp/benchmarks/performance_snd/src/binary_payload_writer.h
@@ -1,0 +1,55 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+#pragma once
+
+#include <ecal/ecal_payload_writer.h>
+#include <cstring>
+
+// a binary payload
+class CBinaryPayload : public eCAL::CPayloadWriter
+{
+public:
+  CBinaryPayload(size_t size_) : size(size_) {}
+
+  bool Write(void* buf_, size_t len_) override
+  {
+    // write complete content to the shared memory file
+    if (len_ < size) return false;
+    memset(buf_, 42, size);
+    return true;
+  };
+
+  bool Update(void* buf_, size_t len_) override
+  {
+    // update content of the shared memory file
+    if (len_ < size) return false;
+    size_t const write_idx((clock % 1024) % len_);
+    char   const write_chr(clock % 10 + 48);
+    static_cast<char*>(buf_)[write_idx] = write_chr;
+    clock++;
+    return true;
+  };
+
+  size_t GetSize() override { return size; };
+
+private:
+  size_t size  = 0;
+  int    clock = 0;
+};

--- a/samples/cpp/benchmarks/pubsub_throughput/src/binary_payload_writer.h
+++ b/samples/cpp/benchmarks/pubsub_throughput/src/binary_payload_writer.h
@@ -1,0 +1,55 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+#pragma once
+
+#include <ecal/ecal_payload_writer.h>
+#include <cstring>
+
+// a binary payload
+class CBinaryPayload : public eCAL::CPayloadWriter
+{
+public:
+  CBinaryPayload(size_t size_) : size(size_) {}
+
+  bool Write(void* buf_, size_t len_) override
+  {
+    // write complete content to the shared memory file
+    if (len_ < size) return false;
+    memset(buf_, 42, size);
+    return true;
+  };
+
+  bool Update(void* buf_, size_t len_) override
+  {
+    // update content of the shared memory file
+    if (len_ < size) return false;
+    size_t const write_idx((clock % 1024) % len_);
+    char   const write_chr(clock % 10 + 48);
+    static_cast<char*>(buf_)[write_idx] = write_chr;
+    clock++;
+    return true;
+  };
+
+  size_t GetSize() override { return size; };
+
+private:
+  size_t size  = 0;
+  int    clock = 0;
+};

--- a/testing/ecal/io_memfile_test/src/memfile_test.cpp
+++ b/testing/ecal/io_memfile_test/src/memfile_test.cpp
@@ -68,7 +68,7 @@ TEST(IO, MemfileReadWrite)
   EXPECT_EQ(false, mem_file.IsOpened());
 
   // write content to memory file before open
-  EXPECT_EQ(0, mem_file.Write((void*)send_s.c_str(), slen, 0));
+  EXPECT_EQ(0, mem_file.WriteBuffer((void*)send_s.c_str(), slen, 0));
 
   // open memory file with write access (timeout 100 ms)
   EXPECT_EQ(true, mem_file.GetWriteAccess(100));
@@ -83,19 +83,19 @@ TEST(IO, MemfileReadWrite)
   EXPECT_EQ(false, mem_file.HasReadAccess());
 
   // write half content to memory file
-  EXPECT_EQ(slen/2, mem_file.Write((void*)send_s.c_str(), slen/2, 0));
+  EXPECT_EQ(slen/2, mem_file.WriteBuffer((void*)send_s.c_str(), slen/2, 0));
 
   // write full content to memory file
-  EXPECT_EQ(slen, mem_file.Write((void*)send_s.c_str(), slen, 0));
+  EXPECT_EQ(slen, mem_file.WriteBuffer((void*)send_s.c_str(), slen, 0));
 
   // write double sized content to memory file
   std::string double_send_s = send_s + send_s;
-  EXPECT_EQ(0, mem_file.Write((void*)double_send_s.c_str(), double_send_s.size(), 0));
+  EXPECT_EQ(0, mem_file.WriteBuffer((void*)double_send_s.c_str(), double_send_s.size(), 0));
 
   // finally write half content to memory file again for later reader test
   slen /= 2;
   send_s.resize(slen);
-  EXPECT_EQ(slen, mem_file.Write((void*)send_s.c_str(), slen, 0));
+  EXPECT_EQ(slen, mem_file.WriteBuffer((void*)send_s.c_str(), slen, 0));
 
   // close memory file
   EXPECT_EQ(true, mem_file.ReleaseWriteAccess());
@@ -110,7 +110,7 @@ TEST(IO, MemfileReadWrite)
   EXPECT_EQ(false, mem_file.HasReadAccess());
 
   // write content to closed memory file
-  EXPECT_EQ(0, mem_file.Write((void*)send_s.c_str(), slen, 0));
+  EXPECT_EQ(0, mem_file.WriteBuffer((void*)send_s.c_str(), slen, 0));
 
   // open memory file with timeout 100 ms
   EXPECT_EQ(true, mem_file.GetReadAccess(100));
@@ -171,7 +171,7 @@ TEST(IO, MemfilePerf)
     EXPECT_EQ(true, mem_file.GetWriteAccess(10));
 
     // write content to memory file
-    EXPECT_EQ(slen, mem_file.Write((void*)send_s.c_str(), slen, 0));
+    EXPECT_EQ(slen, mem_file.WriteBuffer((void*)send_s.c_str(), slen, 0));
 
     // release write access
     EXPECT_EQ(true, mem_file.ReleaseWriteAccess());
@@ -227,7 +227,7 @@ TEST(IO, MemfileConcurrency)
         if (mem_file.HasWriteAccess())
         {
           write_buf[0] = num_writes;
-          auto written = mem_file.Write((void*)write_buf.data(), write_buf.size(), 0);
+          auto written = mem_file.WriteBuffer((void*)write_buf.data(), write_buf.size(), 0);
           EXPECT_EQ(buflen, written);
           std::cout << std::endl;
           std::cout << "producer write access  : " << num_writes << std::endl;


### PR DESCRIPTION
**Pull request type**

Please check the type of change your PR introduces:
- [X] Feature

**What is the current behavior?**
eCAL's current zero copy mode is realizing zero copy on the receiving side only. The sending (publishing) side still makes a single memory copy to provide a generic concept for all transport layers (zero copy and none zero copy capable ones).

**What is the new behavior?**
The new approach applies true zero copy for local publish/subscribe connections. It enables the direct modification of the memory file content without any additional copy action (zero copy).

The pictures shows two applications `ecal_sample_latency_snd -z` and `ecal_sample_latency_rec` running on Ubuntu 22.04, exchanging 32MB payloads in 3 µs.

![Screenshot from 2023-04-11 17-20-48](https://user-images.githubusercontent.com/49162693/231210769-f597163a-7f82-41c1-ba63-ecdba8a7a007.png)

**Does this introduce a breaking change?**

- [X] Yes

New `CPublisher` API functions added using the new `eCAL::payload` class.

**Sample Usage**

```cpp
#include <ecal/ecal.h>
#include <ecal/ecal_publisher.h>

// binary payload writer class to allow zero copy memory operations
//
// the `Write`and `Update` calls may operate on the target memory file directly (zero copy mode)
class CBinaryPayloadWriter : public eCAL::CPayloadWriter
{
public:
  CBinaryPayloadWriter(size_t size_) : m_size(size_) {}

  // the provisioned memory is uninitialized ->
  // perform a full write operation
  bool Write(void* buffer_, size_t size_) override
  {
    memset(buffer_, 42, size_);
    return true;
  };

  // the provisioned memory is initialized and contains the data from the last write operation ->
  // perform a partial write operation or just modify a few bytes here
  bool Update(void* buffer_, size_t size_) override
  {
    size_t const write_idx((m_clock % 1024) % size_);
    char   const write_chr(m_clock % 10 + 48);
    static_cast<char*>(buffer_)[write_idx] = write_chr;
    m_clock++;
    return true;
  };

  // provide the size of the required memory (eCAL needs to allocate for you).
  size_t GetSize() override { return m_size; };

private:
  size_t m_size = 0;
  int    m_clock = 0;
};

// main entry
int main(int argc, char** argv)
{
  // initialize eCAL API
  eCAL::Initialize(argc, argv, "zero_copy_snd");

  // create payload
  CBinaryPayloadWriter binary_payload_writer(8 * 1024 * 1024);

  // create publisher
  eCAL::CPublisher pub("zero_copy_pub");

  // enable zero copy mode
  pub.ShmEnableZeroCopy(true);

  // enable handshake mode
  pub.ShmSetAcknowledgeTimeout(50 /* ms */);

  // send updates
  while (eCAL::Ok())
  {
    // send content
    pub.Send(binary_payload_writer);
  }

  // destroy publisher
  pub.Destroy();

  // finalize eCAL API
  eCAL::Finalize();

  return(0);
}
```
