### PR TITLE
hotfix/monplugins-subscriber-callback

### DIFF
--- a/app/mon/mon_plugins/raw_data_reflection/src/plugin_widget.cpp
+++ b/app/mon/mon_plugins/raw_data_reflection/src/plugin_widget.cpp
@@ -62,6 +62,11 @@ PluginWidget::PluginWidget(const QString& topic_name, const QString&, QWidget* p
   subscriber_.AddReceiveCallback(std::bind(&PluginWidget::ecalMessageReceivedCallback, this, std::placeholders::_2));
 }
 
+PluginWidget::~PluginWidget()
+{
+  subscriber_.RemReceiveCallback();
+}
+
 void PluginWidget::ecalMessageReceivedCallback(const struct eCAL::SReceiveCallbackData* callback_data)
 {
   std::lock_guard<std::mutex> message_lock(message_mutex_);
@@ -109,10 +114,6 @@ void PluginWidget::updatePublishTimeLabel()
   }
 
   ui_.publish_timestamp_label->setText(time_string);
-}
-
-PluginWidget::~PluginWidget()
-{
 }
 
 void PluginWidget::onUpdate()

--- a/app/mon/mon_plugins/string_reflection/src/plugin_widget.cpp
+++ b/app/mon/mon_plugins/string_reflection/src/plugin_widget.cpp
@@ -49,6 +49,11 @@ PluginWidget::PluginWidget(const QString& topic_name, const QString&, QWidget* p
   subscriber_.AddReceiveCallback(std::bind(&PluginWidget::ecalMessageReceivedCallback, this, std::placeholders::_2, std::placeholders::_3));
 }
 
+PluginWidget::~PluginWidget()
+{
+  subscriber_.RemReceiveCallback();
+}
+
 void PluginWidget::ecalMessageReceivedCallback(const std::string& message, long long publish_timestamp_usecs)
 {
   std::lock_guard<std::mutex> message_lock(message_mutex_);
@@ -96,10 +101,6 @@ void PluginWidget::updatePublishTimeLabel()
   }
 
   ui_.publish_timestamp_label->setText(time_string);
-}
-
-PluginWidget::~PluginWidget()
-{
 }
 
 void PluginWidget::onUpdate()


### PR DESCRIPTION
**Pull request type**

Please check the type of change your PR introduces:
- [X] Bugfix

**What is the current behavior?**
Two monitor plugin widgets (raw and string) do not remove the callback of the attached subscriber before destruction. This can lead to data races when closing the plugin window.

**What is the new behavior?**
Data receive callback is removed in the plugin destructor.
