### PR TITLE
feature/entity-unregistration

### DIFF
--- a/ecal/core/src/ecal_expmap.h
+++ b/ecal/core/src/ecal_expmap.h
@@ -212,6 +212,19 @@ namespace eCAL
         }
       };
 
+      // Remove specific element from the cache
+      // @Kerstin, pretty sure that this is not well implemented, please take a look
+      bool remove(const Key& k)
+      {
+        auto it = _key_to_value.find(k);
+        if (it != _key_to_value.end())
+        {
+          _key_to_value.erase(k);
+          return true;
+        }
+        return false;
+      };
+
       // Remove all elements from the cache 
       void clear()
       {

--- a/ecal/core/src/ecal_registration_provider.cpp
+++ b/ecal/core/src/ecal_registration_provider.cpp
@@ -59,7 +59,7 @@ namespace eCAL
                     m_use_shm_monitoring(false)
 
   {
-  };
+  }
 
   CRegistrationProvider::~CRegistrationProvider()
   {
@@ -82,16 +82,8 @@ namespace eCAL
     if (m_use_network_monitoring)
     {
       SSenderAttr attr;
-      bool local_only = !Config::IsNetworkEnabled();
       // for local only communication we switch to local broadcasting to bypass vpn's or firewalls
-      if (local_only)
-      {
-        attr.broadcast = true;
-      }
-      else
-      {
-        attr.broadcast = false;
-      }
+      attr.broadcast = !Config::IsNetworkEnabled();
       attr.ipaddr = UDP::GetRegistrationMulticastAddress();
       attr.port = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_REG_OFF;
       attr.loopback = true;
@@ -137,26 +129,34 @@ namespace eCAL
   bool CRegistrationProvider::RegisterTopic(const std::string& topic_name_, const std::string& topic_id_, const eCAL::pb::Sample& ecal_sample_, const bool force_)
   {
     if(!m_created)    return(false);
-    if(!m_reg_topics) return (false);
+    if(!m_reg_topics) return(false);
 
-    std::lock_guard<std::mutex> lock(m_topics_map_sync);
+    const std::lock_guard<std::mutex> lock(m_topics_map_sync);
     m_topics_map[topic_name_ + topic_id_] = ecal_sample_;
     if(force_)
     {
       RegisterProcess();
-      RegisterSample(topic_name_, ecal_sample_);
+      // apply registration sample
+      ApplySample(topic_name_, ecal_sample_);
       SendSampleList(false);
     }
 
     return(true);
   }
 
-  bool CRegistrationProvider::UnregisterTopic(const std::string& topic_name_, const std::string& topic_id_)
+  bool CRegistrationProvider::UnregisterTopic(const std::string& topic_name_, const std::string& topic_id_, const eCAL::pb::Sample& ecal_sample_, const bool force_)
   {
     if(!m_created) return(false);
 
+    if (force_)
+    {
+      // apply unregistration sample
+      ApplySample(topic_name_, ecal_sample_);
+      SendSampleList(false);
+    }
+
     SampleMapT::iterator iter;
-    std::lock_guard<std::mutex> lock(m_topics_map_sync);
+    const std::lock_guard<std::mutex> lock(m_topics_map_sync);
     iter = m_topics_map.find(topic_name_ + topic_id_);
     if(iter != m_topics_map.end())
     {
@@ -172,24 +172,32 @@ namespace eCAL
     if(!m_created)      return(false);
     if(!m_reg_services) return(false);
 
-    std::lock_guard<std::mutex> lock(m_server_map_sync);
+    const std::lock_guard<std::mutex> lock(m_server_map_sync);
     m_server_map[service_name_ + service_id_] = ecal_sample_;
     if(force_)
     {
       RegisterProcess();
-      RegisterSample(service_name_, ecal_sample_);
+      // apply registration sample
+      ApplySample(service_name_, ecal_sample_);
       SendSampleList(false);
     }
 
     return(true);
   }
 
-  bool CRegistrationProvider::UnregisterServer(const std::string& service_name_, const std::string& service_id_)
+  bool CRegistrationProvider::UnregisterServer(const std::string& service_name_, const std::string& service_id_, const eCAL::pb::Sample& ecal_sample_, const bool force_)
   {
     if(!m_created) return(false);
 
+    if (force_)
+    {
+      // apply unregistration sample
+      ApplySample(service_name_, ecal_sample_);
+      SendSampleList(false);
+    }
+
     SampleMapT::iterator iter;
-    std::lock_guard<std::mutex> lock(m_server_map_sync);
+    const std::lock_guard<std::mutex> lock(m_server_map_sync);
     iter = m_server_map.find(service_name_ + service_id_);
     if(iter != m_server_map.end())
     {
@@ -205,24 +213,32 @@ namespace eCAL
     if (!m_created)      return(false);
     if (!m_reg_services) return(false);
 
-    std::lock_guard<std::mutex> lock(m_client_map_sync);
+    const std::lock_guard<std::mutex> lock(m_client_map_sync);
     m_client_map[client_name_ + client_id_] = ecal_sample_;
     if (force_)
     {
       RegisterProcess();
-      RegisterSample(client_name_, ecal_sample_);
+      // apply registration sample
+      ApplySample(client_name_, ecal_sample_);
       SendSampleList(false);
     }
 
     return(true);
   }
 
-  bool CRegistrationProvider::UnregisterClient(const std::string& client_name_, const std::string& client_id_)
+  bool CRegistrationProvider::UnregisterClient(const std::string& client_name_, const std::string& client_id_, const eCAL::pb::Sample& ecal_sample_, const bool force_)
   {
     if (!m_created) return(false);
 
+    if (force_)
+    {
+      // apply unregistration sample
+      ApplySample(client_name_, ecal_sample_);
+      SendSampleList(false);
+    }
+
     SampleMapT::iterator iter;
-    std::lock_guard<std::mutex> lock(m_client_map_sync);
+    const std::lock_guard<std::mutex> lock(m_client_map_sync);
     iter = m_client_map.find(client_name_ + client_id_);
     if (iter != m_client_map.end())
     {
@@ -235,12 +251,12 @@ namespace eCAL
 
   bool CRegistrationProvider::RegisterProcess()
   {
-    if(!m_created)     return(0);
-    if(!m_reg_process) return(0);
+    if(!m_created)     return(false);
+    if(!m_reg_process) return(false);
 
     eCAL::pb::Sample process_sample;
     process_sample.set_cmd_type(eCAL::pb::bct_reg_process);
-    auto process_sample_mutable_process = process_sample.mutable_process();
+    auto *process_sample_mutable_process = process_sample.mutable_process();
     process_sample_mutable_process->set_hname(Process::GetHostName());
     process_sample_mutable_process->set_pid(Process::GetProcessID());
     process_sample_mutable_process->set_pname(Process::GetProcessName());
@@ -253,7 +269,7 @@ namespace eCAL
     process_sample_mutable_process->set_dataread(google::protobuf::int64(Process::GetRBytes()));
     process_sample_mutable_process->mutable_state()->set_severity(eCAL::pb::eProcessSeverity(g_process_severity));
     process_sample_mutable_process->mutable_state()->set_info(g_process_info);
-    if (!g_timegate())
+    if (g_timegate() == nullptr)
     {
       process_sample_mutable_process->set_tsync_state(eCAL::pb::eTSyncState::tsync_none);
     }
@@ -282,33 +298,33 @@ namespace eCAL
     }
 
     // eCAL initialization state
-    unsigned int comp_state(g_globals()->GetComponents());
+    const unsigned int comp_state(g_globals()->GetComponents());
     process_sample_mutable_process->set_component_init_state(google::protobuf::int32(comp_state));
     std::string component_info;
-    if (comp_state & Init::Publisher)   component_info += "|pub";
-    if (comp_state & Init::Subscriber)  component_info += "|sub";
-    if (comp_state & Init::Service)     component_info += "|srv";
-    if (comp_state & Init::Monitoring)  component_info += "|mon";
-    if (comp_state & Init::Logging)     component_info += "|log";
-    if (comp_state & Init::TimeSync)    component_info += "|time";
+    if ((comp_state & Init::Publisher)  != 0u) component_info += "|pub";
+    if ((comp_state & Init::Subscriber) != 0u) component_info += "|sub";
+    if ((comp_state & Init::Service)    != 0u) component_info += "|srv";
+    if ((comp_state & Init::Monitoring) != 0u) component_info += "|mon";
+    if ((comp_state & Init::Logging)    != 0u) component_info += "|log";
+    if ((comp_state & Init::TimeSync)   != 0u) component_info += "|time";
     if (!component_info.empty()) component_info = component_info.substr(1);
     process_sample_mutable_process->set_component_init_info(component_info);
 
     process_sample_mutable_process->set_ecal_runtime_version(eCAL::GetVersionString());
 
     // register sample
-    bool return_value = RegisterSample(Process::GetHostName(), process_sample);
+    const bool return_value = ApplySample(Process::GetHostName(), process_sample);
 
     return return_value;
   }
 
   bool CRegistrationProvider::RegisterServer()
   {
-    if(!m_created)      return(0);
-    if(!m_reg_services) return(0);
+    if(!m_created)      return(false);
+    if(!m_reg_services) return(false);
 
     bool return_value {true};
-    std::lock_guard<std::mutex> lock(m_server_map_sync);
+    const std::lock_guard<std::mutex> lock(m_server_map_sync);
     for(SampleMapT::const_iterator iter = m_server_map.begin(); iter != m_server_map.end(); ++iter)
     {
       //////////////////////////////////////////////
@@ -323,7 +339,7 @@ namespace eCAL
       //////////////////////////////////////////////
       // send sample to registration layer
       //////////////////////////////////////////////
-      return_value &= RegisterSample(iter->second.service().sname(), iter->second);
+      return_value &= ApplySample(iter->second.service().sname(), iter->second);
     }
 
     return return_value;
@@ -331,15 +347,15 @@ namespace eCAL
 
   bool CRegistrationProvider::RegisterClient()
   {
-    if (!m_created)      return(0);
-    if (!m_reg_services) return(0);
+    if (!m_created)      return(false);
+    if (!m_reg_services) return(false);
 
     bool return_value {true};
-    std::lock_guard<std::mutex> lock(m_client_map_sync);
+    const std::lock_guard<std::mutex> lock(m_client_map_sync);
     for (SampleMapT::const_iterator iter = m_client_map.begin(); iter != m_client_map.end(); ++iter)
     {
       // register sample
-      return_value &= RegisterSample(iter->second.client().sname(), iter->second);
+      return_value &= ApplySample(iter->second.client().sname(), iter->second);
     }
 
     return return_value;
@@ -347,11 +363,11 @@ namespace eCAL
 
   bool CRegistrationProvider::RegisterTopics()
   {
-    if(!m_created)    return(0);
-    if(!m_reg_topics) return(0);
+    if(!m_created)    return(false);
+    if(!m_reg_topics) return(false);
 
     bool return_value {true};
-    std::lock_guard<std::mutex> lock(m_topics_map_sync);
+    const std::lock_guard<std::mutex> lock(m_topics_map_sync);
     for(SampleMapT::const_iterator iter = m_topics_map.begin(); iter != m_topics_map.end(); ++iter)
     {
       //////////////////////////////////////////////
@@ -367,15 +383,15 @@ namespace eCAL
       //////////////////////////////////////////////
       // send sample to registration layer
       //////////////////////////////////////////////
-      return_value &= RegisterSample(iter->second.topic().tname(), iter->second);
+      return_value &= ApplySample(iter->second.topic().tname(), iter->second);
     }
 
     return return_value;
   }
 
-  bool CRegistrationProvider::RegisterSample(const std::string& sample_name_, const eCAL::pb::Sample& sample_)
+  bool CRegistrationProvider::ApplySample(const std::string& sample_name_, const eCAL::pb::Sample& sample_)
   {
-    if(!m_created) return(0);
+    if(!m_created) return(false);
 
     bool return_value {true};
 
@@ -384,7 +400,7 @@ namespace eCAL
 
     if(m_use_shm_monitoring)
     {
-      std::lock_guard<std::mutex> lock(m_sample_list_sync);
+      const std::lock_guard<std::mutex> lock(m_sample_list_sync);
       m_sample_list.mutable_samples()->Add()->CopyFrom(sample_);
     }
 
@@ -399,13 +415,13 @@ namespace eCAL
     if(m_use_shm_monitoring)
     {
       {
-        std::lock_guard<std::mutex> lock(m_sample_list_sync);
+        const std::lock_guard<std::mutex> lock(m_sample_list_sync);
         m_sample_list.SerializeToString(&m_sample_list_buffer);
         if(reset_sample_list_)
           m_sample_list.clear_samples();
       }
 
-      if(m_sample_list_buffer.size())
+      if(!m_sample_list_buffer.empty())
         return_value &=m_memfile_broadcast_writer.Write(m_sample_list_buffer.data(), m_sample_list_buffer.size());
     }
 
@@ -425,44 +441,41 @@ namespace eCAL
     g_process_wbytes_sum = 0;
 
     // refresh subscriber registration
-    if (g_subgate()) g_subgate()->RefreshRegistrations();
+    if (g_subgate() != nullptr) g_subgate()->RefreshRegistrations();
 
     // refresh publisher registration
-    if (g_pubgate()) g_pubgate()->RefreshRegistrations();
+    if (g_pubgate() != nullptr) g_pubgate()->RefreshRegistrations();
 
     // refresh server registration
-    if (g_servicegate()) g_servicegate()->RefreshRegistrations();
+    if (g_servicegate() != nullptr) g_servicegate()->RefreshRegistrations();
 
     // refresh client registration
-    if (g_clientgate()) g_clientgate()->RefreshRegistrations();
-
-    // overall registration send status for debugging
-    /*bool registration_successful {true};*/
+    if (g_clientgate() != nullptr) g_clientgate()->RefreshRegistrations();
 
     // register process
-    /*registration_successful &= */RegisterProcess();
+    RegisterProcess();
 
     // register server
-    /*registration_successful &= */RegisterServer();
+    RegisterServer();
 
     // register clients
-    /*registration_successful &= */RegisterClient();
+    RegisterClient();
 
     // register topics
-    /*registration_successful &= */RegisterTopics();
+    RegisterTopics();
 
     // write sample list to shared memory
-    /*registration_successful &= */SendSampleList();
+    SendSampleList();
 
     return(0);
-  };
+  }
 
   bool CRegistrationProvider::ApplyTopicToDescGate(const std::string& topic_name_
     , const std::string& topic_type_
     , const std::string& topic_desc_
     , bool topic_is_a_publisher_)
   {
-    if (g_descgate())
+    if (g_descgate() != nullptr)
     {
       // calculate the quality of the current info
       ::eCAL::CDescGate::QualityFlags quality = ::eCAL::CDescGate::QualityFlags::NO_QUALITY;
@@ -487,7 +500,7 @@ namespace eCAL
     , const std::string& resp_type_name_
     , const std::string& resp_type_desc_)
   {
-    if (g_descgate())
+    if (g_descgate() != nullptr)
     {
       // Calculate the quality of the current info
       ::eCAL::CDescGate::QualityFlags quality = ::eCAL::CDescGate::QualityFlags::NO_QUALITY;
@@ -501,4 +514,4 @@ namespace eCAL
     }
     return false;
   }
-};
+}

--- a/ecal/core/src/ecal_registration_provider.h
+++ b/ecal/core/src/ecal_registration_provider.h
@@ -59,21 +59,22 @@ namespace eCAL
     void Create(bool topics_, bool services_, bool process_);
     void Destroy();
 
-    bool RegisterTopic(const std::string& topic_name_, const std::string& topic_id_, const eCAL::pb::Sample& ecal_sample_, const bool force_);
-    bool UnregisterTopic(const std::string& topic_name_, const std::string& topic_id_);
+    bool RegisterTopic(const std::string& topic_name_, const std::string& topic_id_, const eCAL::pb::Sample& ecal_sample_, bool force_);
+    bool UnregisterTopic(const std::string& topic_name_, const std::string& topic_id_, const eCAL::pb::Sample& ecal_sample_, bool force_);
 
-    bool RegisterServer(const std::string& service_name_, const std::string& service_id_, const eCAL::pb::Sample& ecal_sample_, const bool force_);
-    bool UnregisterServer(const std::string& service_name_, const std::string& service_id_);
+    bool RegisterServer(const std::string& service_name_, const std::string& service_id_, const eCAL::pb::Sample& ecal_sample_, bool force_);
+    bool UnregisterServer(const std::string& service_name_, const std::string& service_id_, const eCAL::pb::Sample& ecal_sample_, bool force_);
 
-    bool RegisterClient(const std::string& client_name_, const std::string& client_id_, const eCAL::pb::Sample& ecal_sample_, const bool force_);
-    bool UnregisterClient(const std::string& client_name_, const std::string& client_id_);
+    bool RegisterClient(const std::string& client_name_, const std::string& client_id_, const eCAL::pb::Sample& ecal_sample_, bool force_);
+    bool UnregisterClient(const std::string& client_name_, const std::string& client_id_, const eCAL::pb::Sample& ecal_sample_, bool force_);
 
   protected:
     bool RegisterProcess();
     bool RegisterServer();
     bool RegisterClient();
     bool RegisterTopics();
-    bool RegisterSample(const std::string& sample_name_, const eCAL::pb::Sample& sample_);
+
+    bool ApplySample(const std::string& sample_name_, const eCAL::pb::Sample& sample_);
       
     int RegisterSendThread();
 
@@ -101,7 +102,7 @@ namespace eCAL
     CUDPSender                m_reg_snd;
     CThread                   m_reg_snd_thread;
 
-    typedef std::unordered_map<std::string, eCAL::pb::Sample> SampleMapT;
+    using SampleMapT = std::unordered_map<std::string, eCAL::pb::Sample>;
     std::mutex                m_topics_map_sync;
     SampleMapT                m_topics_map;
 

--- a/ecal/core/src/ecal_registration_receiver.h
+++ b/ecal/core/src/ecal_registration_receiver.h
@@ -52,8 +52,8 @@ namespace eCAL
 {
   class CUdpRegistrationReceiver : public CSampleReceiver
   {
-    bool HasSample(const std::string& /*sample_name_*/) { return(true); };
-    size_t ApplySample(const eCAL::pb::Sample& ecal_sample_, eCAL::pb::eTLayerType layer_);
+    bool HasSample(const std::string& /*sample_name_*/) override { return(true); };
+    size_t ApplySample(const eCAL::pb::Sample& ecal_sample_, eCAL::pb::eTLayerType layer_) override;
   };
 
   class CMemfileRegistrationReceiver
@@ -82,11 +82,11 @@ namespace eCAL
     void Destroy();
 
     void EnableLoopback(bool state_);
-    bool LoopBackEnabled() { return m_loopback; };
+    bool LoopBackEnabled() const { return m_loopback; };
 
     size_t ApplySample(const eCAL::pb::Sample& ecal_sample_);
 
-    bool AddRegistrationCallback(enum eCAL_Registration_Event event_, RegistrationCallbackT callback_);
+    bool AddRegistrationCallback(enum eCAL_Registration_Event event_, const RegistrationCallbackT& callback_);
     bool RemRegistrationCallback(enum eCAL_Registration_Event event_);
 
     void SetCustomApplySampleCallback(const ApplySampleCallbackT& callback_);

--- a/ecal/core/src/mon/ecal_monitoring_impl.cpp
+++ b/ecal/core/src/mon/ecal_monitoring_impl.cpp
@@ -24,24 +24,17 @@
 #include <ecal/ecal.h>
 #include <ecal/ecal_config.h>
 
-#include <ecal/ecal_core.h>
-
 #include "ecal_config_reader_hlp.h"
 #include "ecal_monitoring_impl.h"
-
-#include "ecal_def.h"
 
 #include <regex>
 #include <sstream>
 
 #include "../ecal_registration_receiver.h"
 
-namespace eCAL
+namespace
 {
-  ////////////////////////////////////////////////////////
-  // local helper
-  ////////////////////////////////////////////////////////
-  static void GetSampleHost(const eCAL::pb::Sample& ecal_sample_, std::string& host_name_)
+  void GetSampleHost(const eCAL::pb::Sample& ecal_sample_, std::string& host_name_)
   {
     if (ecal_sample_.has_host())
     {
@@ -65,16 +58,18 @@ namespace eCAL
     }
   }
 
-  static bool IsLocalHost(const eCAL::pb::Sample& ecal_sample_)
+  bool IsLocalHost(const eCAL::pb::Sample& ecal_sample_)
   {
     std::string host_name;
     GetSampleHost(ecal_sample_, host_name);
-    if (host_name.empty())                   return(false);
-    if (host_name == Process::GetHostName()) return(true);
+    if (host_name.empty())                         return(false);
+    if (host_name == eCAL::Process::GetHostName()) return(true);
     return(false);
   }
+}
 
-
+namespace eCAL
+{
   ////////////////////////////////////////
   // Monitoring Implementation
   ////////////////////////////////////////
@@ -86,10 +81,6 @@ namespace eCAL
     m_subscriber_map(std::chrono::milliseconds(Config::GetMonitoringTimeoutMs())),
     m_server_map    (std::chrono::milliseconds(Config::GetMonitoringTimeoutMs())),
     m_clients_map   (std::chrono::milliseconds(Config::GetMonitoringTimeoutMs()))
-  {
-  }
-
-  CMonitoringImpl::~CMonitoringImpl()
   {
   }
 
@@ -107,14 +98,14 @@ namespace eCAL
     g_registration_receiver()->SetCustomApplySampleCallback([this](const auto& ecal_sample_){ApplySample(ecal_sample_, eCAL::pb::tl_none);});
 
     // start logging receive thread
-    CLoggingReceiveThread::LogMessageCallbackT logmsg_cb = std::bind(&CMonitoringImpl::RegisterLogMessage, this, std::placeholders::_1);
+    const CLoggingReceiveThread::LogMessageCallbackT logmsg_cb = std::bind(&CMonitoringImpl::RegisterLogMessage, this, std::placeholders::_1);
     m_log_rcv_threadcaller = std::make_shared<CLoggingReceiveThread>(logmsg_cb);
     m_log_rcv_threadcaller->SetNetworkMode(Config::IsNetworkEnabled());
 
     // start monitoring and logging publishing thread
     // we really need to remove this feature !
-    CMonLogPublishingThread::MonitoringCallbackT mon_cb = std::bind(&CMonitoringImpl::GetMonitoringPb, this, std::placeholders::_1, Monitoring::Entity::All);
-    CMonLogPublishingThread::LoggingCallbackT    log_cb = std::bind(&CMonitoringImpl::GetLogging, this, std::placeholders::_1);
+    const CMonLogPublishingThread::MonitoringCallbackT mon_cb = std::bind(&CMonitoringImpl::GetMonitoringPb, this, std::placeholders::_1, Monitoring::Entity::All);
+    const CMonLogPublishingThread::LoggingCallbackT    log_cb = std::bind(&CMonitoringImpl::GetLogging, this, std::placeholders::_1);
     m_pub_threadcaller = std::make_shared<CMonLogPublishingThread>(mon_cb, log_cb);
 
     // setup blacklist and whitelist filter strings#
@@ -149,24 +140,24 @@ namespace eCAL
     {
       // create excluding filter list
       {
-        std::lock_guard<std::mutex> lock(m_topic_filter_excl_mtx);
+        const std::lock_guard<std::mutex> lock(m_topic_filter_excl_mtx);
         Tokenize(m_topic_filter_excl_s, m_topic_filter_excl, ",;", true);
       }
 
       // create including filter list
       {
-        std::lock_guard<std::mutex> lock(m_topic_filter_incl_mtx);
+        const std::lock_guard<std::mutex> lock(m_topic_filter_incl_mtx);
         Tokenize(m_topic_filter_incl_s, m_topic_filter_incl, ",;", true);
       }
     }
     else
     {
       {
-        std::lock_guard<std::mutex> lock(m_topic_filter_excl_mtx);
+        const std::lock_guard<std::mutex> lock(m_topic_filter_excl_mtx);
         m_topic_filter_excl.clear();
       }
       {
-        std::lock_guard<std::mutex> lock(m_topic_filter_incl_mtx);
+        const std::lock_guard<std::mutex> lock(m_topic_filter_incl_mtx);
         m_topic_filter_incl.clear();
       }
     }
@@ -174,7 +165,7 @@ namespace eCAL
 
   size_t CMonitoringImpl::ApplySample(const eCAL::pb::Sample& ecal_sample_, eCAL::pb::eTLayerType /*layer_*/)
   {
-    // if sample is from outside and we are in local network mode
+    // if sample is from outside, and we are in local network mode
     // do not process sample
     if (!IsLocalHost(ecal_sample_) && !m_network) return 0;
 
@@ -189,10 +180,22 @@ namespace eCAL
       RegisterProcess(ecal_sample_);
     }
     break;
+    case eCAL::pb::bct_unreg_process:
+    {
+      // unregister process
+      UnregisterProcess(ecal_sample_);
+    }
+    break;
     case eCAL::pb::bct_reg_service:
     {
       // register service
       RegisterServer(ecal_sample_);
+    }
+    break;
+    case eCAL::pb::bct_unreg_service:
+    {
+      // unregister service
+      UnregisterServer(ecal_sample_);
     }
     break;
     case eCAL::pb::bct_reg_client:
@@ -201,16 +204,34 @@ namespace eCAL
       RegisterClient(ecal_sample_);
     }
     break;
+    case eCAL::pb::bct_unreg_client:
+    {
+      // unregister client
+      UnregisterClient(ecal_sample_);
+    }
+    break;
     case eCAL::pb::bct_reg_publisher:
     {
       // register publisher
       RegisterTopic(ecal_sample_, CMonitoringImpl::publisher);
     }
     break;
+    case eCAL::pb::bct_unreg_publisher:
+    {
+      // unregister publisher
+      UnregisterTopic(ecal_sample_, CMonitoringImpl::publisher);
+    }
+    break;
     case eCAL::pb::bct_reg_subscriber:
     {
       // register subscriber
       RegisterTopic(ecal_sample_, CMonitoringImpl::subscriber);
+    }
+    break;
+    case eCAL::pb::bct_unreg_subscriber:
+    {
+      // unregister subscriber
+      UnregisterTopic(ecal_sample_, CMonitoringImpl::subscriber);
     }
     break;
     default:
@@ -224,31 +245,31 @@ namespace eCAL
 
   bool CMonitoringImpl::RegisterTopic(const eCAL::pb::Sample& sample_, enum ePubSub pubsub_type_)
   {
-    auto sample_topic = sample_.topic();
-    int          process_id      = sample_topic.pid();
-    std::string  topic_name      = sample_topic.tname();
-    size_t       topic_size      = static_cast<size_t>(sample_topic.tsize());
-    bool         topic_tlayer_ecal_udp_mc(false);
-    bool         topic_tlayer_ecal_shm(false);
-    bool         topic_tlayer_ecal_tcp(false);
-    bool         topic_tlayer_inproc(false);
-    for (auto layer : sample_topic.tlayer())
+    const auto& sample_topic = sample_.topic();
+    const int          process_id = sample_topic.pid();
+    const std::string& topic_name = sample_topic.tname();
+    const size_t       topic_size = static_cast<size_t>(sample_topic.tsize());
+    bool               topic_tlayer_ecal_udp_mc(false);
+    bool               topic_tlayer_ecal_shm(false);
+    bool               topic_tlayer_ecal_tcp(false);
+    bool               topic_tlayer_inproc(false);
+    for (const auto& layer : sample_topic.tlayer())
     {
       topic_tlayer_ecal_udp_mc    |= (layer.type() == eCAL::pb::tl_ecal_udp_mc)    && layer.confirmed();
       topic_tlayer_ecal_shm       |= (layer.type() == eCAL::pb::tl_ecal_shm)       && layer.confirmed();
       topic_tlayer_ecal_tcp       |= (layer.type() == eCAL::pb::tl_ecal_tcp)       && layer.confirmed();
       topic_tlayer_inproc         |= (layer.type() == eCAL::pb::tl_inproc)         && layer.confirmed();
     }
-    size_t       connections_loc = static_cast<size_t>(sample_topic.connections_loc());
-    size_t       connections_ext = static_cast<size_t>(sample_topic.connections_ext());
-    long long    did             = sample_topic.did();
-    long long    dclock          = sample_topic.dclock();
-    long long    message_drops   = sample_topic.message_drops();
-    long         dfreq           = sample_topic.dfreq();
+    const size_t       connections_loc = static_cast<size_t>(sample_topic.connections_loc());
+    const size_t       connections_ext = static_cast<size_t>(sample_topic.connections_ext());
+    const long long    did             = sample_topic.did();
+    const long long    dclock          = sample_topic.dclock();
+    const long long    message_drops   = sample_topic.message_drops();
+    const long         dfreq           = sample_topic.dfreq();
 
     // check blacklist topic filter
     {
-      std::lock_guard<std::mutex> lock(m_topic_filter_excl_mtx);
+      const std::lock_guard<std::mutex> lock(m_topic_filter_excl_mtx);
       for (const auto& it : m_topic_filter_excl)
       {
         if (std::regex_match(topic_name, std::regex(it, std::regex::icase)))
@@ -259,7 +280,7 @@ namespace eCAL
     // check whitelist topic filter
     bool is_topic_in_filter(false);
     {
-      std::lock_guard<std::mutex> lock(m_topic_filter_incl_mtx);
+      const std::lock_guard<std::mutex> lock(m_topic_filter_incl_mtx);
       is_topic_in_filter = m_topic_filter_incl.empty();
       for (const auto& it : m_topic_filter_incl)
       {
@@ -271,24 +292,24 @@ namespace eCAL
       }
     }
 
-    if (is_topic_in_filter == false) return (false);
+    if (!is_topic_in_filter) return (false);
 
     /////////////////////////////////
     // register in topic map
     /////////////////////////////////
     STopicMonMap* pTopicMap = GetMap(pubsub_type_);
-    if (pTopicMap)
+    if (pTopicMap != nullptr)
     {
       // acquire access
-      std::lock_guard<std::mutex> lock(pTopicMap->sync);
+      const std::lock_guard<std::mutex> lock(pTopicMap->sync);
 
       // common infos
-      int         host_id              = sample_topic.hid();
-      std::string host_name            = sample_topic.hname();
-      std::string process_name         = sample_topic.pname();
-      std::string unit_name            = sample_topic.uname();
-      std::string topic_id             = sample_topic.tid();
-      std::string direction;
+      const int          host_id      = sample_topic.hid();
+      const std::string& host_name    = sample_topic.hname();
+      const std::string& process_name = sample_topic.pname();
+      const std::string& unit_name    = sample_topic.uname();
+      const std::string& topic_id     = sample_topic.tid();
+      std::string        direction;
       switch (pubsub_type_)
       {
       case publisher:
@@ -300,40 +321,61 @@ namespace eCAL
       default:
         break;
         }
-      std::string topic_type           = sample_topic.ttype();
-      std::string topic_desc           = sample_topic.tdesc();
-      auto attr                        = sample_topic.attr();
+      std::string topic_type = sample_topic.ttype();
+      std::string topic_desc = sample_topic.tdesc();
+      auto attr              = sample_topic.attr();
 
       // try to get topic info
-      std::string topic_name_id = topic_name + topic_id;
+      const std::string topic_name_id = topic_name + topic_id;
       Monitoring::STopicMon& TopicInfo = (*pTopicMap->map)[topic_name_id];
 
       // set static content
-      TopicInfo.hid                   = host_id;
-      TopicInfo.hname                 = std::move(host_name);
-      TopicInfo.pid                   = process_id;
-      TopicInfo.pname                 = std::move(process_name);
-      TopicInfo.uname                 = std::move(unit_name);
-      TopicInfo.tname                 = std::move(topic_name);
-      TopicInfo.direction             = std::move(direction);
-      TopicInfo.tid                   = std::move(topic_id);
+      TopicInfo.hid       = host_id;
+      TopicInfo.hname     = host_name;
+      TopicInfo.pid       = process_id;
+      TopicInfo.pname     = process_name;
+      TopicInfo.uname     = unit_name;
+      TopicInfo.tname     = topic_name;
+      TopicInfo.direction = direction;
+      TopicInfo.tid       = topic_id;
 
       // update flexible content
       TopicInfo.rclock++;
-      TopicInfo.ttype                 = std::move(topic_type);
-      TopicInfo.tdesc                 = std::move(topic_desc);
-      TopicInfo.attr                  = std::map<std::string, std::string>{attr.begin(), attr.end()};
-      TopicInfo.tlayer_ecal_udp_mc    = topic_tlayer_ecal_udp_mc;
-      TopicInfo.tlayer_ecal_shm       = topic_tlayer_ecal_shm;
-      TopicInfo.tlayer_ecal_tcp       = topic_tlayer_ecal_tcp;
-      TopicInfo.tlayer_inproc         = topic_tlayer_inproc;
-      TopicInfo.tsize                 = static_cast<int>(topic_size);
-      TopicInfo.connections_loc       = static_cast<int>(connections_loc);
-      TopicInfo.connections_ext       = static_cast<int>(connections_ext);
-      TopicInfo.did                   = did;
-      TopicInfo.dclock                = dclock;
-      TopicInfo.message_drops         = message_drops;
-      TopicInfo.dfreq                 = dfreq;
+      TopicInfo.ttype              = std::move(topic_type);
+      TopicInfo.tdesc              = std::move(topic_desc);
+      TopicInfo.attr               = std::map<std::string, std::string>{attr.begin(), attr.end()};
+      TopicInfo.tlayer_ecal_udp_mc = topic_tlayer_ecal_udp_mc;
+      TopicInfo.tlayer_ecal_shm    = topic_tlayer_ecal_shm;
+      TopicInfo.tlayer_ecal_tcp    = topic_tlayer_ecal_tcp;
+      TopicInfo.tlayer_inproc      = topic_tlayer_inproc;
+      TopicInfo.tsize              = static_cast<int>(topic_size);
+      TopicInfo.connections_loc    = static_cast<int>(connections_loc);
+      TopicInfo.connections_ext    = static_cast<int>(connections_ext);
+      TopicInfo.did                = did;
+      TopicInfo.dclock             = dclock;
+      TopicInfo.message_drops      = message_drops;
+      TopicInfo.dfreq              = dfreq;
+    }
+
+    return(true);
+  }
+
+  bool CMonitoringImpl::UnregisterTopic(const eCAL::pb::Sample& sample_, enum ePubSub pubsub_type_)
+  {
+    const auto& sample_topic = sample_.topic();
+    const std::string& topic_name = sample_topic.tname();
+    const std::string& topic_id   = sample_topic.tid();
+
+    // unregister from topic map
+    STopicMonMap* pTopicMap = GetMap(pubsub_type_);
+    if (pTopicMap != nullptr)
+    {
+      // acquire access
+      const std::lock_guard<std::mutex> lock(pTopicMap->sync);
+
+      // remove topic info
+      const std::string topic_name_id = topic_name + topic_id;
+      pTopicMap->map->remove(topic_name_id);
     }
 
     return(true);
@@ -341,43 +383,43 @@ namespace eCAL
 
   bool CMonitoringImpl::RegisterProcess(const eCAL::pb::Sample& sample_)
   {
-    auto sample_process = sample_.process();
-    std::string     host_name                    = sample_process.hname();
-    std::string     process_name                 = sample_process.pname();
-    int             process_id                   = sample_process.pid();
-    std::string     process_param                = sample_process.pparam();
-    std::string     unit_name                    = sample_process.uname();
-    long long       process_memory               = sample_process.pmemory();
-    float           process_cpu                  = sample_process.pcpu();
-    float           process_usrptime             = sample_process.usrptime();
-    long long       process_datawrite            = sample_process.datawrite();
-    long long       process_dataread             = sample_process.dataread();
-    auto            sample_process_state         = sample_process.state();
-    int             process_state_severity       = sample_process_state.severity();
-    int             process_state_severity_level = sample_process_state.severity_level();
-    std::string     process_state_info           = sample_process_state.info();
-    int             process_tsync_state          = sample_process.tsync_state();
-    std::string     process_tsync_mod_name       = sample_process.tsync_mod_name();
-    int             component_init_state         = sample_process.component_init_state();
-    std::string     component_init_info          = sample_process.component_init_info();
-    std::string     ecal_runtime_version         = sample_process.ecal_runtime_version();
+    const auto& sample_process = sample_.process();
+    const std::string&    host_name                    = sample_process.hname();
+    const std::string&    process_name                 = sample_process.pname();
+    const int             process_id                   = sample_process.pid();
+    const std::string&    process_param                = sample_process.pparam();
+    const std::string&    unit_name                    = sample_process.uname();
+    const long long       process_memory               = sample_process.pmemory();
+    const float           process_cpu                  = sample_process.pcpu();
+    const float           process_usrptime             = sample_process.usrptime();
+    const long long       process_datawrite            = sample_process.datawrite();
+    const long long       process_dataread             = sample_process.dataread();
+    const auto&           sample_process_state         = sample_process.state();
+    const int             process_state_severity       = sample_process_state.severity();
+    const int             process_state_severity_level = sample_process_state.severity_level();
+    const std::string&    process_state_info           = sample_process_state.info();
+    const int             process_tsync_state          = sample_process.tsync_state();
+    const std::string&    process_tsync_mod_name       = sample_process.tsync_mod_name();
+    const int             component_init_state         = sample_process.component_init_state();
+    const std::string&    component_init_info          = sample_process.component_init_info();
+    const std::string&    ecal_runtime_version         = sample_process.ecal_runtime_version();
 
     std::stringstream process_id_ss;
     process_id_ss << process_id;
-    std::string process_name_id = process_name + process_id_ss.str();
+    const std::string process_name_id = process_name + process_id_ss.str();
 
     // acquire access
-    std::lock_guard<std::mutex> lock(m_process_map.sync);
+    const std::lock_guard<std::mutex> lock(m_process_map.sync);
 
     // try to get process info
     Monitoring::SProcessMon& ProcessInfo = (*m_process_map.map)[process_name_id];
 
     // set static content
-    ProcessInfo.hname  = std::move(host_name);
-    ProcessInfo.pname  = std::move(process_name);
-    ProcessInfo.uname  = std::move(unit_name);
+    ProcessInfo.hname  = host_name;
+    ProcessInfo.pname  = process_name;
+    ProcessInfo.uname  = unit_name;
     ProcessInfo.pid    = process_id;
-    ProcessInfo.pparam = std::move(process_param);
+    ProcessInfo.pparam = process_param;
 
     // update flexible content
     ProcessInfo.rclock++;
@@ -388,43 +430,62 @@ namespace eCAL
     ProcessInfo.dataread             = process_dataread;
     ProcessInfo.state_severity       = process_state_severity;
     ProcessInfo.state_severity_level = process_state_severity_level;
-    ProcessInfo.state_info           = std::move(process_state_info);
+    ProcessInfo.state_info           = process_state_info;
     ProcessInfo.tsync_state          = process_tsync_state;
-    ProcessInfo.tsync_mod_name       = std::move(process_tsync_mod_name);
+    ProcessInfo.tsync_mod_name       = process_tsync_mod_name;
     ProcessInfo.component_init_state = component_init_state;
-    ProcessInfo.component_init_info  = std::move(component_init_info);
-    ProcessInfo.ecal_runtime_version = std::move(ecal_runtime_version);
+    ProcessInfo.component_init_info  = component_init_info;
+    ProcessInfo.ecal_runtime_version = ecal_runtime_version;
+
+    return(true);
+  }
+
+  bool CMonitoringImpl::UnregisterProcess(const pb::Sample &sample_)
+  {
+    const auto& sample_process = sample_.process();
+    const std::string& process_name = sample_process.pname();
+    const int          process_id   = sample_process.pid();
+
+    std::stringstream process_id_ss;
+    process_id_ss << process_id;
+    const std::string process_name_id = process_name + process_id_ss.str();
+
+    // acquire access
+    const std::lock_guard<std::mutex> lock(m_process_map.sync);
+
+    // remove process info
+    m_process_map.map->remove(process_name_id);
 
     return(true);
   }
 
   bool CMonitoringImpl::RegisterServer(const eCAL::pb::Sample& sample_)
   {
-    auto sample_service = sample_.service();
-    std::string  host_name    = sample_service.hname();
-    std::string  service_name = sample_service.sname();
-    std::string  service_id   = sample_service.sid();
-    std::string  process_name = sample_service.pname();
-    std::string  unit_name    = sample_service.uname();
-    int          process_id   = sample_service.pid();
-    int          tcp_port     = sample_service.tcp_port();
+    const auto& sample_service = sample_.service();
+    const std::string& host_name    = sample_service.hname();
+    const std::string& service_name = sample_service.sname();
+    const std::string& service_id   = sample_service.sid();
+    const std::string& process_name = sample_service.pname();
+    const std::string& unit_name    = sample_service.uname();
+    const int          process_id   = sample_service.pid();
+    const int          tcp_port     = sample_service.tcp_port();
 
     std::stringstream process_id_ss;
     process_id_ss << process_id;
-    std::string service_name_id = service_name + service_id + process_id_ss.str();
+    const std::string service_name_id = service_name + service_id + process_id_ss.str();
 
     // acquire access
-    std::lock_guard<std::mutex> lock(m_server_map.sync);
+    const std::lock_guard<std::mutex> lock(m_server_map.sync);
 
     // try to get service info
     Monitoring::SServerMon& ServerInfo = (*m_server_map.map)[service_name_id];
 
     // set static content
-    ServerInfo.hname    = std::move(host_name);
-    ServerInfo.sname    = std::move(service_name);
-    ServerInfo.sid      = std::move(service_id);
-    ServerInfo.pname    = std::move(process_name);
-    ServerInfo.uname    = std::move(unit_name);
+    ServerInfo.hname    = host_name;
+    ServerInfo.sname    = service_name;
+    ServerInfo.sid      = service_id;
+    ServerInfo.pname    = process_name;
+    ServerInfo.uname    = unit_name;
     ServerInfo.pid      = process_id;
     ServerInfo.tcp_port = tcp_port;
 
@@ -447,33 +508,53 @@ namespace eCAL
     return(true);
   }
 
-  bool CMonitoringImpl::RegisterClient(const eCAL::pb::Sample& sample_)
+  bool CMonitoringImpl::UnregisterServer(const eCAL::pb::Sample& sample_)
   {
-    auto sample_client = sample_.client();
-    std::string  host_name    = sample_client.hname();
-    std::string  service_name = sample_client.sname();
-    std::string  service_id   = sample_client.sid();
-    std::string  process_name = sample_client.pname();
-    std::string  unit_name    = sample_client.uname();
-    int          process_id   = sample_client.pid();
+    const auto& sample_service = sample_.service();
+    const std::string& service_name = sample_service.sname();
+    const std::string& service_id   = sample_service.sid();
+    const int          process_id   = sample_service.pid();
 
     std::stringstream process_id_ss;
     process_id_ss << process_id;
-    std::string service_name_id = service_name + service_id + process_id_ss.str();
+    const std::string service_name_id = service_name + service_id + process_id_ss.str();
 
     // acquire access
-    std::lock_guard<std::mutex> lock(m_clients_map.sync);
+    const std::lock_guard<std::mutex> lock(m_server_map.sync);
+
+    // remove service info
+    m_server_map.map->remove(service_name_id);
+
+    return(true);
+  }
+
+  bool CMonitoringImpl::RegisterClient(const eCAL::pb::Sample& sample_)
+  {
+    const auto& sample_client = sample_.client();
+    const std::string& host_name    = sample_client.hname();
+    const std::string& service_name = sample_client.sname();
+    const std::string& service_id   = sample_client.sid();
+    const std::string& process_name = sample_client.pname();
+    const std::string& unit_name    = sample_client.uname();
+    const int          process_id   = sample_client.pid();
+
+    std::stringstream process_id_ss;
+    process_id_ss << process_id;
+    const std::string service_name_id = service_name + service_id + process_id_ss.str();
+
+    // acquire access
+    const std::lock_guard<std::mutex> lock(m_clients_map.sync);
 
     // try to get service info
     Monitoring::SClientMon& ClientInfo = (*m_clients_map.map)[service_name_id];
 
     // set static content
-    ClientInfo.hname = std::move(host_name);
-    ClientInfo.sname = std::move(service_name);
-    ClientInfo.sid   = std::move(service_id);
-    ClientInfo.pname = std::move(process_name);
-    ClientInfo.uname = std::move(unit_name);
-    ClientInfo.pid = process_id;
+    ClientInfo.hname = host_name;
+    ClientInfo.sname = service_name;
+    ClientInfo.sid   = service_id;
+    ClientInfo.pname = process_name;
+    ClientInfo.uname = unit_name;
+    ClientInfo.pid   = process_id;
 
     // update flexible content
     ClientInfo.rclock++;
@@ -481,9 +562,29 @@ namespace eCAL
     return(true);
   }
 
+  bool CMonitoringImpl::UnregisterClient(const eCAL::pb::Sample& sample_)
+  {
+    const auto& sample_client = sample_.client();
+    const std::string& service_name = sample_client.sname();
+    const std::string& service_id   = sample_client.sid();
+    const int          process_id   = sample_client.pid();
+
+    std::stringstream process_id_ss;
+    process_id_ss << process_id;
+    const std::string service_name_id = service_name + service_id + process_id_ss.str();
+
+    // acquire access
+    const std::lock_guard<std::mutex> lock(m_clients_map.sync);
+
+    // remove service info
+    m_clients_map.map->remove(service_name_id);
+
+    return(true);
+  }
+
   void CMonitoringImpl::RegisterLogMessage(const eCAL::pb::LogMessage& log_msg_)
   {
-    std::lock_guard<std::mutex> lock(m_log_msglist_sync);
+    const std::lock_guard<std::mutex> lock(m_log_msglist_sync);
     m_log_msglist.emplace_back(log_msg_);
   }
 
@@ -500,34 +601,34 @@ namespace eCAL
       break;
     }
     return(pHostMap);
-  };
+  }
 
   void CMonitoringImpl::GetMonitoringPb(eCAL::pb::Monitoring& monitoring_, unsigned int entities_)
   {
     // clear protobuf object
     monitoring_.Clear();
 
-    if (entities_ & Monitoring::Entity::Process)
+    if ((entities_ & Monitoring::Entity::Process) != 0u)
     {
       MonitorProcs(monitoring_);
     }
 
-    if (entities_ & Monitoring::Entity::Publisher)
+    if ((entities_ & Monitoring::Entity::Publisher) != 0u)
     {
       MonitorTopics(m_publisher_map, monitoring_, "publisher");
     }
 
-    if (entities_ & Monitoring::Entity::Subscriber)
+    if ((entities_ & Monitoring::Entity::Subscriber) != 0u)
     {
       MonitorTopics(m_subscriber_map, monitoring_, "subscriber");
     }
 
-    if (entities_ & Monitoring::Entity::Server)
+    if ((entities_ & Monitoring::Entity::Server) != 0u)
     {
       MonitorServer(monitoring_);
     }
 
-    if (entities_ & Monitoring::Entity::Client)
+    if ((entities_ & Monitoring::Entity::Client) != 0u)
     {
       MonitorClients(monitoring_);
     }
@@ -535,13 +636,13 @@ namespace eCAL
 
   void CMonitoringImpl::GetMonitoringStructs(eCAL::Monitoring::SMonitoring& monitoring_, unsigned int entities_)
   {
-    if (entities_ & Monitoring::Entity::Process)
+    if ((entities_ & Monitoring::Entity::Process) != 0u)
     {
       // clear target
       monitoring_.process.clear();
 
       // lock map
-      std::lock_guard<std::mutex> lock(m_process_map.sync);
+      const std::lock_guard<std::mutex> lock(m_process_map.sync);
 
       // reserve target
       monitoring_.process.reserve(m_process_map.map->size());
@@ -554,13 +655,13 @@ namespace eCAL
       }
     }
 
-    if (entities_ & Monitoring::Entity::Publisher)
+    if ((entities_ & Monitoring::Entity::Publisher) != 0u)
     {
       // clear target
       monitoring_.publisher.clear();
 
       // lock map
-      std::lock_guard<std::mutex> lock(m_publisher_map.sync);
+      const std::lock_guard<std::mutex> lock(m_publisher_map.sync);
 
       // reserve target
       monitoring_.publisher.reserve(m_publisher_map.map->size());
@@ -573,13 +674,13 @@ namespace eCAL
       }
     }
 
-    if (entities_ & Monitoring::Entity::Subscriber)
+    if ((entities_ & Monitoring::Entity::Subscriber) != 0u)
     {
       // clear target
       monitoring_.subscriber.clear();
 
       // lock map
-      std::lock_guard<std::mutex> lock(m_subscriber_map.sync);
+      const std::lock_guard<std::mutex> lock(m_subscriber_map.sync);
 
       // reserve target
       monitoring_.subscriber.reserve(m_subscriber_map.map->size());
@@ -592,13 +693,13 @@ namespace eCAL
       }
     }
 
-    if (entities_ & Monitoring::Entity::Server)
+    if ((entities_ & Monitoring::Entity::Server) != 0u)
     {
       // clear target
       monitoring_.server.clear();
 
       // lock map
-      std::lock_guard<std::mutex> lock(m_server_map.sync);
+      const std::lock_guard<std::mutex> lock(m_server_map.sync);
 
       // reserve target
       monitoring_.server.reserve(m_server_map.map->size());
@@ -611,13 +712,13 @@ namespace eCAL
       }
     }
 
-    if (entities_ & Monitoring::Entity::Client)
+    if ((entities_ & Monitoring::Entity::Client) != 0u)
     {
       // clear target
       monitoring_.clients.clear();
 
       // lock map
-      std::lock_guard<std::mutex> lock(m_clients_map.sync);
+      const std::lock_guard<std::mutex> lock(m_clients_map.sync);
 
       // reserve target
       monitoring_.clients.reserve(m_clients_map.map->size());
@@ -637,7 +738,7 @@ namespace eCAL
     logging_.Clear();
 
     // acquire access
-    std::lock_guard<std::mutex> lock(m_log_msglist_sync);
+    const std::lock_guard<std::mutex> lock(m_log_msglist_sync);
 
     LogMessageListT::const_iterator siter = m_log_msglist.begin();
     while (siter != m_log_msglist.end())
@@ -672,7 +773,7 @@ namespace eCAL
   void CMonitoringImpl::MonitorProcs(eCAL::pb::Monitoring& monitoring_)
   {
     // acquire access
-    std::lock_guard<std::mutex> lock(m_process_map.sync);
+    const std::lock_guard<std::mutex> lock(m_process_map.sync);
 
     // iterate map
     m_process_map.map->remove_deprecated();
@@ -715,7 +816,7 @@ namespace eCAL
       pMonProcs->set_dataread(process.second.dataread);
 
       // state
-      auto state = pMonProcs->mutable_state();
+      auto *state = pMonProcs->mutable_state();
 
       // severity state
       state->set_severity(eCAL::pb::eProcessSeverity(process.second.state_severity));
@@ -746,7 +847,7 @@ namespace eCAL
   void CMonitoringImpl::MonitorServer(eCAL::pb::Monitoring& monitoring_)
   {
     // acquire access
-    std::lock_guard<std::mutex> lock(m_server_map.sync);
+    const std::lock_guard<std::mutex> lock(m_server_map.sync);
 
     // iterate map
     m_server_map.map->remove_deprecated();
@@ -796,7 +897,7 @@ namespace eCAL
   void CMonitoringImpl::MonitorClients(eCAL::pb::Monitoring& monitoring_)
   {
     // acquire access
-    std::lock_guard<std::mutex> lock(m_clients_map.sync);
+    const std::lock_guard<std::mutex> lock(m_clients_map.sync);
 
     // iterate map
     m_clients_map.map->remove_deprecated();
@@ -831,7 +932,7 @@ namespace eCAL
   void CMonitoringImpl::MonitorTopics(STopicMonMap& map_, eCAL::pb::Monitoring& monitoring_, const std::string& direction_)
   {
     // acquire access
-    std::lock_guard<std::mutex> lock(map_.sync);
+    const std::lock_guard<std::mutex> lock(map_.sync);
 
     // iterate map
     map_.map->remove_deprecated();
@@ -870,25 +971,25 @@ namespace eCAL
       // topic transport layers
       if (topic.second.tlayer_ecal_udp_mc)
       {
-        auto tlayer = pMonTopic->add_tlayer();
+        auto *tlayer = pMonTopic->add_tlayer();
         tlayer->set_type(eCAL::pb::tl_ecal_udp_mc);
         tlayer->set_confirmed(true);
       }
       if (topic.second.tlayer_ecal_shm)
       {
-        auto tlayer = pMonTopic->add_tlayer();
+        auto *tlayer = pMonTopic->add_tlayer();
         tlayer->set_type(eCAL::pb::tl_ecal_shm);
         tlayer->set_confirmed(true);
       }
       if (topic.second.tlayer_ecal_tcp)
       {
-        auto tlayer = pMonTopic->add_tlayer();
+        auto *tlayer = pMonTopic->add_tlayer();
         tlayer->set_type(eCAL::pb::tl_ecal_tcp);
         tlayer->set_confirmed(true);
       }
       if (topic.second.tlayer_inproc)
       {
-        auto tlayer = pMonTopic->add_tlayer();
+        auto *tlayer = pMonTopic->add_tlayer();
         tlayer->set_type(eCAL::pb::tl_inproc);
         tlayer->set_confirmed(true);
       }
@@ -924,7 +1025,8 @@ namespace eCAL
 
   void CMonitoringImpl::Tokenize(const std::string& str, StrICaseSetT& tokens, const std::string& delimiters, bool trimEmpty)
   {
-    std::string::size_type pos, lastPos = 0;
+    std::string::size_type pos = 0;
+    std::string::size_type lastPos = 0;
 
     for (;;)
     {

--- a/ecal/core/src/mon/ecal_monitoring_impl.h
+++ b/ecal/core/src/mon/ecal_monitoring_impl.h
@@ -43,7 +43,7 @@ namespace eCAL
   {
   public:
     CMonitoringImpl();
-    ~CMonitoringImpl();
+    ~CMonitoringImpl() override = default;
 
     void Create();
     void Destroy();
@@ -59,22 +59,30 @@ namespace eCAL
     int PubMonitoring(bool state_, std::string& name_);
     int PubLogging(bool state_, std::string& name_);
 
+    bool HasSample(const std::string& /* sample_name_ */) override { return(true); };
+    size_t ApplySample(const eCAL::pb::Sample& ecal_sample_, eCAL::pb::eTLayerType /*layer_*/) override;
+
+  protected:
+    bool RegisterProcess(const eCAL::pb::Sample& sample_);
+    bool UnregisterProcess(const eCAL::pb::Sample& sample_);
+
+    bool RegisterServer(const eCAL::pb::Sample& sample_);
+    bool UnregisterServer(const eCAL::pb::Sample& sample_);
+
+    bool RegisterClient(const eCAL::pb::Sample& sample_);
+    bool UnregisterClient(const eCAL::pb::Sample& sample_);
+
     enum ePubSub
     {
       publisher = 1,
       subscriber = 2,
     };
 
-    bool HasSample(const std::string& /* sample_name_ */) { return(true); };
-    size_t ApplySample(const eCAL::pb::Sample& ecal_sample_, eCAL::pb::eTLayerType /*layer_*/);
-
-    bool RegisterProcess(const eCAL::pb::Sample& sample_);
-    bool RegisterServer(const eCAL::pb::Sample& sample_);
-    bool RegisterClient(const eCAL::pb::Sample& sample_);
     bool RegisterTopic(const eCAL::pb::Sample& sample_, enum ePubSub pubsub_type_);
+    bool UnregisterTopic(const eCAL::pb::Sample& sample_, enum ePubSub pubsub_type_);
+
     void RegisterLogMessage(const eCAL::pb::LogMessage& log_msg_);
 
-  protected:
     using TopicMonMapT = eCAL::Util::CExpMap<std::string, eCAL::Monitoring::STopicMon>;
     struct STopicMonMap
     {
@@ -131,7 +139,7 @@ namespace eCAL
 #endif
       }
     };
-    typedef std::set<std::string, InsensitiveCompare> StrICaseSetT;
+    using StrICaseSetT = std::set<std::string, InsensitiveCompare>;
 
     STopicMonMap* GetMap(enum ePubSub pubsub_type_);
 
@@ -162,7 +170,7 @@ namespace eCAL
     SClientMonMap                                m_clients_map;
 
     // logging
-    typedef std::list<eCAL::pb::LogMessage> LogMessageListT;
+    using LogMessageListT = std::list<eCAL::pb::LogMessage>;
     std::mutex                                   m_log_msglist_sync;
     LogMessageListT                              m_log_msglist;
 

--- a/ecal/core/src/pubsub/ecal_publisher.cpp
+++ b/ecal/core/src/pubsub/ecal_publisher.cpp
@@ -167,8 +167,7 @@ namespace eCAL
     m_datawriter->Destroy();
 
     // unregister data writer
-    if(g_pubgate() != nullptr)               g_pubgate()->Unregister(m_datawriter->GetTopicName(), m_datawriter);
-    if(g_registration_provider() != nullptr) g_registration_provider()->UnregisterTopic(m_datawriter->GetTopicName(), m_datawriter->GetTopicID());
+    if(g_pubgate() != nullptr) g_pubgate()->Unregister(m_datawriter->GetTopicName(), m_datawriter);
 #ifndef NDEBUG
     // log it
     if (g_log()) g_log()->Log(log_level_debug1, std::string(m_datawriter->GetTopicName() + "::CPublisher::Destroy"));

--- a/ecal/core/src/pubsub/ecal_subscriber.cpp
+++ b/ecal/core/src/pubsub/ecal_subscriber.cpp
@@ -137,8 +137,7 @@ namespace eCAL
     RemReceiveCallback();
 
     // first unregister data reader
-    if(g_subgate())               g_subgate()->Unregister(m_datareader->GetTopicName(), m_datareader);
-    if(g_registration_provider()) g_registration_provider()->UnregisterTopic(m_datareader->GetTopicName(), m_datareader->GetTopicID());
+    if(g_subgate()) g_subgate()->Unregister(m_datareader->GetTopicName(), m_datareader);
 #ifndef NDEBUG
     // log it
     if (g_log()) g_log()->Log(log_level_debug1, std::string(m_datareader->GetTopicName() + "::CSubscriber::Destroy"));

--- a/ecal/core/src/readwrite/ecal_reader.cpp
+++ b/ecal/core/src/readwrite/ecal_reader.cpp
@@ -34,10 +34,10 @@
 #include "readwrite/ecal_reader_shm.h"
 #include "readwrite/ecal_reader_tcp.h"
 
-#include <algorithm>
 #include <iterator>
 #include <sstream>
 #include <iostream>
+#include <utility>
 
 namespace eCAL
 {
@@ -49,9 +49,6 @@ namespace eCAL
                  m_host_id(Process::internal::GetHostID()),
                  m_pid(Process::GetProcessID()),
                  m_pname(Process::GetProcessName()),
-                 m_topic_name(""),
-                 m_topic_id(""),
-                 m_topic_type(""),
                  m_topic_size(0),
                  m_connected(false),
                  m_read_buf_received(false),
@@ -60,7 +57,6 @@ namespace eCAL
                  m_receive_time(0),
                  m_clock(0),
                  m_clock_old(0),
-                 m_rec_time(),
                  m_freq(0),
                  m_message_drops(0),
                  m_loc_published(false),
@@ -104,12 +100,9 @@ namespace eCAL
     m_topic_id = counter.str();
 
     // set registration expiration
-    std::chrono::milliseconds registration_timeout(Config::GetRegistrationTimeoutMs());
+    const std::chrono::milliseconds registration_timeout(Config::GetRegistrationTimeoutMs());
     m_loc_pub_map.set_expiration(registration_timeout);
     m_ext_pub_map.set_expiration(registration_timeout);
-
-    // set sample hash map expiration
-    //m_sample_hash.set_expiration(std::chrono::milliseconds(500));
 
     // allow to share topic type
     m_use_ttype = Config::IsTopicTypeSharingEnabled();
@@ -121,7 +114,7 @@ namespace eCAL
     SubscribeToLayers();
 
     // register
-    DoRegister(false);
+    Register(false);
 
     // mark as created
     m_created = true;
@@ -143,15 +136,18 @@ namespace eCAL
 
     // reset receive callback
     {
-      std::lock_guard<std::mutex> lock(m_receive_callback_sync);
+      const std::lock_guard<std::mutex> lock(m_receive_callback_sync);
       m_receive_callback = nullptr;
     }
 
     // reset event callback map
     {
-      std::lock_guard<std::mutex> lock(m_event_callback_map_sync);
+      const std::lock_guard<std::mutex> lock(m_event_callback_map_sync);
       m_event_callback_map.clear();
     }
+
+    // unregister
+    Unregister(true);
 
     // reset defaults
     m_created                 = false;
@@ -214,15 +210,14 @@ namespace eCAL
     }
   }
 
-  bool CDataReader::DoRegister(const bool force_)
+  bool CDataReader::Register(const bool force_)
   {
-    if(!m_created)           return(false);
     if(m_topic_name.empty()) return(false);
 
     // create command parameter
     eCAL::pb::Sample ecal_reg_sample;
     ecal_reg_sample.set_cmd_type(eCAL::pb::bct_reg_subscriber);
-    auto ecal_reg_sample_mutable_topic = ecal_reg_sample.mutable_topic();
+    auto *ecal_reg_sample_mutable_topic = ecal_reg_sample.mutable_topic();
     ecal_reg_sample_mutable_topic->set_hname(m_host_name);
     ecal_reg_sample_mutable_topic->set_hid(m_host_id);
     ecal_reg_sample_mutable_topic->set_tname(m_topic_name);
@@ -233,28 +228,28 @@ namespace eCAL
     ecal_reg_sample_mutable_topic->set_tsize(google::protobuf::int32(m_topic_size));
     // udp multicast layer
     {
-      auto tlayer = ecal_reg_sample_mutable_topic->add_tlayer();
+      auto *tlayer = ecal_reg_sample_mutable_topic->add_tlayer();
       tlayer->set_type(eCAL::pb::tl_ecal_udp_mc);
       tlayer->set_version(1);
       tlayer->set_confirmed(m_use_udp_mc_confirmed);
     }
     // shm layer
     {
-      auto tlayer = ecal_reg_sample_mutable_topic->add_tlayer();
+      auto *tlayer = ecal_reg_sample_mutable_topic->add_tlayer();
       tlayer->set_type(eCAL::pb::tl_ecal_shm);
       tlayer->set_version(1);
       tlayer->set_confirmed(m_use_shm_confirmed);
     }
     // tcp layer
     {
-      auto tlayer = ecal_reg_sample_mutable_topic->add_tlayer();
+      auto *tlayer = ecal_reg_sample_mutable_topic->add_tlayer();
       tlayer->set_type(eCAL::pb::tl_ecal_tcp);
       tlayer->set_version(1);
       tlayer->set_confirmed(m_use_tcp_confirmed);
     }
     // inproc layer
     {
-      auto tlayer = ecal_reg_sample_mutable_topic->add_tlayer();
+      auto *tlayer = ecal_reg_sample_mutable_topic->add_tlayer();
       tlayer->set_type(eCAL::pb::tl_inproc);
       tlayer->set_version(1);
       tlayer->set_confirmed(m_use_inproc_confirmed);
@@ -269,7 +264,7 @@ namespace eCAL
     size_t loc_connections(0);
     size_t ext_connections(0);
     {
-      std::lock_guard<std::mutex> lock(m_pub_map_sync);
+      const std::lock_guard<std::mutex> lock(m_pub_map_sync);
       loc_connections = m_loc_pub_map.size();
       ext_connections = m_ext_pub_map.size();
     }
@@ -299,10 +294,32 @@ namespace eCAL
     }
 
     // register subscriber
-    if(g_registration_provider()) g_registration_provider()->RegisterTopic(m_topic_name, m_topic_id, ecal_reg_sample, force_);
+    if(g_registration_provider() != nullptr) g_registration_provider()->RegisterTopic(m_topic_name, m_topic_id, ecal_reg_sample, force_);
 #ifndef NDEBUG
     // log it
     Logging::Log(log_level_debug4, m_topic_name + "::CDataReader::DoRegister");
+#endif
+    return(true);
+  }
+
+  bool CDataReader::Unregister(const bool force_)
+  {
+    if (m_topic_name.empty()) return(false);
+
+    // create command parameter
+    eCAL::pb::Sample ecal_unreg_sample;
+    ecal_unreg_sample.set_cmd_type(eCAL::pb::bct_unreg_subscriber);
+    auto *ecal_reg_sample_mutable_topic = ecal_unreg_sample.mutable_topic();
+    ecal_reg_sample_mutable_topic->set_hname(m_host_name);
+    ecal_reg_sample_mutable_topic->set_hid(m_host_id);
+    ecal_reg_sample_mutable_topic->set_tname(m_topic_name);
+    ecal_reg_sample_mutable_topic->set_tid(m_topic_id);
+
+    // unregister subscriber
+    if (g_registration_provider() != nullptr) g_registration_provider()->UnregisterTopic(m_topic_name, m_topic_id, ecal_unreg_sample, force_);
+#ifndef NDEBUG
+    // log it
+    Logging::Log(log_level_debug4, m_topic_name + "::CDataReader::Unregister");
 #endif
     return(true);
   }
@@ -317,7 +334,7 @@ namespace eCAL
   {
     auto current_val = m_attr.find(attr_name_);
 
-    bool force = current_val == m_attr.end() || current_val->second != attr_value_;
+    const bool force = current_val == m_attr.end() || current_val->second != attr_value_;
     m_attr[attr_name_] = attr_value_;
 
 #ifndef NDEBUG
@@ -326,7 +343,7 @@ namespace eCAL
 #endif
 
     // register it
-    DoRegister(force);
+    Register(force);
 
     return(true);
   }
@@ -343,7 +360,7 @@ namespace eCAL
 #endif
 
     // register it
-    DoRegister(force);
+    Register(force);
 
     return(true);
   }
@@ -354,7 +371,7 @@ namespace eCAL
 
     std::unique_lock<std::mutex> read_buffer_lock(m_read_buf_mutex);
 
-    // No need to wait (for whatever time) if something has been received)
+    // No need to wait (for whatever time) if something has been received
     if (!m_read_buf_received)
     {
       if (rcv_timeout_ms_ < 0)
@@ -380,7 +397,7 @@ namespace eCAL
       m_read_buf_received = false;
 
       // apply time
-      if(time_) *time_ = m_read_time;
+      if(time_ != nullptr) *time_ = m_read_time;
 
       // return success
       return(true);
@@ -392,7 +409,7 @@ namespace eCAL
   size_t CDataReader::AddSample(const std::string& tid_, const char* payload_, size_t size_, long long id_, long long clock_, long long time_, size_t hash_, eCAL::pb::eTLayerType layer_)
   {
     // ensure thread safety
-    std::lock_guard<std::mutex> lock(m_receive_callback_sync);
+    const std::lock_guard<std::mutex> lock(m_receive_callback_sync);
     if (!m_created) return(0);
 
     // store receive layer
@@ -415,7 +432,7 @@ namespace eCAL
 #endif
       return(size_);
     }
-    //   this is a new sample -> store it's hash
+    //   this is a new sample -> store its hash
     m_sample_hash_queue.push_back(hash_);
 
     // limit size of hash queue to the last 64 messages
@@ -430,7 +447,7 @@ namespace eCAL
     // check the current message clock
     // if the function returns false we detected
     //  - a dropped message
-    //  - an out of order message
+    //  - an out-of-order message
     //  - a multiple sent message
     if (!CheckMessageClock(tid_, clock_))
     {
@@ -479,7 +496,7 @@ namespace eCAL
     if(!processed)
     {
       // push sample into read buffer
-      std::lock_guard<std::mutex> read_buffer_lock(m_read_buf_mutex);
+      const std::lock_guard<std::mutex> read_buffer_lock(m_read_buf_mutex);
       m_read_buf.clear();
       m_read_buf.assign(payload_, payload_ + size_);
       m_read_time = time_;
@@ -502,12 +519,12 @@ namespace eCAL
 
     // store receive callback
     {
-      std::lock_guard<std::mutex> lock(m_receive_callback_sync);
+      const std::lock_guard<std::mutex> lock(m_receive_callback_sync);
 #ifndef NDEBUG
       // log it
       Logging::Log(log_level_debug2, m_topic_name + "::CDataReader::AddReceiveCallback");
 #endif
-      m_receive_callback = callback_;
+      m_receive_callback = std::move(callback_);
     }
 
     return(true);
@@ -519,7 +536,7 @@ namespace eCAL
 
     // reset receive callback
     {
-      std::lock_guard<std::mutex> lock(m_receive_callback_sync);
+      const std::lock_guard<std::mutex> lock(m_receive_callback_sync);
 #ifndef NDEBUG
       // log it
       Logging::Log(log_level_debug2, m_topic_name + "::CDataReader::RemReceiveCallback");
@@ -536,12 +553,12 @@ namespace eCAL
 
     // store event callback
     {
-      std::lock_guard<std::mutex> lock(m_event_callback_map_sync);
+      const std::lock_guard<std::mutex> lock(m_event_callback_map_sync);
 #ifndef NDEBUG
       // log it
       Logging::Log(log_level_debug2, m_topic_name + "::CDataReader::AddEventCallback");
 #endif
-      m_event_callback_map[type_] = callback_;
+      m_event_callback_map[type_] = std::move(callback_);
     }
 
     return(true);
@@ -553,7 +570,7 @@ namespace eCAL
 
     // reset event callback
     {
-      std::lock_guard<std::mutex> lock(m_event_callback_map_sync);
+      const std::lock_guard<std::mutex> lock(m_event_callback_map_sync);
 #ifndef NDEBUG
       // log it
       Logging::Log(log_level_debug2, m_topic_name + "::CDataReader::RemEventCallback");
@@ -579,7 +596,7 @@ namespace eCAL
   {
     Connect(tid_, ttype_, tdesc_);
     {
-      std::lock_guard<std::mutex> lock(m_pub_map_sync);
+      const std::lock_guard<std::mutex> lock(m_pub_map_sync);
       m_loc_pub_map[process_id_] = true;
     }
     m_loc_published = true;
@@ -589,7 +606,7 @@ namespace eCAL
   {
     Connect(tid_, ttype_, tdesc_);
     {
-      std::lock_guard<std::mutex> lock(m_pub_map_sync);
+      const std::lock_guard<std::mutex> lock(m_pub_map_sync);
       m_ext_pub_map[host_name_] = true;
     }
     m_ext_published = true;
@@ -721,8 +738,8 @@ namespace eCAL
     else
     {
       // calculate difference
-      long long last_clock = iter->second;
-      long long clock_difference = current_clock_ - last_clock;
+      const long long last_clock = iter->second;
+      const long long clock_difference = current_clock_ - last_clock;
 
       // this is perfect, the next message arrived
       if (clock_difference == 1)
@@ -854,12 +871,12 @@ namespace eCAL
     }
 
     // register without send
-    DoRegister(false);
+    Register(false);
 
     // check connection timeouts
-    std::shared_ptr<std::list<std::string>> loc_timeouts = std::make_shared<std::list<std::string>>();
+    const std::shared_ptr<std::list<std::string>> loc_timeouts = std::make_shared<std::list<std::string>>();
     {
-      std::lock_guard<std::mutex> lock(m_pub_map_sync);
+      const std::lock_guard<std::mutex> lock(m_pub_map_sync);
       m_loc_pub_map.remove_deprecated(loc_timeouts.get());
       m_ext_pub_map.remove_deprecated();
 
@@ -881,7 +898,7 @@ namespace eCAL
       m_receive_time += CMN_DATAREADER_TIMEOUT_DTIME;
       if(m_receive_time > m_receive_timeout)
       {
-        std::lock_guard<std::mutex> lock(m_event_callback_map_sync);
+        const std::lock_guard<std::mutex> lock(m_event_callback_map_sync);
         auto iter = m_event_callback_map.find(sub_event_timeout);
         if(iter != m_event_callback_map.end())
         {
@@ -896,10 +913,10 @@ namespace eCAL
     }
   }
 
-  const std::string CDataReader::GetDescription() const
+  std::string CDataReader::GetDescription() const
   {
     std::string topic_desc;
-    if(g_descgate() && g_descgate()->GetTopicDescription(m_topic_name, topic_desc))
+    if((g_descgate() != nullptr) && g_descgate()->GetTopicDescription(m_topic_name, topic_desc))
     {
       return(topic_desc);
     }

--- a/ecal/core/src/readwrite/ecal_reader.h
+++ b/ecal/core/src/readwrite/ecal_reader.h
@@ -87,14 +87,14 @@ namespace eCAL
 
     size_t GetPublisherCount() const
     {
-      std::lock_guard<std::mutex> lock(m_pub_map_sync);
+      const std::lock_guard<std::mutex> lock(m_pub_map_sync);
       return(m_loc_pub_map.size() + m_ext_pub_map.size());
     }
 
-    const std::string GetTopicName()                              const {return(m_topic_name);}
-    const std::string GetTopicID()                                const {return(m_topic_id);}
-    const std::string GetTypeName()                               const {return(m_topic_type);}
-    const std::string GetDescription()                            const;
+    std::string GetTopicName()   const {return(m_topic_name);}
+    std::string GetTopicID()     const {return(m_topic_id);}
+    std::string GetTypeName()    const {return(m_topic_type);}
+    std::string GetDescription() const;
 
     void RefreshRegistration();
     void CheckReceiveTimeout();
@@ -105,7 +105,9 @@ namespace eCAL
     void SubscribeToLayers();
     void UnsubscribeFromLayers();
 
-    bool DoRegister(const bool force_);
+    bool Register(bool force_);
+    bool Unregister(bool force_);
+
     void Connect(const std::string& tid_, const std::string& ttype_, const std::string& tdesc_);
     void Disconnect();
     bool CheckMessageClock(const std::string& tid_, long long current_clock_);
@@ -124,7 +126,7 @@ namespace eCAL
     QOS::SReaderQOS                           m_qos;
 
     std::atomic<bool>                         m_connected;
-    typedef Util::CExpMap<std::string, bool> ConnectedMapT;
+    using ConnectedMapT = Util::CExpMap<std::string, bool>;
     mutable std::mutex                        m_pub_map_sync;
     ConnectedMapT                             m_loc_pub_map;
     ConnectedMapT                             m_ext_pub_map;
@@ -143,7 +145,7 @@ namespace eCAL
     std::deque<size_t>                        m_sample_hash_queue;
 
     std::mutex                                m_event_callback_map_sync;
-    typedef std::map<eCAL_Subscriber_Event, SubEventCallbackT> EventCallbackMapT;
+    using EventCallbackMapT = std::map<eCAL_Subscriber_Event, SubEventCallbackT>;
     EventCallbackMapT                         m_event_callback_map;
 
     std::atomic<long long>                    m_clock;
@@ -153,7 +155,7 @@ namespace eCAL
 
     std::set<long long>                       m_id_set;
     
-    typedef std::unordered_map<std::string, long long> WriterCounterMapT;
+    using WriterCounterMapT = std::unordered_map<std::string, long long>;
     WriterCounterMapT                         m_writer_counter_map;
     long long                                 m_message_drops;
 

--- a/ecal/core/src/readwrite/ecal_writer.h
+++ b/ecal/core/src/readwrite/ecal_writer.h
@@ -105,7 +105,9 @@ namespace eCAL
     long GetFrequency() const {return(m_freq);}
 
   protected:
-    bool DoRegister(bool force_);
+    bool Register(bool force_);
+    bool Unregister(bool force_);
+
     void Connect(const std::string& tid_, const std::string& ttype_, const std::string& tdesc_);
     void Disconnect();
 

--- a/ecal/core/src/service/ecal_service_client_impl.h
+++ b/ecal/core/src/service/ecal_service_client_impl.h
@@ -72,7 +72,7 @@ namespace eCAL
     // check connection state
     bool IsConnected();
 
-    // called by the eCAL::CClientGate to register a service
+    // called by eCAL::CClientGate to register a service
     void RegisterService(const std::string& key_, unsigned int version_, const SServiceAttr& service_);
 
     // called by eCAL:CClientGate every second to update registration layer
@@ -87,6 +87,9 @@ namespace eCAL
     CServiceClientImpl& operator=(CServiceClientImpl&&) = delete;
 
   protected:
+    void Register(bool force_);
+    void Unregister(bool force_);
+
     void CheckForNewServices();
 
     bool SendRequests(const std::string& host_name_, const std::string& method_name_, const std::string& request_, int timeout_);

--- a/ecal/core/src/service/ecal_service_server_impl.h
+++ b/ecal/core/src/service/ecal_service_server_impl.h
@@ -84,6 +84,9 @@ namespace eCAL
     CServiceServerImpl& operator=(CServiceServerImpl&&) = delete;
 
   protected:
+    void Register(bool force_);
+    void Unregister(bool force_);
+
     /**
      * @brief Calls the request callback based on the request and fills the response
      * 

--- a/ecal/core_pb/src/ecal/core/pb/ecal.proto
+++ b/ecal/core_pb/src/ecal/core/pb/ecal.proto
@@ -38,13 +38,19 @@ message Content                                // topic content
 
 enum eCmdType                                  // command type
 {
-  bct_none           = 0;                      // undefined command
-  bct_set_sample     = 1;                      // set sample content
-  bct_reg_publisher  = 2;                      // register publisher
-  bct_reg_subscriber = 3;                      // register subscriber
-  bct_reg_process    = 4;                      // register process
-  bct_reg_service    = 5;                      // register service
-  bct_reg_client     = 6;                      // register client
+  bct_none             =  0;                   // undefined command
+  bct_set_sample       =  1;                   // set sample content
+  bct_reg_publisher    =  2;                   // register publisher
+  bct_reg_subscriber   =  3;                   // register subscriber
+  bct_reg_process      =  4;                   // register process
+  bct_reg_service      =  5;                   // register service
+  bct_reg_client       =  6;                   // register client
+
+  bct_unreg_publisher  = 12;                   // unregister publisher
+  bct_unreg_subscriber = 13;                   // unregister subscriber
+  bct_unreg_process    = 14;                   // unregister process
+  bct_unreg_service    = 15;                   // unregister service
+  bct_unreg_client     = 16;                   // unregister client
 }
 
 message Sample                                 // a sample is a topic, it's descriptions and it's content

--- a/testing/ecal/expmap_test/src/expmap_test.cpp
+++ b/testing/ecal/expmap_test/src/expmap_test.cpp
@@ -159,3 +159,13 @@ TEST(ExpMap, ExpMapSize)
   expmap["A"] = 1;
   EXPECT_EQ(1, expmap.size());
 }
+
+TEST(ExpMap, ExpMapRemove)
+{
+  eCAL::Util::CExpMap<std::string, int> expmap(std::chrono::milliseconds(200));
+  expmap["A"] = 1;
+  EXPECT_EQ(1, expmap.size());
+  EXPECT_TRUE(expmap.remove("A"));
+  EXPECT_EQ(0, expmap.size());
+  EXPECT_FALSE(expmap.remove("B"));
+}


### PR DESCRIPTION
**Pull request type**

Please check the type of change your PR introduces:
- [X] Feature

**What is the current behavior?**
Destroyed entities (publisher, subscriber, client, server) do not active unregister from the monitoring layer. These entities are removed after a monitoring timeout that can be defined in the global configuration ecal.ini file (`[monitoring]/timeout`).

**What is the new behavior?**
New additional unregistration messages are fired by all ecal entities on destruction. Entities disappear immediately from the monitoring layer.