### PR TITLE
Fix building python bindings on unix systems with both python2 and python3 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,10 @@
 
 cmake_minimum_required(VERSION 3.13)
 
+if (UNIX)
+    set(Python_EXECUTABLE /usr/bin/python3)
+endif (UNIX)	   
+
 include(CMakeDependentOption)
 include("${CMAKE_CURRENT_LIST_DIR}/thirdparty/cmake_functions/qt/qt_msvc_path.cmake")
 


### PR DESCRIPTION
**Pull request type**

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


**What is the current behavior?**

Building ecal with python bindings on a unix system with both python2 and python3 fails. CMake selects python2 instead of python3 when both versions are installed on the same system. 

```
-- Could NOT find Python (missing: Python_INCLUDE_DIRS Development Development.Module Development.Embed) (found version "2.7.18")
-- Python interpreter found: /usr/bin/python2.7                                                                                 
-- Installing Python extensions                                                                                                 
-- Could NOT find Python (missing: Python_INCLUDE_DIRS Development Development.Module Development.Embed) (found version "2.7.18")
CMake Error at cmake/helper_functions/ecal_python_functions.cmake:47 (Python_add_library):                                      
  Unknown CMake command "Python_add_library".                                                                                   
Call Stack (most recent call first):                                                                                            
  lang/python/core/CMakeLists.txt:39 (ecal_add_python_module)           

```
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

**What is the new behavior?**
<!-- Please describe the behavior or changes that are being added by this PR. -->

- CMake checks if its a unix system and sets `Python_EXECUTABLE` to  ```/usr/bin/python3```
```
if (UNIX)
     set(Python_EXECUTABLE /usr/bin/python3)
endif (UNIX)
```

**Does this introduce a breaking change?**

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
