### PR TITLE
clang-tidy/can-be-declared-const-2

### DIFF
--- a/ecal/core/src/custom_tclap/advanced_tclap_output.cpp
+++ b/ecal/core/src/custom_tclap/advanced_tclap_output.cpp
@@ -34,8 +34,8 @@ namespace CustomTclap
 
   void AdvancedTclapOutput::version(TCLAP::CmdLineInterface &cmd)
   {
-    std::string progName = cmd.getProgramName();
-    std::string xversion = cmd.getVersion();
+    const std::string progName = cmd.getProgramName();
+    const std::string xversion = cmd.getVersion();
 
     std::stringstream ss;
 
@@ -75,7 +75,7 @@ namespace CustomTclap
 
     // Create string
 
-    std::string progName = cmd.getProgramName();
+    const std::string progName = cmd.getProgramName();
 
     ss << "PARSE ERROR: " << e.argId() << std::endl
       << "             " << e.error() << std::endl << std::endl;
@@ -117,7 +117,7 @@ namespace CustomTclap
   void AdvancedTclapOutput::shortUsage(TCLAP::CmdLineInterface& cmd, std::ostream& os) const
   {
     std::list<TCLAP::Arg*>                arg_list = cmd.getArgList();
-    std::string                           prog_name = cmd.getProgramName();
+    const std::string                     prog_name = cmd.getProgramName();
     TCLAP::XorHandler                     xor_handler = cmd.getXorHandler();
     std::vector<std::vector<TCLAP::Arg*>> xor_list = xor_handler.getXorList();
 
@@ -159,7 +159,7 @@ namespace CustomTclap
   void AdvancedTclapOutput::longUsage(TCLAP::CmdLineInterface& cmd, std::ostream& os) const
   {
     std::list<TCLAP::Arg*>                arg_list = cmd.getArgList();
-    std::string                           message = cmd.getMessage();
+    const std::string                     message = cmd.getMessage();
     TCLAP::XorHandler                     xor_handler = cmd.getXorHandler();
     std::vector<std::vector<TCLAP::Arg*>> xor_list = xor_handler.getXorList();
 

--- a/ecal/core/src/ecal_clang.cpp
+++ b/ecal/core/src/ecal_clang.cpp
@@ -335,7 +335,7 @@ ECAL_API int pub_send(ECAL_HANDLE handle_, const char* payload_, const int lengt
   eCAL::CPublisher* pub = static_cast<eCAL::CPublisher*>(handle_);
   if(pub)
   {
-    size_t ret = pub->Send(payload_, static_cast<size_t>(length_), time_);
+    const size_t ret = pub->Send(payload_, static_cast<size_t>(length_), time_);
     if(static_cast<int>(ret) == length_)
     {
       return(length_);
@@ -352,7 +352,7 @@ ECAL_API int pub_send_sync(ECAL_HANDLE handle_, const char* payload_, const int 
   eCAL::CPublisher* pub = static_cast<eCAL::CPublisher*>(handle_);
   if (pub)
   {
-    size_t ret = pub->Send(payload_, static_cast<size_t>(length_), time_, acknowledge_timeout_ms_);
+    const size_t ret = pub->Send(payload_, static_cast<size_t>(length_), time_, acknowledge_timeout_ms_);
     if (static_cast<int>(ret) == length_)
     {
       return(length_);
@@ -367,7 +367,7 @@ ECAL_API int pub_send_sync(ECAL_HANDLE handle_, const char* payload_, const int 
 static std::mutex g_pub_event_callback_mtx;
 static void g_pub_event_callback(const char* topic_name_, const struct eCAL::SPubEventCallbackData* data_, const PubEventCallbackCT callback_, void* par_)
 {
-  std::lock_guard<std::mutex> lock(g_pub_event_callback_mtx);
+  const std::lock_guard<std::mutex> lock(g_pub_event_callback_mtx);
   SPubEventCallbackDataC data;
   data.type  = data_->type;
   data.time  = data_->time;
@@ -431,7 +431,7 @@ ECAL_API bool sub_destroy(ECAL_HANDLE handle_)
 /****************************************/
 ECAL_API bool sub_set_qos(ECAL_HANDLE handle_, struct SReaderQOSC qos_) //-V813
 {
-  int ret = eCAL_Sub_SetQOS(handle_, qos_);
+  const int ret = eCAL_Sub_SetQOS(handle_, qos_);
   return(ret == 0);
 }
 
@@ -440,7 +440,7 @@ ECAL_API bool sub_set_qos(ECAL_HANDLE handle_, struct SReaderQOSC qos_) //-V813
 /****************************************/
 ECAL_API bool sub_get_qos(ECAL_HANDLE handle_, struct SReaderQOSC* qos_)
 {
-  int ret = eCAL_Sub_GetQOS(handle_, qos_);
+  const int ret = eCAL_Sub_GetQOS(handle_, qos_);
   return(ret == 0);
 }
 
@@ -524,7 +524,7 @@ ECAL_API bool sub_receive_buffer(ECAL_HANDLE handle_, const char** rcv_buf_, int
 static std::mutex g_sub_receive_callback_mtx;
 static void g_sub_receive_callback(const char* topic_name_, const struct eCAL::SReceiveCallbackData* data_, const ReceiveCallbackCT callback_, void* par_)
 {
-  std::lock_guard<std::mutex> lock(g_sub_receive_callback_mtx);
+  const std::lock_guard<std::mutex> lock(g_sub_receive_callback_mtx);
   SReceiveCallbackDataC data;
   data.buf   = data_->buf;
   data.size  = data_->size;
@@ -558,7 +558,7 @@ ECAL_API bool sub_rem_receive_callback(ECAL_HANDLE handle_)
 static std::mutex g_sub_event_callback_mtx;
 static void g_sub_event_callback(const char* topic_name_, const struct eCAL::SSubEventCallbackData* data_, const SubEventCallbackCT callback_, void* par_)
 {
-  std::lock_guard<std::mutex> lock(g_sub_event_callback_mtx);
+  const std::lock_guard<std::mutex> lock(g_sub_event_callback_mtx);
   SSubEventCallbackDataC data;
   data.type  = data_->type;
   data.time  = data_->time;
@@ -632,7 +632,7 @@ ECAL_API bool dyn_json_sub_destroy(ECAL_HANDLE handle_)
 static std::mutex g_dyn_json_sub_receive_callback_mtx;
 static void g_dyn_json_sub_receive_callback(const char* topic_name_, const struct eCAL::SReceiveCallbackData* data_, const ReceiveCallbackCT callback_, void* par_)
 {
-  std::lock_guard<std::mutex> lock(g_dyn_json_sub_receive_callback_mtx);
+  const std::lock_guard<std::mutex> lock(g_dyn_json_sub_receive_callback_mtx);
   SReceiveCallbackDataC data;
   data.buf   = data_->buf;
   data.size  = data_->size;
@@ -699,10 +699,10 @@ ECAL_API bool server_destroy(ECAL_HANDLE handle_)
 static std::mutex g_server_add_method_callback_mtx;
 static int g_server_method_callback(const std::string& method_, const std::string& req_type_, const std::string& resp_type_, const std::string& request_, std::string& response_, const MethodCallbackCT callback_, void* par_)
 {
-  std::lock_guard<std::mutex> lock(g_server_add_method_callback_mtx);
+  const std::lock_guard<std::mutex> lock(g_server_add_method_callback_mtx);
   void* response(nullptr);
   int   response_len(0);
-  int ret = callback_(method_.data(), req_type_.data(), resp_type_.data(), request_.data(), static_cast<int>(request_.size()), &response, &response_len, par_);
+  const int ret = callback_(method_.data(), req_type_.data(), resp_type_.data(), request_.data(), static_cast<int>(request_.size()), &response, &response_len, par_);
   response_ = std::string(static_cast<char*>(response), static_cast<size_t>(response_len));
   return ret;
 }
@@ -875,7 +875,7 @@ ECAL_API int mon_set_filter_state(const bool state_)
 ECAL_API int mon_get_monitoring(const char** mon_buf_, int* mon_buf_len_)
 {
   std::string mon_s;
-  int size = eCAL::Monitoring::GetMonitoring(mon_s);
+  const int size = eCAL::Monitoring::GetMonitoring(mon_s);
   if(size > 0)
   {
     // this has to be freed by caller (ecal_free_mem)
@@ -908,7 +908,7 @@ ECAL_API int mon_get_monitoring(const char** mon_buf_, int* mon_buf_len_)
 ECAL_API int mon_get_logging(const char** log_buf_, int* log_buf_len_)
 {
   std::string log_s;
-  int size = eCAL::Monitoring::GetLogging(log_s);
+  const int size = eCAL::Monitoring::GetLogging(log_s);
   if(size > 0)
   {
     // this has to be freed by caller (ecal_free_mem)

--- a/ecal/core/src/ecal_config.cpp
+++ b/ecal/core/src/ecal_config.cpp
@@ -102,7 +102,7 @@ namespace eCAL
 
     ECAL_API UdpConfigVersion  GetUdpMulticastConfigVersion()
     {
-      std::string udp_config_version_string = eCALPAR(NET, UDP_MULTICAST_CONFIG_VERSION);
+      const std::string udp_config_version_string = eCALPAR(NET, UDP_MULTICAST_CONFIG_VERSION);
       if (udp_config_version_string == "v1")
         return UdpConfigVersion::V1;
       if (udp_config_version_string == "v2")

--- a/ecal/core/src/ecal_config_reader.cpp
+++ b/ecal/core/src/ecal_config_reader.cpp
@@ -59,13 +59,13 @@ namespace
 
   bool fileexists(const std::string& fname_)
   {
-    std::ifstream infile(fname_);
+    const std::ifstream infile(fname_);
     return infile.good();
   }
 
   bool direxists(const std::string& path_)
   {
-    EcalUtils::Filesystem::FileStatus status(path_, EcalUtils::Filesystem::Current);
+    const EcalUtils::Filesystem::FileStatus status(path_, EcalUtils::Filesystem::Current);
     return (status.IsOk() && (status.GetType() == EcalUtils::Filesystem::Type::Dir));
   }
 
@@ -135,7 +135,7 @@ namespace
     if (path.empty()) { return false; };
 
     // check existence of ecal.ini file
-    EcalUtils::Filesystem::FileStatus ecal_ini_status(path + std::string(ECAL_DEFAULT_CFG), EcalUtils::Filesystem::Current);
+    const EcalUtils::Filesystem::FileStatus ecal_ini_status(path + std::string(ECAL_DEFAULT_CFG), EcalUtils::Filesystem::Current);
     if (ecal_ini_status.IsOk() && (ecal_ini_status.GetType() == EcalUtils::Filesystem::Type::RegularFile))
     {
       return true;
@@ -196,17 +196,17 @@ namespace eCAL
       // -----------------------------------------------------------
       // precedence 1: ECAL_DATA variable (windows and linux)
       // -----------------------------------------------------------
-      std::string ecal_data_path{ eCALDataEnvPath() };
+      const std::string ecal_data_path{ eCALDataEnvPath() };
       
       // -----------------------------------------------------------
       // precedence 2:  cmake configured data paths (linux only)
       // -----------------------------------------------------------
-      std::string cmake_data_path{ eCALDataCMakePath() };
+      const std::string cmake_data_path{ eCALDataCMakePath() };
 
       // -----------------------------------------------------------
       // precedence 3: system data path 
       // -----------------------------------------------------------
-      std::string system_data_path(eCALDataSystemPath());
+      const std::string system_data_path(eCALDataSystemPath());
 
       // Check for first directory which contains the ini file.
       std::vector<std::string> search_directories{ ecal_data_path, cmake_data_path, system_data_path };
@@ -327,15 +327,15 @@ namespace eCAL
       {
          auto sec_pos = full_key.find_last_of('/');
          if (sec_pos == std::string::npos) continue;
-         std::string section = full_key.substr(0, sec_pos);
+         const std::string section = full_key.substr(0, sec_pos);
          std::string key     = full_key.substr(sec_pos+1);
 
          auto val_pos = key.find_first_of(':');
          if (val_pos == std::string::npos) continue;
-         std::string value = key.substr(val_pos+1);
+         const std::string value = key.substr(val_pos+1);
          key = key.substr(0, val_pos);
 
-         SI_Error err = SetValue(section.c_str(), key.c_str(), value.c_str());
+         const SI_Error err = SetValue(section.c_str(), key.c_str(), value.c_str());
          if (err == SI_FAIL)
          {
             std::cout << "Error: Could not overwrite key " << key << " in section " << section << ".";
@@ -381,8 +381,8 @@ namespace eCAL
     // use_udp_mc = 2
     // ------------------------------------------------------------------
     {
-      int use_tcp    = get("publisher", "use_tcp",    0);
-      int use_udp_mc = get("publisher", "use_udp_mc", 0);
+      const int use_tcp    = get("publisher", "use_tcp",    0);
+      const int use_udp_mc = get("publisher", "use_udp_mc", 0);
       if ((use_tcp == 2) && (use_udp_mc == 2))
       {
         std::cerr << "eCAL config error: to set [publisher/use_tcp] and [publisher/use_udp_mc] both on auto mode (2) is not allowed" << std::endl;

--- a/ecal/core/src/ecal_descgate.cpp
+++ b/ecal/core/src/ecal_descgate.cpp
@@ -48,7 +48,7 @@ namespace eCAL
 
   bool CDescGate::ApplyTopicDescription(const std::string& topic_name_, const std::string& topic_type_, const std::string& topic_desc_, const QualityFlags description_quality_)
   {
-    std::unique_lock<std::shared_timed_mutex> lock(m_topic_info_map.sync);
+    const std::unique_lock<std::shared_timed_mutex> lock(m_topic_info_map.sync);
     m_topic_info_map.map->remove_deprecated();
 
     const auto topic_info_it = m_topic_info_map.map->find(topic_name_);
@@ -166,7 +166,7 @@ namespace eCAL
   {
     std::unordered_map<std::string, Util::STopicInfo> map;
 
-    std::shared_lock<std::shared_timed_mutex> lock(m_topic_info_map.sync);
+    const std::shared_lock<std::shared_timed_mutex> lock(m_topic_info_map.sync);
     m_topic_info_map.map->remove_deprecated();
     map.reserve(m_topic_info_map.map->size());
 
@@ -181,7 +181,7 @@ namespace eCAL
   {
     topic_names_.clear();
 
-    std::shared_lock<std::shared_timed_mutex> lock(m_topic_info_map.sync);
+    const std::shared_lock<std::shared_timed_mutex> lock(m_topic_info_map.sync);
     m_topic_info_map.map->remove_deprecated();
     topic_names_.reserve(m_topic_info_map.map->size());
 
@@ -195,7 +195,7 @@ namespace eCAL
   {
     if(topic_name_.empty()) return(false);
 
-    std::shared_lock<std::shared_timed_mutex> lock(m_topic_info_map.sync);
+    const std::shared_lock<std::shared_timed_mutex> lock(m_topic_info_map.sync);
     const auto topic_info_it = m_topic_info_map.map->find(topic_name_);
 
     if(topic_info_it == m_topic_info_map.map->end()) return(false);
@@ -207,7 +207,7 @@ namespace eCAL
   {
     if (topic_name_.empty()) return(false);
 
-    std::shared_lock<std::shared_timed_mutex> lock(m_topic_info_map.sync);
+    const std::shared_lock<std::shared_timed_mutex> lock(m_topic_info_map.sync);
     const auto topic_info_it = m_topic_info_map.map->find(topic_name_);
 
     if (topic_info_it == m_topic_info_map.map->end()) return(false);
@@ -225,7 +225,7 @@ namespace eCAL
   {
     std::tuple<std::string, std::string> service_method_tuple = std::make_tuple(service_name_, method_name_);
 
-    std::unique_lock<std::shared_timed_mutex> lock(m_service_info_map.sync);
+    const std::unique_lock<std::shared_timed_mutex> lock(m_service_info_map.sync);
     m_service_info_map.map->remove_deprecated();
 
     auto service_info_map_it = m_service_info_map.map->find(service_method_tuple);
@@ -265,7 +265,7 @@ namespace eCAL
   {
     std::map<std::tuple<std::string, std::string>, Util::SServiceMethodInfo> map;
 
-    std::shared_lock<std::shared_timed_mutex> lock(m_service_info_map.sync);
+    const std::shared_lock<std::shared_timed_mutex> lock(m_service_info_map.sync);
     m_service_info_map.map->remove_deprecated();
 
     for (const auto& service_info : (*m_service_info_map.map))
@@ -279,7 +279,7 @@ namespace eCAL
   {
     service_method_names_.clear();
 
-    std::shared_lock<std::shared_timed_mutex> lock(m_service_info_map.sync);
+    const std::shared_lock<std::shared_timed_mutex> lock(m_service_info_map.sync);
     m_service_info_map.map->remove_deprecated();
     service_method_names_.reserve(m_service_info_map.map->size());
 
@@ -293,7 +293,7 @@ namespace eCAL
   {
     std::tuple<std::string, std::string> service_method_tuple = std::make_tuple(service_name_, method_name_);
 
-    std::shared_lock<std::shared_timed_mutex> lock(m_service_info_map.sync);
+    const std::shared_lock<std::shared_timed_mutex> lock(m_service_info_map.sync);
     auto service_info_map_it = m_service_info_map.map->find(service_method_tuple);
 
     if (service_info_map_it == m_service_info_map.map->end()) return false;
@@ -306,7 +306,7 @@ namespace eCAL
   {
     std::tuple<std::string, std::string> service_method_tuple = std::make_tuple(service_name_, method_name_);
 
-    std::shared_lock<std::shared_timed_mutex> lock(m_service_info_map.sync);
+    const std::shared_lock<std::shared_timed_mutex> lock(m_service_info_map.sync);
     auto service_info_map_it = m_service_info_map.map->find(service_method_tuple);
 
     if (service_info_map_it == m_service_info_map.map->end()) return false;

--- a/ecal/core/src/ecal_globals.cpp
+++ b/ecal/core/src/ecal_globals.cpp
@@ -59,7 +59,7 @@ namespace eCAL
 
       if (!config_instance->Validate())
       {
-        std::string emsg("Core initialization failed cause by a configuration error.");
+        const std::string emsg("Core initialization failed cause by a configuration error.");
 
         std::cerr                                                                 << std::endl;
         std::cerr << "----------------------------------------------------------" << std::endl;

--- a/ecal/core/src/ecal_log_impl.cpp
+++ b/ecal/core/src/ecal_log_impl.cpp
@@ -143,10 +143,10 @@ namespace eCAL
     if(m_filter_mask_file)
     {
       // check ECAL_DATA
-      std::string ecal_log_path = Util::GeteCALLogPath();
+      const std::string ecal_log_path = Util::GeteCALLogPath();
       if (!isDirectory(ecal_log_path)) return;
 
-      std::string tstring = get_time_str();
+      const std::string tstring = get_time_str();
 
       m_logfile_name = ecal_log_path + tstring + "_" + eCAL::Process::GetUnitName() + "_" + std::to_string(m_pid) + ".log";
       m_logfile = fopen(m_logfile_name.c_str(), "w");
@@ -156,7 +156,7 @@ namespace eCAL
     if(m_filter_mask_udp)
     {
       SSenderAttr attr;
-      bool local_only = !Config::IsNetworkEnabled();
+      const bool local_only = !Config::IsNetworkEnabled();
       // for local only communication we switch to local broadcasting to bypass vpn's or firewalls
       if (local_only)
       {
@@ -182,7 +182,7 @@ namespace eCAL
   {
     if(!m_created) return;
 
-    std::lock_guard<std::mutex> lock(m_log_sync);
+    const std::lock_guard<std::mutex> lock(m_log_sync);
 
     m_udp_sender->Destroy();
 
@@ -193,27 +193,27 @@ namespace eCAL
   }
 
   void CLog::SetLogLevel(const eCAL_Logging_eLogLevel level_)
-  { 
-    std::lock_guard<std::mutex> lock(m_log_sync);
+  {
+    const std::lock_guard<std::mutex> lock(m_log_sync);
     m_level = level_;
   };
 
   eCAL_Logging_eLogLevel CLog::GetLogLevel()
-  { 
-    std::lock_guard<std::mutex> lock(m_log_sync);
+  {
+    const std::lock_guard<std::mutex> lock(m_log_sync);
     return(m_level);
   };
 
   void CLog::Log(const eCAL_Logging_eLogLevel level_, const std::string& msg_)
   {
-    std::lock_guard<std::mutex> lock(m_log_sync);
+    const std::lock_guard<std::mutex> lock(m_log_sync);
 
     if(!m_created) return;
     if(msg_.empty()) return;
 
-    eCAL_Logging_Filter log_con  = level_ & m_filter_mask_con;
-    eCAL_Logging_Filter log_file = level_ & m_filter_mask_file;
-    eCAL_Logging_Filter log_udp  = level_ & m_filter_mask_udp;
+    const eCAL_Logging_Filter log_con  = level_ & m_filter_mask_con;
+    const eCAL_Logging_Filter log_file = level_ & m_filter_mask_file;
+    const eCAL_Logging_Filter log_udp  = level_ & m_filter_mask_udp;
     if(!(log_con | log_file | log_udp)) return;
 
     static eCAL::pb::LogMessage ecal_msg;
@@ -300,28 +300,28 @@ namespace eCAL
 
   void CLog::StartCoreTimer()
   {
-    std::lock_guard<std::mutex> lock(m_log_sync);
+    const std::lock_guard<std::mutex> lock(m_log_sync);
 
     m_core_time_start = std::chrono::steady_clock::now();
   }
 
   void CLog::StopCoreTimer()
   {
-    std::lock_guard<std::mutex> lock(m_log_sync);
+    const std::lock_guard<std::mutex> lock(m_log_sync);
 
     m_core_time = std::chrono::steady_clock::now() - m_core_time_start;
   }
 
   void CLog::SetCoreTime(const std::chrono::duration<double>& time_)
   {
-    std::lock_guard<std::mutex> lock(m_log_sync);
+    const std::lock_guard<std::mutex> lock(m_log_sync);
 
     m_core_time = time_;
   }
 
   std::chrono::duration<double> CLog::GetCoreTime()
   {
-    std::lock_guard<std::mutex> lock(m_log_sync);
+    const std::lock_guard<std::mutex> lock(m_log_sync);
 
     return(m_core_time);
   }

--- a/ecal/core/src/ecal_process.cpp
+++ b/ecal/core/src/ecal_process.cpp
@@ -146,7 +146,7 @@ namespace
     // get all adapter infos
     PIP_ADAPTER_INFO pAdapter(nullptr);
     pAdapter = reinterpret_cast<PIP_ADAPTER_INFO>(adapter_mem.get());
-    DWORD dwStatus = GetAdaptersInfo(pAdapter, &alloc_adapters_size);
+    const DWORD dwStatus = GetAdaptersInfo(pAdapter, &alloc_adapters_size);
     if (dwStatus != ERROR_SUCCESS) return std::make_pair(false, 0);
 
     // iterate adapters and create hash
@@ -234,7 +234,7 @@ namespace eCAL
       sstream << "Multicast cfg version    : v" << static_cast<uint32_t>(Config::GetUdpMulticastConfigVersion()) << std::endl;
       sstream << "Multicast group          : " << Config::GetUdpMulticastGroup() << std::endl;
       sstream << "Multicast mask           : " << Config::GetUdpMulticastMask() << std::endl;
-      int port = Config::GetUdpMulticastPort();
+      const int port = Config::GetUdpMulticastPort();
       sstream << "Multicast ports          : " << port << " - " << port + 10 << std::endl;
       sstream << "Multicast join all IFs   : " << (Config::IsUdpMulticastJoinAllIfEnabled() ? "on" : "off") << std::endl;
       auto bandwidth = Config::GetMaxUdpBandwidthBytesPerSecond();
@@ -505,7 +505,7 @@ namespace eCAL
     {
       PROCESS_MEMORY_COUNTERS pmc;
       GetProcessMemoryInfo(GetCurrentProcess(), &pmc, sizeof(pmc));
-      SIZE_T msize = pmc.PagefileUsage;
+      const SIZE_T msize = pmc.PagefileUsage;
       return(static_cast<unsigned long>(msize));
     }
 
@@ -520,7 +520,7 @@ namespace eCAL
         proc_name = exp_name;
       }
 
-      std::string proc_args = proc_args_;
+      const std::string proc_args = proc_args_;
       if (!proc_args.empty())
       {
         proc_name += " ";

--- a/ecal/core/src/ecal_time.cpp
+++ b/ecal/core/src/ecal_time.cpp
@@ -43,7 +43,7 @@ namespace eCAL
     {
       if (!g_timegate() || !g_timegate()->IsValid())
       {
-        std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
+        const std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
         return(std::chrono::duration_cast<std::chrono::microseconds>(now.time_since_epoch()).count());
       }
       return(g_timegate()->GetMicroSeconds());
@@ -53,7 +53,7 @@ namespace eCAL
     {
       if (!g_timegate() || !g_timegate()->IsValid())
       {
-        std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
+        const std::chrono::system_clock::time_point now = std::chrono::system_clock::now();
         return(std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count());
       }
       return(g_timegate()->GetNanoSeconds());

--- a/ecal/core/src/ecal_timer.cpp
+++ b/ecal/core/src/ecal_timer.cpp
@@ -66,7 +66,7 @@ namespace eCAL
       if (callback_ == nullptr) return;
       if (delay_ > 0) eCAL::Time::sleep_for(std::chrono::milliseconds(delay_));
 
-      std::chrono::nanoseconds loop_duration((long long)timeout_ * 1000LL * 1000LL);
+      const std::chrono::nanoseconds loop_duration((long long)timeout_ * 1000LL * 1000LL);
       m_last_error = std::chrono::nanoseconds(0);
 
       while (!m_stop)

--- a/ecal/core/src/ecal_util.cpp
+++ b/ecal/core/src/ecal_util.cpp
@@ -78,14 +78,14 @@ namespace eCAL
     **/
     void ShutdownProcess(const std::string& process_name_)
     {
-      eCAL::pb::Monitoring monitoring = GetMonitoring();
-      std::string          host_name  = eCAL::Process::GetHostName();
+      const eCAL::pb::Monitoring monitoring = GetMonitoring();
+      const std::string          host_name  = eCAL::Process::GetHostName();
 
       std::vector<int> proc_id_list;
       for (int i = 0; i < monitoring.processes().size(); i++)
       {
         const eCAL::pb::Process& process = monitoring.processes(i);
-        std::string pname = process.pname();
+        const std::string pname = process.pname();
         if ((pname == process_name_)
           && (process.hname() == host_name)
           )
@@ -107,7 +107,7 @@ namespace eCAL
     **/
     void ShutdownProcess(const int process_id_)
     {
-      std::string event_name = EVENT_SHUTDOWN_PROC + std::string("_") + std::to_string(process_id_);
+      const std::string event_name = EVENT_SHUTDOWN_PROC + std::string("_") + std::to_string(process_id_);
       EventHandleT event;
       if (gOpenEvent(&event, event_name))
       {
@@ -122,14 +122,14 @@ namespace eCAL
     **/
     void ShutdownProcesses()
     {
-      eCAL::pb::Monitoring monitoring = GetMonitoring();
-      std::string          host_name  = eCAL::Process::GetHostName();
+      const eCAL::pb::Monitoring monitoring = GetMonitoring();
+      const std::string          host_name  = eCAL::Process::GetHostName();
 
       std::vector<int> proc_id_list;
       for (int i = 0; i < monitoring.processes().size(); i++)
       {
         const eCAL::pb::Process& process = monitoring.processes(i);
-        std::string uname = process.uname();
+        const std::string uname = process.uname();
         if  ((uname != "eCALMon")
           && (uname != "eCALRPCService")
           && (uname != "eCALParam")
@@ -158,14 +158,14 @@ namespace eCAL
     **/
     void ShutdownCore()
     {
-      eCAL::pb::Monitoring monitoring = GetMonitoring();
-      std::string          host_name  = eCAL::Process::GetHostName();
+      const eCAL::pb::Monitoring monitoring = GetMonitoring();
+      const std::string          host_name  = eCAL::Process::GetHostName();
 
       std::vector<int> proc_id_list;
       for (int i = 0; i < monitoring.processes().size(); i++)
       {
         const eCAL::pb::Process& process = monitoring.processes(i);
-        std::string uname = process.uname();
+        const std::string uname = process.uname();
         if (((uname == "eCALMon")
           || (uname == "eCALParam")
           || (uname == "eCALPlay")

--- a/ecal/core/src/ecalc.cpp
+++ b/ecal/core/src/ecalc.cpp
@@ -469,7 +469,7 @@ extern "C"
   ECALC_API ECAL_HANDLE eCAL_Event_gOpenEvent(const char* event_name_)
   {
     eCAL::EventHandleT* event_handle = new eCAL::EventHandleT;
-    bool success = eCAL::gOpenEvent(event_handle, event_name_);
+    const bool success = eCAL::gOpenEvent(event_handle, event_name_);
     if (success)
     {
       return(event_handle);
@@ -518,7 +518,7 @@ extern "C"
 static std::recursive_mutex g_pub_callback_mtx;
 static void g_pub_event_callback(const char* topic_name_, const struct eCAL::SPubEventCallbackData* data_, const PubEventCallbackCT callback_, void* par_)
 {
-  std::lock_guard<std::recursive_mutex> lock(g_pub_callback_mtx);
+  const std::lock_guard<std::recursive_mutex> lock(g_pub_callback_mtx);
   SPubEventCallbackDataC data;
   data.type  = data_->type;
   data.time  = data_->time;
@@ -619,7 +619,7 @@ extern "C"
     if (handle_ == NULL) return(0);
     if (qos_    == NULL) return(0);
     eCAL::CPublisher* pub = static_cast<eCAL::CPublisher*>(handle_);
-    eCAL::QOS::SWriterQOS qos = pub->GetQOS();
+    const eCAL::QOS::SWriterQOS qos = pub->GetQOS();
     qos_->history_kind       = static_cast<eQOSPolicy_HistoryKindC>(qos.history_kind);
     qos_->history_kind_depth = qos.history_kind_depth;;
     qos_->reliability        = static_cast<eQOSPolicy_ReliabilityC>(qos.reliability);
@@ -678,7 +678,7 @@ extern "C"
   {
     if(handle_ == NULL) return(0);
     eCAL::CPublisher* pub = static_cast<eCAL::CPublisher*>(handle_);
-    size_t ret = pub->Send(buf_, static_cast<size_t>(buf_len_), time_);
+    const size_t ret = pub->Send(buf_, static_cast<size_t>(buf_len_), time_);
     if(static_cast<int>(ret) == buf_len_)
     {
       return(buf_len_);
@@ -712,7 +712,7 @@ extern "C"
   {
     if(handle_   == NULL) return(0);
     eCAL::CPublisher* pub = static_cast<eCAL::CPublisher*>(handle_);
-    std::string dump = pub->Dump();
+    const std::string dump = pub->Dump();
     if(!dump.empty())
     {
       return(CopyBuffer(buf_, buf_len_, dump));
@@ -727,7 +727,7 @@ extern "C"
 static std::recursive_mutex g_sub_callback_mtx;
 static void g_sub_receive_callback(const char* topic_name_, const struct eCAL::SReceiveCallbackData* data_, const ReceiveCallbackCT callback_, void* par_)
 {
-  std::lock_guard<std::recursive_mutex> lock(g_sub_callback_mtx);
+  const std::lock_guard<std::recursive_mutex> lock(g_sub_callback_mtx);
   SReceiveCallbackDataC data;
   data.buf   = data_->buf;
   data.size  = data_->size;
@@ -739,7 +739,7 @@ static void g_sub_receive_callback(const char* topic_name_, const struct eCAL::S
 
 static void g_sub_event_callback(const char* topic_name_, const struct eCAL::SSubEventCallbackData* data_, const SubEventCallbackCT callback_, void* par_)
 {
-  std::lock_guard<std::recursive_mutex> lock(g_sub_callback_mtx);
+  const std::lock_guard<std::recursive_mutex> lock(g_sub_callback_mtx);
   SSubEventCallbackDataC data;
   data.type  = data_->type;
   data.time  = data_->time;
@@ -824,7 +824,7 @@ extern "C"
     if (handle_ == NULL) return(0);
     if (qos_ == NULL) return(0);
     eCAL::CSubscriber* sub = static_cast<eCAL::CSubscriber*>(handle_);
-    eCAL::QOS::SReaderQOS qos = sub->GetQOS();
+    const eCAL::QOS::SReaderQOS qos = sub->GetQOS();
     qos_->history_kind       = static_cast<eQOSPolicy_HistoryKindC>(qos.history_kind);
     qos_->history_kind_depth = qos.history_kind_depth;;
     qos_->reliability        = static_cast<eQOSPolicy_ReliabilityC>(qos.reliability);
@@ -932,7 +932,7 @@ extern "C"
   {
     if(handle_ == NULL) return(0);
     eCAL::CSubscriber* sub = static_cast<eCAL::CSubscriber*>(handle_);
-    std::string desc = sub->GetDescription();
+    const std::string desc = sub->GetDescription();
     int buffer_len = CopyBuffer(buf_, buf_len_, desc);
     if (buffer_len != static_cast<int>(desc.size()))
     {
@@ -955,7 +955,7 @@ extern "C"
   {
     if(handle_ == NULL) return(0);
     eCAL::CSubscriber* sub = static_cast<eCAL::CSubscriber*>(handle_);
-    std::string dump = sub->Dump();
+    const std::string dump = sub->Dump();
     if(!dump.empty())
     {
       return(CopyBuffer(buf_, buf_len_, dump));
@@ -967,7 +967,7 @@ extern "C"
 static std::recursive_mutex g_dyn_json_sub_receive_callback_mtx;
 static void g_dyn_json_sub_receive_callback(const char* topic_name_, const struct eCAL::SReceiveCallbackData* data_, const ReceiveCallbackCT callback_, void* par_)
 {
-  std::lock_guard<std::recursive_mutex> lock(g_dyn_json_sub_receive_callback_mtx);
+  const std::lock_guard<std::recursive_mutex> lock(g_dyn_json_sub_receive_callback_mtx);
   SReceiveCallbackDataC data;
   data.buf   = data_->buf;
   data.size  = data_->size;
@@ -1028,7 +1028,7 @@ extern "C"
 /////////////////////////////////////////////////////////
 ECALC_API int eCAL_Time_GetName(void* name_, int name_len_)
 {
-  std::string name = eCAL::Time::GetName();
+  const std::string name = eCAL::Time::GetName();
   if (!name.empty())
   {
     return(CopyBuffer(name_, name_len_, name));
@@ -1092,7 +1092,7 @@ ECALC_API int eCAL_Time_GetStatus(int* error_, char** status_message_, const int
 static std::recursive_mutex g_timer_callback_mtx;
 static void g_timer_callback(const TimerCallbackCT callback_, void* par_)
 {
-  std::lock_guard<std::recursive_mutex> lock(g_timer_callback_mtx);
+  const std::lock_guard<std::recursive_mutex> lock(g_timer_callback_mtx);
   callback_(par_);
 }
 
@@ -1139,10 +1139,10 @@ extern "C"
   static std::recursive_mutex g_request_callback_mtx;
   static int g_method_callback(const std::string& method_, const std::string& req_type_, const std::string& resp_type_, const std::string& request_, std::string& response_, MethodCallbackCT callback_, void* par_)
   {
-    std::lock_guard<std::recursive_mutex> lock(g_request_callback_mtx);
+    const std::lock_guard<std::recursive_mutex> lock(g_request_callback_mtx);
     void* response(nullptr);
     int   response_len(ECAL_ALLOCATE_4ME);
-    int ret_state = callback_(method_.c_str(), req_type_.c_str(), resp_type_.c_str(), request_.c_str(), static_cast<int>(request_.size()), &response, &response_len, par_);
+    const int ret_state = callback_(method_.c_str(), req_type_.c_str(), resp_type_.c_str(), request_.c_str(), static_cast<int>(request_.size()), &response, &response_len, par_);
     if (response_len > 0)
     {
       response_ = std::string(static_cast<const char*>(response), static_cast<size_t>(response_len));
@@ -1152,7 +1152,7 @@ extern "C"
 
   static void g_server_event_callback(const char* name_, const struct eCAL::SServerEventCallbackData* data_, const ServerEventCallbackCT callback_, void* par_)
   {
-    std::lock_guard<std::recursive_mutex> lock(g_sub_callback_mtx);
+    const std::lock_guard<std::recursive_mutex> lock(g_sub_callback_mtx);
     SServerEventCallbackDataC data;
     data.time = data_->time;
     data.type = data_->type;
@@ -1221,7 +1221,7 @@ extern "C"
   {
     if (handle_ == NULL) return(0);
     eCAL::CServiceServer* server = static_cast<eCAL::CServiceServer*>(handle_);
-    std::string service_name = server->GetServiceName();
+    const std::string service_name = server->GetServiceName();
     int buffer_len = CopyBuffer(buf_, buf_len_, service_name);
     if (buffer_len != static_cast<int>(service_name.size()))
     {
@@ -1242,7 +1242,7 @@ extern "C"
   static std::recursive_mutex g_response_callback_mtx;
   static void g_response_callback(const struct eCAL::SServiceResponse& service_response_, const ResponseCallbackCT callback_, void* par_)
   {
-    std::lock_guard<std::recursive_mutex> lock(g_response_callback_mtx);
+    const std::lock_guard<std::recursive_mutex> lock(g_response_callback_mtx);
     struct SServiceResponseC service_response;
     service_response.host_name    = service_response_.host_name.c_str();
     service_response.service_name = service_response_.service_name.c_str();
@@ -1258,7 +1258,7 @@ extern "C"
 
   static void g_client_event_callback(const char* name_, const struct eCAL::SClientEventCallbackData* data_, const ClientEventCallbackCT callback_, void* par_)
   {
-    std::lock_guard<std::recursive_mutex> lock(g_sub_callback_mtx);
+    const std::lock_guard<std::recursive_mutex> lock(g_sub_callback_mtx);
     SClientEventCallbackDataC data;
     data.time = data_->time;
     data.type = data_->type;
@@ -1373,8 +1373,8 @@ ECALC_API int eCAL_Client_GetServiceName(ECAL_HANDLE handle_, void* buf_, int bu
 {
   if (handle_ == NULL) return(0);
   eCAL::CServiceClient* client = static_cast<eCAL::CServiceClient*>(handle_);
-  std::string service_name = client->GetServiceName();
-  int buffer_len = CopyBuffer(buf_, buf_len_, service_name);
+  const std::string service_name = client->GetServiceName();
+  const int buffer_len = CopyBuffer(buf_, buf_len_, service_name);
   if (buffer_len != static_cast<int>(service_name.size()))
   {
     return(0);

--- a/ecal/core/src/io/ecal_memfile_db.cpp
+++ b/ecal/core/src/io/ecal_memfile_db.cpp
@@ -37,7 +37,7 @@ namespace eCAL
   void CMemFileMap::Destroy()
   {
     // lock memory map access
-    std::lock_guard<std::mutex> lock(m_memfile_map_mtx);
+    const std::lock_guard<std::mutex> lock(m_memfile_map_mtx);
 
     // erase memory files from memory map
     for (MemFileMapT::iterator iter = m_memfile_map.begin(); iter != m_memfile_map.end(); ++iter)
@@ -64,10 +64,10 @@ namespace eCAL
     assert(len_ > 0);
 
     // lock memory map access
-    std::lock_guard<std::mutex> lock(m_memfile_map_mtx);
+    const std::lock_guard<std::mutex> lock(m_memfile_map_mtx);
 
     // check for existing memory file
-    MemFileMapT::iterator iter = m_memfile_map.find(name_);
+    const MemFileMapT::iterator iter = m_memfile_map.find(name_);
     if (iter == m_memfile_map.end())
     {
       // create memory file
@@ -108,11 +108,11 @@ namespace eCAL
   bool CMemFileMap::RemoveFile(const std::string& name_, const bool remove_)
   {
     // lock memory map access
-    std::lock_guard<std::mutex> lock(m_memfile_map_mtx);
+    const std::lock_guard<std::mutex> lock(m_memfile_map_mtx);
 
     // erase memory file from memory map
     auto& memfile_map = m_memfile_map;
-    MemFileMapT::iterator iter = memfile_map.find(name_);
+    const MemFileMapT::iterator iter = memfile_map.find(name_);
     if (iter != memfile_map.end())
     {
       auto& memfile_info = iter->second;
@@ -123,7 +123,7 @@ namespace eCAL
       memfile_info.remove |= remove_;
       if (memfile_info.refcnt < 1)
       {
-        bool remove_from_system = memfile_info.remove;
+        const bool remove_from_system = memfile_info.remove;
 
         // unmap memory file
         memfile::os::UnMapFile(memfile_info);
@@ -150,7 +150,7 @@ namespace eCAL
     memfile::os::CheckFileSize(len_, false, mem_file_info_);
 
     // lock memory map access
-    std::lock_guard<std::mutex> lock(m_memfile_map_mtx);
+    const std::lock_guard<std::mutex> lock(m_memfile_map_mtx);
 
     // update/set info
     m_memfile_map[name_] = mem_file_info_;

--- a/ecal/core/src/io/ecal_memfile_pool.cpp
+++ b/ecal/core/src/io/ecal_memfile_pool.cpp
@@ -180,7 +180,7 @@ namespace eCAL
             // clear receive buffer
             receive_buffer.clear();
 
-            bool zero_copy_allowed = mfile_hdr.options.zero_copy != 0;
+            const bool zero_copy_allowed = mfile_hdr.options.zero_copy != 0;
             bool post_process_buffer(false);
             // -------------------------------------------------------------------------
             // zero copy mode
@@ -274,16 +274,16 @@ namespace eCAL
   bool CMemFileObserver::ReadFileHeader(SMemFileHeader& mfile_hdr_)
   {
     // retrieve size of received buffer
-    size_t buffer_size = m_memfile.CurDataSize();
+    const size_t buffer_size = m_memfile.CurDataSize();
 
     // do we have at least the first two bytes ? (hdr_size)
     if (buffer_size >= 2)
     {
       // read received header's size
       m_memfile.Read(&mfile_hdr_, 2, 0);
-      uint16_t rcv_hdr_size = mfile_hdr_.hdr_size;
+      const uint16_t rcv_hdr_size = mfile_hdr_.hdr_size;
       // if the header size exceeds current header version size -> limit it to that one
-      uint16_t hdr_bytes2copy = std::min(rcv_hdr_size, static_cast<uint16_t>(sizeof(SMemFileHeader)));
+      const uint16_t hdr_bytes2copy = std::min(rcv_hdr_size, static_cast<uint16_t>(sizeof(SMemFileHeader)));
       if (hdr_bytes2copy <= buffer_size)
       {
         // now read all we can get from the received header
@@ -322,14 +322,14 @@ namespace eCAL
 
     // stop cleanup thread
     {
-      std::lock_guard<std::mutex> lock(m_do_cleanup_mtx);
+      const std::lock_guard<std::mutex> lock(m_do_cleanup_mtx);
       m_do_cleanup = false;
       m_do_cleanup_cv.notify_one();
     }
     if (m_cleanup_thread.joinable()) m_cleanup_thread.join();
 
     // lock pool
-    std::lock_guard<std::mutex> lock(m_observer_pool_sync);
+    const std::lock_guard<std::mutex> lock(m_observer_pool_sync);
 
     // stop all running observers
     for (auto & observer : m_observer_pool) observer.second->Stop();
@@ -346,7 +346,7 @@ namespace eCAL
     if(memfile_name_.empty()) return(false);
 
     // lock pool
-    std::lock_guard<std::mutex> lock(m_observer_pool_sync);
+    const std::lock_guard<std::mutex> lock(m_observer_pool_sync);
 
     // if the observer is existing reset its timeout
     // this should avoid that an observer will timeout in the case that
@@ -405,7 +405,7 @@ namespace eCAL
   void CMemFileThreadPool::CleanupPool()
   {
     // lock pool
-    std::lock_guard<std::mutex> lock(m_observer_pool_sync);
+    const std::lock_guard<std::mutex> lock(m_observer_pool_sync);
 
     // remove outdated / finished observer from the thread pool
     for(auto observer = m_observer_pool.begin(); observer != m_observer_pool.end();)

--- a/ecal/core/src/io/rcv_sample.cpp
+++ b/ecal/core/src/io/rcv_sample.cpp
@@ -163,9 +163,9 @@ int CSampleReceiver::CSampleReceiveSlot::OnMessageCompleted(std::vector<char> &&
   if(!m_sample_receiver) return(0);
 
   // read sample_name size
-  unsigned short sample_name_size = ((unsigned short*)(msg_buffer_.data()))[0];
+  const unsigned short sample_name_size = ((unsigned short*)(msg_buffer_.data()))[0];
   // read sample_name
-  std::string    sample_name(msg_buffer_.data() + sizeof(sample_name_size));
+  const std::string sample_name(msg_buffer_.data() + sizeof(sample_name_size));
 
   if(m_sample_receiver->HasSample(sample_name))
   {
@@ -235,7 +235,7 @@ int CSampleReceiver::Receive(eCAL::CUDPReceiver* sample_receiver_)
   if(!sample_receiver_) return(-1);
 
   // wait for any incoming message
-  size_t recv_len = sample_receiver_->Receive(m_msg_buffer.data(), m_msg_buffer.size(), 10);
+  const size_t recv_len = sample_receiver_->Receive(m_msg_buffer.data(), m_msg_buffer.size(), 10);
   if(recv_len > 0)
   {
     return(Process(m_msg_buffer.data(), recv_len));
@@ -312,7 +312,7 @@ int CSampleReceiver::Process(const char* sample_buffer_, size_t sample_buffer_le
     unsigned short sample_name_size = 0;
     memcpy(&sample_name_size, ecal_message->payload, 2);
     // read sample_name
-    std::string sample_name = ecal_message->payload + sizeof(sample_name_size);
+    const std::string sample_name = ecal_message->payload + sizeof(sample_name_size);
 
     if (HasSample(sample_name))
     {
@@ -392,7 +392,7 @@ int CSampleReceiver::Process(const char* sample_buffer_, size_t sample_buffer_le
       unsigned short sample_name_size = 0;
       memcpy(&sample_name_size, ecal_message->payload, 2);
       // read sample_name
-      std::string sample_name = ecal_message->payload + sizeof(sample_name_size);
+      const std::string sample_name = ecal_message->payload + sizeof(sample_name_size);
 
       // remove the matching slot if we are not interested in this sample
       if (!HasSample(sample_name))
@@ -425,20 +425,20 @@ int CSampleReceiver::Process(const char* sample_buffer_, size_t sample_buffer_le
 
   // cleanup finished or zombie received slots
   auto diff_time = std::chrono::steady_clock::now() - m_cleanup_start;
-  std::chrono::duration<double> step_time = std::chrono::milliseconds(NET_UDP_RECBUFFER_CLEANUP);
+  const std::chrono::duration<double> step_time = std::chrono::milliseconds(NET_UDP_RECBUFFER_CLEANUP);
   if (diff_time > step_time)
   {
     m_cleanup_start = std::chrono::steady_clock::now();
 
     for (ReceiveSlotMapT::iterator riter = m_receive_slot_map.begin(); riter != m_receive_slot_map.end();)
     {
-      bool finished = riter->second->HasFinished();
-      bool timeouted = riter->second->HasTimedOut(step_time);
+      const bool finished = riter->second->HasFinished();
+      const bool timeouted = riter->second->HasTimedOut(step_time);
       if (finished || timeouted)
       {
 #ifndef NDEBUG
-        int32_t total_len = riter->second->GetMessageTotalLength();
-        int32_t current_len = riter->second->GetMessageCurrentLength();
+        const int32_t total_len = riter->second->GetMessageTotalLength();
+        const int32_t current_len = riter->second->GetMessageCurrentLength();
 #endif
         riter = m_receive_slot_map.erase(riter);
 #ifndef NDEBUG

--- a/ecal/core/src/io/snd_raw_buffer.cpp
+++ b/ecal/core/src/io/snd_raw_buffer.cpp
@@ -51,13 +51,13 @@ namespace eCAL
 {
   size_t CreateSampleBuffer(const std::string& sample_name_, const eCAL::pb::Sample& ecal_sample_, std::vector<char>& payload_)
   {
-    unsigned short sample_name_size = (unsigned short)sample_name_.size() + 1;
+    const unsigned short sample_name_size = (unsigned short)sample_name_.size() + 1;
 #if GOOGLE_PROTOBUF_VERSION >= 3001000
-    size_t         sample_size = ecal_sample_.ByteSizeLong();
+    const size_t         sample_size = ecal_sample_.ByteSizeLong();
 #else
     size_t         sample_size = ecal_sample_.ByteSize();
 #endif
-    size_t         data_size = sizeof(sample_name_size) + sample_name_size + sample_size;
+    const size_t         data_size = sizeof(sample_name_size) + sample_name_size + sample_size;
 
     // create payload buffer with reserved space for first message head
     payload_.resize(data_size + sizeof(struct SUDPMessageHead));

--- a/ecal/core/src/io/snd_sample.cpp
+++ b/ecal/core/src/io/snd_sample.cpp
@@ -45,7 +45,7 @@ namespace eCAL
     size_t sent_sum(0);
 
     std::vector<char> payload_sum;
-    size_t data_size = CreateSampleBuffer(sample_name_, ecal_sample_, payload_sum);
+    const size_t data_size = CreateSampleBuffer(sample_name_, ecal_sample_, payload_sum);
     if (data_size > 0)
     {
       // and send it

--- a/ecal/core/src/io/udp_configurations.cpp
+++ b/ecal/core/src/io/udp_configurations.cpp
@@ -8,7 +8,7 @@ const std::string localhost_udp_address{ "127.255.255.255" };
 
 std::string eCAL::UDP::GetRegistrationMulticastAddress()
 {
-  bool local_only = !Config::IsNetworkEnabled();
+  const bool local_only = !Config::IsNetworkEnabled();
   if (local_only)
   {
     return localhost_udp_address;

--- a/ecal/core/src/io/udp_init.cpp
+++ b/ecal/core/src/io/udp_init.cpp
@@ -42,10 +42,10 @@ namespace eCAL
       if(g_socket_init_refcnt == 1)
       {
 #ifdef ECAL_OS_WINDOWS
-        WORD wVersionRequested = MAKEWORD(2, 2);
+        const WORD wVersionRequested = MAKEWORD(2, 2);
 
         WSADATA wsaData;
-        int err = WSAStartup(wVersionRequested, &wsaData);
+        const int err = WSAStartup(wVersionRequested, &wsaData);
         if (err != 0)
         {
           /* Tell the user that we could not find a usable */

--- a/ecal/core/src/io/udp_receiver_asio.cpp
+++ b/ecal/core/src/io/udp_receiver_asio.cpp
@@ -43,7 +43,7 @@ namespace eCAL
     }
 
     // create socket
-    asio::ip::udp::endpoint listen_endpoint(asio::ip::udp::v4(), static_cast<unsigned short>(attr_.port));
+    const asio::ip::udp::endpoint listen_endpoint(asio::ip::udp::v4(), static_cast<unsigned short>(attr_.port));
     {
       asio::error_code ec;
       m_socket.open(listen_endpoint.protocol(), ec);
@@ -78,7 +78,7 @@ namespace eCAL
     if (!m_unicast)
     {
       // set loopback option
-      asio::ip::multicast::enable_loopback loopback(attr_.loopback);
+      const asio::ip::multicast::enable_loopback loopback(attr_.loopback);
       asio::error_code ec;
       m_socket.set_option(loopback, ec);
       if (ec)
@@ -91,7 +91,7 @@ namespace eCAL
     {
       int rcvbuf = 1024 * 1024;
       if (attr_.rcvbuf > 0) rcvbuf = attr_.rcvbuf;
-      asio::socket_base::receive_buffer_size recbufsize(rcvbuf);
+      const asio::socket_base::receive_buffer_size recbufsize(rcvbuf);
       asio::error_code ec;
       m_socket.set_option(recbufsize, ec);
       if (ec)

--- a/ecal/core/src/io/udp_sender.cpp
+++ b/ecal/core/src/io/udp_sender.cpp
@@ -76,7 +76,7 @@ namespace eCAL
     if (m_broadcast || m_unicast)
     {
       // set unicast packet TTL
-      asio::ip::unicast::hops ttl(attr_.ttl);
+      const asio::ip::unicast::hops ttl(attr_.ttl);
       asio::error_code ec;
       m_socket.set_option(ttl, ec);
       if (ec)
@@ -86,7 +86,7 @@ namespace eCAL
     {
       // set multicast packet TTL
       {
-        asio::ip::multicast::hops ttl(attr_.ttl);
+        const asio::ip::multicast::hops ttl(attr_.ttl);
         asio::error_code ec;
         m_socket.set_option(ttl, ec);
         if (ec)
@@ -95,7 +95,7 @@ namespace eCAL
 
       // set loopback option
       {
-        asio::ip::multicast::enable_loopback loopback(attr_.loopback);
+        const asio::ip::multicast::enable_loopback loopback(attr_.loopback);
         asio::error_code ec;
         m_socket.set_option(loopback);
         if (ec)
@@ -114,7 +114,7 @@ namespace eCAL
 
   size_t CUDPSenderImpl::Send(const void* buf_, const size_t len_, const char* ipaddr_)
   {
-    asio::socket_base::message_flags flags(0);
+    const asio::socket_base::message_flags flags(0);
     asio::error_code                 ec;
     size_t                           sent(0);
     if (ipaddr_ && (ipaddr_[0] != '\0')) sent = m_socket.send_to(asio::buffer(buf_, len_), asio::ip::udp::endpoint(asio::ip::make_address(ipaddr_), m_port), flags, ec);

--- a/ecal/core/src/io/win32/ecal_named_mutex_impl.cpp
+++ b/ecal/core/src/io/win32/ecal_named_mutex_impl.cpp
@@ -81,7 +81,7 @@ namespace eCAL
     m_was_recovered = false;
 
     // wait for access
-    DWORD result = WaitForSingleObject(m_mutex_handle, static_cast<DWORD>(timeout_));
+    const DWORD result = WaitForSingleObject(m_mutex_handle, static_cast<DWORD>(timeout_));
     if (result == WAIT_OBJECT_0)
       return true;
     else if (result == WAIT_ABANDONED)

--- a/ecal/core/src/mon/ecal_monitoring_threads.cpp
+++ b/ecal/core/src/mon/ecal_monitoring_threads.cpp
@@ -36,7 +36,7 @@ namespace eCAL
 {
   static bool IsLocalHost(const eCAL::pb::LogMessage& ecal_message_)
   {
-    std::string host_name = ecal_message_.hname();
+    const std::string host_name = ecal_message_.hname();
     if (host_name.empty())                   return(false);
     if (host_name == Process::GetHostName()) return(true);
     return(false);
@@ -80,7 +80,7 @@ namespace eCAL
   int CLoggingReceiveThread::ThreadFun()
   {
     // wait for any incoming message
-    size_t recv_len = m_log_rcv.Receive(m_msg_buffer.data(), m_msg_buffer.size(), 10);
+    const size_t recv_len = m_log_rcv.Receive(m_msg_buffer.data(), m_msg_buffer.size(), 10);
     if (recv_len > 0)
     {
       m_log_ecal_msg.Clear();

--- a/ecal/core/src/pubsub/ecal_proto_dyn_json_sub.cpp
+++ b/ecal/core/src/pubsub/ecal_proto_dyn_json_sub.cpp
@@ -144,7 +144,7 @@ namespace eCAL
           std::string error_s;
           google::protobuf::FileDescriptorSet proto_desc;
           proto_desc.ParseFromString(topic_desc);
-          std::shared_ptr<google::protobuf::Message> msg(msg_decoder->GetProtoMessageFromDescriptorSet(proto_desc, topic_type, error_s));
+          const std::shared_ptr<google::protobuf::Message> msg(msg_decoder->GetProtoMessageFromDescriptorSet(proto_desc, topic_type, error_s));
           resolver_.reset(google::protobuf::util::NewTypeResolverForDescriptorPool("", msg_decoder->GetDescriptorPool()));
         }
 

--- a/ecal/core/src/service/ecal_tcpclient.cpp
+++ b/ecal/core/src/service/ecal_tcpclient.cpp
@@ -73,7 +73,7 @@ namespace eCAL
       asio::connect(*m_socket, resolver.resolve({ host_name_, std::to_string(port_) }));
       
       // set TCP no delay, so Nagle's algorithm will not stuff multiple messages in one TCP segment
-      asio::ip::tcp::no_delay no_delay_option(true);
+      const asio::ip::tcp::no_delay no_delay_option(true);
       m_socket->set_option(no_delay_option);
 
       // mark as connected
@@ -134,7 +134,7 @@ namespace eCAL
 
   size_t CTcpClient::ExecuteRequest(const std::string& request_, int timeout_, std::string& response_)
   {
-    std::lock_guard<std::mutex> lock(m_socket_write_mutex);
+    const std::lock_guard<std::mutex> lock(m_socket_write_mutex);
 
     if (!m_created) return 0;
 
@@ -145,7 +145,7 @@ namespace eCAL
 
   void CTcpClient::ExecuteRequestAsync(const std::string& request_, int timeout_, AsyncCallbackT callback)
   {
-    std::unique_lock<std::mutex> lock(m_socket_write_mutex);
+    const std::unique_lock<std::mutex> lock(m_socket_write_mutex);
     if (!m_async_request_in_progress)
     {
       m_async_request_in_progress.store(true);
@@ -241,7 +241,7 @@ namespace eCAL
       // read stream header (sync)
       else
       {
-        size_t bytes_read = m_socket->read_some(asio::buffer(&tcp_header, sizeof(tcp_header)));
+        const size_t bytes_read = m_socket->read_some(asio::buffer(&tcp_header, sizeof(tcp_header)));
         if (bytes_read != sizeof(tcp_header)) read_failed = true;
         else                                  read_done   = true;
       }
@@ -280,9 +280,9 @@ namespace eCAL
       {
         const size_t buffer_size(1024);
         char buffer[buffer_size];
-        size_t bytes_left    = rsize - response_.size();
-        size_t bytes_to_read = std::min(buffer_size, bytes_left);
-        size_t bytes_read    = m_socket->read_some(asio::buffer(buffer, bytes_to_read));
+        const size_t bytes_left    = rsize - response_.size();
+        const size_t bytes_to_read = std::min(buffer_size, bytes_left);
+        const size_t bytes_read    = m_socket->read_some(asio::buffer(buffer, bytes_to_read));
         response_ += std::string(buffer, bytes_read);
 
         //std::cout << "CTcpClient::ReceiveResponse read response bytes " << bytes_read << " to " << response_.size() << std::endl;
@@ -326,7 +326,7 @@ namespace eCAL
     //  }
     //);
 
-    std::shared_ptr<STcpHeader> tcp_header = std::make_shared<STcpHeader>();
+    const std::shared_ptr<STcpHeader> tcp_header = std::make_shared<STcpHeader>();
     //std::unique_lock<std::mutex> lock(m_socket_read_mutex);
 
     m_socket->async_read_some(asio::buffer(tcp_header.get(), sizeof(tcp_header)),

--- a/ecal/core/src/sys_usage.cpp
+++ b/ecal/core/src/sys_usage.cpp
@@ -108,14 +108,14 @@ short CpuUsage::GetUsage()
       since the last measurement (made up of kernel + user) and the total
       amount of time the process has run (kernel + user).
       */
-      ULONGLONG ftSysKernelDiff = SubtractTimes(ftSysKernel, m_ftPrevSysKernel);
-      ULONGLONG ftSysUserDiff = SubtractTimes(ftSysUser, m_ftPrevSysUser);
+      const ULONGLONG ftSysKernelDiff = SubtractTimes(ftSysKernel, m_ftPrevSysKernel);
+      const ULONGLONG ftSysUserDiff = SubtractTimes(ftSysUser, m_ftPrevSysUser);
 
-      ULONGLONG ftProcKernelDiff = SubtractTimes(ftProcKernel, m_ftPrevProcKernel);
-      ULONGLONG ftProcUserDiff = SubtractTimes(ftProcUser, m_ftPrevProcUser);
+      const ULONGLONG ftProcKernelDiff = SubtractTimes(ftProcKernel, m_ftPrevProcKernel);
+      const ULONGLONG ftProcUserDiff = SubtractTimes(ftProcUser, m_ftPrevProcUser);
 
-      ULONGLONG nTotalSys =  ftSysKernelDiff + ftSysUserDiff;
-      ULONGLONG nTotalProc = ftProcKernelDiff + ftProcUserDiff;
+      const ULONGLONG nTotalSys =  ftSysKernelDiff + ftSysUserDiff;
+      const ULONGLONG nTotalProc = ftProcKernelDiff + ftProcUserDiff;
 
       if (nTotalSys > 0)
       {
@@ -166,9 +166,9 @@ bool CpuUsage::EnoughTimePassed()
   ULONGLONG dwCurrentTickCount = GetTickCount();
 #else
   #if defined(_WIN64)
-  ULONGLONG dwCurrentTickCount = GetTickCount64();
+  const ULONGLONG dwCurrentTickCount = GetTickCount64();
   #else
-  ULONGLONG dwCurrentTickCount = GetTickCount();
+  const ULONGLONG dwCurrentTickCount = GetTickCount();
   #endif
 #endif
 
@@ -180,7 +180,7 @@ static CpuUsage g_cpu_usage;
 float GetCPULoad()
 {
   static float usage = 0.0f;
-  short cpu_usage = g_cpu_usage.GetUsage();
+  const short cpu_usage = g_cpu_usage.GetUsage();
   // -1 means could not be evaluated yet, do not use that value ..
   if (cpu_usage != -1) usage = 0.98f * usage + 0.02f * static_cast<float>(cpu_usage);
   return(usage * 0.01f);


### PR DESCRIPTION

**Pull request type**

Please check the type of change your PR introduces:
- [X] Other (please describe): 
Clang-Tidy

**What is the current behavior?**
Clang-tidy warnings.

**What is the new behavior?**
Fixed only clang-tidy warning: local variable could be declared as const for all core files

**Does this introduce a breaking change?**

- [X] No
