### PR TITLE
Fixed output folder structure of meas cutter

### DIFF
--- a/app/meas_cutter/src/measurement_converter.cpp
+++ b/app/meas_cutter/src/measurement_converter.cpp
@@ -269,7 +269,7 @@ bool MeasurementConverter::convert()
   }
 
   auto input_path  = EcalUtils::Filesystem::ToNativeSeperators(EcalUtils::Filesystem::CleanPath(_importer.getLoadedPath()));
-  auto output_path = EcalUtils::Filesystem::ToNativeSeperators(EcalUtils::Filesystem::CleanPath(_exporter.getOutputPath()));
+  auto output_path = EcalUtils::Filesystem::ToNativeSeperators(EcalUtils::Filesystem::CleanPath(_exporter.getRootOutputPath()));
 
   auto file_status = EcalUtils::Filesystem::FileStatus(input_path, EcalUtils::Filesystem::OsStyle::Current);
   if (file_status.GetType() == EcalUtils::Filesystem::Type::Dir)

--- a/app/meas_cutter/src/measurement_exporter.cpp
+++ b/app/meas_cutter/src/measurement_exporter.cpp
@@ -27,7 +27,8 @@ MeasurementExporter::MeasurementExporter():
 
 void MeasurementExporter::setPath(const std::string& path, const std::string& base_name, const size_t& max_size_per_file)
 {
-  _output_path = EcalUtils::Filesystem::CleanPath(path + EcalUtils::Filesystem::NativeSeparator(EcalUtils::Filesystem::OsStyle::Current) + eCALMeasCutterUtils::kDefaultFolderOutput, EcalUtils::Filesystem::OsStyle::Current);
+  _root_output_path = EcalUtils::Filesystem::CleanPath(path);
+  _output_path = EcalUtils::Filesystem::CleanPath(_root_output_path + EcalUtils::Filesystem::NativeSeparator(EcalUtils::Filesystem::OsStyle::Current) + eCALMeasCutterUtils::kDefaultFolderOutput, EcalUtils::Filesystem::OsStyle::Current);
   if (!_writer->Open(_output_path))
   {
     throw ExporterException("Unable to create HDF5 protobuf output path " + path + ".");
@@ -83,7 +84,12 @@ void MeasurementExporter::setData(eCALMeasCutterUtils::Timestamp timestamp, cons
   }
 }
 
-std::string MeasurementExporter::getOutputPath()
+std::string MeasurementExporter::getOutputPath() const
 {
   return _output_path;
+}
+
+std::string MeasurementExporter::getRootOutputPath() const
+{
+  return _root_output_path;
 }

--- a/app/meas_cutter/src/measurement_exporter.h
+++ b/app/meas_cutter/src/measurement_exporter.h
@@ -39,12 +39,14 @@ public:
   void        setPath(const std::string& path, const std::string& base_name, const size_t& max_size_per_file);
   void        createChannel(const std::string& channel_name, const eCALMeasCutterUtils::ChannelInfo& channel_info);
   void        setData(eCALMeasCutterUtils::Timestamp timestamp, const eCALMeasCutterUtils::MetaData& meta_data, const std::string& payload);
-  std::string getOutputPath();
+  std::string getOutputPath() const;
+  std::string getRootOutputPath() const;
 
 private:
   std::unique_ptr<eCAL::measurement::base::Writer>      _writer;
   std::string                                           _current_channel_name;
   std::string                                           _output_path;
+  std::string                                           _root_output_path;
 };
 
 class ExporterException : public std::exception


### PR DESCRIPTION
**Pull request type**

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


**What is the current behavior?**

Current output folder structure of meas cutter is

Recording_Folder
+ MEASUREMENT_CONVERTER
    + doc
        + ...
    + *.ecalmeas
    + *.hdf5
+ config.yaml

which is not similar to eCAL's recording folder structure

Recording_Folder
+ doc
+ PC1
    + *.hdf5
+ PC2
    + *.hdf5
+ *.ecalmeas

Issue Number: #1109 

**What is the new behavior?**
The new output folder structure of meas cutter is aligned to eCAL rec

Recording_Folder
+ doc
+ MEASUREMENT_CONVERTER
    + *.hdf5
+ *.ecalmeas

**Does this introduce a breaking change?**

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

**Other information**

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
