### PR TITLE
Python: Zero size messages should create zero size bytearray instead …

### DIFF
--- a/lang/python/core/src/ecal_wrap.cxx
+++ b/lang/python/core/src/ecal_wrap.cxx
@@ -589,7 +589,7 @@ static void c_subscriber_callback(const char* topic_name_, const struct eCAL::SR
   PyGILState_STATE state = PyGILState_Ensure();
 
   PyObject* topic_name = Py_BuildValue("s",  topic_name_);
-  PyObject* content    = Py_BuildValue(python_formatter.c_str(), data_->buf, (Py_ssize_t) data_->size);
+  PyObject* content    = PyByteArray_FromStringAndSize((char*)data_->buf, (Py_ssize_t)data_->size);
   PyObject* time       = Py_BuildValue("L",  data_->time);
 
   PyObject* args = PyTuple_New(3);


### PR DESCRIPTION
…of None. #1104

Please check the type of change your PR introduces:
- [x] Bugfix

**What is the current behavior?**
Sending empty messages creates Python `None` types instead of a zero size Byte array.