### PR TITLE
hotfix/data-loss-memfile-buffering

### DIFF
--- a/ecal/core/src/io/ecal_memfile_sync.cpp
+++ b/ecal/core/src/io/ecal_memfile_sync.cpp
@@ -225,6 +225,11 @@ namespace eCAL
     return m_memfile_name;
   }
 
+  size_t CSyncMemoryFile::GetSize() const
+  {
+    return m_attr.min_size;
+  }
+
   bool CSyncMemoryFile::Create(const std::string& base_name_, size_t size_)
   {
     if (m_created) return false;

--- a/ecal/core/src/io/ecal_memfile_sync.h
+++ b/ecal/core/src/io/ecal_memfile_sync.h
@@ -56,6 +56,7 @@ namespace eCAL
     bool Write(CPayloadWriter& payload_, const SWriterAttr& data_);
 
     std::string GetName() const;
+    size_t GetSize() const;
 
   protected:
     bool Create(const std::string& base_name_, size_t size_);

--- a/ecal/core/src/readwrite/ecal_writer.cpp
+++ b/ecal/core/src/readwrite/ecal_writer.cpp
@@ -352,7 +352,11 @@ namespace eCAL
 
   bool CDataWriter::ShmSetBufferCount(size_t buffering_)
   {
-    if (buffering_ < 1) return false;
+    if (buffering_ < 1)
+    {
+      buffering_ = 1;
+      std::cerr << "CDataWriter::ShmSetBufferCount minimal number of memory files is 1 !" << std::endl;
+    }
     m_buffering_shm = static_cast<size_t>(buffering_);
 
     // adapt number of used memory files

--- a/ecal/core/src/readwrite/ecal_writer.cpp
+++ b/ecal/core/src/readwrite/ecal_writer.cpp
@@ -354,8 +354,8 @@ namespace eCAL
   {
     if (buffering_ < 1)
     {
-      buffering_ = 1;
-      std::cerr << "CDataWriter::ShmSetBufferCount minimal number of memory files is 1 !" << std::endl;
+      Logging::Log(log_level_error, m_topic_name + "::CDataWriter::ShmSetBufferCount minimal number of memory files is 1 !");
+      return false;
     }
     m_buffering_shm = static_cast<size_t>(buffering_);
 

--- a/ecal/core/src/readwrite/ecal_writer.cpp
+++ b/ecal/core/src/readwrite/ecal_writer.cpp
@@ -160,6 +160,9 @@ namespace eCAL
     Logging::Log(log_level_debug1, m_topic_name + "::CDataWriter::Created");
 #endif
 
+    // adapt number of used memory file
+    ShmSetBufferCount(m_buffering_shm);
+
     return(true);
   }
 
@@ -347,18 +350,17 @@ namespace eCAL
     return true;
   }
 
-  bool CDataWriter::ShmSetBufferCount(long buffering_)
+  bool CDataWriter::ShmSetBufferCount(size_t buffering_)
   {
     if (buffering_ < 1) return false;
     m_buffering_shm = static_cast<size_t>(buffering_);
+
+    // adapt number of used memory files
     if (m_created)
     {
-      // we force the shm writer to just prepare the next write operation
-      // if the number of buffered files changed, the writer will adapt this
-      struct SWriterAttr wattr;
-      wattr.buffering = m_buffering_shm;
-      m_writer.shm.PrepareWrite(wattr);
+      m_writer.shm.SetBufferCount(buffering_);
     }
+
     return true;
   }
 

--- a/ecal/core/src/readwrite/ecal_writer.cpp
+++ b/ecal/core/src/readwrite/ecal_writer.cpp
@@ -351,6 +351,14 @@ namespace eCAL
   {
     if (buffering_ < 1) return false;
     m_buffering_shm = static_cast<size_t>(buffering_);
+    if (m_created)
+    {
+      // we force the shm writer to just prepare the next write operation
+      // if the number of buffered files changed, the writer will adapt this
+      struct SWriterAttr wattr;
+      wattr.buffering = m_buffering_shm;
+      m_writer.shm.PrepareWrite(wattr);
+    }
     return true;
   }
 

--- a/ecal/core/src/readwrite/ecal_writer.h
+++ b/ecal/core/src/readwrite/ecal_writer.h
@@ -66,7 +66,7 @@ namespace eCAL
     bool SetLayerMode(TLayer::eTransportLayer layer_, TLayer::eSendMode mode_);
     bool SetMaxBandwidthUDP(long bandwidth_);
 
-    bool ShmSetBufferCount(long buffering_);
+    bool ShmSetBufferCount(size_t buffering_);
     bool ShmEnableZeroCopy(bool state_);
 
     bool ShmSetAcknowledgeTimeout(long long acknowledge_timeout_ms_);
@@ -98,11 +98,8 @@ namespace eCAL
     }
 
     const std::string& GetTopicName() const {return(m_topic_name);}
-    const std::string& GetTopicID() const {return(m_topic_id);}
     const std::string& GetTypeName() const {return(m_topic_type);}
     const std::string& GetDescription() const {return(m_topic_desc);}
-    long long GetClock() const {return(m_clock);}
-    long GetFrequency() const {return(m_freq);}
 
   protected:
     bool Register(bool force_);

--- a/ecal/core/src/readwrite/ecal_writer_shm.cpp
+++ b/ecal/core/src/readwrite/ecal_writer_shm.cpp
@@ -78,12 +78,8 @@ namespace eCAL
     m_memory_file_attr.timeout_open_ms = PUB_MEMFILE_OPEN_TO;
     m_memory_file_attr.timeout_ack_ms  = Config::GetMemfileAckTimeoutMs();
 
-    // create the files
-    for (size_t num(0); num < m_buffer_count; ++num)
-    {
-      auto sync_memfile = std::make_shared<CSyncMemoryFile>(m_memfile_base_name, 0, m_memory_file_attr);
-      m_memory_file_vec.push_back(sync_memfile);
-    }
+    // initialize memory file buffer
+    SetBufferCount(m_buffer_count);
 
     m_created = true;
     return m_created;
@@ -105,66 +101,77 @@ namespace eCAL
     return true;
   }
 
+  bool CDataWriterSHM::SetBufferCount(size_t buffer_count_)
+  {
+    if(buffer_count_ < 1) buffer_count_ = 1;
+
+    size_t memory_file_size(0);
+    if (!m_memory_file_vec.empty())
+    {
+      memory_file_size = m_memory_file_vec[0]->GetSize();
+    }
+    else
+    {
+      memory_file_size = m_memory_file_attr.min_size;
+    }
+
+    // ----------------------------------------------------------------------
+    // REMOVE ME IN ECAL6
+    // ----------------------------------------------------------------------
+    // recreate memory buffer list to stay compatible to older versions
+    // for the case that we have ONE existing buffer
+    // and that single buffer is communicated with an older shm datareader
+    // in this case we need to invalidate (destroy) the existing buffer
+    // and the old datareader will get blind (fail safe)
+    // otherwise it would still receive every n-th write
+    // this state change will lead to some lost samples
+    if ((m_memory_file_vec.size() == 1) && (m_memory_file_vec.size() < buffer_count_))
+    {
+      m_memory_file_vec.clear();
+    }
+    // ----------------------------------------------------------------------
+    // REMOVE ME IN ECAL6
+    // ----------------------------------------------------------------------
+
+    // increase buffer count
+    while (m_memory_file_vec.size() < buffer_count_)
+    {
+      auto sync_memfile = std::make_shared<CSyncMemoryFile>(m_memfile_base_name, memory_file_size, m_memory_file_attr);
+      m_memory_file_vec.push_back(sync_memfile);
+    }
+
+    // decrease buffer count
+    while (m_memory_file_vec.size() > buffer_count_)
+    {
+      m_memory_file_vec.pop_back();
+    }
+
+    return true;
+  }
+
   bool CDataWriterSHM::PrepareWrite(const SWriterAttr& attr_)
   {
     if (!m_created) return false;
-
-    size_t memory_file_size(attr_.len);
-    if (memory_file_size == 0)
-    {
-      // this may happen to just adapt the number of memory files that
-      // should be handled, so we take the size of the existing file[0]
-      if (m_memory_file_vec.empty()) return false;
-      memory_file_size = m_memory_file_vec[0]->GetSize();
-    }
 
     // false signals no rematching / exchanging of
     // connection parameters needed
     bool ret_state(false);
 
-    // check number of requested memory file buffer
+    // adapt number of used memory files if needed
     if (attr_.buffering != m_buffer_count)
     {
-      // store new size and flag change
+      SetBufferCount(attr_.buffering);
+
+      // store new buffer count and flag change
       m_buffer_count = attr_.buffering;
       ret_state |= true;
-
-      // ----------------------------------------------------------------------
-      // REMOVE ME IN ECAL6
-      // ----------------------------------------------------------------------
-      // recreate memory buffer list to stay compatible to older versions
-      // for the case that we have ONE existing buffer
-      // and that single buffer is communicated with an older shm datareader
-      // in this case we need to invalidate (destroy) the existing buffer
-      // and the old datareader will get blind (fail safe)
-      // otherwise it would still receive every n-th write
-      // this state change will lead to some lost samples
-      if ((m_memory_file_vec.size() == 1) && (m_memory_file_vec.size() < m_buffer_count))
-      {
-        m_memory_file_vec.clear();
-      }
-      // ----------------------------------------------------------------------
-      // REMOVE ME IN ECAL6
-      // ----------------------------------------------------------------------
-
-      // increase buffer count
-      while (m_memory_file_vec.size() < m_buffer_count)
-      {
-        auto sync_memfile = std::make_shared<CSyncMemoryFile>(m_memfile_base_name, memory_file_size, m_memory_file_attr);
-        m_memory_file_vec.push_back(sync_memfile);
-      }
-      // decrease buffer count
-      while (m_memory_file_vec.size() > m_buffer_count)
-      {
-        m_memory_file_vec.pop_back();
-      }
     }
 
     // adapt write index if needed
     m_write_idx %= m_memory_file_vec.size();
       
     // check size and reserve new if needed
-    ret_state |= m_memory_file_vec[m_write_idx]->CheckSize(memory_file_size);
+    ret_state |= m_memory_file_vec[m_write_idx]->CheckSize(attr_.len);
 
     return ret_state;
   }

--- a/ecal/core/src/readwrite/ecal_writer_shm.cpp
+++ b/ecal/core/src/readwrite/ecal_writer_shm.cpp
@@ -105,8 +105,8 @@ namespace eCAL
   {
     if (buffer_count_ < 1)
     {
-      buffer_count_ = 1;
-      std::cerr << "CDataWriterSHM::SetBufferCount minimal number of memory files is 1 !" << std::endl;
+      Logging::Log(log_level_error, m_topic_name + "::CDataWriterSHM::SetBufferCount minimal number of memory files is 1 !");
+      return false;
     }
 
     size_t memory_file_size(0);

--- a/ecal/core/src/readwrite/ecal_writer_shm.cpp
+++ b/ecal/core/src/readwrite/ecal_writer_shm.cpp
@@ -103,7 +103,11 @@ namespace eCAL
 
   bool CDataWriterSHM::SetBufferCount(size_t buffer_count_)
   {
-    if(buffer_count_ < 1) buffer_count_ = 1;
+    if (buffer_count_ < 1)
+    {
+      buffer_count_ = 1;
+      std::cerr << "CDataWriterSHM::SetBufferCount minimal number of memory files is 1 !" << std::endl;
+    }
 
     size_t memory_file_size(0);
     if (!m_memory_file_vec.empty())

--- a/ecal/core/src/readwrite/ecal_writer_shm.h
+++ b/ecal/core/src/readwrite/ecal_writer_shm.h
@@ -45,6 +45,7 @@ namespace eCAL
     bool Destroy() final;
 
     bool SetQOS(const QOS::SWriterQOS& qos_) override;
+    bool SetBufferCount(size_t buffer_count_);
 
     bool PrepareWrite(const SWriterAttr& attr_) override;
 
@@ -55,7 +56,7 @@ namespace eCAL
 
     std::string GetConnectionParameter() override;
 
-  protected:
+  protected:      
     size_t                                        m_write_idx    = 0;
     size_t                                        m_buffer_count = 1;
     SSyncMemoryFileAttr                           m_memory_file_attr = {};

--- a/testing/ecal/pubsub_test/src/pubsub_test.cpp
+++ b/testing/ecal/pubsub_test/src/pubsub_test.cpp
@@ -584,7 +584,7 @@ TEST(IO, SimpleMessageCBSHMBufferCount)
   // let's match them
   eCAL::Process::SleepMS(2 * CMN_REGISTRATION_REFRESH);
 
-  int iterations = 100;
+  int iterations = 50;
   for (int i = 0; i < iterations; ++i)
   {
     // send content

--- a/testing/ecal/pubsub_test/src/pubsub_test.cpp
+++ b/testing/ecal/pubsub_test/src/pubsub_test.cpp
@@ -551,6 +551,57 @@ TEST(IO, DynamicCreate)
   eCAL::Finalize();
 }
 
+TEST(IO, SimpleMessageCBSHMBufferCount)
+{
+  // default send string
+  std::string send_s = CreatePayLoad(PAYLOAD_SIZE);
+
+  // initialize eCAL API
+  eCAL::Initialize(0, nullptr, "pubsub_test");
+
+  // publish / subscribe match in the same process
+  eCAL::Util::EnableLoopback(true);
+
+  // create subscriber for topic "A"
+  eCAL::CSubscriber sub("A");
+
+  // create publisher for topic "A"
+  eCAL::CPublisher pub("A");
+  pub.SetLayerMode(eCAL::TLayer::tlayer_all, eCAL::TLayer::smode_off);
+  pub.SetLayerMode(eCAL::TLayer::tlayer_shm, eCAL::TLayer::smode_on);
+  pub.ShmSetBufferCount(2);
+
+  std::atomic<size_t> received_count{ 0 };
+  std::atomic<size_t> received_bytes{ 0 };
+
+  // add callback
+  auto lambda = [&received_count, &received_bytes](const char* /*topic_name_*/, const eCAL::SReceiveCallbackData* data_) {
+    received_bytes += data_->size;
+    ++received_count;
+  };
+  EXPECT_EQ(true, sub.AddReceiveCallback(lambda));
+
+  // let's match them
+  eCAL::Process::SleepMS(2 * CMN_REGISTRATION_REFRESH);
+
+  int iterations = 100;
+  for (int i = 0; i < iterations; ++i)
+  {
+    // send content
+    EXPECT_EQ(send_s.size(), pub.Send(send_s));
+
+    // let the data flow
+    eCAL::Process::SleepMS(DATA_FLOW_TIME);
+  }
+
+  // check callback receive
+  EXPECT_EQ(send_s.size() * iterations, received_bytes);
+  EXPECT_EQ(iterations, received_count);
+
+  // finalize eCAL API
+  eCAL::Finalize();
+}
+
 TEST(IO, ZeroPayloadMessageInProc)
 {
   // default send string


### PR DESCRIPTION
**Pull request type**

Please check the type of change your PR introduces:
- [X] Bugfix

**What is the current behavior?**
If we set  the number of memory files that should be used by a Publisher, the change is applied in the Send/Write action. Because registration of these shm paramters need some time (registration refresh cylce) the first data packages get lost.

Issue Number: #1074

**What is the new behavior?**
The number of handled memory files will be adapted and communicated by ShmSetBufferCount.

**Does this introduce a breaking change?**

- [X] No