### PR TITLE
[bugfix] eCAL::core: Avoid possible deadlocks inside callbacks

### DIFF
--- a/ecal/core/include/ecal/ecal_publisher.h
+++ b/ecal/core/include/ecal/ecal_publisher.h
@@ -32,6 +32,7 @@
 #include <ecal/types/topic_information.h>
 
 #include <chrono>
+#include <memory>
 #include <string>
 
 namespace eCAL
@@ -65,17 +66,17 @@ namespace eCAL
    *            size_t snd_len = pub.Send(send_s);
    * @endcode
   **/
-  class ECAL_API CPublisher
+  class CPublisher
   {
   public:
 
-    static constexpr long long DEFAULT_TIME_ARGUMENT        = -1;
-    static constexpr long long DEFAULT_ACKNOWLEDGE_ARGUMENT = -1;
+    ECAL_API static constexpr long long DEFAULT_TIME_ARGUMENT        = -1;
+    ECAL_API static constexpr long long DEFAULT_ACKNOWLEDGE_ARGUMENT = -1;
 
     /**
      * @brief Constructor. 
     **/
-    CPublisher();
+    ECAL_API CPublisher();
 
     /**
      * @brief Constructor. 
@@ -85,7 +86,7 @@ namespace eCAL
      * @param topic_desc_   Type description (optional). 
     **/
     [[deprecated("Please use the constructor CPublisher(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6.")]]
-    CPublisher(const std::string& topic_name_, const std::string& topic_type_, const std::string& topic_desc_ = "");
+    ECAL_API CPublisher(const std::string& topic_name_, const std::string& topic_type_, const std::string& topic_desc_ = "");
 
     /**
     * @brief Constructor.
@@ -93,7 +94,7 @@ namespace eCAL
     * @param topic_name_   Unique topic name.
     * @param topic_info_   Topic information (encoding, type, descriptor)
     **/
-    CPublisher(const std::string& topic_name_, const STopicInformation& topic_info_);
+    ECAL_API CPublisher(const std::string& topic_name_, const STopicInformation& topic_info_);
 
     /**
     * @brief Constructor.
@@ -101,32 +102,32 @@ namespace eCAL
     * @param topic_name_   Unique topic name.
     * @param topic_info_   Topic information (encoding, type, descriptor)
     **/
-    CPublisher(const std::string& topic_name_);
+    ECAL_API CPublisher(const std::string& topic_name_);
 
     /**
      * @brief Destructor. 
     **/
-    virtual ~CPublisher();
+    ECAL_API virtual ~CPublisher();
 
     /**
      * @brief CPublishers are non-copyable
     **/
-    CPublisher(const CPublisher&) = delete;
+    ECAL_API CPublisher(const CPublisher&) = delete;
 
     /**
      * @brief CPublishers are non-copyable
     **/
-    CPublisher& operator=(const CPublisher&) = delete;
+    ECAL_API CPublisher& operator=(const CPublisher&) = delete;
 
     /**
      * @brief CPublishers are move-enabled
     **/
-    CPublisher(CPublisher&& rhs) noexcept;
+    ECAL_API CPublisher(CPublisher&& rhs) noexcept;
 
     /**
      * @brief CPublishers are move-enabled
     **/
-    CPublisher& operator=(CPublisher&& rhs) noexcept;
+    ECAL_API CPublisher& operator=(CPublisher&& rhs) noexcept;
 
     /**
      * @brief Creates this object. 
@@ -138,7 +139,7 @@ namespace eCAL
      * @return  True if it succeeds, false if it fails. 
     **/
     [[deprecated("Please use the create method bool Create(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6.")]]
-    bool Create(const std::string& topic_name_, const std::string& topic_type_, const std::string& topic_desc_ = "");
+    ECAL_API bool Create(const std::string& topic_name_, const std::string& topic_type_, const std::string& topic_desc_ = "");
 
     /**
      * @brief Creates this object.
@@ -148,7 +149,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails.
     **/
-    bool Create(const std::string& topic_name_, const STopicInformation& topic_info_);
+    ECAL_API bool Create(const std::string& topic_name_, const STopicInformation& topic_info_);
 
     /**
      * @brief Creates this object.
@@ -158,7 +159,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails.
     **/
-    bool Create(const std::string& topic_name_)
+    ECAL_API bool Create(const std::string& topic_name_)
     {
       return Create(topic_name_, STopicInformation());
     }
@@ -169,7 +170,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails. 
     **/
-    bool Destroy();
+    ECAL_API bool Destroy();
 
     /**
      * @brief Setup topic type name.
@@ -179,7 +180,7 @@ namespace eCAL
      * @return  True if it succeeds, false if it fails.
     **/
     [[deprecated("Please use the method bool SetTopicInformation(const STopicInformation& topic_info_) instead. This function will be removed in eCAL6")]]
-    bool SetTypeName(const std::string& topic_type_name_);
+    ECAL_API bool SetTypeName(const std::string& topic_type_name_);
 
     /**
      * @brief Setup topic description. 
@@ -189,7 +190,7 @@ namespace eCAL
      * @return  True if it succeeds, false if it fails. 
     **/
     [[deprecated("Please use the method bool SetTopicInformation(const STopicInformation& topic_info_) instead. This function will be removed in eCAL6")]]
-    bool SetDescription(const std::string& topic_desc_);
+    ECAL_API bool SetDescription(const std::string& topic_desc_);
 
     /**
     * @brief Setup topic information.
@@ -198,7 +199,7 @@ namespace eCAL
     *
     * @return  True if it succeeds, false if it fails.
     **/
-    bool SetTopicInformation(const STopicInformation& topic_info_);
+    ECAL_API bool SetTopicInformation(const STopicInformation& topic_info_);
 
     /**
      * @brief Sets publisher attribute. 
@@ -209,7 +210,7 @@ namespace eCAL
      * @return  True if it succeeds, false if it fails. 
      * @experimental
     **/
-    bool SetAttribute(const std::string& attr_name_, const std::string& attr_value_);
+    ECAL_API bool SetAttribute(const std::string& attr_name_, const std::string& attr_value_);
 
     /**
      * @brief Removes publisher attribute. 
@@ -219,7 +220,7 @@ namespace eCAL
      * @return  True if it succeeds, false if it fails.
      * @experimental
     **/
-    bool ClearAttribute(const std::string& attr_name_);
+    ECAL_API bool ClearAttribute(const std::string& attr_name_);
 
     /**
      * @brief Share topic type.
@@ -228,7 +229,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails.
     **/
-    bool ShareType(bool state_ = true);
+    ECAL_API bool ShareType(bool state_ = true);
 
     /**
      * @brief Share topic description.
@@ -237,7 +238,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails.
     **/
-    bool ShareDescription(bool state_ = true);
+    ECAL_API bool ShareDescription(bool state_ = true);
 
     /**
      * @brief Set publisher quality of service attributes.
@@ -246,14 +247,14 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails.
     **/
-    bool SetQOS(const QOS::SWriterQOS& qos_);
+    ECAL_API bool SetQOS(const QOS::SWriterQOS& qos_);
 
     /**
      * @brief Get current publisher quality of service attributes.
      *
      * @return  Quality of service attributes.
     **/
-    QOS::SWriterQOS GetQOS();
+    ECAL_API QOS::SWriterQOS GetQOS();
 
     /**
      * @brief Set publisher send mode for specific transport layer. 
@@ -263,7 +264,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails. 
     **/
-    bool SetLayerMode(TLayer::eTransportLayer layer_, TLayer::eSendMode mode_);
+    ECAL_API bool SetLayerMode(TLayer::eTransportLayer layer_, TLayer::eSendMode mode_);
 
     /**
      * @brief Set publisher maximum transmit bandwidth for the udp layer.
@@ -272,7 +273,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails.
     **/
-    bool SetMaxBandwidthUDP(long bandwidth_);
+    ECAL_API bool SetMaxBandwidthUDP(long bandwidth_);
 
     /**
      * @brief Set publisher maximum number of used shared memory buffers.
@@ -281,7 +282,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails.
     **/
-    bool ShmSetBufferCount(long buffering_);
+    ECAL_API bool ShmSetBufferCount(long buffering_);
 
     /**
      * @brief Enable zero copy shared memory transport mode.
@@ -310,7 +311,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails.
     **/
-    bool ShmEnableZeroCopy(bool state_);
+    ECAL_API bool ShmEnableZeroCopy(bool state_);
 
     /**
      * @brief Force connected subscribers to send acknowledge event after processing the message and 
@@ -332,7 +333,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails.
     **/
-    bool ShmSetAcknowledgeTimeout(long long acknowledge_timeout_ms_);
+    ECAL_API bool ShmSetAcknowledgeTimeout(long long acknowledge_timeout_ms_);
 
     /**
      * @brief Force connected subscribers to send acknowledge event after processing the message and
@@ -358,7 +359,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails.
     **/
-    bool SetID(long long id_);
+    ECAL_API bool SetID(long long id_);
 
     /**
      * @brief Send a message to all subscribers. 
@@ -369,7 +370,7 @@ namespace eCAL
      *
      * @return  Number of bytes sent. 
     **/
-    size_t Send(const void* buf_, size_t len_, long long time_ = DEFAULT_TIME_ARGUMENT) const;
+    ECAL_API size_t Send(const void* buf_, size_t len_, long long time_ = DEFAULT_TIME_ARGUMENT) const;
 
     /**
      * @brief Send a message to all subscribers.
@@ -379,7 +380,7 @@ namespace eCAL
      *
      * @return  Number of bytes sent.
     **/
-    size_t Send(CPayloadWriter& payload_, long long time_ = DEFAULT_TIME_ARGUMENT) const;
+    ECAL_API size_t Send(CPayloadWriter& payload_, long long time_ = DEFAULT_TIME_ARGUMENT) const;
 
     /**
      * @brief Send a message to all subscribers synchronized with acknowledge timeout (see also ShmSetAcknowledgeTimeout).
@@ -393,7 +394,7 @@ namespace eCAL
      *
      * @return  Number of bytes sent.
     **/
-    size_t Send(const void* buf_, size_t len_, long long time_, long long acknowledge_timeout_ms_) const;
+    ECAL_API size_t Send(const void* buf_, size_t len_, long long time_, long long acknowledge_timeout_ms_) const;
 
     /**
      * @brief Send a message to all subscribers synchronized with acknowledge timeout (see also ShmSetAcknowledgeTimeout).
@@ -408,7 +409,7 @@ namespace eCAL
      * @return  Number of bytes sent.
     **/
     [[deprecated]]
-    size_t SendSynchronized(const void* const buf_, size_t len_, long long time_, long long acknowledge_timeout_ms_) const
+    ECAL_API size_t SendSynchronized(const void* const buf_, size_t len_, long long time_, long long acknowledge_timeout_ms_) const
     {
       return Send(buf_, len_, time_, acknowledge_timeout_ms_);
     }
@@ -424,7 +425,7 @@ namespace eCAL
      *
      * @return  Number of bytes sent.
     **/
-    size_t Send(CPayloadWriter& payload_, long long time_, long long acknowledge_timeout_ms_) const;
+    ECAL_API size_t Send(CPayloadWriter& payload_, long long time_, long long acknowledge_timeout_ms_) const;
 
     /**
      * @brief Send a message to all subscribers.
@@ -434,7 +435,7 @@ namespace eCAL
      *
      * @return  Number of bytes sent.
     **/
-    size_t Send(const std::string& s_, long long time_ = DEFAULT_TIME_ARGUMENT) const
+    ECAL_API size_t Send(const std::string& s_, long long time_ = DEFAULT_TIME_ARGUMENT) const
     {
       return(Send(s_.data(), s_.size(), time_, DEFAULT_ACKNOWLEDGE_ARGUMENT));
     }
@@ -448,7 +449,7 @@ namespace eCAL
      *
      * @return  Number of bytes sent.
     **/
-    size_t Send(const std::string& s_, long long time_, long long acknowledge_timeout_ms_) const
+    ECAL_API size_t Send(const std::string& s_, long long time_, long long acknowledge_timeout_ms_) const
     {
       return(Send(s_.data(), s_.size(), time_, acknowledge_timeout_ms_));
     }
@@ -461,7 +462,7 @@ namespace eCAL
      *
      * @return  True if succeeded, false if not.
     **/
-    bool AddEventCallback(eCAL_Publisher_Event type_, PubEventCallbackT callback_);
+    ECAL_API bool AddEventCallback(eCAL_Publisher_Event type_, PubEventCallbackT callback_);
 
     /**
      * @brief Remove callback function for publisher events.
@@ -470,35 +471,35 @@ namespace eCAL
      *
      * @return  True if succeeded, false if not.
     **/
-    bool RemEventCallback(eCAL_Publisher_Event type_);
+    ECAL_API bool RemEventCallback(eCAL_Publisher_Event type_);
 
     /**
      * @brief Query if the publisher is created. 
      *
      * @return  True if created, false if not. 
     **/
-    bool IsCreated() const {return(m_created);}
+    ECAL_API bool IsCreated() const {return(m_created);}
 
     /**
      * @brief Query if the publisher is subscribed. 
      *
      * @return  true if subscribed, false if not. 
     **/
-    bool IsSubscribed() const;
+    ECAL_API bool IsSubscribed() const;
 
     /**
      * @brief Query the number of subscribers. 
      *
      * @return  Number of subscribers. 
     **/
-    size_t GetSubscriberCount() const;
+    ECAL_API size_t GetSubscriberCount() const;
 
     /**
      * @brief Gets name of the connected topic. 
      *
      * @return  The topic name. 
     **/
-    std::string GetTopicName() const;
+    ECAL_API std::string GetTopicName() const;
 
     /**
      * @brief Gets type of the connected topic. 
@@ -506,7 +507,7 @@ namespace eCAL
      * @return  The type name. 
     **/
     [[deprecated("Please use the method STopicInformation GetTopicInformation() instead. You can extract the typename from the STopicInformation variable. This function will be removed in eCAL6.")]]
-    std::string GetTypeName() const;
+    ECAL_API std::string GetTypeName() const;
 
     /**
      * @brief Gets description of the connected topic. 
@@ -514,14 +515,14 @@ namespace eCAL
      * @return  The description. 
     **/
     [[deprecated("Please use the method STopicInformation GetTopicInformation() instead. You can extract the descriptor from the STopicInformation variable. This function will be removed in eCAL6.")]]
-    std::string GetDescription() const;
+    ECAL_API std::string GetDescription() const;
 
     /**
     * @brief Gets description of the connected topic.
     *
     * @return  The topic information.
     **/
-    STopicInformation GetTopicInformation() const;
+    ECAL_API STopicInformation GetTopicInformation() const;
 
     /**
      * @brief Dump the whole class state into a string. 
@@ -530,7 +531,7 @@ namespace eCAL
      *
      * @return  The dump string. 
     **/
-    std::string Dump(const std::string& indent_ = "") const;
+    ECAL_API std::string Dump(const std::string& indent_ = "") const;
 
   protected:
     void InitializeQOS();
@@ -538,7 +539,7 @@ namespace eCAL
     bool ApplyTopicToDescGate(const std::string& topic_name_, const STopicInformation& topic_info_);
 
     // class members
-    CDataWriter*                     m_datawriter;
+    std::shared_ptr<CDataWriter>     m_datawriter;
     struct ECAL_API QOS::SWriterQOS  m_qos;
     struct ECAL_API TLayer::STLayer  m_tlayer;
     long long                        m_id;

--- a/ecal/core/include/ecal/ecal_subscriber.h
+++ b/ecal/core/include/ecal/ecal_subscriber.h
@@ -29,6 +29,7 @@
 #include <ecal/ecal_qos.h>
 #include <ecal/types/topic_information.h>
 
+#include <memory>
 #include <set>
 #include <string>
 
@@ -79,13 +80,13 @@ namespace eCAL
    * @endcode
   **/
 
-  class ECAL_API CSubscriber
+  class CSubscriber
   {
   public:
     /**
      * @brief Constructor. 
     **/
-    CSubscriber();
+    ECAL_API CSubscriber();
 
     /**
      * @brief Constructor. 
@@ -95,7 +96,7 @@ namespace eCAL
      * @param topic_desc_   Type description (optional for description checking).
      **/
     [[deprecated("Please use the constructor CSubscriber(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6.")]]
-    CSubscriber(const std::string& topic_name_, const std::string& topic_type_, const std::string& topic_desc_ = "");
+    ECAL_API CSubscriber(const std::string& topic_name_, const std::string& topic_type_, const std::string& topic_desc_ = "");
 
     /**
     * @brief Constructor.
@@ -103,39 +104,39 @@ namespace eCAL
     * @param topic_name_   Unique topic name.
     * @param topic_info_   Topic information (encoding, type, descriptor)
     **/
-    CSubscriber(const std::string& topic_name_, const STopicInformation& topic_info_);
+    ECAL_API CSubscriber(const std::string& topic_name_, const STopicInformation& topic_info_);
 
     /**
     * @brief Constructor.
     * 
     * @param topic_name_   Unique topic name.
     **/
-    CSubscriber(const std::string& topic_name_);
+    ECAL_API CSubscriber(const std::string& topic_name_);
 
     /**
      * @brief Destructor. 
     **/
-    virtual ~CSubscriber();
+    ECAL_API virtual ~CSubscriber();
 
     /**
      * @brief CSubscribers are non-copyable
     **/
-    CSubscriber(const CSubscriber&) = delete;
+    ECAL_API CSubscriber(const CSubscriber&) = delete;
 
     /**
      * @brief CSubscribers are non-copyable
     **/
-    CSubscriber& operator=(const CSubscriber&) = delete;
+    ECAL_API CSubscriber& operator=(const CSubscriber&) = delete;
 
     /**
      * @brief CSubscribers are move-enabled
     **/
-    CSubscriber(CSubscriber&& rhs) noexcept;
+    ECAL_API CSubscriber(CSubscriber&& rhs) noexcept;
 
     /**
      * @brief CSubscribers are move-enabled
     **/
-    CSubscriber& operator=(CSubscriber&& rhs) noexcept;
+    ECAL_API CSubscriber& operator=(CSubscriber&& rhs) noexcept;
 
     /**
      * @brief Creates this object. 
@@ -147,7 +148,7 @@ namespace eCAL
      * @return  true if it succeeds, false if it fails. 
     **/
     [[deprecated("Please use the create method bool Create(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6.")]]
-    bool Create(const std::string& topic_name_, const std::string& topic_type_, const std::string& topic_desc_ = "");
+    ECAL_API bool Create(const std::string& topic_name_, const std::string& topic_type_, const std::string& topic_desc_ = "");
 
     /**
      * @brief Creates this object.
@@ -156,7 +157,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails.
     **/
-    bool Create(const std::string& topic_name_) {
+    ECAL_API bool Create(const std::string& topic_name_) {
       return Create(topic_name_, STopicInformation{});
     }
 
@@ -168,14 +169,14 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails.
     **/
-    bool Create(const std::string& topic_name_, const STopicInformation& topic_info_);
+    ECAL_API bool Create(const std::string& topic_name_, const STopicInformation& topic_info_);
 
     /**
      * @brief Destroys this object. 
      *
      * @return  true if it succeeds, false if it fails. 
     **/
-    bool Destroy();
+    ECAL_API bool Destroy();
 
     /**
      * @brief Set subscriber quality of service attributes.
@@ -184,14 +185,14 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails.
     **/
-    bool SetQOS(const QOS::SReaderQOS& qos_);
+    ECAL_API bool SetQOS(const QOS::SReaderQOS& qos_);
 
     /**
      * @brief Get current subscriber quality of service attributes.
      *
      * @return  Quality of service attributes.
     **/
-    QOS::SReaderQOS GetQOS();
+    ECAL_API QOS::SReaderQOS GetQOS();
 
     /**
      * @brief Set a set of id's to prefiltering topics (see CPublisher::SetID).
@@ -200,7 +201,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails.
     **/
-    bool SetID(const std::set<long long>& id_set_);
+    ECAL_API bool SetID(const std::set<long long>& id_set_);
 
     /**
      * @brief Sets subscriber attribute. 
@@ -211,7 +212,7 @@ namespace eCAL
      * @return  True if it succeeds, false if it fails. 
      * @experimental
     **/
-    bool SetAttribute(const std::string& attr_name_, const std::string& attr_value_);
+    ECAL_API bool SetAttribute(const std::string& attr_name_, const std::string& attr_value_);
 
     /**
      * @brief Removes subscriber attribute. 
@@ -221,7 +222,7 @@ namespace eCAL
      * @return  True if it succeeds, false if it fails.
      * @experimental
     **/
-    bool ClearAttribute(const std::string& attr_name_);
+    ECAL_API bool ClearAttribute(const std::string& attr_name_);
 
     /**
      * @brief Receive a message from the publisher. 
@@ -233,7 +234,7 @@ namespace eCAL
      * @return  Length of received buffer. 
     **/
     [[deprecated]]
-    size_t Receive(std::string& buf_, long long* time_ = nullptr, int rcv_timeout_ = 0) const;
+    ECAL_API size_t Receive(std::string& buf_, long long* time_ = nullptr, int rcv_timeout_ = 0) const;
 
     /**
      * @brief Receive a message from the publisher (able to process zero length buffer).
@@ -244,7 +245,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails.
     **/
-    bool ReceiveBuffer(std::string& buf_, long long* time_ = nullptr, int rcv_timeout_ = 0) const;
+    ECAL_API bool ReceiveBuffer(std::string& buf_, long long* time_ = nullptr, int rcv_timeout_ = 0) const;
 
     /**
      * @brief Add callback function for incoming receives. 
@@ -253,14 +254,14 @@ namespace eCAL
      *
      * @return  True if succeeded, false if not. 
     **/
-    bool AddReceiveCallback(ReceiveCallbackT callback_);
+    ECAL_API bool AddReceiveCallback(ReceiveCallbackT callback_);
 
     /**
      * @brief Remove callback function for incoming receives. 
      *
      * @return  True if succeeded, false if not. 
     **/
-    bool RemReceiveCallback();
+    ECAL_API bool RemReceiveCallback();
 
     /**
      * @brief Add callback function for subscriber events.
@@ -270,7 +271,7 @@ namespace eCAL
      *
      * @return  True if succeeded, false if not.
     **/
-    bool AddEventCallback(eCAL_Subscriber_Event type_, SubEventCallbackT callback_);
+    ECAL_API bool AddEventCallback(eCAL_Subscriber_Event type_, SubEventCallbackT callback_);
 
     /**
      * @brief Remove callback function for subscriber events.
@@ -279,28 +280,28 @@ namespace eCAL
      *
      * @return  True if succeeded, false if not.
     **/
-    bool RemEventCallback(eCAL_Subscriber_Event type_);
+    ECAL_API bool RemEventCallback(eCAL_Subscriber_Event type_);
 
     /**
      * @brief Query if this object is created. 
      *
      * @return  true if created, false if not. 
     **/
-    bool IsCreated() const {return(m_created);}
+    ECAL_API bool IsCreated() const {return(m_created);}
 
     /**
      * @brief Query the number of publishers. 
      *
      * @return  Number of publishers. 
     **/
-    size_t GetPublisherCount() const;
+    ECAL_API size_t GetPublisherCount() const;
 
     /**
      * @brief Gets name of the connected topic. 
      *
      * @return  The topic name. 
     **/
-    std::string GetTopicName() const;
+    ECAL_API std::string GetTopicName() const;
 
     /**
      * @brief Gets type of the connected topic. 
@@ -308,7 +309,7 @@ namespace eCAL
      * @return  The type name. 
     **/
     [[deprecated("Please use the method STopicInformation GetTopicInformation() instead. You can extract the typename from the STopicInformation variable. This function will be removed in eCAL6.")]]
-    std::string GetTypeName() const;
+    ECAL_API std::string GetTypeName() const;
 
     /**
      * @brief Gets description of the connected topic. 
@@ -316,14 +317,14 @@ namespace eCAL
      * @return  The description. 
     **/
     [[deprecated("Please use the method STopicInformation GetTopicInformation() instead. You can extract the descriptor from the STopicInformation variable. This function will be removed in eCAL6.")]]
-    std::string GetDescription() const;
+    ECAL_API std::string GetDescription() const;
 
     /**
     * @brief Gets description of the connected topic.
     *
     * @return  The topic information.
     **/
-    STopicInformation GetTopicInformation() const;
+    ECAL_API STopicInformation GetTopicInformation() const;
 
     /**
      * @brief Set the timeout parameter for triggering
@@ -333,7 +334,7 @@ namespace eCAL
      *
      * @return  True if succeeded, false if not.
     **/
-    bool SetTimeout(int timeout_);
+    ECAL_API bool SetTimeout(int timeout_);
 
     /**
      * @brief Dump the whole class state into a string. 
@@ -342,14 +343,14 @@ namespace eCAL
      *
      * @return  The dump sting. 
     **/
-    std::string Dump(const std::string& indent_ = "") const;
+    ECAL_API std::string Dump(const std::string& indent_ = "") const;
 
   protected:
     void InitializeQOS();
     bool ApplyTopicToDescGate(const std::string& topic_name_, const STopicInformation& topic_info_);
 
     // class members
-    CDataReader*                     m_datareader;
+    std::shared_ptr<CDataReader>     m_datareader;
     struct ECAL_API QOS::SReaderQOS  m_qos;
     bool                             m_created;
     bool                             m_initialized;

--- a/ecal/core/src/pubsub/ecal_pubgate.cpp
+++ b/ecal/core/src/pubsub/ecal_pubgate.cpp
@@ -77,7 +77,7 @@ namespace eCAL
     m_share_desc = state_;
   }
 
-  bool CPubGate::Register(const std::string& topic_name_, std::shared_ptr<CDataWriter> datawriter_)
+  bool CPubGate::Register(const std::string& topic_name_, const std::shared_ptr<CDataWriter>& datawriter_)
   {
     if(!m_created) return(false);
 
@@ -88,7 +88,7 @@ namespace eCAL
     return(true);
   }
 
-  bool CPubGate::Unregister(const std::string& topic_name_, std::shared_ptr<CDataWriter> datawriter_)
+  bool CPubGate::Unregister(const std::string& topic_name_, const std::shared_ptr<CDataWriter>& datawriter_)
   {
     if(!m_created) return(false);
     bool ret_state = false;

--- a/ecal/core/src/pubsub/ecal_pubgate.cpp
+++ b/ecal/core/src/pubsub/ecal_pubgate.cpp
@@ -77,18 +77,18 @@ namespace eCAL
     m_share_desc = state_;
   }
 
-  bool CPubGate::Register(const std::string& topic_name_, CDataWriter* datawriter_)
+  bool CPubGate::Register(const std::string& topic_name_, std::shared_ptr<CDataWriter> datawriter_)
   {
     if(!m_created) return(false);
 
     // register writer and multicast group
     const std::unique_lock<std::shared_timed_mutex> lock(m_topic_name_datawriter_sync);
-    m_topic_name_datawriter_map.emplace(std::pair<std::string, CDataWriter*>(topic_name_, datawriter_));
+    m_topic_name_datawriter_map.emplace(std::pair<std::string, std::shared_ptr<CDataWriter>>(topic_name_, datawriter_));
 
     return(true);
   }
 
-  bool CPubGate::Unregister(const std::string& topic_name_, CDataWriter* datawriter_)
+  bool CPubGate::Unregister(const std::string& topic_name_, std::shared_ptr<CDataWriter> datawriter_)
   {
     if(!m_created) return(false);
     bool ret_state = false;

--- a/ecal/core/src/pubsub/ecal_pubgate.h
+++ b/ecal/core/src/pubsub/ecal_pubgate.h
@@ -49,8 +49,8 @@ namespace eCAL
     void ShareDescription(bool state_);
     bool DescriptionShared() const { return m_share_desc; };
 
-    bool Register(const std::string& topic_name_, std::shared_ptr<CDataWriter> datawriter_);
-    bool Unregister(const std::string& topic_name_, std::shared_ptr<CDataWriter> datawriter_);
+    bool Register(const std::string& topic_name_, const std::shared_ptr<CDataWriter>& datawriter_);
+    bool Unregister(const std::string& topic_name_, const std::shared_ptr<CDataWriter>& datawriter_);
 
     void ApplyLocSubRegistration(const eCAL::pb::Sample& ecal_sample_);
     void ApplyLocSubUnregistration(const eCAL::pb::Sample& ecal_sample_);

--- a/ecal/core/src/pubsub/ecal_pubgate.h
+++ b/ecal/core/src/pubsub/ecal_pubgate.h
@@ -49,8 +49,8 @@ namespace eCAL
     void ShareDescription(bool state_);
     bool DescriptionShared() const { return m_share_desc; };
 
-    bool Register(const std::string& topic_name_, CDataWriter* datawriter_);
-    bool Unregister(const std::string& topic_name_, CDataWriter* datawriter_);
+    bool Register(const std::string& topic_name_, std::shared_ptr<CDataWriter> datawriter_);
+    bool Unregister(const std::string& topic_name_, std::shared_ptr<CDataWriter> datawriter_);
 
     void ApplyLocSubRegistration(const eCAL::pb::Sample& ecal_sample_);
     void ApplyLocSubUnregistration(const eCAL::pb::Sample& ecal_sample_);
@@ -67,7 +67,7 @@ namespace eCAL
     bool                      m_share_type;
     bool                      m_share_desc;
 
-    using TopicNameDataWriterMapT = std::multimap<std::string, CDataWriter *>;
+    using TopicNameDataWriterMapT = std::multimap<std::string, std::shared_ptr<CDataWriter>>;
     std::shared_timed_mutex   m_topic_name_datawriter_sync;
     TopicNameDataWriterMapT   m_topic_name_datawriter_map;
   };

--- a/ecal/core/src/pubsub/ecal_publisher.cpp
+++ b/ecal/core/src/pubsub/ecal_publisher.cpp
@@ -139,7 +139,7 @@ namespace eCAL
     if (m_tlayer.sm_inproc == TLayer::smode_none) m_tlayer.sm_inproc = Config::GetPublisherInprocMode();
 
     // create data writer
-    m_datawriter = new CDataWriter();
+    m_datawriter = std::make_shared<CDataWriter>();
     // set qos
     m_datawriter->SetQOS(m_qos);
     // set transport layer
@@ -188,8 +188,7 @@ namespace eCAL
 #endif
 
     // free datawriter
-    delete m_datawriter;
-    m_datawriter = nullptr;
+    m_datawriter.reset();
 
     // we made it :-)
     m_created = false;

--- a/ecal/core/src/pubsub/ecal_subgate.cpp
+++ b/ecal/core/src/pubsub/ecal_subgate.cpp
@@ -155,12 +155,22 @@ namespace eCAL
       const auto& ecal_sample_content_payload = ecal_sample_content.payload();
       g_process_rbytes_sum += ecal_sample_.content().payload().size();
 
-      // apply sample to data reader
-      const std::shared_lock<std::shared_timed_mutex> lock(m_topic_name_datareader_sync);
-      auto res = m_topic_name_datareader_map.equal_range(ecal_sample_.topic().tname());
-      for (auto it = res.first; it != res.second; ++it)
+      std::vector<std::shared_ptr<CDataReader>> readers_to_apply;
+
+      // Lock the sync map only while extracting the relevant shared pointers to the Datareaders.
+      // Apply the samples to the readers afterwards.
       {
-        sent = it->second->AddSample(
+        // apply sample to data reader
+        const std::shared_lock<std::shared_timed_mutex> lock(m_topic_name_datareader_sync);
+        auto res = m_topic_name_datareader_map.equal_range(ecal_sample_.topic().tname());
+        std::transform(
+          res.first, res.second, std::back_inserter(readers_to_apply), [](const auto& match) { return match.second; }
+        );
+      }
+
+      for (const auto& reader : readers_to_apply)
+      {
+        sent = reader->AddSample(
           ecal_sample_.topic().tid(),
           ecal_sample_content_payload.data(),
           ecal_sample_content_payload.size(),
@@ -190,11 +200,22 @@ namespace eCAL
 
     // apply sample to data reader
     size_t sent(0);
-    const std::shared_lock<std::shared_timed_mutex> lock(m_topic_name_datareader_sync);
-    auto res = m_topic_name_datareader_map.equal_range(topic_name_);
-    for (auto it = res.first; it != res.second; ++it)
+    std::vector<std::shared_ptr<CDataReader>> readers_to_apply;
+
+    // Lock the sync map only while extracting the relevant shared pointers to the Datareaders.
+    // Apply the samples to the readers afterwards.
     {
-      sent = it->second->AddSample(topic_id_, buf_, len_, id_, clock_, time_, hash_, layer_);
+      const std::shared_lock<std::shared_timed_mutex> lock(m_topic_name_datareader_sync);
+      auto res = m_topic_name_datareader_map.equal_range(topic_name_);
+      std::transform(
+        res.first, res.second, std::back_inserter(readers_to_apply), [](const auto& match) { return match.second; }
+      );
+    }
+
+
+    for (const auto& reader : readers_to_apply)
+    {
+      sent = reader->AddSample(topic_id_, buf_, len_, id_, clock_, time_, hash_, layer_);
     }
 
     return (sent > 0);

--- a/ecal/core/src/pubsub/ecal_subgate.cpp
+++ b/ecal/core/src/pubsub/ecal_subgate.cpp
@@ -94,7 +94,7 @@ namespace eCAL
     m_created = false;
   }
 
-  bool CSubGate::Register(const std::string& topic_name_, std::shared_ptr<CDataReader> datareader_)
+  bool CSubGate::Register(const std::string& topic_name_, const std::shared_ptr<CDataReader>& datareader_)
   {
     if(!m_created) return(false);
 
@@ -105,7 +105,7 @@ namespace eCAL
     return(true);
   }
 
-  bool CSubGate::Unregister(const std::string& topic_name_, std::shared_ptr<CDataReader> datareader_)
+  bool CSubGate::Unregister(const std::string& topic_name_, const std::shared_ptr<CDataReader>& datareader_)
   {
     if(!m_created) return(false);
     bool ret_state = false;

--- a/ecal/core/src/pubsub/ecal_subgate.cpp
+++ b/ecal/core/src/pubsub/ecal_subgate.cpp
@@ -94,18 +94,18 @@ namespace eCAL
     m_created = false;
   }
 
-  bool CSubGate::Register(const std::string& topic_name_, CDataReader* datareader_)
+  bool CSubGate::Register(const std::string& topic_name_, std::shared_ptr<CDataReader> datareader_)
   {
     if(!m_created) return(false);
 
     // register reader
     const std::unique_lock<std::shared_timed_mutex> lock(m_topic_name_datareader_sync);
-    m_topic_name_datareader_map.emplace(std::pair<std::string, CDataReader*>(topic_name_, datareader_));
+    m_topic_name_datareader_map.emplace(std::pair<std::string, std::shared_ptr<CDataReader>>(topic_name_, datareader_));
 
     return(true);
   }
 
-  bool CSubGate::Unregister(const std::string& topic_name_, CDataReader* datareader_)
+  bool CSubGate::Unregister(const std::string& topic_name_, std::shared_ptr<CDataReader> datareader_)
   {
     if(!m_created) return(false);
     bool ret_state = false;

--- a/ecal/core/src/pubsub/ecal_subgate.h
+++ b/ecal/core/src/pubsub/ecal_subgate.h
@@ -43,8 +43,8 @@ namespace eCAL
     void Create();
     void Destroy();
 
-    bool Register(const std::string& topic_name_, std::shared_ptr<CDataReader> datareader_);
-    bool Unregister(const std::string& topic_name_, std::shared_ptr<CDataReader> datareader_);
+    bool Register(const std::string& topic_name_, const std::shared_ptr<CDataReader>& datareader_);
+    bool Unregister(const std::string& topic_name_, const std::shared_ptr<CDataReader>& datareader_);
 
     bool HasSample(const std::string& sample_name_);
     bool ApplySample(const eCAL::pb::Sample& ecal_sample_, eCAL::pb::eTLayerType layer_);

--- a/ecal/core/src/pubsub/ecal_subgate.h
+++ b/ecal/core/src/pubsub/ecal_subgate.h
@@ -43,8 +43,8 @@ namespace eCAL
     void Create();
     void Destroy();
 
-    bool Register(const std::string& topic_name_, CDataReader* datareader_);
-    bool Unregister(const std::string& topic_name_, CDataReader* datareader_);
+    bool Register(const std::string& topic_name_, std::shared_ptr<CDataReader> datareader_);
+    bool Unregister(const std::string& topic_name_, std::shared_ptr<CDataReader> datareader_);
 
     bool HasSample(const std::string& sample_name_);
     bool ApplySample(const eCAL::pb::Sample& ecal_sample_, eCAL::pb::eTLayerType layer_);
@@ -65,7 +65,7 @@ namespace eCAL
     static std::atomic<bool> m_created;
 
     // database data reader
-    using TopicNameDataReaderMapT = std::unordered_multimap<std::string, CDataReader *>;
+    using TopicNameDataReaderMapT = std::unordered_multimap<std::string, std::shared_ptr<CDataReader>>;
     std::shared_timed_mutex  m_topic_name_datareader_sync;
     TopicNameDataReaderMapT  m_topic_name_datareader_map;
 

--- a/ecal/core/src/pubsub/ecal_subscriber.cpp
+++ b/ecal/core/src/pubsub/ecal_subscriber.cpp
@@ -112,7 +112,7 @@ namespace eCAL
     }
 
     // create data reader
-    m_datareader = new CDataReader;
+    m_datareader = std::make_shared<CDataReader>();
     // set qos
     m_datareader->SetQOS(m_qos);
     // create it
@@ -159,9 +159,8 @@ namespace eCAL
     m_datareader->Destroy();
 
     // free datareader
-    delete m_datareader;
-    m_datareader = nullptr;
-
+    m_datareader.reset();
+    
     // we made it :-)
     m_created = false;
 


### PR DESCRIPTION
- Transform Subscriber / Subgate datareader to shared_ptr instead of raw pointer.
- Transform CPublisher / CPubGate CDataWriter to shared_ptr instead of raw pointer.
- Successfully allow to call Destroy() function in callbacks. (Lock map only to retreive datareaders).

Please check the type of change your PR introduces:
- [x] Bugfix

fixes #1073
fixes #707
