### PR TITLE
Install older macos protobuf (3.21)

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -85,6 +85,7 @@ jobs:
         -DECAL_THIRDPARTY_BUILD_QWT=ON \
         -DECAL_THIRDPARTY_BUILD_YAML-CPP=ON \
         -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_PREFIX_PATH=/usr/local/opt/protobuf@21 \
         -DCMAKE_CXX_STANDARD=14 \
         -DPython_FIND_STRATEGY=LOCATION \
         -DPython_FIND_REGISTRY=NEVER

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -25,7 +25,7 @@ jobs:
         target: 'desktop'
 
     - name: Install Dependencies
-      run: brew install ninja doxygen graphviz protobuf hdf5 pkg-config
+      run: brew install ninja doxygen graphviz protobuf@21 hdf5 pkg-config
 
     - name: Install Cap’n Proto
       run: |


### PR DESCRIPTION
The current MacOs Build is failing:

```
==> Fetching dependencies for protobuf: abseil
==> Fetching abseil
==> Downloading https://ghcr.io/v2/homebrew/core/abseil/manifests/20230125.3-1
==> Downloading https://ghcr.io/v2/homebrew/core/abseil/blobs/sha256:42d1faa5ff28d113705a651d57edcdc29580c8b7c941a9db5f3f06c97306966f
==> Downloading from https://pkg-containers.githubusercontent.com/ghcr1/blobs/sha256:42d1faa5ff28d113705a651d57edcdc29580c8b7c941a9db5f3f06c97306966f?se=2023-06-23T13%3A55%3A00Z&sig=s%2Floazqe4YswGGN0T%2Bw9pbzKgRIMudtAp4N55VcIyMA%3D&sp=r&spr=https&sr=b&sv=2019-12-12
==> Fetching protobuf
==> Downloading https://ghcr.io/v2/homebrew/core/protobuf/manifests/23.3
==> Downloading https://ghcr.io/v2/homebrew/core/protobuf/blobs/sha256:d529c07b5c32da9f6ce554b254deb080efb3d52afde57ecea86fc0ad38b6aaf2


In file included from /usr/local/include/absl/types/optional.h:39:
/usr/local/include/absl/utility/utility.h:164:12: error: no member named 'in_place_t' in namespace 'std'
using std::in_place_t;
      ~~~~~^
/usr/local/include/absl/utility/utility.h:165:12: error: no member named 'in_place' in namespace 'std'
using std::in_place;
      ~~~~~^
/usr/local/include/absl/utility/utility.h:181:12: error: no member named 'in_place_type' in namespace 'std'
using std::in_place_type;

Runner Image
  Image: macos-12
  Version: 20230618.1
```

So let's downgrade protobuf that doesn't have an abseil issue. Also see [here](https://github.com/abseil/abseil-cpp/issues/1483)

- [x] Build related changes

