### PR TITLE
Core: Fixed compatibility with old gcc versions

### DIFF
--- a/ecal/core/src/mon/ecal_monitoring_impl.cpp
+++ b/ecal/core/src/mon/ecal_monitoring_impl.cpp
@@ -94,7 +94,7 @@ namespace eCAL
     m_host_name = Process::GetHostName();
 
     // utilize registration receiver to enrich monitor information
-    g_registration_receiver()->SetCustomApplySampleCallback([this](const auto& ecal_sample_){ApplySample(ecal_sample_, eCAL::pb::tl_none);});
+    g_registration_receiver()->SetCustomApplySampleCallback([this](const auto& ecal_sample_){this->ApplySample(ecal_sample_, eCAL::pb::tl_none);});
 
     // start logging receive thread
     const CLoggingReceiveThread::LogMessageCallbackT logmsg_cb = std::bind(&CMonitoringImpl::RegisterLogMessage, this, std::placeholders::_1);

--- a/ecal/core/src/pubsub/ecal_subgate.cpp
+++ b/ecal/core/src/pubsub/ecal_subgate.cpp
@@ -21,6 +21,8 @@
  * @brief  eCAL subscriber gateway class
 **/
 
+#include <algorithm>
+
 #include <ecal/ecal.h>
 
 #ifdef ECAL_OS_LINUX

--- a/ecal/core/src/readwrite/ecal_reader.cpp
+++ b/ecal/core/src/readwrite/ecal_reader.cpp
@@ -38,6 +38,7 @@
 #include <sstream>
 #include <iostream>
 #include <utility>
+#include <algorithm>
 
 namespace eCAL
 {


### PR DESCRIPTION
This commit compiles with gcc 5.4 dating back to 2016, which should be C++14 capable. but not more.

Fixes #1138 