### PR TITLE
hotfix/ecal-udp-sender-shutdown

### DIFF
--- a/ecal/core/src/ecal_registration_provider.cpp
+++ b/ecal/core/src/ecal_registration_provider.cpp
@@ -105,6 +105,7 @@ namespace eCAL
       m_memfile_broadcast_writer.Bind(&m_memfile_broadcast);
     }
 
+    // start cyclic registration thread
     m_reg_sample_snd_thread.Start(Config::GetRegistrationRefreshMs(), std::bind(&CRegistrationProvider::RegisterSendThread, this));
 
     m_created = true;
@@ -114,12 +115,15 @@ namespace eCAL
   {
     if(!m_created) return;
 
-    // this is our last (un)registration message to the world
+    // stop cyclic registration thread
+    m_reg_sample_snd_thread.Stop();
+
+    // send one last (un)registration message to the world
     // thank you and goodbye :-)
     UnregisterProcess();
 
+    // destroy registration sample sender
     m_reg_sample_snd.reset();
-    m_reg_sample_snd_thread.Stop();
 
     if(m_use_shm_monitoring)
     {


### PR DESCRIPTION
**Pull request type**

Please check the type of change your PR introduces:
- [X] Bugfix

**What is the current behavior?**
On eCAL::Finalize the registration udp send socket is closed while registration thread is still running.

Fixes #1141 

**What is the new behavior?**
Stop cyclic registration thread before sending last (un)registration message and finally closing the udp send socket.

**Does this introduce a breaking change?**

- [X] No
