### PR TITLE
Core: Create macros to deprecate functions / variables, since a given…

### DIFF
--- a/ecal/core/CMakeLists.txt
+++ b/ecal/core/CMakeLists.txt
@@ -318,6 +318,7 @@ set(ecal_header_cmn
     include/ecal/ecal_client.h
     include/ecal/ecal_config.h
     include/ecal/ecal_core.h
+    include/ecal/ecal_deprecate.h
     include/ecal/ecal_event.h
     include/ecal/ecal_eventhandle.h
     include/ecal/ecal_init.h

--- a/ecal/core/include/ecal/ecal_callback.h
+++ b/ecal/core/include/ecal/ecal_callback.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <ecal/ecal_deprecate.h>
 #include <ecal/cimpl/ecal_callback_cimpl.h>
 #include <ecal/types/topic_information.h>
 
@@ -67,9 +68,9 @@ namespace eCAL
     long long            time;    //!< publisher event time in µs
     long long            clock;   //!< publisher event clock
     std::string          tid;     //!< topic id of the of the connected subscriber              (for pub_event_update_connection only)
-    [[deprecated("Use the separate infos encoding and type in member tinfo instead of ttype.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Use the separate infos encoding and type in member tinfo instead of ttype.")
     std::string          ttype;  //!< topic type information of the connected publisher         (for sub_event_update_connection only)
-    [[deprecated("Use the tinfo.descriptor instead of tdesc.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Use the tinfo.descriptor instead of tdesc.")
     std::string          tdesc;  //!< topic descriptor information of the connected publisher   (for sub_event_update_connection only)
     STopicInformation    tinfo;   //!< topic information of the connected subscriber            (for pub_event_update_connection only)
   };
@@ -89,9 +90,9 @@ namespace eCAL
     long long             time;   //!< subscriber event time in µs
     long long             clock;  //!< subscriber event clock
     std::string           tid;    //!< topic id of the of the connected publisher              (for sub_event_update_connection only)
-    [[deprecated("Use the separate infos encoding and type in member tinfo instead of ttype.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Use the separate infos encoding and type in member tinfo instead of ttype.")
     std::string           ttype;  //!< topic type information of the connected publisher       (for sub_event_update_connection only)
-    [[deprecated("Use the tinfo.descriptor instead of tdesc.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Use the tinfo.descriptor instead of tdesc.")
     std::string           tdesc;  //!< topic descriptor information of the connected publisher (for sub_event_update_connection only)
     STopicInformation     tinfo;  //!< topic information of the connected subscriber           (for pub_event_update_connection only)
   };

--- a/ecal/core/include/ecal/ecal_deprecate.h
+++ b/ecal/core/include/ecal/ecal_deprecate.h
@@ -1,0 +1,44 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+/**
+ * @file   ecal_deprecate.h
+ * @brief  eCAL funciton / variable deprecation macros
+**/
+
+#pragma once
+
+#include <ecal/ecal_defs.h>
+
+#define ECAL_VERSION_INTEGER                          ECAL_VERSION_CALCULATE(ECAL_VERSION_MAJOR, ECAL_VERSION_MINOR, ECAL_VERSION_PATCH)
+#define ECAL_VERSION_CALCULATE(major, minor, patch)   ((major<<16)|(minor<<8)|(patch))
+
+
+#if ECAL_VERSION_INTEGER >= ECAL_VERSION_CALCULATE(5, 12, 0)
+#define ECAL_DEPRECATE_SINCE_5_12(__message__) [[deprecated(__message__)]]
+#else 
+#define ECAL_DEPRECATE_SINCE_5_12(__message__)
+#endif
+
+
+#if ECAL_VERSION_INTEGER >= ECAL_VERSION_CALCULATE(5, 13, 0)
+#define ECAL_DEPRECATE_SINCE_5_13(__message__) [[deprecated(__message__)]]
+#else 
+#define ECAL_DEPRECATE_SINCE_5_13(__message__)
+#endif

--- a/ecal/core/include/ecal/ecal_monitoring.h
+++ b/ecal/core/include/ecal/ecal_monitoring.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <ecal/ecal_os.h>
+#include <ecal/ecal_deprecate.h>
 #include <ecal/ecal_monitoring_entity.h>
 #include <string>
 
@@ -95,7 +96,7 @@ namespace eCAL
      *
      * @return Zero if succeeded.
     **/
-    [[deprecated("use GetMonitoring and publish yourself")]]
+    ECAL_DEPRECATE_SINCE_5_12("use GetMonitoring and publish yourself")
     ECAL_API int PubMonitoring(bool state_, std::string name_ = "ecal.monitoring");
 
     /**
@@ -106,7 +107,7 @@ namespace eCAL
      *
      * @return Zero if succeeded.
     **/
-    [[deprecated("use GetLogging and publish yourself")]]
+    ECAL_DEPRECATE_SINCE_5_12("use GetLogging and publish yourself")
     ECAL_API int PubLogging(bool state_, std::string name_ = "ecal.logging");
   }
   /** @example monitoring_rec.cpp

--- a/ecal/core/include/ecal/ecal_publisher.h
+++ b/ecal/core/include/ecal/ecal_publisher.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <ecal/ecal_os.h>
+#include <ecal/ecal_deprecate.h>
 #include <ecal/ecal_callback.h>
 #include <ecal/ecal_payload_writer.h>
 #include <ecal/ecal_qos.h>
@@ -84,7 +85,7 @@ namespace eCAL
      * @param topic_type_   Type name. 
      * @param topic_desc_   Type description (optional). 
     **/
-    [[deprecated("Please use the constructor CPublisher(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the constructor CPublisher(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6.")
     CPublisher(const std::string& topic_name_, const std::string& topic_type_, const std::string& topic_desc_ = "");
 
     /**
@@ -137,7 +138,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails. 
     **/
-    [[deprecated("Please use the create method bool Create(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the create method bool Create(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6.")
     bool Create(const std::string& topic_name_, const std::string& topic_type_, const std::string& topic_desc_ = "");
 
     /**
@@ -178,7 +179,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails.
     **/
-    [[deprecated("Please use the method bool SetTopicInformation(const STopicInformation& topic_info_) instead. This function will be removed in eCAL6")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the method bool SetTopicInformation(const STopicInformation& topic_info_) instead. This function will be removed in eCAL6")
     bool SetTypeName(const std::string& topic_type_name_);
 
     /**
@@ -188,7 +189,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails. 
     **/
-    [[deprecated("Please use the method bool SetTopicInformation(const STopicInformation& topic_info_) instead. This function will be removed in eCAL6")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the method bool SetTopicInformation(const STopicInformation& topic_info_) instead. This function will be removed in eCAL6")
     bool SetDescription(const std::string& topic_desc_);
 
     /**
@@ -407,7 +408,7 @@ namespace eCAL
      *
      * @return  Number of bytes sent.
     **/
-    [[deprecated]]
+    ECAL_DEPRECATE_SINCE_5_12("Please use the method size_t Send(CPayloadWriter& payload_, long long time_, long long acknowledge_timeout_ms_) const instead. This function will be removed in eCAL6.")
     size_t SendSynchronized(const void* const buf_, size_t len_, long long time_, long long acknowledge_timeout_ms_) const
     {
       return Send(buf_, len_, time_, acknowledge_timeout_ms_);
@@ -505,7 +506,7 @@ namespace eCAL
      *
      * @return  The type name. 
     **/
-    [[deprecated("Please use the method STopicInformation GetTopicInformation() instead. You can extract the typename from the STopicInformation variable. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the method STopicInformation GetTopicInformation() instead. You can extract the typename from the STopicInformation variable. This function will be removed in eCAL6.")
     std::string GetTypeName() const;
 
     /**
@@ -513,7 +514,7 @@ namespace eCAL
      *
      * @return  The description. 
     **/
-    [[deprecated("Please use the method STopicInformation GetTopicInformation() instead. You can extract the descriptor from the STopicInformation variable. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the method STopicInformation GetTopicInformation() instead. You can extract the descriptor from the STopicInformation variable. This function will be removed in eCAL6.")
     std::string GetDescription() const;
 
     /**

--- a/ecal/core/include/ecal/ecal_subscriber.h
+++ b/ecal/core/include/ecal/ecal_subscriber.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <ecal/ecal_os.h>
+#include <ecal/ecal_deprecate.h>
 #include <ecal/ecal_callback.h>
 #include <ecal/ecal_qos.h>
 #include <ecal/types/topic_information.h>
@@ -94,7 +95,7 @@ namespace eCAL
      * @param topic_type_   Type name (optional for type checking).
      * @param topic_desc_   Type description (optional for description checking).
      **/
-    [[deprecated("Please use the constructor CSubscriber(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the constructor CSubscriber(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6.")
     CSubscriber(const std::string& topic_name_, const std::string& topic_type_, const std::string& topic_desc_ = "");
 
     /**
@@ -146,7 +147,7 @@ namespace eCAL
      *
      * @return  true if it succeeds, false if it fails. 
     **/
-    [[deprecated("Please use the create method bool Create(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the create method bool Create(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6.")
     bool Create(const std::string& topic_name_, const std::string& topic_type_, const std::string& topic_desc_ = "");
 
     /**
@@ -307,7 +308,7 @@ namespace eCAL
      *
      * @return  The type name. 
     **/
-    [[deprecated("Please use the method STopicInformation GetTopicInformation() instead. You can extract the typename from the STopicInformation variable. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the method STopicInformation GetTopicInformation() instead. You can extract the typename from the STopicInformation variable. This function will be removed in eCAL6.")
     std::string GetTypeName() const;
 
     /**
@@ -315,7 +316,7 @@ namespace eCAL
      *
      * @return  The description. 
     **/
-    [[deprecated("Please use the method STopicInformation GetTopicInformation() instead. You can extract the descriptor from the STopicInformation variable. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the method STopicInformation GetTopicInformation() instead. You can extract the descriptor from the STopicInformation variable. This function will be removed in eCAL6.")
     std::string GetDescription() const;
 
     /**

--- a/ecal/core/include/ecal/ecal_util.h
+++ b/ecal/core/include/ecal/ecal_util.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <ecal/ecal_os.h>
+#include <ecal/ecal_deprecate.h>
 #include <ecal/types/topic_information.h>
 
 #include <map>
@@ -164,7 +165,7 @@ namespace eCAL
      *
      * @return  True if succeeded.
     **/
-    [[deprecated("Please use the method bool GetTopicInformation(const std::string& topic_name_, STopicInformation& topic_info_) instead. You can extract the type information from the members encoding and type of the STopicInformation variable. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the method bool GetTopicInformation(const std::string& topic_name_, STopicInformation& topic_info_) instead. You can extract the type information from the members encoding and type of the STopicInformation variable. This function will be removed in eCAL6.")
     ECAL_API bool GetTopicTypeName(const std::string& topic_name_, std::string& topic_type_);
 
     /**
@@ -174,7 +175,7 @@ namespace eCAL
      *
      * @return  Topic type name.
     **/
-    [[deprecated("Please use the method bool GetTopicInformation(const std::string& topic_name_, STopicInformation& topic_info_) instead. You can extract the type information from the members encoding and type of the STopicInformation variable. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the method bool GetTopicInformation(const std::string& topic_name_, STopicInformation& topic_info_) instead. You can extract the type information from the members encoding and type of the STopicInformation variable. This function will be removed in eCAL6.")
     ECAL_API std::string GetTopicTypeName(const std::string& topic_name_);
 
     /**
@@ -185,7 +186,7 @@ namespace eCAL
      *
      * @return  True if succeeded.
     **/
-    [[deprecated("Please use the method bool GetTopicInformation(const std::string& topic_name_, STopicInformation& topic_info_) instead. You can extract the descriptor from the STopicInformation variable. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the method bool GetTopicInformation(const std::string& topic_name_, STopicInformation& topic_info_) instead. You can extract the descriptor from the STopicInformation variable. This function will be removed in eCAL6.")
     ECAL_API bool GetTopicDescription(const std::string& topic_name_, std::string& topic_desc_);
 
     /**
@@ -195,7 +196,7 @@ namespace eCAL
      *
      * @return  Topic description.
     **/
-    [[deprecated("Please use the method bool GetTopicInformation(const std::string& topic_name_, STopicInformation& topic_info_) instead. You can extract the descriptor from the STopicInformation variable. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the method bool GetTopicInformation(const std::string& topic_name_, STopicInformation& topic_info_) instead. You can extract the descriptor from the STopicInformation variable. This function will be removed in eCAL6.")
     ECAL_API std::string GetTopicDescription(const std::string& topic_name_);
 
     /**
@@ -264,7 +265,7 @@ namespace eCAL
      *
      * @return  True if succeeded.
     **/
-    [[deprecated("Please use the method bool GetTopicInformation(const std::string& topic_name_, STopicInformation& topic_info_) instead. You can extract the type information from the members encoding and type of the STopicInformation variable. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the method bool GetTopicInformation(const std::string& topic_name_, STopicInformation& topic_info_) instead. You can extract the type information from the members encoding and type of the STopicInformation variable. This function will be removed in eCAL6.")
     ECAL_API bool GetTypeName(const std::string& topic_name_, std::string& topic_type_);
 
     /**
@@ -276,7 +277,7 @@ namespace eCAL
      *
      * @return  Topic type name.
     **/
-    [[deprecated("Please use the method bool GetTopicInformation(const std::string& topic_name_, STopicInformation& topic_info_) instead. You can extract the type information from the members encoding and type of the STopicInformation variable. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the method bool GetTopicInformation(const std::string& topic_name_, STopicInformation& topic_info_) instead. You can extract the type information from the members encoding and type of the STopicInformation variable. This function will be removed in eCAL6.")
     ECAL_API std::string GetTypeName(const std::string& topic_name_);
 
     /**
@@ -289,7 +290,7 @@ namespace eCAL
      *
      * @return  True if succeeded.
     **/
-    [[deprecated("Please use the method bool GetTopicInformation(const std::string& topic_name_, STopicInformation& topic_info_) instead. You can extract the type information from the members encoding and type of the STopicInformation variable. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the method bool GetTopicInformation(const std::string& topic_name_, STopicInformation& topic_info_) instead. You can extract the type information from the members encoding and type of the STopicInformation variable. This function will be removed in eCAL6.")
     ECAL_API bool GetDescription(const std::string& topic_name_, std::string& topic_desc_);
 
     /**
@@ -301,7 +302,7 @@ namespace eCAL
      *
      * @return  Topic description.
     **/
-    [[deprecated("Please use the method bool GetTopicInformation(const std::string& topic_name_, STopicInformation& topic_info_) instead. You can extract the type information from the members encoding and type of the STopicInformation variable. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the method bool GetTopicInformation(const std::string& topic_name_, STopicInformation& topic_info_) instead. You can extract the type information from the members encoding and type of the STopicInformation variable. This function will be removed in eCAL6.")
     ECAL_API std::string GetDescription(const std::string& topic_name_);
 
     /**

--- a/ecal/core/include/ecal/msg/capnproto/dynamic.h
+++ b/ecal/core/include/ecal/msg/capnproto/dynamic.h
@@ -32,6 +32,7 @@
 #pragma warning(pop)
 #endif /*_MSC_VER*/
 
+#include <ecal/ecal_deprecate.h>
 #include <ecal/msg/capnproto/subscriber.h>
 #include <ecal/msg/capnproto/helper.h>
 
@@ -170,7 +171,7 @@ namespace eCAL
       *
       * @return  Type name.
       **/
-      [[deprecated("Please use the method STopicInformation GetTopicInformation() instead. You can extract the typename from the STopicInformation variable. This function will be removed in eCAL6.")]]
+      ECAL_DEPRECATE_SINCE_5_13("Please use the method STopicInformation GetTopicInformation() instead. You can extract the typename from the STopicInformation variable. This function will be removed in eCAL6.")
       std::string GetTypeName() const
       {
         return ("");

--- a/ecal/core/include/ecal/msg/capnproto/subscriber.h
+++ b/ecal/core/include/ecal/msg/capnproto/subscriber.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <ecal/ecal_deprecate.h>
 #include <ecal/msg/subscriber.h>
 #include <ecal/msg/capnproto/helper.h>
 
@@ -243,7 +244,7 @@ namespace eCAL
       *
       * @return  Type name.
       **/
-      [[deprecated("Please use STopicInformation GetTopicInformation() instead. This function will be removed in eCAL6.")]]
+      ECAL_DEPRECATE_SINCE_5_13("Please use STopicInformation GetTopicInformation() instead. This function will be removed in eCAL6.")
       std::string GetTypeName() const
       {
         return eCAL::capnproto::TypeAsString<message_type>();

--- a/ecal/core/include/ecal/msg/protobuf/publisher.h
+++ b/ecal/core/include/ecal/msg/protobuf/publisher.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <ecal/ecal_deprecate.h>
 #include <ecal/msg/publisher.h>
 #include <ecal/protobuf/ecal_proto_hlp.h>
 
@@ -175,7 +176,7 @@ namespace eCAL
        *
        * @return  Type name.
       **/
-      [[deprecated("Please use STopicInformation GetTopicInformation() instead. This function will be removed in eCAL6.")]]
+      ECAL_DEPRECATE_SINCE_5_13("Please use STopicInformation GetTopicInformation() instead. This function will be removed in eCAL6.")
       std::string GetTypeName() const
       {
         STopicInformation topic_info{ GetTopicInformation() };
@@ -188,7 +189,7 @@ namespace eCAL
        *
        * @return  Description string.
       **/
-      [[deprecated("Please use STopicInformation GetTopicInformation() instead. This function will be removed in eCAL6.")]]
+      ECAL_DEPRECATE_SINCE_5_13("Please use STopicInformation GetTopicInformation() instead. This function will be removed in eCAL6.")
       std::string GetDescription() const
       {
         return GetTopicInformation().descriptor;

--- a/ecal/core/include/ecal/msg/publisher.h
+++ b/ecal/core/include/ecal/msg/publisher.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <ecal/ecal_deprecate.h>
 #include <ecal/ecal_publisher.h>
 #include <ecal/ecal_util.h>
 
@@ -59,7 +60,7 @@ namespace eCAL
      * @param topic_type_  Type name (optional for type checking). 
      * @param topic_desc_  Type description (optional for description checking). 
     **/
-    [[deprecated("Please use the constructor CMsgPublisher(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6. ")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the constructor CMsgPublisher(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6. ")
     CMsgPublisher(const std::string& topic_name_, const std::string& topic_type_, const std::string& topic_desc_ = "") : CPublisher(topic_name_, topic_type_, topic_desc_)
     {
     }
@@ -103,7 +104,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails. 
     **/
-    [[deprecated("Please use the method CMsgSubscriber(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6. ")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the method CMsgSubscriber(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6. ")
     bool Create(const std::string& topic_name_, const std::string& topic_type_ = "", const std::string& topic_desc_ = "")
     {
       return(CPublisher::Create(topic_name_, topic_type_, topic_desc_));
@@ -176,14 +177,14 @@ namespace eCAL
     }
 
   protected:
-    [[deprecated("Please use STopicInformation GetTopicInformation() instead. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use STopicInformation GetTopicInformation() instead. This function will be removed in eCAL6.")
     virtual std::string GetTypeName() const
     {
       STopicInformation topic_info{ GetTopicInformation() };
       return Util::CombinedTopicEncodingAndType(topic_info.encoding, topic_info.type);
     };
 
-    [[deprecated("Please use STopicInformation GetTopicInformation() instead. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use STopicInformation GetTopicInformation() instead. This function will be removed in eCAL6.")
     virtual std::string GetDescription() const
     {
       return GetTopicInformation().descriptor;

--- a/ecal/core/include/ecal/msg/string/publisher.h
+++ b/ecal/core/include/ecal/msg/string/publisher.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <ecal/ecal_deprecate.h>
 #include <ecal/msg/publisher.h>
 
 #include <string>
@@ -69,7 +70,7 @@ namespace eCAL
        * @param topic_type_  Type name (optional).
        * @param topic_desc_  Type description (optional).
       **/
-      [[deprecated("Plase use eCAL::string::CPublisher(const std::string& topic_name_) instead. This function will be removed in eCAL6.")]]
+      ECAL_DEPRECATE_SINCE_5_13("Plase use eCAL::string::CPublisher(const std::string& topic_name_) instead. This function will be removed in eCAL6.")
       CPublisher(const std::string& topic_name_, const std::string& topic_type_, const std::string& topic_desc_) : CMsgPublisher<T>(topic_name_, topic_type_, topic_desc_)
       {
       }

--- a/ecal/core/include/ecal/msg/subscriber.h
+++ b/ecal/core/include/ecal/msg/subscriber.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <ecal/ecal_deprecate.h>
 #include <ecal/ecal_subscriber.h>
 #include <ecal/ecal_util.h>
 
@@ -60,7 +61,7 @@ namespace eCAL
      * @param topic_type_  Type name (optional for type checking).
      * @param topic_desc_  Type description (optional for description checking).
     **/
-    [[deprecated("Please use the constructor CMsgSubscriber(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6. ")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the constructor CMsgSubscriber(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6. ")
     CMsgSubscriber(const std::string& topic_name_, const std::string& topic_type_ = "", const std::string& topic_desc_ = "") : CSubscriber(topic_name_, topic_type_, topic_desc_)
     {
     }
@@ -135,7 +136,7 @@ namespace eCAL
      *
      * @return  true if it succeeds, false if it fails.
     **/
-    [[deprecated("Please use the method CMsgSubscriber(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6. ")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the method CMsgSubscriber(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6. ")
     bool Create(const std::string& topic_name_, const std::string& topic_type_ = "", const std::string& topic_desc_ = "")
     {
       return(CSubscriber::Create(topic_name_, topic_type_, topic_desc_));
@@ -224,14 +225,14 @@ namespace eCAL
     }
 
 protected:
-    [[deprecated("Please use STopicInformation GetTopicInformation() instead. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use STopicInformation GetTopicInformation() instead. This function will be removed in eCAL6.")
     virtual std::string GetTypeName() const
     {
       STopicInformation topic_info{ GetTopicInformation() };
       return Util::CombinedTopicEncodingAndType(topic_info.encoding, topic_info.type);
     };
 
-    [[deprecated("Please use STopicInformation GetTopicInformation() instead. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use STopicInformation GetTopicInformation() instead. This function will be removed in eCAL6.")
     virtual std::string GetDescription() const
     {
       return GetTopicInformation().descriptor;


### PR DESCRIPTION
… eCAL version.

This allows users to see directly, when something will be / has been deprecated.

**Pull request type**

Please check the type of change your PR introduces:
- [x] Refactoring (no functional changes, no api changes)

**What is the current behavior?**
We deprecate functionality and the user can not see, when it was deprecated.
Also we cannot deprecate functionality for upcoming releases, which makes code maintenance harder.