### PR TITLE
Core: Create macros to deprecate functions / variables, since a given…

### DIFF
--- a/ecal/core/CMakeLists.txt
+++ b/ecal/core/CMakeLists.txt
@@ -318,6 +318,7 @@ set(ecal_header_cmn
     include/ecal/ecal_client.h
     include/ecal/ecal_config.h
     include/ecal/ecal_core.h
+    include/ecal/ecal_deprecate.h
     include/ecal/ecal_event.h
     include/ecal/ecal_eventhandle.h
     include/ecal/ecal_init.h

--- a/ecal/core/include/ecal/ecal_callback.h
+++ b/ecal/core/include/ecal/ecal_callback.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <ecal/ecal_deprecate.h>
 #include <ecal/cimpl/ecal_callback_cimpl.h>
 #include <ecal/types/topic_information.h>
 
@@ -67,9 +68,9 @@ namespace eCAL
     long long            time;    //!< publisher event time in µs
     long long            clock;   //!< publisher event clock
     std::string          tid;     //!< topic id of the of the connected subscriber              (for pub_event_update_connection only)
-    [[deprecated("Use the separate infos encoding and type in member tinfo instead of ttype.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Use the separate infos encoding and type in member tinfo instead of ttype.")
     std::string          ttype;  //!< topic type information of the connected publisher         (for sub_event_update_connection only)
-    [[deprecated("Use the tinfo.descriptor instead of tdesc.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Use the tinfo.descriptor instead of tdesc.")
     std::string          tdesc;  //!< topic descriptor information of the connected publisher   (for sub_event_update_connection only)
     STopicInformation    tinfo;   //!< topic information of the connected subscriber            (for pub_event_update_connection only)
   };
@@ -89,9 +90,9 @@ namespace eCAL
     long long             time;   //!< subscriber event time in µs
     long long             clock;  //!< subscriber event clock
     std::string           tid;    //!< topic id of the of the connected publisher              (for sub_event_update_connection only)
-    [[deprecated("Use the separate infos encoding and type in member tinfo instead of ttype.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Use the separate infos encoding and type in member tinfo instead of ttype.")
     std::string           ttype;  //!< topic type information of the connected publisher       (for sub_event_update_connection only)
-    [[deprecated("Use the tinfo.descriptor instead of tdesc.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Use the tinfo.descriptor instead of tdesc.")
     std::string           tdesc;  //!< topic descriptor information of the connected publisher (for sub_event_update_connection only)
     STopicInformation     tinfo;  //!< topic information of the connected subscriber           (for pub_event_update_connection only)
   };

--- a/ecal/core/include/ecal/ecal_client.h
+++ b/ecal/core/include/ecal/ecal_client.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <ecal/ecal_deprecate.h>
 #include <ecal/ecal_os.h>
 #include <ecal/ecal_callback.h>
 #include <ecal/ecal_service_info.h>
@@ -128,7 +129,7 @@ namespace eCAL
      *
      * @return  True if successful.
     **/
-    [[deprecated]]
+    ECAL_DEPRECATE_SINCE_5_10("Please use the create method bool Call(const std::string& method_name_, const std::string& request_, int timeout_, ServiceResponseVecT* service_response_vec_) instead. This function will be removed in eCAL6.")
     bool Call(const std::string& host_name_, const std::string& method_name_, const std::string& request_, struct SServiceResponse& service_info_, std::string& response_);
 
     /**

--- a/ecal/core/include/ecal/ecal_deprecate.h
+++ b/ecal/core/include/ecal/ecal_deprecate.h
@@ -19,16 +19,12 @@
 
 /**
  * @file   ecal_deprecate.h
- * @brief  eCAL funciton / variable deprecation macros
+ * @brief  eCAL function / variable deprecation macros
 **/
 
 #pragma once
 
 #include <ecal/ecal_defs.h>
-
-#define ECAL_VERSION_INTEGER                          ECAL_VERSION_CALCULATE(ECAL_VERSION_MAJOR, ECAL_VERSION_MINOR, ECAL_VERSION_PATCH)
-#define ECAL_VERSION_CALCULATE(major, minor, patch)   ((major<<16)|(minor<<8)|(patch))
-
 
 #if ECAL_VERSION_INTEGER >= ECAL_VERSION_CALCULATE(5, 12, 0)
 #define ECAL_DEPRECATE_SINCE_5_12(__message__) [[deprecated(__message__)]]

--- a/ecal/core/include/ecal/ecal_deprecate.h
+++ b/ecal/core/include/ecal/ecal_deprecate.h
@@ -26,12 +26,30 @@
 
 #include <ecal/ecal_defs.h>
 
+#if ECAL_VERSION_INTEGER >= ECAL_VERSION_CALCULATE(5, 4, 0)
+#define ECAL_DEPRECATE_SINCE_5_4(__message__) [[deprecated(__message__)]]
+#else 
+#define ECAL_DEPRECATE_SINCE_5_4(__message__)
+#endif
+
+
+#if ECAL_VERSION_INTEGER >= ECAL_VERSION_CALCULATE(5, 10, 0)
+#define ECAL_DEPRECATE_SINCE_5_10(__message__) [[deprecated(__message__)]]
+#else 
+#define ECAL_DEPRECATE_SINCE_5_10(__message__)
+#endif
+
+#if ECAL_VERSION_INTEGER >= ECAL_VERSION_CALCULATE(5, 11, 0)
+#define ECAL_DEPRECATE_SINCE_5_11(__message__) [[deprecated(__message__)]]
+#else 
+#define ECAL_DEPRECATE_SINCE_5_11(__message__)
+#endif
+
 #if ECAL_VERSION_INTEGER >= ECAL_VERSION_CALCULATE(5, 12, 0)
 #define ECAL_DEPRECATE_SINCE_5_12(__message__) [[deprecated(__message__)]]
 #else 
 #define ECAL_DEPRECATE_SINCE_5_12(__message__)
 #endif
-
 
 #if ECAL_VERSION_INTEGER >= ECAL_VERSION_CALCULATE(5, 13, 0)
 #define ECAL_DEPRECATE_SINCE_5_13(__message__) [[deprecated(__message__)]]

--- a/ecal/core/include/ecal/ecal_deprecate.h
+++ b/ecal/core/include/ecal/ecal_deprecate.h
@@ -1,0 +1,44 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+/**
+ * @file   ecal_deprecate.h
+ * @brief  eCAL funciton / variable deprecation macros
+**/
+
+#pragma once
+
+#include <ecal/ecal_defs.h>
+
+#define ECAL_VERSION_INTEGER                          ECAL_VERSION_CALCULATE(ECAL_VERSION_MAJOR, ECAL_VERSION_MINOR, ECAL_VERSION_PATCH)
+#define ECAL_VERSION_CALCULATE(major, minor, patch)   ((major<<16)|(minor<<8)|(patch))
+
+
+#if ECAL_VERSION_INTEGER >= ECAL_VERSION_CALCULATE(5, 12, 0)
+#define ECAL_DEPRECATE_SINCE_5_12(__message__) [[deprecated(__message__)]]
+#else 
+#define ECAL_DEPRECATE_SINCE_5_12(__message__)
+#endif
+
+
+#if ECAL_VERSION_INTEGER >= ECAL_VERSION_CALCULATE(5, 13, 0)
+#define ECAL_DEPRECATE_SINCE_5_13(__message__) [[deprecated(__message__)]]
+#else 
+#define ECAL_DEPRECATE_SINCE_5_13(__message__)
+#endif

--- a/ecal/core/include/ecal/ecal_monitoring.h
+++ b/ecal/core/include/ecal/ecal_monitoring.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <ecal/ecal_os.h>
+#include <ecal/ecal_deprecate.h>
 #include <ecal/ecal_monitoring_entity.h>
 #include <string>
 
@@ -95,7 +96,7 @@ namespace eCAL
      *
      * @return Zero if succeeded.
     **/
-    [[deprecated("use GetMonitoring and publish yourself")]]
+    ECAL_DEPRECATE_SINCE_5_12("use GetMonitoring and publish yourself")
     ECAL_API int PubMonitoring(bool state_, std::string name_ = "ecal.monitoring");
 
     /**
@@ -106,7 +107,7 @@ namespace eCAL
      *
      * @return Zero if succeeded.
     **/
-    [[deprecated("use GetLogging and publish yourself")]]
+    ECAL_DEPRECATE_SINCE_5_12("use GetLogging and publish yourself")
     ECAL_API int PubLogging(bool state_, std::string name_ = "ecal.logging");
   }
   /** @example monitoring_rec.cpp

--- a/ecal/core/include/ecal/ecal_process.h
+++ b/ecal/core/include/ecal/ecal_process.h
@@ -27,6 +27,7 @@
 #include <chrono>
 #include <string>
 
+#include <ecal/ecal_deprecate.h>
 #include <ecal/ecal_os.h>
 #include <ecal/ecal_process_mode.h>
 #include <ecal/ecal_process_severity.h>
@@ -60,7 +61,7 @@ namespace eCAL
      *
      * @return  Host id or zero if failed.
     **/
-    [[deprecated]]
+    ECAL_DEPRECATE_SINCE_5_10("This function will be removed in eCAL6.")
     ECAL_API int GetHostID();
 
     /**
@@ -162,14 +163,14 @@ namespace eCAL
     /**
      * @deprecated  Use the function GetWClock() instead
     **/
-    [[deprecated("use GetWClock() instead")]]
+    ECAL_DEPRECATE_SINCE_5_4("use GetWClock() instead")
     ECAL_API long long GetSClock();
 
     /**
      * @deprecated  Use the function GetWBytes() instead
     **/
 
-    [[deprecated("use GetWBytes() instead")]]
+    ECAL_DEPRECATE_SINCE_5_4("use GetWBytes() instead")
     ECAL_API long long GetSBytes();
 
     /**

--- a/ecal/core/include/ecal/ecal_publisher.h
+++ b/ecal/core/include/ecal/ecal_publisher.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <ecal/ecal_os.h>
+#include <ecal/ecal_deprecate.h>
 #include <ecal/ecal_callback.h>
 #include <ecal/ecal_payload_writer.h>
 #include <ecal/ecal_qos.h>
@@ -85,7 +86,7 @@ namespace eCAL
      * @param topic_type_   Type name. 
      * @param topic_desc_   Type description (optional). 
     **/
-    [[deprecated("Please use the constructor CPublisher(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the constructor CPublisher(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6.")
     ECAL_API CPublisher(const std::string& topic_name_, const std::string& topic_type_, const std::string& topic_desc_ = "");
 
     /**
@@ -138,7 +139,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails. 
     **/
-    [[deprecated("Please use the create method bool Create(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the create method bool Create(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6.")
     ECAL_API bool Create(const std::string& topic_name_, const std::string& topic_type_, const std::string& topic_desc_ = "");
 
     /**
@@ -179,7 +180,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails.
     **/
-    [[deprecated("Please use the method bool SetTopicInformation(const STopicInformation& topic_info_) instead. This function will be removed in eCAL6")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the method bool SetTopicInformation(const STopicInformation& topic_info_) instead. This function will be removed in eCAL6")
     ECAL_API bool SetTypeName(const std::string& topic_type_name_);
 
     /**
@@ -189,7 +190,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails. 
     **/
-    [[deprecated("Please use the method bool SetTopicInformation(const STopicInformation& topic_info_) instead. This function will be removed in eCAL6")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the method bool SetTopicInformation(const STopicInformation& topic_info_) instead. This function will be removed in eCAL6")
     ECAL_API bool SetDescription(const std::string& topic_desc_);
 
     /**
@@ -408,7 +409,7 @@ namespace eCAL
      *
      * @return  Number of bytes sent.
     **/
-    [[deprecated]]
+    ECAL_DEPRECATE_SINCE_5_12("Please use the method size_t Send(CPayloadWriter& payload_, long long time_, long long acknowledge_timeout_ms_) const instead. This function will be removed in eCAL6.")
     ECAL_API size_t SendSynchronized(const void* const buf_, size_t len_, long long time_, long long acknowledge_timeout_ms_) const
     {
       return Send(buf_, len_, time_, acknowledge_timeout_ms_);
@@ -506,7 +507,7 @@ namespace eCAL
      *
      * @return  The type name. 
     **/
-    [[deprecated("Please use the method STopicInformation GetTopicInformation() instead. You can extract the typename from the STopicInformation variable. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the method STopicInformation GetTopicInformation() instead. You can extract the typename from the STopicInformation variable. This function will be removed in eCAL6.")
     ECAL_API std::string GetTypeName() const;
 
     /**
@@ -514,7 +515,7 @@ namespace eCAL
      *
      * @return  The description. 
     **/
-    [[deprecated("Please use the method STopicInformation GetTopicInformation() instead. You can extract the descriptor from the STopicInformation variable. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the method STopicInformation GetTopicInformation() instead. You can extract the descriptor from the STopicInformation variable. This function will be removed in eCAL6.")
     ECAL_API std::string GetDescription() const;
 
     /**

--- a/ecal/core/include/ecal/ecal_subscriber.h
+++ b/ecal/core/include/ecal/ecal_subscriber.h
@@ -234,7 +234,7 @@ namespace eCAL
      *
      * @return  Length of received buffer. 
     **/
-    [[deprecated]]
+    ECAL_DEPRECATE_SINCE_5_10("Please use the method bool ReceiveBuffer(std::string& buf_, long long* time_ = nullptr, int rcv_timeout_ = 0) instead. This function will be removed in eCAL6.")
     ECAL_API size_t Receive(std::string& buf_, long long* time_ = nullptr, int rcv_timeout_ = 0) const;
 
     /**

--- a/ecal/core/include/ecal/ecal_subscriber.h
+++ b/ecal/core/include/ecal/ecal_subscriber.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <ecal/ecal_os.h>
+#include <ecal/ecal_deprecate.h>
 #include <ecal/ecal_callback.h>
 #include <ecal/ecal_qos.h>
 #include <ecal/types/topic_information.h>
@@ -95,7 +96,7 @@ namespace eCAL
      * @param topic_type_   Type name (optional for type checking).
      * @param topic_desc_   Type description (optional for description checking).
      **/
-    [[deprecated("Please use the constructor CSubscriber(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the constructor CSubscriber(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6.")
     ECAL_API CSubscriber(const std::string& topic_name_, const std::string& topic_type_, const std::string& topic_desc_ = "");
 
     /**
@@ -147,7 +148,7 @@ namespace eCAL
      *
      * @return  true if it succeeds, false if it fails. 
     **/
-    [[deprecated("Please use the create method bool Create(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the create method bool Create(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6.")
     ECAL_API bool Create(const std::string& topic_name_, const std::string& topic_type_, const std::string& topic_desc_ = "");
 
     /**
@@ -308,7 +309,7 @@ namespace eCAL
      *
      * @return  The type name. 
     **/
-    [[deprecated("Please use the method STopicInformation GetTopicInformation() instead. You can extract the typename from the STopicInformation variable. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the method STopicInformation GetTopicInformation() instead. You can extract the typename from the STopicInformation variable. This function will be removed in eCAL6.")
     ECAL_API std::string GetTypeName() const;
 
     /**
@@ -316,7 +317,7 @@ namespace eCAL
      *
      * @return  The description. 
     **/
-    [[deprecated("Please use the method STopicInformation GetTopicInformation() instead. You can extract the descriptor from the STopicInformation variable. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the method STopicInformation GetTopicInformation() instead. You can extract the descriptor from the STopicInformation variable. This function will be removed in eCAL6.")
     ECAL_API std::string GetDescription() const;
 
     /**

--- a/ecal/core/include/ecal/ecal_util.h
+++ b/ecal/core/include/ecal/ecal_util.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <ecal/ecal_deprecate.h>
 #include <ecal/ecal_os.h>
 #include <ecal/ecal_deprecate.h>
 #include <ecal/types/topic_information.h>
@@ -45,7 +46,7 @@ namespace eCAL
      *
      * @return  eCAL home path.
     **/
-    [[deprecated]]
+    ECAL_DEPRECATE_SINCE_5_10("Please use the method std::string GeteCALConfigPath() instead. This function will be removed in eCAL6.")
     ECAL_API std::string GeteCALHomePath();
 
     /**
@@ -90,7 +91,7 @@ namespace eCAL
      *
      * @return  eCAL default ini file name.
     **/
-    [[deprecated]]
+    ECAL_DEPRECATE_SINCE_5_10("Please use the method std::string GeteCALActiveIniFile() instead. This function will be removed in eCAL6.")
     ECAL_API std::string GeteCALDefaultIniFile();
 
     /**

--- a/ecal/core/include/ecal/ecal_util.h
+++ b/ecal/core/include/ecal/ecal_util.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <ecal/ecal_os.h>
+#include <ecal/ecal_deprecate.h>
 #include <ecal/types/topic_information.h>
 
 #include <map>
@@ -164,7 +165,7 @@ namespace eCAL
      *
      * @return  True if succeeded.
     **/
-    [[deprecated("Please use the method bool GetTopicInformation(const std::string& topic_name_, STopicInformation& topic_info_) instead. You can extract the type information from the members encoding and type of the STopicInformation variable. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the method bool GetTopicInformation(const std::string& topic_name_, STopicInformation& topic_info_) instead. You can extract the type information from the members encoding and type of the STopicInformation variable. This function will be removed in eCAL6.")
     ECAL_API bool GetTopicTypeName(const std::string& topic_name_, std::string& topic_type_);
 
     /**
@@ -174,7 +175,7 @@ namespace eCAL
      *
      * @return  Topic type name.
     **/
-    [[deprecated("Please use the method bool GetTopicInformation(const std::string& topic_name_, STopicInformation& topic_info_) instead. You can extract the type information from the members encoding and type of the STopicInformation variable. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the method bool GetTopicInformation(const std::string& topic_name_, STopicInformation& topic_info_) instead. You can extract the type information from the members encoding and type of the STopicInformation variable. This function will be removed in eCAL6.")
     ECAL_API std::string GetTopicTypeName(const std::string& topic_name_);
 
     /**
@@ -185,7 +186,7 @@ namespace eCAL
      *
      * @return  True if succeeded.
     **/
-    [[deprecated("Please use the method bool GetTopicInformation(const std::string& topic_name_, STopicInformation& topic_info_) instead. You can extract the descriptor from the STopicInformation variable. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the method bool GetTopicInformation(const std::string& topic_name_, STopicInformation& topic_info_) instead. You can extract the descriptor from the STopicInformation variable. This function will be removed in eCAL6.")
     ECAL_API bool GetTopicDescription(const std::string& topic_name_, std::string& topic_desc_);
 
     /**
@@ -195,7 +196,7 @@ namespace eCAL
      *
      * @return  Topic description.
     **/
-    [[deprecated("Please use the method bool GetTopicInformation(const std::string& topic_name_, STopicInformation& topic_info_) instead. You can extract the descriptor from the STopicInformation variable. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the method bool GetTopicInformation(const std::string& topic_name_, STopicInformation& topic_info_) instead. You can extract the descriptor from the STopicInformation variable. This function will be removed in eCAL6.")
     ECAL_API std::string GetTopicDescription(const std::string& topic_name_);
 
     /**
@@ -264,7 +265,7 @@ namespace eCAL
      *
      * @return  True if succeeded.
     **/
-    [[deprecated("Please use the method bool GetTopicInformation(const std::string& topic_name_, STopicInformation& topic_info_) instead. You can extract the type information from the members encoding and type of the STopicInformation variable. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the method bool GetTopicInformation(const std::string& topic_name_, STopicInformation& topic_info_) instead. You can extract the type information from the members encoding and type of the STopicInformation variable. This function will be removed in eCAL6.")
     ECAL_API bool GetTypeName(const std::string& topic_name_, std::string& topic_type_);
 
     /**
@@ -276,7 +277,7 @@ namespace eCAL
      *
      * @return  Topic type name.
     **/
-    [[deprecated("Please use the method bool GetTopicInformation(const std::string& topic_name_, STopicInformation& topic_info_) instead. You can extract the type information from the members encoding and type of the STopicInformation variable. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the method bool GetTopicInformation(const std::string& topic_name_, STopicInformation& topic_info_) instead. You can extract the type information from the members encoding and type of the STopicInformation variable. This function will be removed in eCAL6.")
     ECAL_API std::string GetTypeName(const std::string& topic_name_);
 
     /**
@@ -289,7 +290,7 @@ namespace eCAL
      *
      * @return  True if succeeded.
     **/
-    [[deprecated("Please use the method bool GetTopicInformation(const std::string& topic_name_, STopicInformation& topic_info_) instead. You can extract the type information from the members encoding and type of the STopicInformation variable. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the method bool GetTopicInformation(const std::string& topic_name_, STopicInformation& topic_info_) instead. You can extract the type information from the members encoding and type of the STopicInformation variable. This function will be removed in eCAL6.")
     ECAL_API bool GetDescription(const std::string& topic_name_, std::string& topic_desc_);
 
     /**
@@ -301,7 +302,7 @@ namespace eCAL
      *
      * @return  Topic description.
     **/
-    [[deprecated("Please use the method bool GetTopicInformation(const std::string& topic_name_, STopicInformation& topic_info_) instead. You can extract the type information from the members encoding and type of the STopicInformation variable. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the method bool GetTopicInformation(const std::string& topic_name_, STopicInformation& topic_info_) instead. You can extract the type information from the members encoding and type of the STopicInformation variable. This function will be removed in eCAL6.")
     ECAL_API std::string GetDescription(const std::string& topic_name_);
 
     /**

--- a/ecal/core/include/ecal/msg/capnproto/dynamic.h
+++ b/ecal/core/include/ecal/msg/capnproto/dynamic.h
@@ -32,6 +32,7 @@
 #pragma warning(pop)
 #endif /*_MSC_VER*/
 
+#include <ecal/ecal_deprecate.h>
 #include <ecal/msg/capnproto/subscriber.h>
 #include <ecal/msg/capnproto/helper.h>
 
@@ -170,7 +171,7 @@ namespace eCAL
       *
       * @return  Type name.
       **/
-      [[deprecated("Please use the method STopicInformation GetTopicInformation() instead. You can extract the typename from the STopicInformation variable. This function will be removed in eCAL6.")]]
+      ECAL_DEPRECATE_SINCE_5_13("Please use the method STopicInformation GetTopicInformation() instead. You can extract the typename from the STopicInformation variable. This function will be removed in eCAL6.")
       std::string GetTypeName() const
       {
         return ("");

--- a/ecal/core/include/ecal/msg/capnproto/subscriber.h
+++ b/ecal/core/include/ecal/msg/capnproto/subscriber.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <ecal/ecal_deprecate.h>
 #include <ecal/msg/subscriber.h>
 #include <ecal/msg/capnproto/helper.h>
 
@@ -243,7 +244,7 @@ namespace eCAL
       *
       * @return  Type name.
       **/
-      [[deprecated("Please use STopicInformation GetTopicInformation() instead. This function will be removed in eCAL6.")]]
+      ECAL_DEPRECATE_SINCE_5_13("Please use STopicInformation GetTopicInformation() instead. This function will be removed in eCAL6.")
       std::string GetTypeName() const
       {
         return eCAL::capnproto::TypeAsString<message_type>();

--- a/ecal/core/include/ecal/msg/protobuf/client.h
+++ b/ecal/core/include/ecal/msg/protobuf/client.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <ecal/ecal_deprecate.h>
 #include <ecal/ecal_client.h>
 #include <ecal/protobuf/ecal_proto_hlp.h>
 
@@ -168,7 +169,7 @@ namespace eCAL
        *
        * @return  True if successful.
       **/
-      [[deprecated]]
+      ECAL_DEPRECATE_SINCE_5_10("Please use the method bool Call(const std::string& method_name_, const google::protobuf::Message& request_, const int timeout_, ServiceResponseVecT* service_response_vec_) instead. This function will be removed in eCAL6.")
       bool Call(const std::string& host_name_, const std::string& method_name_, const google::protobuf::Message& request_, struct SServiceResponse& service_response_, google::protobuf::Message& response_)
       {
         ServiceResponseVecT service_response_vec;

--- a/ecal/core/include/ecal/msg/protobuf/dynamic_subscriber.h
+++ b/ecal/core/include/ecal/msg/protobuf/dynamic_subscriber.h
@@ -27,6 +27,7 @@
 #include <exception>
 #include <sstream>
 #include <ecal/ecal.h>
+#include <ecal/ecal_deprecate.h>
 #include <ecal/protobuf/ecal_proto_dyn.h>
 #include <ecal/msg/dynamic.h>
 
@@ -112,12 +113,13 @@ namespace eCAL
        * This function is deprecated and will return a nullptr now.
        *
       **/
-      [[deprecated]]
+      ECAL_DEPRECATE_SINCE_5_10("This function will be removed in eCAL6.")
       google::protobuf::Message* getMessagePointer();
 
       /**
        * @brief Manually receive the next sample
       **/
+      ECAL_DEPRECATE_SINCE_5_10("This function was broken with eCAL 5.10, please use callback instead of receive.")
       bool Receive(google::protobuf::Message& msg_, long long* time_ = nullptr, int rcv_timeout_ = 0);
 
       /**

--- a/ecal/core/include/ecal/msg/protobuf/publisher.h
+++ b/ecal/core/include/ecal/msg/protobuf/publisher.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <ecal/ecal_deprecate.h>
 #include <ecal/msg/publisher.h>
 #include <ecal/protobuf/ecal_proto_hlp.h>
 
@@ -175,7 +176,7 @@ namespace eCAL
        *
        * @return  Type name.
       **/
-      [[deprecated("Please use STopicInformation GetTopicInformation() instead. This function will be removed in eCAL6.")]]
+      ECAL_DEPRECATE_SINCE_5_13("Please use STopicInformation GetTopicInformation() instead. This function will be removed in eCAL6.")
       std::string GetTypeName() const
       {
         STopicInformation topic_info{ GetTopicInformation() };
@@ -188,7 +189,7 @@ namespace eCAL
        *
        * @return  Description string.
       **/
-      [[deprecated("Please use STopicInformation GetTopicInformation() instead. This function will be removed in eCAL6.")]]
+      ECAL_DEPRECATE_SINCE_5_13("Please use STopicInformation GetTopicInformation() instead. This function will be removed in eCAL6.")
       std::string GetDescription() const
       {
         return GetTopicInformation().descriptor;

--- a/ecal/core/include/ecal/msg/publisher.h
+++ b/ecal/core/include/ecal/msg/publisher.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <ecal/ecal_deprecate.h>
 #include <ecal/ecal_publisher.h>
 #include <ecal/ecal_util.h>
 
@@ -59,7 +60,7 @@ namespace eCAL
      * @param topic_type_  Type name (optional for type checking). 
      * @param topic_desc_  Type description (optional for description checking). 
     **/
-    [[deprecated("Please use the constructor CMsgPublisher(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6. ")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the constructor CMsgPublisher(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6. ")
     CMsgPublisher(const std::string& topic_name_, const std::string& topic_type_, const std::string& topic_desc_ = "") : CPublisher(topic_name_, topic_type_, topic_desc_)
     {
     }
@@ -105,7 +106,7 @@ namespace eCAL
      *
      * @return  True if it succeeds, false if it fails.
     **/
-    [[deprecated("Please use the method Create(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6. ")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the method Create(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6. ")
     bool Create(const std::string& topic_name_, const std::string& topic_type_ = "", const std::string& topic_desc_ = "")
     {
       return(CPublisher::Create(topic_name_, topic_type_, topic_desc_));
@@ -191,14 +192,14 @@ namespace eCAL
     }
 
   protected:
-    [[deprecated("Please use STopicInformation GetTopicInformation() instead. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use STopicInformation GetTopicInformation() instead. This function will be removed in eCAL6.")
     virtual std::string GetTypeName() const
     {
       STopicInformation topic_info{ GetTopicInformation() };
       return Util::CombinedTopicEncodingAndType(topic_info.encoding, topic_info.type);
     };
 
-    [[deprecated("Please use STopicInformation GetTopicInformation() instead. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use STopicInformation GetTopicInformation() instead. This function will be removed in eCAL6.")
     virtual std::string GetDescription() const
     {
       return GetTopicInformation().descriptor;

--- a/ecal/core/include/ecal/msg/string/publisher.h
+++ b/ecal/core/include/ecal/msg/string/publisher.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <ecal/ecal_deprecate.h>
 #include <ecal/msg/publisher.h>
 
 #include <string>
@@ -69,7 +70,7 @@ namespace eCAL
        * @param topic_type_  Type name (optional).
        * @param topic_desc_  Type description (optional).
       **/
-      [[deprecated("Plase use eCAL::string::CPublisher(const std::string& topic_name_) instead. This function will be removed in eCAL6.")]]
+      ECAL_DEPRECATE_SINCE_5_13("Plase use eCAL::string::CPublisher(const std::string& topic_name_) instead. This function will be removed in eCAL6.")
       CPublisher(const std::string& topic_name_, const std::string& topic_type_, const std::string& topic_desc_) : CMsgPublisher<T>(topic_name_, topic_type_, topic_desc_)
       {
       }

--- a/ecal/core/include/ecal/msg/subscriber.h
+++ b/ecal/core/include/ecal/msg/subscriber.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <ecal/ecal_deprecate.h>
 #include <ecal/ecal_subscriber.h>
 #include <ecal/ecal_util.h>
 
@@ -60,7 +61,7 @@ namespace eCAL
      * @param topic_type_  Type name (optional for type checking).
      * @param topic_desc_  Type description (optional for description checking).
     **/
-    [[deprecated("Please use the constructor CMsgSubscriber(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6. ")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the constructor CMsgSubscriber(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6. ")
     CMsgSubscriber(const std::string& topic_name_, const std::string& topic_type_ = "", const std::string& topic_desc_ = "") : CSubscriber(topic_name_, topic_type_, topic_desc_)
     {
     }
@@ -135,7 +136,7 @@ namespace eCAL
      *
      * @return  true if it succeeds, false if it fails.
     **/
-    [[deprecated("Please use the method CMsgSubscriber(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6. ")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use the method CMsgSubscriber(const std::string& topic_name_, const STopicInformation& topic_info_) instead. This function will be removed in eCAL6. ")
     bool Create(const std::string& topic_name_, const std::string& topic_type_ = "", const std::string& topic_desc_ = "")
     {
       return(CSubscriber::Create(topic_name_, topic_type_, topic_desc_));
@@ -224,14 +225,14 @@ namespace eCAL
     }
 
 protected:
-    [[deprecated("Please use STopicInformation GetTopicInformation() instead. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use STopicInformation GetTopicInformation() instead. This function will be removed in eCAL6.")
     virtual std::string GetTypeName() const
     {
       STopicInformation topic_info{ GetTopicInformation() };
       return Util::CombinedTopicEncodingAndType(topic_info.encoding, topic_info.type);
     };
 
-    [[deprecated("Please use STopicInformation GetTopicInformation() instead. This function will be removed in eCAL6.")]]
+    ECAL_DEPRECATE_SINCE_5_13("Please use STopicInformation GetTopicInformation() instead. This function will be removed in eCAL6.")
     virtual std::string GetDescription() const
     {
       return GetTopicInformation().descriptor;

--- a/ecal/core/src/ecal_defs.h.in
+++ b/ecal/core/src/ecal_defs.h.in
@@ -1,3 +1,27 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+/**
+ * @file   ecal_defs.h
+ * @brief  eCAL core defines (version numbers)
+**/
+
 #ifndef ecal_defs_h_included
 #define ecal_defs_h_included
 #define ECAL_VERSION_MAJOR (@GIT_REVISION_MAJOR@)
@@ -6,6 +30,9 @@
 #define ECAL_VERSION "@GIT_DESCRIBE_TAG@"
 #define ECAL_DATE "@GIT_REVISION_DATE@"
 #define ECAL_PLATFORMTOOLSET "@eCAL_PLATFORM_TOOLSET@"
+
+#define ECAL_VERSION_INTEGER                          ECAL_VERSION_CALCULATE(ECAL_VERSION_MAJOR, ECAL_VERSION_MINOR, ECAL_VERSION_PATCH)
+#define ECAL_VERSION_CALCULATE(major, minor, patch)   (((major)<<16)|((minor)<<8)|(patch))
 
 #define ECAL_INSTALL_APP_DIR     "@eCAL_install_app_dir@"
 #define ECAL_INSTALL_SAMPLES_DIR "@eCAL_install_samples_dir@"

--- a/ecal/core/src/service/ecal_service_client_impl.cpp
+++ b/ecal/core/src/service/ecal_service_client_impl.cpp
@@ -171,7 +171,7 @@ namespace eCAL
   }
 
   // blocking call, no broadcast, first matching service only, response will be returned in service_response_
-  [[deprecated]]
+  //[[deprecated]]
   bool CServiceClientImpl::Call(const std::string& method_name_, const std::string& request_, struct SServiceResponse& service_response_)
   {
     if (g_clientgate() == nullptr) return false;

--- a/ecal/core/src/service/ecal_service_client_impl.h
+++ b/ecal/core/src/service/ecal_service_client_impl.h
@@ -22,6 +22,7 @@
 **/
 
 #include <ecal/ecal.h>
+#include <ecal/ecal_deprecate.h>
 #include <ecal/ecal_callback.h>
 
 #include "service/ecal_tcpclient.h"
@@ -57,7 +58,7 @@ namespace eCAL
     bool RemEventCallback(eCAL_Client_Event type_);
       
     // blocking call, no broadcast, first matching service only, response will be returned in service_response_
-    [[deprecated]]
+    ECAL_DEPRECATE_SINCE_5_10("Please use bool Call(const std::string& method_name_, const std::string& request_, int timeout_, ServiceResponseVecT* service_response_vec_) instead. This function will be removed in eCAL6.")
     bool Call(const std::string& method_name_, const std::string& request_, struct SServiceResponse& service_response_);
     
     // blocking call, all responses will be returned in service_response_vec_


### PR DESCRIPTION
… eCAL version.

**Pull request type**

Please check the type of change your PR introduces:
- [x] Refactoring (no functional changes, no api changes)

**What is the current behavior?**
We deprecate functionality and the user can not see, when it was deprecated.
Also we cannot deprecate functionality for upcoming releases, which makes code maintenance harder.