### PR TITLE
Mon: Fixed text color of "Debug x" string in Log panel

### DIFF
--- a/app/mon/mon_gui/src/widgets/models/log_model.cpp
+++ b/app/mon/mon_gui/src/widgets/models/log_model.cpp
@@ -136,7 +136,7 @@ QString LogModel::logLevelToString(int log_level)
   }
 }
 
-QColor LogModel::logLevelColor(int log_level)
+QVariant LogModel::logLevelColor(int log_level)
 {
   switch (log_level)
   {
@@ -149,7 +149,7 @@ QColor LogModel::logLevelColor(int log_level)
   case eCAL_Logging_eLogLevel::log_level_fatal:
     return QColor(192, 0, 0);
   default:
-    return QColor(0, 0, 0);
+    return QVariant::Invalid; // Default color for "Debug x"
   }
 }
 

--- a/app/mon/mon_gui/src/widgets/models/log_model.h
+++ b/app/mon/mon_gui/src/widgets/models/log_model.h
@@ -101,6 +101,6 @@ private:
   bool parse_time_enabled_;
 
   static QString logLevelToString(int log_level);
-  static QColor logLevelColor(int log_level);
+  static QVariant logLevelColor(int log_level);
   QString timeToString(long long milliseconds) const;
 };


### PR DESCRIPTION
Now, the default text color is used (black in light mode and white in dark mode). Before, it was always black, which rendered the string unreadable in dark-mode.

Fixes #1135