### PR TITLE
core: remove unused and untested udp sendasync method

### DIFF
--- a/ecal/core/src/io/udp_sender.h
+++ b/ecal/core/src/io/udp_sender.h
@@ -45,9 +45,7 @@ namespace eCAL
   {
   public:
     CUDPSender(const SSenderAttr& attr_);
-
-    size_t Send     (const void* buf_, size_t len_, const char* ipaddr_ = nullptr);
-    void   SendAsync(const void* buf_, size_t len_, const char* ipaddr_ = nullptr);
+    size_t Send(const void* buf_, size_t len_, const char* ipaddr_ = nullptr);
 
   protected:
     std::shared_ptr<CUDPSenderImpl> m_socket_impl;


### PR DESCRIPTION
**Pull request type**

Please check the type of change your PR introduces:
- [X] Other (please describe): There is an untested, unused internal async udp send method. We should remove this code.


**What is the current behavior?**
Untested, internal [`CUDPSender::SendAsync`](https://github.com/eclipse-ecal/ecal/blob/50699d8326f3ad48e06b847b20b6002284bda92a/ecal/core/src/io/udp_sender.h#L50) API.

**What is the new behavior?**
API removed.

**Does this introduce a breaking change?**

- [X] No

**Cherry-pick to:**
- _none_
