### PR TITLE
GitHub: Radically shortened the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,38 +1,8 @@
-**Pull request type**
+**Description**
+<!-- What does your PR change? -->
 
-<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
+**Related issues**
+<!-- Type "Fixes #123" to close that issue, when this PR is merged -->
 
-<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 
-
-Please check the type of change your PR introduces:
-- [ ] Bugfix
-- [ ] Feature
-- [ ] Code style update (formatting, renaming)
-- [ ] Refactoring (no functional changes, no api changes)
-- [ ] Build related changes
-- [ ] Documentation content changes
-- [ ] Other (please describe): 
-
-
-**What is the current behavior?**
-<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
-
-Issue Number: N/A
-
-**What is the new behavior?**
-<!-- Please describe the behavior or changes that are being added by this PR. -->
-
--
--
--
-
-**Does this introduce a breaking change?**
-
-- [ ] Yes
-- [ ] No
-
-<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
-
-**Other information**
-
-<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
+**Cherry-pick to**:
+<!-- Leave empty, if you don't know. For master-only changes type "none" -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,8 @@
-**Description**
+### Description
 <!-- What does your PR change? -->
 
-**Related issues**
-<!-- Type "Fixes #123" to close that issue, when this PR is merged -->
+### Related issues
+- <!-- Type "Fixes #123" to close that issue, when this PR is merged -->
 
-**Cherry-pick to**:
-<!-- Leave empty, if you don't know. For master-only changes type "none" -->
+### Cherry-pick to
+- <!-- Leave empty, if you don't know. For master-only changes type "none" -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 <!-- What does your PR change? -->
 
 ### Related issues
-<!-- Type "Fixes #123" to close that issue, when this PR is merged -->
+<!-- Type "Fixes #123" to automatically close that issue, when this PR is merged -->
 - 
 
 ### Cherry-pick to

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,12 @@
 <!-- What does your PR change? -->
 
 ### Related issues
-- <!-- Type "Fixes #123" to close that issue, when this PR is merged -->
+<!-- Type "Fixes #123" to close that issue, when this PR is merged -->
+- 
 
 ### Cherry-pick to
-- <!-- Leave empty, if you don't know. For master-only changes type "none" -->
+<!-- Leave empty, if you don't know. For master-only changes use "none"
+- _none_
+- 5.11 (old stable)
+- 5.12 (current stable)
+-->


### PR DESCRIPTION
**Description**

The old issue template was very long. It was hard to fill out correctly and thus often contained wrong information. Thousands of checkboxes distracted from what is actually important.

The most important thing for a PR should always be: What does it change.

I also added a section for related issues and cherry-pick. The latter is meant for giving myself a better overview over what still needs to be cherry-picked to which branch and what is master-only. Usually the developer knows that when submitting the PR.

**Related issues**
- _none_

**Cherry-pick to**:
- _none_