### PR TITLE
#1186 Make compatible with ftxui 5.0.0

### DIFF
--- a/app/mon/mon_tui/CMakeLists.txt
+++ b/app/mon/mon_tui/CMakeLists.txt
@@ -108,7 +108,10 @@ target_include_directories(${PROJECT_NAME}
   PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>)
 
 target_compile_definitions(${PROJECT_NAME}
-  PRIVATE $<$<BOOL:${MSVC}>:PCRE_STATIC;_UNICODE>)
+  PRIVATE 
+    $<$<BOOL:${MSVC}>:PCRE_STATIC;_UNICODE>
+    FTXUI_VERSION_MAJOR=${ftxui_VERSION_MAJOR}
+  )
 
 create_targets_protobuf()
 

--- a/app/mon/mon_tui/src/tui/style_sheet.hpp
+++ b/app/mon/mon_tui/src/tui/style_sheet.hpp
@@ -100,7 +100,12 @@ struct StyleSheet
         default: return nothing;
       }
     };
-    sheet.tab.entries.transform = [](EntryState state)
+#if FTXUI_VERSION_MAJOR >= 5
+    sheet.tab.entries_option.transform =
+#else
+    sheet.tab.entries.transform =
+#endif
+      [](EntryState state)
     {
       if(state.active)
       {
@@ -110,7 +115,11 @@ struct StyleSheet
       }
       return text(state.label);
     };
+#if FTXUI_VERSION_MAJOR >= 5
+    sheet.tab.direction = Direction::Right;
+#else
     sheet.tab.direction = MenuOption::Right;
+#endif
     sheet.tab.elements_prefix = [] {
       return text(" ");
     };
@@ -202,14 +211,23 @@ struct StyleSheet
         default: return nothing;
       }
     };
-    sheet.tab.entries.transform = [](EntryState state) {
+#if FTXUI_VERSION_MAJOR >= 5
+    sheet.tab.entries_option.transform = 
+#else
+    sheet.tab.entries.transform =
+#endif
+    [](EntryState state) {
       if(state.active)
       {
         return text(state.label) | inverted;
       }
       return text(state.label);
     };
+#if FTXUI_VERSION_MAJOR >= 5
+    sheet.tab.direction = Direction::Right;
+#else
     sheet.tab.direction = MenuOption::Right;
+#endif
     sheet.tab.elements_prefix = [] {
       return text(" ");
     };

--- a/thirdparty/build-ftxui.cmake
+++ b/thirdparty/build-ftxui.cmake
@@ -1,3 +1,12 @@
 option(FTXUI_BUILD_EXAMPLES "Set to ON to build examples" OFF)
 
 add_subdirectory(thirdparty/ftxui EXCLUDE_FROM_ALL)
+
+# Set ftxui_VERSION_MAJOR, because it's only defined in the subdirectory scope and we cannot access it
+# Reading it automatically is less error prone than setting itt by hand
+file(READ thirdparty/ftxui/CMakeLists.txt content)
+if(content MATCHES "VERSION ([0-9]+)\\.[0-9]+\\.[0-9]+")
+  set(ftxui_VERSION_MAJOR "${CMAKE_MATCH_1}")
+else()
+  message(FATAL_ERROR "Couldn't read version info")
+endif()


### PR DESCRIPTION
### Description
Allows to build `mon_tui` with latest ftxui.

### Related issues
Fixes https://github.com/eclipse-ecal/ecal/issues/1186

### Cherry-pick to
- 5.11 (old stable) - ??? (we have to decide)
- 5.12 (current stable) - ??? (we have to decide)
