### PR TITLE
Rec GUI: Fixed a tooltip typo

### DIFF
--- a/app/rec/rec_gui/src/widgets/recordermanager_widget/recorder_model.cpp
+++ b/app/rec/rec_gui/src/widgets/recordermanager_widget/recorder_model.cpp
@@ -511,7 +511,7 @@ QVariant RecorderModel::data(const QModelIndex &index, int role) const
     {
       if (recorder_list_[row].recording_enabled_ && recorder_list_[row].time_error_warning_)
       {
-        return "On of the recorders appears to be out of sync!";
+        return "One of the recorders appears to be out of sync!";
       }
     }
 


### PR DESCRIPTION
### Description
![grafik](https://github.com/eclipse-ecal/ecal/assets/11774314/257857f9-75c8-4d38-8a4e-be47fe25de2f)

Fixed this typo

### Cherry-pick to
- 5.11 (old stable)
- 5.12 (current stable)