### PR TITLE
Sphinx Doc: downgrade sphinxcontrib-youtube

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -7,6 +7,6 @@ empy
 semantic-version 
 exhale
 Jinja2
-sphinxcontrib-youtube
+sphinxcontrib-youtube<=1.2
 sphinxcontrib-apidoc
 


### PR DESCRIPTION
### Description
The latest version of sphinxcontrib-youtube is not compatible with our Sphinx version (4.5) anymore. I downgraded sphinxcontrib-youtube to 1.2 or lower.

### Cherry-pick to
- 5.12 (current stable)
- 5.11 (probably needs to be re-implemented)
