### PR TITLE
eCAL Core: Callback after zero length send contains stale message

### DIFF
--- a/ecal/core/src/io/ecal_memfile_pool.cpp
+++ b/ecal/core/src/io/ecal_memfile_pool.cpp
@@ -206,19 +206,18 @@ namespace eCAL
             // and close the file immediately
             else
             {
+              // need to resize the buffer especially if data_size = 0, otherwise it might contain stale data.
+              receive_buffer.resize((size_t)mfile_hdr.data_size);
+
               // read payload
               // if data length == 0, there is no need to further read data
               // we just flag to process the empty buffer
-              if (mfile_hdr.data_size == 0)
+              if (mfile_hdr.data_size != 0)
               {
-                post_process_buffer = true;
-              }
-              else
-              {
-                receive_buffer.resize((size_t)mfile_hdr.data_size);
                 m_memfile.Read(receive_buffer.data(), (size_t)mfile_hdr.data_size, mfile_hdr.hdr_size);
-                post_process_buffer = true;
               }
+
+              post_process_buffer = true;
             }
 
             // store clock


### PR DESCRIPTION
### Description
2333d20 introduced a bug when sending zero length messages over SHM - the callback would contain stale non-zero length messages from the previous call.

This commit fixes the introduced bug, and adds a testcase for this scenario.

### Related issues
Fixes #1200  

### Cherry-pick to
- 5.11 (old stable) -> probably cannot be cherry picked, but requires a different commit
- 5.12 (current stable)
