### PR TITLE
GH Actions: Remove Python 3.6 wheel build on Windows

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -240,18 +240,6 @@ jobs:
       shell: cmd
       working-directory: ${{ runner.workspace }}/_build/complete
 
-    - name: Build Python 3.6 Wheel
-      run: |
-        mkdir ".venv_36"
-        py -3.6 -m venv ".venv_36"
-        CALL ".venv_36\Scripts\activate.bat"
-        pip install wheel
-        cmake %GITHUB_WORKSPACE% -G "Visual Studio 16 2019" -A x64 -T v142 -DPython_FIND_VIRTUALENV=FIRST
-        cmake %GITHUB_WORKSPACE% -G "Visual Studio 16 2019" -A x64 -T v142 -DPython_FIND_VIRTUALENV=ONLY
-        cmake --build . --target create_python_wheel --config Release
-      shell: cmd
-      working-directory: ${{ runner.workspace }}/_build/complete
-
 #    - name: Build Documentation C
 #      run: cmake --build . --target documentation_c
 #      working-directory: ${{ runner.workspace }}/_build


### PR DESCRIPTION
### Description
The default GH Action runners dropped Python 3.6, so we are dropping it as well.

### Cherry-pick to
- 5.11 (old stable)
- 5.12 (current stable)
