### PR TITLE
HDF5: Make sure datasets are always closed upon reading...

### DIFF
--- a/contrib/ecalhdf5/src/eh5_meas_dir.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_dir.cpp
@@ -95,18 +95,20 @@ bool eCAL::eh5::HDF5MeasDir::Open(const std::string& path, eAccessType access /*
 
 bool eCAL::eh5::HDF5MeasDir::Close()
 {
+  bool successfully_closed{ true };
+
   if (access_ == eAccessType::CREATE)
   {
     // Close all existing file writers
     for (auto& file_writer : file_writers_)
     {
-      file_writer.second->Close();
+      successfully_closed &= file_writer.second->Close();
     }
 
     // Clear the list of all file writers, which will delete them
     file_writers_.clear();
 
-    return true;
+    return successfully_closed;
   }
   else
   {
@@ -114,7 +116,7 @@ bool eCAL::eh5::HDF5MeasDir::Close()
     {
       if (file != nullptr)
       {
-        file->Close();
+        successfully_closed &= file->Close();
         delete file;
         file = nullptr;
       }
@@ -125,7 +127,7 @@ bool eCAL::eh5::HDF5MeasDir::Close()
     entries_by_id_.clear();
     entries_by_chn_.clear();
 
-    return true;
+    return successfully_closed;
   }
 }
 

--- a/contrib/ecalhdf5/src/eh5_meas_file_v2.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v2.cpp
@@ -294,13 +294,15 @@ bool eCAL::eh5::HDF5MeasFileV2::GetEntryData(long long entry_id, void* data) con
 
   auto size = H5Dget_storage_size(dataset_id);
 
-  if (size <= 0) return false;
-
-  auto readStatus = H5Dread(dataset_id, H5T_NATIVE_UCHAR, H5S_ALL, H5S_ALL, H5P_DEFAULT, data);
+  herr_t read_status = -1;
+  if (size >= 0)
+  {
+    read_status = H5Dread(dataset_id, H5T_NATIVE_UCHAR, H5S_ALL, H5S_ALL, H5P_DEFAULT, data);
+  }
 
   H5Dclose(dataset_id);
 
-  return (readStatus >= 0);
+  return (read_status >= 0);
 }
 
 

--- a/testing/contrib/ecalhdf5/hdf5_test/src/hdf5_test.cpp
+++ b/testing/contrib/ecalhdf5/hdf5_test/src/hdf5_test.cpp
@@ -84,7 +84,7 @@ TEST(HDF5, WriteReadIntegrity)
   const long long   t1_clock         = 11LL;
 
   const std::string t2_name          = "another,topic";
-  const std::string t2_data          = "Data of topic 2";
+  const std::string t2_data          = "";
   const long long   t2_snd_timestamp = 1002LL;
   const long long   t2_rcv_timestamp = 2002LL;
   const long long   t2_id            = 2LL;


### PR DESCRIPTION
, even when size 0 data is read.

HDF5MeasDir should return if all files were closed properly.

### Description
Properly Close Opened hdf5 datasets when reading

### Related issues
Fixes #1210

### Cherry-pick to
- 5.11 (old stable)
- 5.12 (current stable)
