### PR TITLE
Added Youtube video to the main documentation page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ doc/rst/_download_archive
 doc/rst/_download_main_page
 doc/extensions/_autogen
 doc/rst/getting_started/**/*_pb2.py
+doc/rst/.venv
 *.pyc
 
 # Clion

--- a/doc/rst/index.rst
+++ b/doc/rst/index.rst
@@ -22,6 +22,10 @@ This chapter will walk you through
 * The :ref:`applications <getting_started_applications>` that come with eCAL
 * Writing your first :ref:`Hello World <getting_started_hello_world>` program 
 
+Learn about how to use and develop with eCAL in our Webinar:
+
+.. youtube:: 8AAxlu1WbdU
+
 .. include:: _download_main_page/_main_page_download_section.rst.txt
 
 Links
@@ -37,7 +41,7 @@ To contribute, please visit our github repository:
          <span class="btn-text">eCAL on Github</span>
       </a>
    </p>
-   
+
 License
 =======
 


### PR DESCRIPTION
### Description
Added the Shifting Gears Webinar to the main documentation page. I think it is a good fit. But if you hate it, that's ok, too! 😀

![image](https://github.com/eclipse-ecal/ecal/assets/11774314/8824c156-cb8a-4b31-b9ad-1bdbee3d55f0)


### Related issues
- None

### Cherry-pick to
- _none_