### PR TITLE
bugfix/unregistration memfile event handling

### DIFF
--- a/ecal/core/src/io/ecal_memfile_sync.cpp
+++ b/ecal/core/src/io/ecal_memfile_sync.cpp
@@ -87,26 +87,17 @@ namespace eCAL
     }
   }
 
-  bool CSyncMemoryFile::Disconnect(const std::string& process_id_)
+  bool CSyncMemoryFile::Disconnect(const std::string& /* process_id_ */)
   {
-    if (!m_created) return false;
-
-    // a local subscriber connection timed out
-    // we close the associated sync events and
-    // remove them from the event handle map
-
-    const std::lock_guard<std::mutex> lock(m_event_handle_map_sync);
-    const EventHandleMapT::const_iterator iter = m_event_handle_map.find(process_id_);
-    if (iter != m_event_handle_map.end())
-    {
-      const SEventHandlePair event_pair = iter->second;
-      gCloseEvent(event_pair.event_snd);
-      gCloseEvent(event_pair.event_ack);
-      m_event_handle_map.erase(iter);
-      return true;
-    }
-
-    return false;
+    // a local subscriber connection timed out or was unregistered actively
+    //
+    // we do not close or remove the associated sync events
+    // because they are still used by the memfile observer logic
+    // in the connected process
+    //
+    // the events will be cleaned up finally with the destruction
+    // of the memory file
+    return true;
   }
 
   bool CSyncMemoryFile::CheckSize(size_t size_)

--- a/ecal/core/src/readwrite/ecal_writer.cpp
+++ b/ecal/core/src/readwrite/ecal_writer.cpp
@@ -668,8 +668,10 @@ namespace eCAL
     m_loc_subscribed = true;
 
     // add a new local subscription
-    m_writer.udp_mc.AddLocConnection (local_info_.process_id, reader_par_);
-    m_writer.shm.AddLocConnection    (local_info_.process_id, reader_par_);
+    // currently for the shm writer implemented only
+    m_writer.udp_mc.AddLocConnection (local_info_.process_id, local_info_.topic_id, reader_par_);
+    m_writer.shm.AddLocConnection    (local_info_.process_id, local_info_.topic_id, reader_par_);
+    m_writer.tcp.AddLocConnection    (local_info_.process_id, local_info_.topic_id, reader_par_);
 
 #ifndef NDEBUG
     // log it
@@ -686,8 +688,10 @@ namespace eCAL
     }
 
     // remove a local subscription
-    m_writer.udp_mc.RemLocConnection (local_info_.process_id);
-    m_writer.shm.RemLocConnection    (local_info_.process_id);
+    // currently all these functions are not implemented (there is no need to react on)
+    m_writer.udp_mc.RemLocConnection (local_info_.process_id, local_info_.topic_id);
+    m_writer.shm.RemLocConnection    (local_info_.process_id, local_info_.topic_id);
+    m_writer.tcp.RemLocConnection    (local_info_.process_id, local_info_.topic_id);
 
 #ifndef NDEBUG
     // log it
@@ -708,8 +712,10 @@ namespace eCAL
     m_ext_subscribed = true;
 
     // add a new external subscription
-    m_writer.udp_mc.AddExtConnection (external_info_.host_name, external_info_.process_id, reader_par_);
-    m_writer.shm.AddExtConnection    (external_info_.host_name, external_info_.process_id, reader_par_);
+    // currently all these functions are not implemented (there is no need to react on)
+    m_writer.udp_mc.AddExtConnection (external_info_.host_name, external_info_.process_id, external_info_.topic_id, reader_par_);
+    m_writer.shm.AddExtConnection    (external_info_.host_name, external_info_.process_id, external_info_.topic_id, reader_par_);
+    m_writer.tcp.AddExtConnection    (external_info_.host_name, external_info_.process_id, external_info_.topic_id, reader_par_);
 
 #ifndef NDEBUG
     // log it
@@ -726,8 +732,10 @@ namespace eCAL
     }
 
     // remove external subscription
-    m_writer.udp_mc.RemExtConnection (external_info_.host_name, external_info_.process_id);
-    m_writer.shm.RemExtConnection    (external_info_.host_name, external_info_.process_id);
+    // currently all these functions are not implemented (there is no need to react on)
+    m_writer.udp_mc.RemExtConnection (external_info_.host_name, external_info_.process_id, external_info_.topic_id);
+    m_writer.shm.RemExtConnection    (external_info_.host_name, external_info_.process_id, external_info_.topic_id);
+    m_writer.tcp.RemExtConnection    (external_info_.host_name, external_info_.process_id, external_info_.topic_id);
   }
 
   void CDataWriter::RefreshRegistration()
@@ -764,20 +772,13 @@ namespace eCAL
     Register(false);
 
     // check connection timeouts
-    // Todo: Why are only Local connections removed, not external connections?
-    const std::shared_ptr<std::list<SLocalSubscriptionInfo>> loc_timeouts = std::make_shared<std::list<SLocalSubscriptionInfo>>();
     {
       const std::lock_guard<std::mutex> lock(m_sub_map_sync);
-      m_loc_sub_map.remove_deprecated(loc_timeouts.get());
+      m_loc_sub_map.remove_deprecated();
       m_ext_sub_map.remove_deprecated();
 
       m_loc_subscribed = !m_loc_sub_map.empty();
       m_ext_subscribed = !m_ext_sub_map.empty();
-    }
-
-    for(const auto& loc_sub : *loc_timeouts)
-    {
-      m_writer.shm.RemLocConnection(loc_sub.process_id);
     }
 
     if (!m_loc_subscribed && !m_ext_subscribed)

--- a/ecal/core/src/readwrite/ecal_writer_base.h
+++ b/ecal/core/src/readwrite/ecal_writer_base.h
@@ -48,11 +48,11 @@ namespace eCAL
     virtual bool SetQOS(const QOS::SWriterQOS& qos_) { m_qos = qos_; return true; };
     QOS::SWriterQOS GetQOS() { return(m_qos); };
 
-    virtual bool AddLocConnection(const std::string& /*process_id_*/, const std::string& /*conn_par_*/) { return false; };
-    virtual bool RemLocConnection(const std::string& /*process_id_*/) { return false; };
+    virtual bool AddLocConnection(const std::string& /*process_id_*/, const std::string& /*topic_id_*/, const std::string& /*conn_par_*/) { return false; };
+    virtual bool RemLocConnection(const std::string& /*process_id_*/, const std::string& /*topic_id_*/) { return false; };
 
-    virtual bool AddExtConnection(const std::string& /*host_name_*/, const std::string& /*process_id_*/, const std::string& /*conn_par_*/) { return false; };
-    virtual bool RemExtConnection(const std::string& /*host_name_*/, const std::string& /*process_id_*/) { return false; };
+    virtual bool AddExtConnection(const std::string& /*host_name_*/, const std::string& /*process_id_*/, const std::string& /*topic_id_*/, const std::string& /*conn_par_*/) { return false; };
+    virtual bool RemExtConnection(const std::string& /*host_name_*/, const std::string& /*process_id_*/, const std::string& /*topic_id_*/) { return false; };
 
     virtual std::string GetConnectionParameter() { return ""; };
 

--- a/ecal/core/src/readwrite/ecal_writer_shm.cpp
+++ b/ecal/core/src/readwrite/ecal_writer_shm.cpp
@@ -177,7 +177,7 @@ namespace eCAL
     return sent;
   }
 
-  bool CDataWriterSHM::AddLocConnection(const std::string& process_id_, const std::string& /*conn_par_*/)
+  bool CDataWriterSHM::AddLocConnection(const std::string& process_id_, const std::string& /*topic_id_*/, const std::string& /*conn_par_*/)
   {
     if (!m_created) return false;
     bool ret_state(true);
@@ -185,20 +185,6 @@ namespace eCAL
     for (auto& memory_file : m_memory_file_vec)
     {
       ret_state &= memory_file->Connect(process_id_);
-    }
-
-    return ret_state;
-  }
-
-  bool CDataWriterSHM::RemLocConnection(const std::string& process_id_)
-  {
-    if (!m_created) return false;
-    bool ret_state(true);
-
-    for (auto& memory_file : m_memory_file_vec)
-    {
-      // this function is doing nothing currently
-      ret_state &= memory_file->Disconnect(process_id_);
     }
 
     return ret_state;

--- a/ecal/core/src/readwrite/ecal_writer_shm.cpp
+++ b/ecal/core/src/readwrite/ecal_writer_shm.cpp
@@ -197,16 +197,8 @@ namespace eCAL
 
     for (auto& memory_file : m_memory_file_vec)
     {
-      // This is not working correctly under POSIX for memory files that are read and written within the same process.
-      // 
-      // The functions 'CSyncMemoryFile::Disconnect' and 'CDataWriterSHM::RemLocConnection' are now called
-      // by the new Subscriber Unregistration event logic and were never called in any previous eCAL version.
-      // 
-      // TODO: Fix this in 'CSyncMemoryFile::Disconnect' to handle event resources properly.
-      if (std::to_string(eCAL::Process::GetProcessID()) != process_id_)
-      {
-        ret_state &= memory_file->Disconnect(process_id_);
-      }
+      // this function is doing nothing currently
+      ret_state &= memory_file->Disconnect(process_id_);
     }
 
     return ret_state;

--- a/ecal/core/src/readwrite/ecal_writer_shm.h
+++ b/ecal/core/src/readwrite/ecal_writer_shm.h
@@ -51,8 +51,7 @@ namespace eCAL
 
     bool Write(CPayloadWriter& payload_, const SWriterAttr& attr_) override;
 
-    bool AddLocConnection(const std::string& process_id_, const std::string& conn_par_) override;
-    bool RemLocConnection(const std::string& process_id_) override;
+    bool AddLocConnection(const std::string& process_id_, const std::string& topic_id_, const std::string& conn_par_) override;
 
     std::string GetConnectionParameter() override;
 

--- a/testing/ecal/pubsub_test/src/pubsub_test.cpp
+++ b/testing/ecal/pubsub_test/src/pubsub_test.cpp
@@ -869,10 +869,6 @@ TEST(IO, MultipleSendsUDP)
   eCAL::Finalize();
 }
 
-
-
-
-
 #if 0
 TEST(IO, ZeroPayloadMessageTCP)
 {
@@ -923,8 +919,6 @@ TEST(IO, ZeroPayloadMessageTCP)
 }
 #endif
 
-#include <ecal/msg/string/publisher.h>
-#include <ecal/msg/string/subscriber.h>
 TEST(IO, DestroyInCallback)
 {
   /* Test setup :
@@ -984,6 +978,77 @@ TEST(IO, DestroyInCallback)
 
   pub_foo_t.join();
   pub_destroy_t.join();
+
+  // finalize eCAL API
+  // without destroying any pub / sub
+  eCAL::Finalize();
+}
+
+TEST(IO, SubscriberReconnection)
+{
+  /* Test setup :
+   * publisher runs permanently in a thread
+   * subscriber start reading
+   * subscriber gets out of scope (destruction)
+   * subscriber starts again in a new scope
+   * Test ensures that subscriber is reconnecting and all sync mechanism are working properly again.
+  */
+
+  // initialize eCAL API
+  eCAL::Initialize(0, nullptr, "SubscriberReconnection");
+
+  // enable loop back communication in the same thread
+  eCAL::Util::EnableLoopback(true);
+
+  // start publishing thread
+  std::atomic<bool> stop_publishing(false);
+  eCAL::string::CPublisher<std::string> pub_foo("foo");
+  std::thread pub_foo_t([&pub_foo, &stop_publishing]() {
+    while (!stop_publishing)
+    {
+      pub_foo.Send("Hello World");
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    std::cout << "Stopped publishing" << std::endl;
+  });
+
+  // scope 1
+  {
+    size_t callback_received_count(0);
+
+    eCAL::string::CSubscriber<std::string> sub_foo("foo");
+    auto receive_lambda = [&sub_foo, &callback_received_count](const char* /*topic_*/, const std::string& /*msg*/, long long /*time_*/, long long /*clock_*/, long long /*id_*/) {
+      std::cout << "Receiving in scope 1" << std::endl;
+      callback_received_count++;
+    };
+    sub_foo.AddReceiveCallback(receive_lambda);
+
+    // sleep for 2 seconds, we should receive something
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    EXPECT_TRUE(callback_received_count > 0);
+  }
+
+  // scope 2
+  {
+    size_t callback_received_count(0);
+
+    eCAL::string::CSubscriber<std::string> sub_foo("foo");
+    auto receive_lambda = [&sub_foo, &callback_received_count](const char* /*topic_*/, const std::string& /*msg*/, long long /*time_*/, long long /*clock_*/, long long /*id_*/) {
+      std::cout << "Receiving in scope 2" << std::endl;
+      callback_received_count++;
+    };
+    sub_foo.AddReceiveCallback(receive_lambda);
+
+    // sleep for 2 seconds, we should receive something
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    EXPECT_TRUE(callback_received_count > 0);
+  }
+
+  // stop publishing and join thread
+  stop_publishing = true;
+  pub_foo_t.join();
 
   // finalize eCAL API
   // without destroying any pub / sub


### PR DESCRIPTION
### Description
The new introduced "active register/unregister logic" calls depending on the connection type specific functions like (AddLocConnection/RemLocConnection,AddExtConnection/RemExtConnection) for the SHM and UDP data writer (TCP was just not handled for now).

The RemLocConnection was not called in that context before the new unregister/register logic and is closing the 2 connection events for updating and acknowledging memory file data transfer/receive. This leads to a dead shm connection when the subscriber on the other side is destroyed (triggering RemLocConnection in the publishing process) and created again.

Solution: Events are not closed on that level but are cleaned up together with the memory file resource (CSyncMemFile) properly.

### Related issues
No issue now, will be created soon ..

### Cherry-pick to
- None
