### PR TITLE
new owner flag added to event creation (used on linux os only)

### DIFF
--- a/ecal/core/include/ecal/ecal_event.h
+++ b/ecal/core/include/ecal/ecal_event.h
@@ -35,10 +35,11 @@ namespace eCAL
    *
    * @param [out] event_       Returned event struct.
    * @param       event_name_  Event name ("" == unnamed).
+   * @param       owner_       Event is owned by the caller and will be destroyed on CloseEvent
    *
    * @return  True if succeeded.
   **/
-  ECAL_API bool gOpenEvent(eCAL::EventHandleT* event_, const std::string& event_name_ = "");
+  ECAL_API bool gOpenEvent(eCAL::EventHandleT* event_, const std::string& event_name_ = "", bool owner_ = true);
 
   /**
    * @brief Close an event.

--- a/ecal/core/src/ecal_event.cpp
+++ b/ecal/core/src/ecal_event.cpp
@@ -37,7 +37,7 @@
 
 namespace eCAL
 {
-  bool gOpenEvent(EventHandleT* event_, const std::string& event_name_)
+  bool gOpenEvent(EventHandleT* event_, const std::string& event_name_, bool /*owner_*/)
   {
     if(event_ == nullptr) return(false);
     EventHandleT event;
@@ -302,9 +302,10 @@ namespace eCAL
   class CNamedEvent
   {
   public:
-    explicit CNamedEvent(const std::string& name_) :
+    explicit CNamedEvent(const std::string& name_, bool owner_) :
       m_name(name_ + "_evt"),
-      m_event(nullptr)
+      m_event(nullptr),
+      m_owner(owner_)
     {
       m_name = (m_name[0] != '/') ? "/" + m_name : m_name; // make memory file path compatible for all posix systems
       m_event = named_event_open(m_name.c_str());
@@ -318,7 +319,10 @@ namespace eCAL
     {
       if(m_event == nullptr) return;
       named_event_close(m_event);
-      named_event_destroy(m_name.c_str());
+      if(m_owner)
+      {
+        named_event_destroy(m_name.c_str());
+      }
     }
 
     void set()
@@ -371,9 +375,10 @@ namespace eCAL
 
     std::string     m_name;
     named_event_t*  m_event;
+    bool            m_owner;
   };
 
-  bool gOpenEvent(EventHandleT* event_, const std::string& event_name_)
+  bool gOpenEvent(EventHandleT* event_, const std::string& event_name_, bool owner_)
   {
     if(event_ == nullptr) return(false);
 
@@ -386,7 +391,7 @@ namespace eCAL
     }
     else
     {
-      event.handle = new CNamedEvent(event.name);
+      event.handle = new CNamedEvent(event.name, owner_);
     }
 
     if(event.handle != nullptr)

--- a/ecal/core/src/io/ecal_memfile_pool.cpp
+++ b/ecal/core/src/io/ecal_memfile_pool.cpp
@@ -54,8 +54,8 @@ namespace eCAL
     if (m_created) return false;
 
     // open memory file events
-    gOpenEvent(&m_event_snd, memfile_event_);
-    gOpenEvent(&m_event_ack, memfile_event_ + "_ack");
+    gOpenEvent(&m_event_snd, memfile_event_, false);
+    gOpenEvent(&m_event_ack, memfile_event_ + "_ack", false);
 
     // create memory file access
     m_memfile.Create(memfile_name_.c_str(), false);

--- a/testing/ecal/pubsub_test/src/pubsub_test.cpp
+++ b/testing/ecal/pubsub_test/src/pubsub_test.cpp
@@ -869,10 +869,6 @@ TEST(IO, MultipleSendsUDP)
   eCAL::Finalize();
 }
 
-
-
-
-
 #if 0
 TEST(IO, ZeroPayloadMessageTCP)
 {
@@ -923,8 +919,6 @@ TEST(IO, ZeroPayloadMessageTCP)
 }
 #endif
 
-#include <ecal/msg/string/publisher.h>
-#include <ecal/msg/string/subscriber.h>
 TEST(IO, DestroyInCallback)
 {
   /* Test setup :
@@ -984,6 +978,77 @@ TEST(IO, DestroyInCallback)
 
   pub_foo_t.join();
   pub_destroy_t.join();
+
+  // finalize eCAL API
+  // without destroying any pub / sub
+  eCAL::Finalize();
+}
+
+TEST(IO, SubscriberReconnection)
+{
+  /* Test setup :
+   * publisher runs permanently in a thread
+   * subscriber start reading
+   * subscriber gets out of scope (destruction)
+   * subscriber starts again in a new scope
+   * Test ensures that subscriber is reconnecting and all sync mechanism are working properly again.
+  */
+
+  // initialize eCAL API
+  eCAL::Initialize(0, nullptr, "SubscriberReconnection");
+
+  // enable loop back communication in the same thread
+  eCAL::Util::EnableLoopback(true);
+
+  // start publishing thread
+  std::atomic<bool> stop_publishing(false);
+  eCAL::string::CPublisher<std::string> pub_foo("foo");
+  std::thread pub_foo_t([&pub_foo, &stop_publishing]() {
+    while (!stop_publishing)
+    {
+      pub_foo.Send("Hello World");
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    std::cout << "Stopped publishing" << std::endl;
+  });
+
+  // scope 1
+  {
+    size_t callback_received_count(0);
+
+    eCAL::string::CSubscriber<std::string> sub_foo("foo");
+    auto receive_lambda = [&sub_foo, &callback_received_count](const char* /*topic_*/, const std::string& /*msg*/, long long /*time_*/, long long /*clock_*/, long long /*id_*/) {
+      std::cout << "Receiving in scope 1" << std::endl;
+      callback_received_count++;
+    };
+    sub_foo.AddReceiveCallback(receive_lambda);
+
+    // sleep for 2 seconds, we should receive something
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    EXPECT_TRUE(callback_received_count > 0);
+  }
+
+  // scope 2
+  {
+    size_t callback_received_count(0);
+
+    eCAL::string::CSubscriber<std::string> sub_foo("foo");
+    auto receive_lambda = [&sub_foo, &callback_received_count](const char* /*topic_*/, const std::string& /*msg*/, long long /*time_*/, long long /*clock_*/, long long /*id_*/) {
+      std::cout << "Receiving in scope 2" << std::endl;
+      callback_received_count++;
+    };
+    sub_foo.AddReceiveCallback(receive_lambda);
+
+    // sleep for 2 seconds, we should receive something
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    EXPECT_TRUE(callback_received_count > 0);
+  }
+
+  // stop publishing and join thread
+  stop_publishing = true;
+  pub_foo_t.join();
 
   // finalize eCAL API
   // without destroying any pub / sub


### PR DESCRIPTION
### Description
Introducing ownership flag for named event creation.

### Related issues
Fixes #1218

### Cherry-pick to
- ~5.12 (current stable)~
- This PR changes public API and must not be cherry-picked
