### PR TITLE
cleanup add/rem datawriter connection logic

### DIFF
--- a/ecal/core/src/readwrite/ecal_writer_base.h
+++ b/ecal/core/src/readwrite/ecal_writer_base.h
@@ -48,11 +48,11 @@ namespace eCAL
     virtual bool SetQOS(const QOS::SWriterQOS& qos_) { m_qos = qos_; return true; };
     QOS::SWriterQOS GetQOS() { return(m_qos); };
 
-    virtual bool AddLocConnection(const std::string& /*process_id_*/, const std::string& /*conn_par_*/) { return false; };
-    virtual bool RemLocConnection(const std::string& /*process_id_*/) { return false; };
+    virtual bool AddLocConnection(const std::string& /*process_id_*/, const std::string& /*topic_id_*/, const std::string& /*conn_par_*/) { return false; };
+    virtual bool RemLocConnection(const std::string& /*process_id_*/, const std::string& /*topic_id_*/) { return false; };
 
-    virtual bool AddExtConnection(const std::string& /*host_name_*/, const std::string& /*process_id_*/, const std::string& /*conn_par_*/) { return false; };
-    virtual bool RemExtConnection(const std::string& /*host_name_*/, const std::string& /*process_id_*/) { return false; };
+    virtual bool AddExtConnection(const std::string& /*host_name_*/, const std::string& /*process_id_*/, const std::string& /*topic_id_*/, const std::string& /*conn_par_*/) { return false; };
+    virtual bool RemExtConnection(const std::string& /*host_name_*/, const std::string& /*process_id_*/, const std::string& /*topic_id_*/) { return false; };
 
     virtual std::string GetConnectionParameter() { return ""; };
 

--- a/ecal/core/src/readwrite/ecal_writer_base.h
+++ b/ecal/core/src/readwrite/ecal_writer_base.h
@@ -48,11 +48,11 @@ namespace eCAL
     virtual bool SetQOS(const QOS::SWriterQOS& qos_) { m_qos = qos_; return true; };
     QOS::SWriterQOS GetQOS() { return(m_qos); };
 
-    virtual bool AddLocConnection(const std::string& /*process_id_*/, const std::string& /*topic_id_*/, const std::string& /*conn_par_*/) { return false; };
-    virtual bool RemLocConnection(const std::string& /*process_id_*/, const std::string& /*topic_id_*/) { return false; };
+    virtual void AddLocConnection(const std::string& /*process_id_*/, const std::string& /*topic_id_*/, const std::string& /*conn_par_*/) {};
+    virtual void RemLocConnection(const std::string& /*process_id_*/, const std::string& /*topic_id_*/) {};
 
-    virtual bool AddExtConnection(const std::string& /*host_name_*/, const std::string& /*process_id_*/, const std::string& /*topic_id_*/, const std::string& /*conn_par_*/) { return false; };
-    virtual bool RemExtConnection(const std::string& /*host_name_*/, const std::string& /*process_id_*/, const std::string& /*topic_id_*/) { return false; };
+    virtual void AddExtConnection(const std::string& /*host_name_*/, const std::string& /*process_id_*/, const std::string& /*topic_id_*/, const std::string& /*conn_par_*/) {};
+    virtual void RemExtConnection(const std::string& /*host_name_*/, const std::string& /*process_id_*/, const std::string& /*topic_id_*/) {};
 
     virtual std::string GetConnectionParameter() { return ""; };
 

--- a/ecal/core/src/readwrite/ecal_writer_shm.cpp
+++ b/ecal/core/src/readwrite/ecal_writer_shm.cpp
@@ -177,7 +177,7 @@ namespace eCAL
     return sent;
   }
 
-  bool CDataWriterSHM::AddLocConnection(const std::string& process_id_, const std::string& /*conn_par_*/)
+  bool CDataWriterSHM::AddLocConnection(const std::string& process_id_, const std::string& /*topic_id_*/, const std::string& /*conn_par_*/)
   {
     if (!m_created) return false;
     bool ret_state(true);
@@ -185,28 +185,6 @@ namespace eCAL
     for (auto& memory_file : m_memory_file_vec)
     {
       ret_state &= memory_file->Connect(process_id_);
-    }
-
-    return ret_state;
-  }
-
-  bool CDataWriterSHM::RemLocConnection(const std::string& process_id_)
-  {
-    if (!m_created) return false;
-    bool ret_state(true);
-
-    for (auto& memory_file : m_memory_file_vec)
-    {
-      // This is not working correctly under POSIX for memory files that are read and written within the same process.
-      // 
-      // The functions 'CSyncMemoryFile::Disconnect' and 'CDataWriterSHM::RemLocConnection' are now called
-      // by the new Subscriber Unregistration event logic and were never called in any previous eCAL version.
-      // 
-      // TODO: Fix this in 'CSyncMemoryFile::Disconnect' to handle event resources properly.
-      if (std::to_string(eCAL::Process::GetProcessID()) != process_id_)
-      {
-        ret_state &= memory_file->Disconnect(process_id_);
-      }
     }
 
     return ret_state;

--- a/ecal/core/src/readwrite/ecal_writer_shm.cpp
+++ b/ecal/core/src/readwrite/ecal_writer_shm.cpp
@@ -177,17 +177,14 @@ namespace eCAL
     return sent;
   }
 
-  bool CDataWriterSHM::AddLocConnection(const std::string& process_id_, const std::string& /*topic_id_*/, const std::string& /*conn_par_*/)
+  void CDataWriterSHM::AddLocConnection(const std::string& process_id_, const std::string& /*topic_id_*/, const std::string& /*conn_par_*/)
   {
-    if (!m_created) return false;
-    bool ret_state(true);
+    if (!m_created) return;
 
     for (auto& memory_file : m_memory_file_vec)
     {
-      ret_state &= memory_file->Connect(process_id_);
+      memory_file->Connect(process_id_);
     }
-
-    return ret_state;
   }
 
   std::string CDataWriterSHM::GetConnectionParameter()

--- a/ecal/core/src/readwrite/ecal_writer_shm.h
+++ b/ecal/core/src/readwrite/ecal_writer_shm.h
@@ -51,8 +51,7 @@ namespace eCAL
 
     bool Write(CPayloadWriter& payload_, const SWriterAttr& attr_) override;
 
-    bool AddLocConnection(const std::string& process_id_, const std::string& conn_par_) override;
-    bool RemLocConnection(const std::string& process_id_) override;
+    bool AddLocConnection(const std::string& process_id_, const std::string& /*topic_id_*/, const std::string& conn_par_) override;
 
     std::string GetConnectionParameter() override;
 

--- a/ecal/core/src/readwrite/ecal_writer_shm.h
+++ b/ecal/core/src/readwrite/ecal_writer_shm.h
@@ -51,7 +51,7 @@ namespace eCAL
 
     bool Write(CPayloadWriter& payload_, const SWriterAttr& attr_) override;
 
-    bool AddLocConnection(const std::string& process_id_, const std::string& /*topic_id_*/, const std::string& conn_par_) override;
+    void AddLocConnection(const std::string& process_id_, const std::string& /*topic_id_*/, const std::string& conn_par_) override;
 
     std::string GetConnectionParameter() override;
 

--- a/samples/cpp/pubsub/protobuf/person_rec_events/src/person_rec_events.cpp
+++ b/samples/cpp/pubsub/protobuf/person_rec_events/src/person_rec_events.cpp
@@ -26,7 +26,7 @@
 
 void OnEvent(const char* topic_name_, const struct eCAL::SSubEventCallbackData* data_)
 {
-  std::cout << "topic name         : " << topic_name_ << std::endl;
+  std::cout << "topic name       : " << topic_name_ << std::endl;
   switch (data_->type)
   {
   case sub_event_connected:

--- a/samples/cpp/pubsub/protobuf/person_snd_events/src/person_snd_events.cpp
+++ b/samples/cpp/pubsub/protobuf/person_snd_events/src/person_snd_events.cpp
@@ -26,7 +26,7 @@
 
 void OnEvent(const char* topic_name_, const struct eCAL::SPubEventCallbackData* data_)
 {
-  std::cout << "topic name         : " << topic_name_ << std::endl;
+  std::cout << "topic name       : " << topic_name_ << std::endl;
   switch (data_->type)
   {
   case pub_event_connected:


### PR DESCRIPTION
### Description
- `RemLocConnection` call for SHM removed from ecal_writer.cpp
  - this call is unnecessary (events are closed on `CSyncMemFile Destruction/Disconnect`)
  - this call disconnects to a process even there are still additional subscriber for the same topics in this process
- calls `AddLocConnection`/`AddExtConnection`, `RemLocConnection`/`RemExtConnection `for all layers (including tcp) even function are unimplemented
- changed signature for all `AddXXXConnection`/`RemXXXConnection `functions to provide now unambiguous information host name, process id, topic id and not only process id

### Cherry-pick to
- _none_
