### PR TITLE
unintended semicolon in if statement

### DIFF
--- a/ecal/core/src/service/ecal_service_client_impl.cpp
+++ b/ecal/core/src/service/ecal_service_client_impl.cpp
@@ -562,7 +562,7 @@ namespace eCAL
                           }
                         };
 
-          if (client->second->async_call_service(request_shared_ptr, response_callback));
+          if (client->second->async_call_service(request_shared_ptr, response_callback))
             at_least_one_service_was_called = true;
         }
       }


### PR DESCRIPTION
### Description
Unintended semicolon in if statement removed.

### Cherry-pick to
- _none_
