### PR TITLE
tried to cleanup the naming of the ecal unit tests a bit

### DIFF
--- a/ecal/service/test/src/ecal_tcp_service_test.cpp
+++ b/ecal/service/test/src/ecal_tcp_service_test.cpp
@@ -1306,7 +1306,7 @@ TEST(CommunicationAndCallbacks, StressfulCommunicationMassivePayload) // NOLINT
 #endif
 
 #if 1
-TEST(callback, ServerAndClientManagers) // NOLINT
+TEST(Callback, ServerAndClientManagers) // NOLINT
 {
   for (std::uint8_t protocol_version = min_protocol_version; protocol_version <= max_protocol_version; protocol_version++)
   {

--- a/testing/contrib/ecalproto/dynproto_test/src/dynproto_test.cpp
+++ b/testing/contrib/ecalproto/dynproto_test/src/dynproto_test.cpp
@@ -29,7 +29,7 @@
 void ProcProtoMsg(const google::protobuf::Message& msg_, const std::string& prefix_ /* = "" */);
 
 // google test
-TEST(IO, dynproto)
+TEST(DynProto, dynproto)
 { 
   // generate a class instance of Person
   pb::People::Person person;

--- a/testing/contrib/ecalproto/ecal_proto_test/src/test_filters.cpp
+++ b/testing/contrib/ecalproto/ecal_proto_test/src/test_filters.cpp
@@ -29,14 +29,14 @@
 
 using namespace eCAL::protobuf;
 
-TEST(filter, nofilter)
+TEST(Filter, nofilter)
 {
   NoFilter filter;
   bool result = filter.Filter("abc");
   EXPECT_EQ(true, result);
 }
 
-TEST(filter, include_filter_clear)
+TEST(Filter, include_filter_clear)
 {
   SimpleIncludeFilter filter;
   std::string a("a");
@@ -90,7 +90,7 @@ void test_regular_includes(BaseIncludeFilter& filter)
   EXPECT_EQ(false, filter.Filter(adf));
 }
 
-TEST(filter, include_filter)
+TEST(Filter, include_filter)
 {
   SimpleIncludeFilter simple_filter;
   test_regular_includes(simple_filter);
@@ -98,7 +98,7 @@ TEST(filter, include_filter)
   test_regular_includes(complex_filter);
 }
 
-TEST(filter, include_filter_array_simple)
+TEST(Filter, include_filter_array_simple)
 {
   const std::string a("a");
   const std::string a1("a[1]");
@@ -130,7 +130,7 @@ TEST(filter, include_filter_array_simple)
   EXPECT_EQ(false, filter.Filter(a2b)); // should not accept a[2].b
 }
 
-TEST(filter, include_filter_array_complex)
+TEST(Filter, include_filter_array_complex)
 {
   const std::string a    ("a"          );
   const std::string a1   ("a[1]"       );

--- a/testing/ecal/clientserver_test/src/clientserver_getservices.cpp
+++ b/testing/ecal/clientserver_test/src/clientserver_getservices.cpp
@@ -24,7 +24,7 @@
 
 #define CMN_MONITORING_TIMEOUT 5000
 
-TEST(IO, GetServices)
+TEST(ClientServer, GetServices)
 {
   // initialize eCAL API
   eCAL::Initialize(0, nullptr, "clientserver_getservices");

--- a/testing/ecal/clientserver_test/src/clientserver_test.cpp
+++ b/testing/ecal/clientserver_test/src/clientserver_test.cpp
@@ -92,7 +92,7 @@ namespace
 
 #if ClientConnectEventTest
 
-TEST(IO, ClientConnectEvent)
+TEST(ClientServer, ClientConnectEvent)
 {
   // initialize eCAL API
   eCAL::Initialize(0, nullptr, "clientserver base connect event callback");
@@ -156,7 +156,7 @@ TEST(IO, ClientConnectEvent)
 
 #if ServerConnectEventTest
 
-TEST(IO, ServerConnectEvent)
+TEST(ClientServer, ServerConnectEvent)
 {
   // initialize eCAL API
   eCAL::Initialize(0, nullptr, "clientserver base connect event callback");
@@ -218,7 +218,7 @@ TEST(IO, ServerConnectEvent)
 
 #if ClientServerBaseCallbackTest
 
-TEST(IO, ClientServerBaseCallback)
+TEST(ClientServer, ClientServerBaseCallback)
 {
   const int num_services(2);
   const int num_clients(3);
@@ -332,7 +332,7 @@ TEST(IO, ClientServerBaseCallback)
 
 #if ClientServerBaseCallbackTimeoutTest
 
-TEST(IO, ClientServerBaseCallbackTimeout)
+TEST(ClientServer, ClientServerBaseCallbackTimeout)
 {
   const int num_services(2);
   const int num_clients(3);
@@ -502,7 +502,7 @@ TEST(IO, ClientServerBaseCallbackTimeout)
 
 #if ClientServerBaseAsyncCallbackTest
 
-TEST(IO, ClientServerBaseAsyncCallback)
+TEST(ClientServer, ClientServerBaseAsyncCallback)
 {
   const int calls(1);
   const int sleep(100);
@@ -576,7 +576,7 @@ TEST(IO, ClientServerBaseAsyncCallback)
 
 #if ClientServerBaseAsyncTest
 
-TEST(IO, ClientServerBaseAsyncTest)
+TEST(ClientServer, ClientServerBaseAsyncTest)
 {
   const int calls(5);
 
@@ -683,7 +683,7 @@ TEST(IO, ClientServerBaseAsyncTest)
 
 #if ClientServerBaseBlockingTest
 
-TEST(IO, ClientServerBaseBlocking)
+TEST(ClientServer, ClientServerBaseBlocking)
 {
   const int num_services(2);
   const int num_clients(3);
@@ -818,7 +818,7 @@ public:
   }
 };
 
-TEST(IO, ClientServerProtoCallback)
+TEST(ClientServer, ClientServerProtoCallback)
 {
   // initialize eCAL API
   eCAL::Initialize(0, nullptr, "clientserver proto callback test");
@@ -907,7 +907,7 @@ public:
   }
 };
 
-TEST(IO, ClientServerProtoBlocking)
+TEST(ClientServer, ClientServerProtoBlocking)
 {
   // initialize eCAL API
   eCAL::Initialize(0, nullptr, "clientserver proto blocking test");
@@ -959,7 +959,7 @@ TEST(IO, ClientServerProtoBlocking)
 
 #if NestedRPCCallTest
 
-TEST(IO, NestedRPCCall)
+TEST(ClientServer, NestedRPCCall)
 {
   const int calls(1);
   const int sleep(0);

--- a/testing/ecal/io_memfile_test/src/memfile_naming_test.cpp
+++ b/testing/ecal/io_memfile_test/src/memfile_naming_test.cpp
@@ -28,7 +28,7 @@
 #include <gtest/gtest.h>
 
 
-TEST(IO, MemfileNaming)
+TEST(MemFile, MemfileNaming)
 {
   std::chrono::steady_clock::time_point timepoint{};
 
@@ -37,5 +37,4 @@ TEST(IO, MemfileNaming)
 
   EXPECT_LE(memfile_name_1.size(), 13);
   EXPECT_NE(memfile_name_1, memfile_name_2);
-
 }

--- a/testing/ecal/io_memfile_test/src/memfile_test.cpp
+++ b/testing/ecal/io_memfile_test/src/memfile_test.cpp
@@ -38,7 +38,7 @@ namespace eCAL
   }
 }
 
-TEST(IO, MemfileReadWrite)
+TEST(MemFile, MemfileReadWrite)
 {
   eCAL::CMemoryFile mem_file;
 
@@ -140,7 +140,7 @@ TEST(IO, MemfileReadWrite)
   EXPECT_EQ(true, mem_file.Destroy(true));
 }
 
-TEST(IO, MemfilePerf)
+TEST(MemFile, MemfilePerf)
 {
   eCAL::CMemoryFile mem_file;
 
@@ -200,7 +200,7 @@ TEST(IO, MemfilePerf)
   EXPECT_EQ(true, mem_file.Destroy(true));
 }
 
-TEST(IO, MemfileConcurrency)
+TEST(MemFile, MemfileConcurrency)
 {
   eCAL::CMemoryFile mem_file;
 

--- a/testing/ecal/pubsub_inproc_test/src/pubsub_inproc_test.cpp
+++ b/testing/ecal/pubsub_inproc_test/src/pubsub_inproc_test.cpp
@@ -52,7 +52,7 @@ void OnReceive3()
   sub_clock3++;
 }
 
-TEST(INPROC, CLOCKS)
+TEST(PubSubInproc, CLOCKS)
 { 
   // initialize eCAL API
   EXPECT_EQ(0, eCAL::Initialize(0, nullptr, "inproc_clock_test"));

--- a/testing/ecal/pubsub_proto_test/src/proto_dyn_subscriber_test.cpp
+++ b/testing/ecal/pubsub_proto_test/src/proto_dyn_subscriber_test.cpp
@@ -131,6 +131,3 @@ TEST_F(ProtoDynSubscriberTest, SendReceive)
   auto id = extract_id(*message);
   ASSERT_EQ(id, 1);
 }
-
-
-

--- a/testing/ecal/pubsub_test/src/pubsub_acknowledge.cpp
+++ b/testing/ecal/pubsub_test/src/pubsub_acknowledge.cpp
@@ -47,7 +47,7 @@ namespace
 }
 
 // This test asserts that a timeouted acknowledge does not break subsequent calls
-TEST(Core, TimeoutAcknowledgment)
+TEST(PubSub, TimeoutAcknowledgment)
 {
   // initialize eCAL API
   EXPECT_EQ(0, eCAL::Initialize(0, nullptr, "TimeoutAcknowledgment", eCAL::Init::All));

--- a/testing/ecal/pubsub_test/src/pubsub_gettopics.cpp
+++ b/testing/ecal/pubsub_test/src/pubsub_gettopics.cpp
@@ -26,7 +26,7 @@
 #define CMN_REGISTRATION_REFRESH   1000
 #define CMN_MONITORING_TIMEOUT     5000
 
-TEST(IO, GetTopics)
+TEST(PubSub, GetTopics)
 {
   // initialize eCAL API
   eCAL::Initialize(0, nullptr, "pubsub_gettopics");

--- a/testing/ecal/pubsub_test/src/pubsub_multibuffer.cpp
+++ b/testing/ecal/pubsub_test/src/pubsub_multibuffer.cpp
@@ -65,7 +65,7 @@ private:
   int    clock = 0;
 };
 
-TEST(IO, MultibufferPubSub)
+TEST(PubSub, MultibufferPubSub)
 { 
   // create payload
   CBinaryPayload binary_payload(PAYLOAD_SIZE);

--- a/testing/ecal/pubsub_test/src/pubsub_receive_test.cpp
+++ b/testing/ecal/pubsub_test/src/pubsub_receive_test.cpp
@@ -65,7 +65,7 @@ void measure_execution_within_range(const std::string& description, std::functio
 }
 
 
-TEST(SUBSCRIBER, TimingSubscriberReceive)
+TEST(PubSub, TimingSubscriberReceive)
 {
   // initialize eCAL API
   EXPECT_EQ(0, eCAL::Initialize(0, nullptr, "subscriber_receive_timing"));
@@ -164,7 +164,7 @@ TEST(SUBSCRIBER, TimingSubscriberReceive)
 
 
 // This tests test for sporadically received empty messages which were a problem.
-TEST(SUBSCRIBER, SporadicEmptyReceives)
+TEST(PubSub, SporadicEmptyReceives)
 { 
   // initialize eCAL API
   EXPECT_EQ(0, eCAL::Initialize(0, nullptr, "sporadic_empty_receives"));

--- a/testing/ecal/pubsub_test/src/pubsub_test.cpp
+++ b/testing/ecal/pubsub_test/src/pubsub_test.cpp
@@ -51,7 +51,7 @@ static std::string CreatePayLoad(size_t payload_size_)
   return(s);
 }
 
-TEST(IO, InitializeFinalize)
+TEST(PubSub, InitializeFinalize)
 { 
   // Is eCAL API initialized ?
   EXPECT_EQ(0, eCAL::IsInitialized());
@@ -91,7 +91,7 @@ TEST(IO, InitializeFinalize)
   EXPECT_EQ(1, eCAL::Finalize());
 }
 
-TEST(IO, CreateDestroy)
+TEST(PubSub, CreateDestroy)
 { 
   // initialize eCAL API
   eCAL::Initialize(0, nullptr, "pubsub_test");
@@ -130,7 +130,7 @@ TEST(IO, CreateDestroy)
   eCAL::Finalize();
 }
 
-TEST(IO, TypeDescriptionStatic)
+TEST(PubSub, TypeDescriptionStatic)
 {
   // initialize eCAL API
   eCAL::Initialize(0, nullptr, "pubsub_test");
@@ -153,7 +153,7 @@ TEST(IO, TypeDescriptionStatic)
   eCAL::Finalize();
 }
 
-TEST(IO, TypeDescriptionDynamic)
+TEST(PubSub, TypeDescriptionDynamic)
 {
   // initialize eCAL API
   eCAL::Initialize(0, nullptr, "pubsub_test");
@@ -257,7 +257,7 @@ TEST(IO, TypeDescriptionDynamic)
   eCAL::Finalize();
 }
 
-TEST(IO, SimpleMessage1)
+TEST(PubSub, SimpleMessage1)
 { 
   // default send / receive strings
   std::string send_s = CreatePayLoad(PAYLOAD_SIZE);
@@ -302,7 +302,7 @@ TEST(IO, SimpleMessage1)
   eCAL::Finalize();
 }
 
-TEST(IO, SimpleMessage2)
+TEST(PubSub, SimpleMessage2)
 { 
   // default send / receive strings
   std::string send_s = CreatePayLoad(PAYLOAD_SIZE);
@@ -341,7 +341,7 @@ TEST(IO, SimpleMessage2)
   eCAL::Finalize();
 }
 
-TEST(IO, SimpleMessageCB)
+TEST(PubSub, SimpleMessageCB)
 { 
   // default send string
   std::string send_s = CreatePayLoad(PAYLOAD_SIZE);
@@ -420,7 +420,7 @@ TEST(IO, SimpleMessageCB)
   eCAL::Finalize();
 }
 
-TEST(IO, DynamicSizeCB)
+TEST(PubSub, DynamicSizeCB)
 { 
   // default send string
   std::string send_s = CreatePayLoad(PAYLOAD_SIZE);
@@ -476,7 +476,7 @@ TEST(IO, DynamicSizeCB)
   eCAL::Finalize();
 }
 
-TEST(IO, DynamicCreate)
+TEST(PubSub, DynamicCreate)
 { 
   // default send string
   std::string send_s = CreatePayLoad(PAYLOAD_SIZE);
@@ -568,7 +568,7 @@ TEST(IO, DynamicCreate)
   eCAL::Finalize();
 }
 
-TEST(IO, SimpleMessageCBSHMBufferCount)
+TEST(PubSub, SimpleMessageCBSHMBufferCount)
 {
   // default send string
   std::string send_s = CreatePayLoad(PAYLOAD_SIZE);
@@ -619,7 +619,7 @@ TEST(IO, SimpleMessageCBSHMBufferCount)
   eCAL::Finalize();
 }
 
-TEST(IO, ZeroPayloadMessageInProc)
+TEST(PubSub, ZeroPayloadMessageInProc)
 {
   // default send string
   std::string send_s;
@@ -667,7 +667,7 @@ TEST(IO, ZeroPayloadMessageInProc)
   eCAL::Finalize();
 }
 
-TEST(IO, ZeroPayloadMessageSHM)
+TEST(PubSub, ZeroPayloadMessageSHM)
 {
   // default send string
   std::string send_s;
@@ -715,7 +715,7 @@ TEST(IO, ZeroPayloadMessageSHM)
   eCAL::Finalize();
 }
 
-TEST(IO, ZeroPayloadMessageUDP)
+TEST(PubSub, ZeroPayloadMessageUDP)
 {
   // default send string
   std::string send_s;
@@ -764,7 +764,7 @@ TEST(IO, ZeroPayloadMessageUDP)
 }
 
 
-TEST(IO, MultipleSendsSHM)
+TEST(PubSub, MultipleSendsSHM)
 {
   // default send string
   std::vector<std::string> send_vector{ "this", "is", "a", "", "testtest" };
@@ -817,7 +817,7 @@ TEST(IO, MultipleSendsSHM)
 }
 
 
-TEST(IO, MultipleSendsUDP)
+TEST(PubSub, MultipleSendsUDP)
 {
   // default send string
   std::vector<std::string> send_vector{ "this", "is", "a", "", "testtest" };
@@ -874,7 +874,7 @@ TEST(IO, MultipleSendsUDP)
 
 
 #if 0
-TEST(IO, ZeroPayloadMessageTCP)
+TEST(PubSub, ZeroPayloadMessageTCP)
 {
   // default send string
   std::string send_s;
@@ -925,7 +925,7 @@ TEST(IO, ZeroPayloadMessageTCP)
 
 #include <ecal/msg/string/publisher.h>
 #include <ecal/msg/string/subscriber.h>
-TEST(IO, DestroyInCallback)
+TEST(PubSub, DestroyInCallback)
 {
   /* Test setup :
    * 2 pair of pub_sub connections ("foo" and "destroy")

--- a/testing/ecal/util_test/src/util_test.cpp
+++ b/testing/ecal/util_test/src/util_test.cpp
@@ -45,7 +45,6 @@ TEST(Util, CombineTopicEncodingAndType)
   TestCombinedTopicEncodingAndType("", "MyType", "MyType");
 }
 
-
 TEST(Util, SplitCombinedTopicType)
 {
   TestSplitCombinedTopicType("", "", "");


### PR DESCRIPTION
### Description
Inconsistent unit test naming cleaned up.

### Cherry-pick to
- _none_
