### PR TITLE
switch off monitoring of other hosts if network_mode=local

### DIFF
--- a/ecal/core/src/mon/ecal_monitoring_impl.h
+++ b/ecal/core/src/mon/ecal_monitoring_impl.h
@@ -152,6 +152,7 @@ namespace eCAL
 
     bool                                         m_init;
     std::string                                  m_host_name;
+    bool                                         m_network_mode;
 
     std::mutex                                   m_topic_filter_excl_mtx;
     std::string                                  m_topic_filter_excl_s;


### PR DESCRIPTION
### Description
If network mode is set to local (`network_enabled=false`) in the ecal global configuration (`ecal.ini`) the traffic of other/external hosts should not monitored.

### Related issues
Fixes #1191 

### Cherry-pick to
- _none_
