### PR TITLE
GCC 13: Added workaround for termcolor bug (missing include)

### DIFF
--- a/app/play/play_cli/src/ecal_play_cli.cpp
+++ b/app/play/play_cli/src/ecal_play_cli.cpp
@@ -43,6 +43,7 @@
 #pragma warning(push)
 #pragma warning(disable: 4800 )
 #endif //_MSC_VER
+#include <cstdint> // Needed for termcolor. Currently (2023-10-26) termcolor does not include this header file, but it is needed for Ubuntu 23.10 / gcc 13.2: https://github.com/ikalnytskyi/termcolor/pull/72
 #include <termcolor/termcolor.hpp>
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/app/rec/rec_server_cli/src/commands/status.cpp
+++ b/app/rec/rec_server_cli/src/commands/status.cpp
@@ -38,6 +38,7 @@
   #pragma warning(disable: 4800) // disable termcolor warnings
 #endif
 
+  #include <cstdint> // Needed for termcolor. Currently (2023-10-26) termcolor does not include this header file, but it is needed for Ubuntu 23.10 / gcc 13.2: https://github.com/ikalnytskyi/termcolor/pull/72
   #include <termcolor/termcolor.hpp>
 
 #ifdef _MSC_VER

--- a/app/rec/rec_server_cli/src/commands/table_printer.cpp
+++ b/app/rec/rec_server_cli/src/commands/table_printer.cpp
@@ -30,6 +30,7 @@
   #pragma warning(disable: 4800) // disable termcolor warnings
 #endif
 
+  #include <cstdint> // Needed for termcolor. Currently (2023-10-26) termcolor does not include this header file, but it is needed for Ubuntu 23.10 / gcc 13.2: https://github.com/ikalnytskyi/termcolor/pull/72
   #include <termcolor/termcolor.hpp>
 
 #ifdef _MSC_VER

--- a/app/sys/sys_cli/src/commands/list.cpp
+++ b/app/sys/sys_cli/src/commands/list.cpp
@@ -32,6 +32,7 @@
 #pragma warning(push)
 #pragma warning(disable: 4800) // disable termcolor warnings
 #endif
+#include <cstdint> // Needed for termcolor. Currently (2023-10-26) termcolor does not include this header file.
 #include <termcolor/termcolor.hpp>
 #ifdef _MSC_VER
 #pragma warning(pop)


### PR DESCRIPTION
### Description

Currently (2023-10-26) termcolor does not include the cstdint header file, but it is needed for Ubuntu 23.10 / gcc 13.2: https://github.com/ikalnytskyi/termcolor/pull/72

### Related issues
- None

### Cherry-pick to
- 5.11 (old stable)
- 5.12 (current stable)
