### PR TITLE
switch off udp receiving of other hosts if network_mode=local

### DIFF
--- a/ecal/core/src/ecal_log_impl.cpp
+++ b/ecal/core/src/ecal_log_impl.cpp
@@ -153,13 +153,18 @@ namespace eCAL
     {
       SSenderAttr attr;
       // for local only communication we switch to local broadcasting to bypass vpn's or firewalls
-      attr.localhost = !Config::IsNetworkEnabled();
       attr.broadcast = !Config::IsNetworkEnabled();
       attr.ipaddr    = UDP::GetLoggingMulticastAddress();
       attr.port      = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_LOG_OFF;
       attr.loopback  = true;
       attr.ttl       = Config::GetUdpMulticastTtl();
       attr.sndbuf    = Config::GetUdpMulticastSndBufSizeBytes();
+
+      // for local only communication we force the ttl (udp package 'hop limit') to 0
+      if (!Config::IsNetworkEnabled())
+      {
+        attr.ttl = 0;
+      }
 
       m_udp_sender = std::make_unique<CUDPSender>(attr);
     }

--- a/ecal/core/src/ecal_log_impl.cpp
+++ b/ecal/core/src/ecal_log_impl.cpp
@@ -152,12 +152,11 @@ namespace eCAL
     if(m_filter_mask_udp != 0)
     {
       SSenderAttr attr;
-      // for local only communication we switch to local broadcasting to bypass vpn's or firewalls
-      attr.broadcast = !Config::IsNetworkEnabled();
       attr.ipaddr    = UDP::GetLoggingMulticastAddress();
       attr.port      = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_LOG_OFF;
-      attr.loopback  = true;
       attr.ttl       = Config::GetUdpMulticastTtl();
+      attr.localhost = !Config::IsNetworkEnabled();
+      attr.loopback  = true;
       attr.sndbuf    = Config::GetUdpMulticastSndBufSizeBytes();
 
       // for local only communication we force the ttl (udp package 'hop limit') to 0

--- a/ecal/core/src/ecal_log_impl.cpp
+++ b/ecal/core/src/ecal_log_impl.cpp
@@ -153,6 +153,7 @@ namespace eCAL
     {
       SSenderAttr attr;
       // for local only communication we switch to local broadcasting to bypass vpn's or firewalls
+      attr.localhost = !Config::IsNetworkEnabled();
       attr.broadcast = !Config::IsNetworkEnabled();
       attr.ipaddr    = UDP::GetLoggingMulticastAddress();
       attr.port      = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_LOG_OFF;

--- a/ecal/core/src/ecal_registration_provider.cpp
+++ b/ecal/core/src/ecal_registration_provider.cpp
@@ -83,6 +83,7 @@ namespace eCAL
       // set network attributes
       SSenderAttr attr;
       attr.ipaddr    = UDP::GetRegistrationMulticastAddress();
+      attr.localhost = !Config::IsNetworkEnabled();
       attr.port      = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_REG_OFF;
       attr.ttl       = Config::GetUdpMulticastTtl();
       // for local only communication we switch to local broadcasting to bypass vpn's or firewalls

--- a/ecal/core/src/ecal_registration_provider.cpp
+++ b/ecal/core/src/ecal_registration_provider.cpp
@@ -85,8 +85,7 @@ namespace eCAL
       attr.ipaddr    = UDP::GetRegistrationMulticastAddress();
       attr.port      = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_REG_OFF;
       attr.ttl       = Config::GetUdpMulticastTtl();
-      // for local only communication we switch to local broadcasting to bypass vpn's or firewalls
-      attr.broadcast = !Config::IsNetworkEnabled();
+      attr.localhost = !Config::IsNetworkEnabled();
       attr.loopback  = true;
       attr.sndbuf    = Config::GetUdpMulticastSndBufSizeBytes();
 

--- a/ecal/core/src/ecal_registration_provider.cpp
+++ b/ecal/core/src/ecal_registration_provider.cpp
@@ -83,13 +83,18 @@ namespace eCAL
       // set network attributes
       SSenderAttr attr;
       attr.ipaddr    = UDP::GetRegistrationMulticastAddress();
-      attr.localhost = !Config::IsNetworkEnabled();
       attr.port      = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_REG_OFF;
       attr.ttl       = Config::GetUdpMulticastTtl();
       // for local only communication we switch to local broadcasting to bypass vpn's or firewalls
       attr.broadcast = !Config::IsNetworkEnabled();
       attr.loopback  = true;
       attr.sndbuf    = Config::GetUdpMulticastSndBufSizeBytes();
+
+      // for local only communication we force the ttl (udp package 'hop limit') to 0
+      if (!Config::IsNetworkEnabled())
+      {
+        attr.ttl = 0;
+      }
 
       // create udp sample sender
       m_reg_sample_snd = std::make_shared<CSampleSender>(attr);

--- a/ecal/core/src/ecal_registration_receiver.cpp
+++ b/ecal/core/src/ecal_registration_receiver.cpp
@@ -141,6 +141,7 @@ namespace eCAL
       attr.broadcast = !Config::IsNetworkEnabled();
       attr.ipaddr    = UDP::GetRegistrationMulticastAddress();
       attr.port      = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_REG_OFF;
+      attr.localhost = !Config::IsNetworkEnabled();
       attr.loopback  = true;
       attr.rcvbuf    = Config::GetUdpMulticastRcvBufSizeBytes();
 

--- a/ecal/core/src/ecal_registration_receiver.cpp
+++ b/ecal/core/src/ecal_registration_receiver.cpp
@@ -137,8 +137,6 @@ namespace eCAL
     {
       // start registration receive thread
       SReceiverAttr attr;
-      // for local only communication we switch to local broadcasting to bypass vpn's or firewalls
-      attr.broadcast = !Config::IsNetworkEnabled();
       attr.ipaddr    = UDP::GetRegistrationMulticastAddress();
       attr.port      = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_REG_OFF;
       attr.localhost = !Config::IsNetworkEnabled();

--- a/ecal/core/src/io/ecal_named_mutex.cpp
+++ b/ecal/core/src/io/ecal_named_mutex.cpp
@@ -25,6 +25,8 @@
 
 #include "ecal_named_mutex.h"
 
+#include <iostream>
+
 #ifdef ECAL_OS_LINUX
 #include "linux/ecal_named_mutex_impl.h"
 #if defined(ECAL_HAS_ROBUST_MUTEX) || defined(ECAL_HAS_CLOCKLOCK_MUTEX)
@@ -119,6 +121,10 @@ namespace eCAL
 
   bool CNamedMutex::Lock(int64_t timeout_)
   {
+    if (timeout_ == 0)
+    {
+      std::cerr << "WTF" << std::endl;
+    }
     return m_impl->Lock(timeout_);
   }
 

--- a/ecal/core/src/io/ecal_receiver.h
+++ b/ecal/core/src/io/ecal_receiver.h
@@ -45,22 +45,13 @@ namespace eCAL
   ////////////////////////////////////////////////////////
   struct SReceiverAttr
   {
-    SReceiverAttr() :
-      port(0),
-      broadcast(false),
-      unicast(false),
-      localhost(false),
-      loopback(true),
-      rcvbuf(1024 * 1024)
-    {};
-
     std::string ipaddr;
-    int         port;
-    bool        broadcast;
-    bool        unicast;
-    bool        localhost;
-    bool        loopback;
-    int         rcvbuf;
+    bool        localhost = false;
+    int         port      = 0;
+    bool        broadcast = false;
+    bool        unicast   = false;
+    bool        loopback  = true;
+    int         rcvbuf    = 1024 * 1024;
   };
 
   class CReceiver

--- a/ecal/core/src/io/ecal_receiver.h
+++ b/ecal/core/src/io/ecal_receiver.h
@@ -46,10 +46,8 @@ namespace eCAL
   struct SReceiverAttr
   {
     std::string ipaddr;
-    bool        localhost = false;
     int         port      = 0;
-    bool        broadcast = false;
-    bool        unicast   = false;
+    bool        localhost = false;
     bool        loopback  = true;
     int         rcvbuf    = 1024 * 1024;
   };

--- a/ecal/core/src/io/ecal_receiver.h
+++ b/ecal/core/src/io/ecal_receiver.h
@@ -49,6 +49,7 @@ namespace eCAL
       port(0),
       broadcast(false),
       unicast(false),
+      localhost(false),
       loopback(true),
       rcvbuf(1024 * 1024)
     {};
@@ -57,6 +58,7 @@ namespace eCAL
     int         port;
     bool        broadcast;
     bool        unicast;
+    bool        localhost;
     bool        loopback;
     int         rcvbuf;
   };

--- a/ecal/core/src/io/snd_sample.cpp
+++ b/ecal/core/src/io/snd_sample.cpp
@@ -30,7 +30,14 @@ namespace
 {
   size_t TransmitToUDP(const void* buf_, const size_t len_, const std::shared_ptr<eCAL::CUDPSender>& sample_sender_, const std::string& mcast_address_)
   {
-    return (sample_sender_->Send(buf_, len_, mcast_address_.c_str()));
+    if (mcast_address_.empty())
+    {
+      return (sample_sender_->Send(buf_, len_));
+    }
+    else
+    {
+      return (sample_sender_->Send(buf_, len_, mcast_address_.c_str()));
+    }
   }
 }
 

--- a/ecal/core/src/io/udp_configurations.cpp
+++ b/ecal/core/src/io/udp_configurations.cpp
@@ -1,36 +1,81 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
 #include "io/udp_configurations.h"
 
 #include <ecal/ecal_config.h>
 #include "topic2mcast.h"
 
-const std::string localhost_udp_address{ "127.255.255.255" };
-
-
-std::string eCAL::UDP::GetRegistrationMulticastAddress()
+namespace eCAL
 {
-  const bool local_only = !Config::IsNetworkEnabled();
-  if (local_only)
+  namespace UDP
   {
-    return localhost_udp_address;
-  }
-  else
-  {
-    // both in v1 and v2, the mulicast group is returned as the adress for the registration layer
-    return Config::GetUdpMulticastGroup();
-  }
-}
+    std::string LocalHost()
+    {
+      return "127.0.0.1";
+    }
 
-std::string eCAL::UDP::GetLoggingMulticastAddress()
-{
-  //TODO: At the moment, both logging and monitoring addresses seem to be the same
-  // Should it be kept or changed?
-  return GetRegistrationMulticastAddress();
-}
+    std::string GetRegistrationMulticastAddress()
+    {
+      const bool local_only = !Config::IsNetworkEnabled();
+      if (local_only)
+      {
+        return LocalHost();
+      }
+      else
+      {
+        // both in v1 and v2, the mulicast group is returned as the adress for the registration layer
+        return Config::GetUdpMulticastGroup();
+      }
+    }
 
-std::string eCAL::UDP::GetTopicMulticastAddress(const std::string& topic_name)
-{
-  if (Config::GetUdpMulticastConfigVersion() == Config::UdpConfigVersion::V1)
-    return UDP::V1::topic2mcast(topic_name, Config::GetUdpMulticastGroup(), Config::GetUdpMulticastMask());
-  // v2
-  return  UDP::V2::topic2mcast(topic_name, Config::GetUdpMulticastGroup(), Config::GetUdpMulticastMask());
+    std::string GetLoggingMulticastAddress()
+    {
+      //TODO: At the moment, both logging and monitoring addresses seem to be the same
+      // Should it be kept or changed?
+      return GetRegistrationMulticastAddress();
+    }
+
+    std::string GetTopicMulticastAddress(const std::string& topic_name)
+    {
+      const bool local_only = !Config::IsNetworkEnabled();
+      if (local_only)
+      {
+        return LocalHost();
+      }
+      else
+      {
+        if (topic_name.empty())
+        {
+          return Config::GetUdpMulticastGroup();
+        }
+        else
+        {
+          // v1
+          if (Config::GetUdpMulticastConfigVersion() == Config::UdpConfigVersion::V1)
+          {
+            return UDP::V1::topic2mcast(topic_name, Config::GetUdpMulticastGroup(), Config::GetUdpMulticastMask());
+          }
+          // v2
+          return  UDP::V2::topic2mcast(topic_name, Config::GetUdpMulticastGroup(), Config::GetUdpMulticastMask());
+        }
+      }
+    }
+  }
 }

--- a/ecal/core/src/io/udp_configurations.h
+++ b/ecal/core/src/io/udp_configurations.h
@@ -29,12 +29,19 @@ namespace eCAL
 {
   namespace UDP
   {
-    // Return the Multicast Adress used for sending Registration information
+    // these functions return specific multicast address for registration / logging and payload transport
+    // in the local host mode (network_enabled = false) they all return LocalHost()
+
+    // return the local host udp address
+    std::string LocalHost();
+
+    // return the multicast adress used for sending/receiving the registration information
     std::string GetRegistrationMulticastAddress();
 
+    // return the multicast adress used for sending/receiving the logging information
     std::string GetLoggingMulticastAddress();
 
+    // return the multicast adress used for sending/receiving the topic payload
     std::string GetTopicMulticastAddress(const std::string& topic_name);
   }
-
 }

--- a/ecal/core/src/io/udp_receiver_asio.cpp
+++ b/ecal/core/src/io/udp_receiver_asio.cpp
@@ -34,6 +34,7 @@ namespace eCAL
     m_created(false),
     m_broadcast(attr_.broadcast),
     m_unicast(attr_.unicast),
+    m_localhost(attr_.localhost),
     m_socket(m_iocontext)
   {
     if (m_broadcast && m_unicast)
@@ -42,8 +43,16 @@ namespace eCAL
       return;
     }
 
+    // define endpoint
+    asio::ip::udp::endpoint ext_endpoint(asio::ip::udp::v4(), static_cast<unsigned short>(attr_.port));
+    asio::ip::udp::endpoint loc_endpoint(asio::ip::address::from_string("127.0.0.1"), static_cast<unsigned short>(attr_.port));
+    asio::ip::udp::endpoint& listen_endpoint = ext_endpoint;
+    if (m_localhost)
+    {
+      listen_endpoint = loc_endpoint;
+    }
+
     // create socket
-    const asio::ip::udp::endpoint listen_endpoint(asio::ip::udp::v4(), static_cast<unsigned short>(attr_.port));
     {
       asio::error_code ec;
       m_socket.open(listen_endpoint.protocol(), ec);

--- a/ecal/core/src/io/udp_receiver_asio.cpp
+++ b/ecal/core/src/io/udp_receiver_asio.cpp
@@ -43,16 +43,8 @@ namespace eCAL
       return;
     }
 
-    // define endpoint
-    asio::ip::udp::endpoint ext_endpoint(asio::ip::udp::v4(), static_cast<unsigned short>(attr_.port));
-    asio::ip::udp::endpoint loc_endpoint(asio::ip::address::from_string("127.0.0.1"), static_cast<unsigned short>(attr_.port));
-    asio::ip::udp::endpoint& listen_endpoint = ext_endpoint;
-    if (m_localhost)
-    {
-      listen_endpoint = loc_endpoint;
-    }
-
     // create socket
+    const asio::ip::udp::endpoint listen_endpoint(asio::ip::udp::v4(), static_cast<unsigned short>(attr_.port));
     {
       asio::error_code ec;
       m_socket.open(listen_endpoint.protocol(), ec);
@@ -110,7 +102,14 @@ namespace eCAL
     }
 
     // join multicast group
-    AddMultiCastGroup(attr_.ipaddr.c_str());
+    if (m_localhost)
+    {
+      AddMultiCastGroup("127.0.0.1");
+    }
+    else
+    {
+      AddMultiCastGroup(attr_.ipaddr.c_str());
+    }
 
     // state successful creation
     m_created = true;

--- a/ecal/core/src/io/udp_receiver_asio.cpp
+++ b/ecal/core/src/io/udp_receiver_asio.cpp
@@ -47,7 +47,7 @@ namespace
     // For IPv4, the private address ranges are 10.0.0.0/8, 172.16.0.0/12, and 192.168.0.0/16.
     if (address.is_v4())
     {
-      uint32_t ip = address.to_v4().to_ulong();
+      const uint32_t ip = address.to_v4().to_ulong();
       return !((ip & 0xFF000000) == 0x0A000000) &&  // Not in 10.0.0.0/8
              !((ip & 0xFFF00000) == 0xAC100000) &&  // Not in 172.16.0.0/12
              !((ip & 0xFFFF0000) == 0xC0A80000);    // Not in 192.168.0.0/16
@@ -229,19 +229,16 @@ namespace eCAL
     }
 
     // is the caller interested in the source address ?
-    if (address_)
+    if (address_ != nullptr)
     {
-      // retrieve underlaying raw socket informations
+      // retrieve underlying raw socket information
       if (m_sender_endpoint.address().is_v4())
       {
         asio::detail::sockaddr_in4_type* in4 = reinterpret_cast<asio::detail::sockaddr_in4_type*>(m_sender_endpoint.data());
-        if (address_)
-        {
-          address_->sin_addr   = in4->sin_addr;
-          address_->sin_family = in4->sin_family;
-          address_->sin_port   = in4->sin_port;
-          memset(&(address_->sin_zero), 0, 8);
-        }
+        address_->sin_addr   = in4->sin_addr;
+        address_->sin_family = in4->sin_family;
+        address_->sin_port   = in4->sin_port;
+        memset(&(address_->sin_zero), 0, 8);
       }
       else
       {

--- a/ecal/core/src/io/udp_receiver_asio.h
+++ b/ecal/core/src/io/udp_receiver_asio.h
@@ -48,9 +48,9 @@ namespace eCAL
     void RunIOContext(const asio::chrono::steady_clock::duration& timeout);
 
     bool                    m_created;
+    bool                    m_localhost;
     bool                    m_broadcast;
     bool                    m_unicast;
-    bool                    m_localhost;
     asio::io_context        m_iocontext;
     asio::ip::udp::socket   m_socket;
     asio::ip::udp::endpoint m_sender_endpoint;

--- a/ecal/core/src/io/udp_receiver_asio.h
+++ b/ecal/core/src/io/udp_receiver_asio.h
@@ -50,6 +50,7 @@ namespace eCAL
     bool                    m_created;
     bool                    m_broadcast;
     bool                    m_unicast;
+    bool                    m_localhost;
     asio::io_context        m_iocontext;
     asio::ip::udp::socket   m_socket;
     asio::ip::udp::endpoint m_sender_endpoint;

--- a/ecal/core/src/io/udp_receiver_asio.h
+++ b/ecal/core/src/io/udp_receiver_asio.h
@@ -49,8 +49,6 @@ namespace eCAL
 
     bool                    m_created;
     bool                    m_localhost;
-    bool                    m_broadcast;
-    bool                    m_unicast;
     asio::io_context        m_iocontext;
     asio::ip::udp::socket   m_socket;
     asio::ip::udp::endpoint m_sender_endpoint;

--- a/ecal/core/src/io/udp_receiver_npcap.cpp
+++ b/ecal/core/src/io/udp_receiver_npcap.cpp
@@ -27,6 +27,7 @@ namespace eCAL
     : CUDPReceiverBase(attr_)
     , m_created(false)
     , m_unicast(attr_.unicast)
+    , m_localhost(attr_.localhost)
   {
     // set receive buffer size (default = 1 MB)
     int rcvbuf = 1024 * 1024;
@@ -39,8 +40,19 @@ namespace eCAL
       std::cerr << "CUDPReceiverPcap: Unable to set receive buffer size." << std::endl;
     }
 
+    // define host address
+    Udpcap::HostAddress host_address;
+    if (m_localhost)
+    {
+      host_address = Udpcap::HostAddress::LocalHost();
+    }
+    else
+    {
+      host_address = Udpcap::HostAddress::Any();
+    }
+
     // bind socket
-    if (!m_socket.bind(Udpcap::HostAddress::Any(), static_cast<uint16_t>(attr_.port)))
+    if (!m_socket.bind(host_address, static_cast<uint16_t>(attr_.port)))
     {
       std::cerr << "CUDPReceiverPcap: Unable to bind socket." << std::endl;
       return;

--- a/ecal/core/src/io/udp_receiver_npcap.cpp
+++ b/ecal/core/src/io/udp_receiver_npcap.cpp
@@ -40,19 +40,8 @@ namespace eCAL
       std::cerr << "CUDPReceiverPcap: Unable to set receive buffer size." << std::endl;
     }
 
-    // define host address
-    Udpcap::HostAddress host_address;
-    if (m_localhost)
-    {
-      host_address = Udpcap::HostAddress::LocalHost();
-    }
-    else
-    {
-      host_address = Udpcap::HostAddress::Any();
-    }
-
     // bind socket
-    if (!m_socket.bind(host_address, static_cast<uint16_t>(attr_.port)))
+    if (!m_socket.bind(Udpcap::HostAddress::Any(), static_cast<uint16_t>(attr_.port)))
     {
       std::cerr << "CUDPReceiverPcap: Unable to bind socket." << std::endl;
       return;
@@ -65,7 +54,14 @@ namespace eCAL
     }
 
     // join multicast group
-    AddMultiCastGroup(attr_.ipaddr.c_str());
+    if (m_localhost)
+    {
+      AddMultiCastGroup("127.0.0.1");
+    }
+    else
+    {
+      AddMultiCastGroup(attr_.ipaddr.c_str());
+    }
 
     // state successful creation
     m_created = true;

--- a/ecal/core/src/io/udp_receiver_npcap.cpp
+++ b/ecal/core/src/io/udp_receiver_npcap.cpp
@@ -43,10 +43,10 @@ namespace
       // For IPv4, the private address ranges are 10.0.0.0/8, 172.16.0.0/12, and 192.168.0.0/16.
       if (address.isValid())
       {
-        uint32_t ip = address.toInt();
+        const uint32_t ip = address.toInt();
         return !((ip & 0xFF000000) == 0x0A000000) &&  // Not in 10.0.0.0/8
-          !((ip & 0xFFF00000) == 0xAC100000) &&  // Not in 172.16.0.0/12
-          !((ip & 0xFFFF0000) == 0xC0A80000);    // Not in 192.168.0.0/16
+               !((ip & 0xFFF00000) == 0xAC100000) &&  // Not in 172.16.0.0/12
+               !((ip & 0xFFFF0000) == 0xC0A80000);    // Not in 192.168.0.0/16
       }
 
       return true;
@@ -140,7 +140,7 @@ namespace eCAL
     }
 
     // is the caller interested in the source address ?
-    if (address_)
+    if (address_ != nullptr)
     {
       if (source_address.isValid())
       {

--- a/ecal/core/src/io/udp_receiver_npcap.h
+++ b/ecal/core/src/io/udp_receiver_npcap.h
@@ -44,7 +44,6 @@ namespace eCAL
   protected:
     bool                 m_created;
     bool                 m_localhost;
-    bool                 m_unicast;
     Udpcap::UdpcapSocket m_socket;
   };
 

--- a/ecal/core/src/io/udp_receiver_npcap.h
+++ b/ecal/core/src/io/udp_receiver_npcap.h
@@ -43,8 +43,8 @@ namespace eCAL
 
   protected:
     bool                 m_created;
-    bool                 m_unicast;
     bool                 m_localhost;
+    bool                 m_unicast;
     Udpcap::UdpcapSocket m_socket;
   };
 

--- a/ecal/core/src/io/udp_receiver_npcap.h
+++ b/ecal/core/src/io/udp_receiver_npcap.h
@@ -44,6 +44,7 @@ namespace eCAL
   protected:
     bool                 m_created;
     bool                 m_unicast;
+    bool                 m_localhost;
     Udpcap::UdpcapSocket m_socket;
   };
 

--- a/ecal/core/src/io/udp_sender.cpp
+++ b/ecal/core/src/io/udp_sender.cpp
@@ -47,7 +47,6 @@ namespace eCAL
     size_t Send(const void* buf_, size_t len_, const char* ipaddr_ = nullptr);
 
   protected:
-    bool                    m_localhost;
     bool                    m_broadcast;
     bool                    m_unicast;
     asio::io_context        m_iocontext;
@@ -57,19 +56,12 @@ namespace eCAL
   };
 
   CUDPSenderImpl::CUDPSenderImpl(const SSenderAttr& attr_) :
-    m_localhost(attr_.localhost),
     m_broadcast(attr_.broadcast),
     m_unicast(attr_.unicast),
     m_endpoint(asio::ip::make_address(attr_.ipaddr), static_cast<unsigned short>(attr_.port)),
     m_socket(m_iocontext, m_endpoint.protocol()),
     m_port(static_cast<unsigned short>(attr_.port))
   {
-    if (m_localhost)
-    {
-      m_endpoint.address(asio::ip::address::from_string("127.0.0.1"));
-      return;
-    }
-
     if (m_broadcast && m_unicast)
     {
       std::cerr << "CUDPSender: Setting broadcast and unicast option true is not allowed." << std::endl;
@@ -118,10 +110,10 @@ namespace eCAL
   size_t CUDPSenderImpl::Send(const void* buf_, const size_t len_, const char* ipaddr_)
   {
     const asio::socket_base::message_flags flags(0);
-    asio::error_code                       ec;
-    size_t                                 sent(0);
-    if (!m_localhost && (ipaddr_ != nullptr) && (ipaddr_[0] != '\0')) sent = m_socket.send_to(asio::buffer(buf_, len_), asio::ip::udp::endpoint(asio::ip::make_address(ipaddr_), m_port), flags, ec);
-    else                                                              sent = m_socket.send_to(asio::buffer(buf_, len_), m_endpoint, flags, ec);
+    asio::error_code                 ec;
+    size_t                           sent(0);
+    if ((ipaddr_ != nullptr) && (ipaddr_[0] != '\0')) sent = m_socket.send_to(asio::buffer(buf_, len_), asio::ip::udp::endpoint(asio::ip::make_address(ipaddr_), m_port), flags, ec);
+    else                                              sent = m_socket.send_to(asio::buffer(buf_, len_), m_endpoint, flags, ec);
     if (ec)
     {
       std::cout << "CUDPSender::Send failed with: \'" << ec.message() << "\'" << std::endl;

--- a/ecal/core/src/io/udp_sender.cpp
+++ b/ecal/core/src/io/udp_sender.cpp
@@ -47,6 +47,7 @@ namespace eCAL
     size_t Send(const void* buf_, size_t len_, const char* ipaddr_ = nullptr);
 
   protected:
+    bool                    m_localhost;
     bool                    m_broadcast;
     bool                    m_unicast;
     asio::io_context        m_iocontext;
@@ -56,12 +57,19 @@ namespace eCAL
   };
 
   CUDPSenderImpl::CUDPSenderImpl(const SSenderAttr& attr_) :
+    m_localhost(attr_.localhost),
     m_broadcast(attr_.broadcast),
     m_unicast(attr_.unicast),
     m_endpoint(asio::ip::make_address(attr_.ipaddr), static_cast<unsigned short>(attr_.port)),
     m_socket(m_iocontext, m_endpoint.protocol()),
     m_port(static_cast<unsigned short>(attr_.port))
   {
+    if (m_localhost)
+    {
+      m_endpoint.address(asio::ip::address::from_string("127.0.0.1"));
+      return;
+    }
+
     if (m_broadcast && m_unicast)
     {
       std::cerr << "CUDPSender: Setting broadcast and unicast option true is not allowed." << std::endl;
@@ -110,10 +118,10 @@ namespace eCAL
   size_t CUDPSenderImpl::Send(const void* buf_, const size_t len_, const char* ipaddr_)
   {
     const asio::socket_base::message_flags flags(0);
-    asio::error_code                 ec;
-    size_t                           sent(0);
-    if ((ipaddr_ != nullptr) && (ipaddr_[0] != '\0')) sent = m_socket.send_to(asio::buffer(buf_, len_), asio::ip::udp::endpoint(asio::ip::make_address(ipaddr_), m_port), flags, ec);
-    else                                              sent = m_socket.send_to(asio::buffer(buf_, len_), m_endpoint, flags, ec);
+    asio::error_code                       ec;
+    size_t                                 sent(0);
+    if (!m_localhost && (ipaddr_ != nullptr) && (ipaddr_[0] != '\0')) sent = m_socket.send_to(asio::buffer(buf_, len_), asio::ip::udp::endpoint(asio::ip::make_address(ipaddr_), m_port), flags, ec);
+    else                                                              sent = m_socket.send_to(asio::buffer(buf_, len_), m_endpoint, flags, ec);
     if (ec)
     {
       std::cout << "CUDPSender::Send failed with: \'" << ec.message() << "\'" << std::endl;

--- a/ecal/core/src/io/udp_sender.h
+++ b/ecal/core/src/io/udp_sender.h
@@ -33,8 +33,7 @@ namespace eCAL
     std::string ipaddr;
     int         port      = 0;
     int         ttl       = 0;
-    bool        broadcast = false;
-    bool        unicast   = false;
+    bool        localhost = false;
     bool        loopback  = true;
     int         sndbuf    = 1024 * 1024;
   };
@@ -45,7 +44,9 @@ namespace eCAL
   {
   public:
     CUDPSender(const SSenderAttr& attr_);
-    size_t Send(const void* buf_, size_t len_, const char* ipaddr_ = nullptr);
+
+    size_t Send(const void* buf_, size_t len_);
+    size_t Send(const void* buf_, size_t len_, const char* ipaddr_);
 
   protected:
     std::shared_ptr<CUDPSenderImpl> m_socket_impl;

--- a/ecal/core/src/io/udp_sender.h
+++ b/ecal/core/src/io/udp_sender.h
@@ -31,7 +31,6 @@ namespace eCAL
   struct SSenderAttr
   {
     std::string ipaddr;
-    bool        localhost = false;
     int         port      = 0;
     int         ttl       = 0;
     bool        broadcast = false;

--- a/ecal/core/src/io/udp_sender.h
+++ b/ecal/core/src/io/udp_sender.h
@@ -31,6 +31,7 @@ namespace eCAL
   struct SSenderAttr
   {
     std::string ipaddr;
+    bool        localhost = false;
     int         port      = 0;
     int         ttl       = 0;
     bool        broadcast = false;

--- a/ecal/core/src/mon/ecal_monitoring_threads.cpp
+++ b/ecal/core/src/mon/ecal_monitoring_threads.cpp
@@ -56,10 +56,11 @@ namespace eCAL
     {
       attr.broadcast = false;
     }
-    attr.ipaddr   = UDP::GetLoggingMulticastAddress();
-    attr.port     = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_LOG_OFF;
-    attr.loopback = true;
-    attr.rcvbuf   = Config::GetUdpMulticastRcvBufSizeBytes();
+    attr.ipaddr    = UDP::GetLoggingMulticastAddress();
+    attr.port      = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_LOG_OFF;
+    attr.localhost = !Config::IsNetworkEnabled();
+    attr.loopback  = true;
+    attr.rcvbuf    = Config::GetUdpMulticastRcvBufSizeBytes();
 
     m_log_rcv.Create(attr);
     m_log_rcv_thread.Start(0, std::bind(&CLoggingReceiveThread::ThreadFun, this));

--- a/ecal/core/src/mon/ecal_monitoring_threads.cpp
+++ b/ecal/core/src/mon/ecal_monitoring_threads.cpp
@@ -46,16 +46,6 @@ namespace eCAL
     m_network_mode(false), m_log_cb(log_cb_)
   {
     SReceiverAttr attr;
-    bool local_only = !Config::IsNetworkEnabled();
-    // for local only communication we switch to local broadcasting to bypass vpn's or firewalls
-    if (local_only)
-    {
-      attr.broadcast = true;
-    }
-    else
-    {
-      attr.broadcast = false;
-    }
     attr.ipaddr    = UDP::GetLoggingMulticastAddress();
     attr.port      = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_LOG_OFF;
     attr.localhost = !Config::IsNetworkEnabled();

--- a/ecal/core/src/readwrite/ecal_reader_udp_mc.cpp
+++ b/ecal/core/src/readwrite/ecal_reader_udp_mc.cpp
@@ -60,9 +60,8 @@ namespace eCAL
   void CUDPReaderLayer::Initialize()
   {
     SReceiverAttr attr;
-    attr.ipaddr    = Config::GetUdpMulticastGroup();
+    attr.ipaddr    = UDP::GetTopicMulticastAddress("");
     attr.port      = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_SAMPLE_OFF;
-    attr.unicast   = false;
     attr.localhost = !Config::IsNetworkEnabled();
     attr.loopback  = true;
     attr.rcvbuf    = Config::GetUdpMulticastRcvBufSizeBytes();
@@ -76,6 +75,10 @@ namespace eCAL
       thread.Start(0, std::bind(&CDataReaderUDP::Receive, &reader, &rcv));
       started = true;
     }
+
+    // local host mode ?
+    if (!Config::IsNetworkEnabled()) return;
+
     // add topic name based multicast address
     const std::string mcast_address = UDP::GetTopicMulticastAddress(topic_name_);
     if (topic_name_mcast_map.find(mcast_address) == topic_name_mcast_map.end())
@@ -88,6 +91,9 @@ namespace eCAL
 
   void CUDPReaderLayer::RemSubscription(const std::string& /*host_name_*/, const std::string& topic_name_, const std::string& /*topic_id_*/)
   {
+    // local host mode ?
+    if (!Config::IsNetworkEnabled()) return;
+
     const std::string mcast_address = UDP::GetTopicMulticastAddress(topic_name_);
     if (topic_name_mcast_map.find(mcast_address) == topic_name_mcast_map.end())
     {

--- a/ecal/core/src/readwrite/ecal_reader_udp_mc.cpp
+++ b/ecal/core/src/readwrite/ecal_reader_udp_mc.cpp
@@ -60,11 +60,12 @@ namespace eCAL
   void CUDPReaderLayer::Initialize()
   {
     SReceiverAttr attr;
-    attr.ipaddr = Config::GetUdpMulticastGroup();
-    attr.port = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_SAMPLE_OFF;
-    attr.unicast = false;
-    attr.loopback = true;
-    attr.rcvbuf = Config::GetUdpMulticastRcvBufSizeBytes();
+    attr.ipaddr    = Config::GetUdpMulticastGroup();
+    attr.port      = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_SAMPLE_OFF;
+    attr.unicast   = false;
+    attr.localhost = !Config::IsNetworkEnabled();
+    attr.loopback  = true;
+    attr.rcvbuf    = Config::GetUdpMulticastRcvBufSizeBytes();
     rcv.Create(attr);
   }
 

--- a/ecal/core/src/readwrite/ecal_writer_udp_mc.cpp
+++ b/ecal/core/src/readwrite/ecal_writer_udp_mc.cpp
@@ -67,6 +67,7 @@ namespace eCAL
     // set network attributes
     SSenderAttr attr;
     attr.ipaddr     = m_udp_ipaddr;
+    attr.localhost  = !Config::IsNetworkEnabled();
     attr.port       = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_SAMPLE_OFF;
     attr.ttl        = Config::GetUdpMulticastTtl();
     attr.sndbuf     = Config::GetUdpMulticastSndBufSizeBytes();

--- a/ecal/core/src/readwrite/ecal_writer_udp_mc.cpp
+++ b/ecal/core/src/readwrite/ecal_writer_udp_mc.cpp
@@ -66,17 +66,25 @@ namespace eCAL
 
     // set network attributes
     SSenderAttr attr;
-    attr.ipaddr     = m_udp_ipaddr;
-    attr.port       = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_SAMPLE_OFF;
-    attr.ttl        = Config::GetUdpMulticastTtl();
-    attr.sndbuf     = Config::GetUdpMulticastSndBufSizeBytes();
+    attr.ipaddr    = m_udp_ipaddr;
+    attr.port      = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_SAMPLE_OFF;
+    attr.ttl       = Config::GetUdpMulticastTtl();
+    attr.localhost = !Config::IsNetworkEnabled();
+    attr.loopback  = true;
+    attr.sndbuf    = Config::GetUdpMulticastSndBufSizeBytes();
+
+    // for local only communication we force the ttl (udp package 'hop limit') to 0
+    if (!Config::IsNetworkEnabled())
+    {
+      attr.ttl = 0;
+    }
 
     // create udp/sample sender with activated loop-back
-    attr.loopback   = true;
+    attr.loopback = true;
     m_sample_sender_loopback = std::make_shared<CSampleSender>(attr);
 
     // create udp/sample sender without activated loop-back
-    attr.loopback   = false;
+    attr.loopback = false;
     m_sample_sender_no_loopback = std::make_shared<CSampleSender>(attr);
 
     m_created = true;

--- a/ecal/core/src/readwrite/ecal_writer_udp_mc.cpp
+++ b/ecal/core/src/readwrite/ecal_writer_udp_mc.cpp
@@ -67,7 +67,6 @@ namespace eCAL
     // set network attributes
     SSenderAttr attr;
     attr.ipaddr     = m_udp_ipaddr;
-    attr.localhost  = !Config::IsNetworkEnabled();
     attr.port       = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_SAMPLE_OFF;
     attr.ttl        = Config::GetUdpMulticastTtl();
     attr.sndbuf     = Config::GetUdpMulticastSndBufSizeBytes();


### PR DESCRIPTION
### Description
If network mode is set to local (`network_enabled=false`) in the ecal global configuration (`ecal.ini`) the receiving of any kind of udp samples is switched off.

### Related issues
Fixes #1191 

### Cherry-pick to
- _none_
