### PR TITLE
Fix segfault in GetCpuCores

### DIFF
--- a/contrib/mma/src/linux/mma_linux.cpp
+++ b/contrib/mma/src/linux/mma_linux.cpp
@@ -488,6 +488,7 @@ int MMALinux::GetCpuCores(void)
   std::list <std::string> cpuinfo_list = TokenizeIntoLines(FileToString("/proc/cpuinfo"));
   std::vector <std::string> cpucore_vect;
   auto idx = 0;
+#ifdef __x86_64__
   if(!is_vrm)
   {
     for (auto iter : cpuinfo_list)
@@ -502,6 +503,7 @@ int MMALinux::GetCpuCores(void)
     return std::stoi(cpucore_vect[3]);
   }
   else
+#endif
   {
     auto cpu_cores=0;
     for (auto iter : cpuinfo_list)

--- a/contrib/mma/src/linux/mma_linux.cpp
+++ b/contrib/mma/src/linux/mma_linux.cpp
@@ -28,6 +28,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include <sys/sysinfo.h>
 
 #include "../include/linux/mma_linux.h"
 
@@ -485,40 +486,7 @@ bool MMALinux::MergeBootWithRootARM(ResourceLinux::DiskStatsList& /*disk_stats_i
 
 int MMALinux::GetCpuCores(void)
 {
-  std::list <std::string> cpuinfo_list = TokenizeIntoLines(FileToString("/proc/cpuinfo"));
-  std::vector <std::string> cpucore_vect;
-  auto idx = 0;
-#ifdef __x86_64__
-  if(!is_vrm)
-  {
-    for (auto iter : cpuinfo_list)
-    {
-      if (idx == 12)
-      {
-        cpucore_vect = SplitLine(iter);
-        break;
-      }
-      idx++;
-    }
-    return std::stoi(cpucore_vect[3]);
-  }
-  else
-#endif
-  {
-    auto cpu_cores=0;
-    for (auto iter : cpuinfo_list)
-    {
-        cpucore_vect = SplitLine(iter);
-        for(auto iter1:cpucore_vect)
-        {
-            if(iter1.find("processor")!= std::string::npos)
-            {
-                cpu_cores++;
-            }
-        }
-    }
-   return cpu_cores;
-  }
+  return get_nprocs();
 }
 
 bool MMALinux::CheckIfIsALinuxVRM()


### PR DESCRIPTION
### Description
<!-- What does your PR change? -->
The branch reading line 12 of /proc/cpuinfo is valid only for `__x86_64__`.
So, bugfix is to restrict this branch for `__x86_64__` only.
Or, simpler and more generic, use `get_ncores()`.

### Related issues
<!-- Type "Fixes #123" to automatically close that issue, when this PR is merged -->
- Fixes #1233

### Cherry-pick to
- 5.11 (old stable)
- 5.12 (current stable)
