### PR TITLE
cleanup udp configuration and sender/receiver attributes

### DIFF
--- a/ecal/core/src/ecal_log_impl.cpp
+++ b/ecal/core/src/ecal_log_impl.cpp
@@ -152,10 +152,9 @@ namespace eCAL
     if(m_filter_mask_udp != 0)
     {
       SSenderAttr attr;
-      // for local only communication we switch to local broadcasting to bypass vpn's or firewalls
-      attr.broadcast = !Config::IsNetworkEnabled();
       attr.ipaddr    = UDP::GetLoggingMulticastAddress();
       attr.port      = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_LOG_OFF;
+      attr.localhost = !Config::IsNetworkEnabled();
       attr.loopback  = true;
       attr.ttl       = Config::GetUdpMulticastTtl();
       attr.sndbuf    = Config::GetUdpMulticastSndBufSizeBytes();

--- a/ecal/core/src/ecal_log_impl.cpp
+++ b/ecal/core/src/ecal_log_impl.cpp
@@ -25,10 +25,7 @@
 #include <ecal/ecal_os.h>
 #include <ecal/ecal_config.h>
 
-#include "ecal_def.h"
-
 #include "ecal_log_impl.h"
-
 #include "io/udp_configurations.h"
 
 #include <mutex>
@@ -153,10 +150,10 @@ namespace eCAL
     {
       SSenderAttr attr;
       attr.ipaddr    = UDP::GetLoggingMulticastAddress();
-      attr.port      = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_LOG_OFF;
+      attr.port      = UDP::GetLoggingPort();
       attr.localhost = !Config::IsNetworkEnabled();
       attr.loopback  = true;
-      attr.ttl       = Config::GetUdpMulticastTtl();
+      attr.ttl       = UDP::GetMulticastTtl();
       attr.sndbuf    = Config::GetUdpMulticastSndBufSizeBytes();
 
       m_udp_sender = std::make_unique<CUDPSender>(attr);

--- a/ecal/core/src/ecal_log_impl.cpp
+++ b/ecal/core/src/ecal_log_impl.cpp
@@ -149,9 +149,9 @@ namespace eCAL
     if(m_filter_mask_udp != 0)
     {
       SSenderAttr attr;
-      attr.ipaddr    = UDP::GetLoggingMulticastAddress();
+      attr.address   = UDP::GetLoggingMulticastAddress();
       attr.port      = UDP::GetLoggingPort();
-      attr.localhost = !Config::IsNetworkEnabled();
+      attr.broadcast = !Config::IsNetworkEnabled();
       attr.loopback  = true;
       attr.ttl       = UDP::GetMulticastTtl();
       attr.sndbuf    = Config::GetUdpMulticastSndBufSizeBytes();

--- a/ecal/core/src/ecal_process.cpp
+++ b/ecal/core/src/ecal_process.cpp
@@ -26,10 +26,10 @@
 
 #include "ecal_def.h"
 #include "ecal_config_reader_hlp.h"
-#include "ecal_registration_provider.h"
 #include "ecal_registration_receiver.h"
 #include "ecal_globals.h"
 #include "ecal_process.h"
+#include "io/udp_configurations.h"
 
 #include <array>
 #include <chrono>
@@ -42,8 +42,8 @@
 
 #include "sys_usage.h"
 
-#include <stdlib.h>
-#include <stdio.h>
+#include <cstdlib>
+#include <cstdio>
 #include <string>
 #include <cstring>
 #include <atomic>
@@ -229,7 +229,7 @@ namespace eCAL
       {
         sstream << "Network mode             : local" << std::endl;
       }
-      sstream << "Network ttl              : " << Config::GetUdpMulticastTtl() << std::endl;
+      sstream << "Network ttl              : " << UDP::GetMulticastTtl() << std::endl;
       sstream << "Network sndbuf           : " << GetBufferStr(Config::GetUdpMulticastSndBufSizeBytes()) << std::endl;
       sstream << "Network rcvbuf           : " << GetBufferStr(Config::GetUdpMulticastRcvBufSizeBytes()) << std::endl;
       sstream << "Multicast cfg version    : v" << static_cast<uint32_t>(Config::GetUdpMulticastConfigVersion()) << std::endl;
@@ -549,7 +549,7 @@ namespace eCAL
         creation_flag = CREATE_NEW_CONSOLE;
       }
 
-      short win_state;
+      short win_state = 0;
       switch (process_mode_)
       {
       case 0:

--- a/ecal/core/src/ecal_registration_provider.cpp
+++ b/ecal/core/src/ecal_registration_provider.cpp
@@ -82,10 +82,10 @@ namespace eCAL
     {
       // set network attributes
       SSenderAttr attr;
-      attr.ipaddr    = UDP::GetRegistrationMulticastAddress();
+      attr.address    = UDP::GetRegistrationMulticastAddress();
       attr.port      = UDP::GetRegistrationPort();
       attr.ttl       = UDP::GetMulticastTtl();
-      attr.localhost = !Config::IsNetworkEnabled();
+      attr.broadcast = !Config::IsNetworkEnabled();
       attr.loopback  = true;
       attr.sndbuf    = Config::GetUdpMulticastSndBufSizeBytes();
 

--- a/ecal/core/src/ecal_registration_provider.cpp
+++ b/ecal/core/src/ecal_registration_provider.cpp
@@ -85,8 +85,7 @@ namespace eCAL
       attr.ipaddr    = UDP::GetRegistrationMulticastAddress();
       attr.port      = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_REG_OFF;
       attr.ttl       = Config::GetUdpMulticastTtl();
-      // for local only communication we switch to local broadcasting to bypass vpn's or firewalls
-      attr.broadcast = !Config::IsNetworkEnabled();
+      attr.localhost = !Config::IsNetworkEnabled();
       attr.loopback  = true;
       attr.sndbuf    = Config::GetUdpMulticastSndBufSizeBytes();
 

--- a/ecal/core/src/ecal_registration_provider.cpp
+++ b/ecal/core/src/ecal_registration_provider.cpp
@@ -83,8 +83,8 @@ namespace eCAL
       // set network attributes
       SSenderAttr attr;
       attr.ipaddr    = UDP::GetRegistrationMulticastAddress();
-      attr.port      = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_REG_OFF;
-      attr.ttl       = Config::GetUdpMulticastTtl();
+      attr.port      = UDP::GetRegistrationPort();
+      attr.ttl       = UDP::GetMulticastTtl();
       attr.localhost = !Config::IsNetworkEnabled();
       attr.loopback  = true;
       attr.sndbuf    = Config::GetUdpMulticastSndBufSizeBytes();

--- a/ecal/core/src/ecal_registration_receiver.cpp
+++ b/ecal/core/src/ecal_registration_receiver.cpp
@@ -137,10 +137,9 @@ namespace eCAL
     {
       // start registration receive thread
       SReceiverAttr attr;
-      // for local only communication we switch to local broadcasting to bypass vpn's or firewalls
-      attr.broadcast = !Config::IsNetworkEnabled();
       attr.ipaddr    = UDP::GetRegistrationMulticastAddress();
       attr.port      = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_REG_OFF;
+      attr.localhost = !Config::IsNetworkEnabled();
       attr.loopback  = true;
       attr.rcvbuf    = Config::GetUdpMulticastRcvBufSizeBytes();
 

--- a/ecal/core/src/ecal_registration_receiver.cpp
+++ b/ecal/core/src/ecal_registration_receiver.cpp
@@ -137,9 +137,9 @@ namespace eCAL
     {
       // start registration receive thread
       SReceiverAttr attr;
-      attr.ipaddr    = UDP::GetRegistrationMulticastAddress();
+      attr.address   = UDP::GetRegistrationMulticastAddress();
       attr.port      = UDP::GetRegistrationPort();
-      attr.localhost = !Config::IsNetworkEnabled();
+      attr.broadcast = !Config::IsNetworkEnabled();
       attr.loopback  = true;
       attr.rcvbuf    = Config::GetUdpMulticastRcvBufSizeBytes();
 

--- a/ecal/core/src/ecal_registration_receiver.cpp
+++ b/ecal/core/src/ecal_registration_receiver.cpp
@@ -138,7 +138,7 @@ namespace eCAL
       // start registration receive thread
       SReceiverAttr attr;
       attr.ipaddr    = UDP::GetRegistrationMulticastAddress();
-      attr.port      = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_REG_OFF;
+      attr.port      = UDP::GetRegistrationPort();
       attr.localhost = !Config::IsNetworkEnabled();
       attr.loopback  = true;
       attr.rcvbuf    = Config::GetUdpMulticastRcvBufSizeBytes();

--- a/ecal/core/src/io/ecal_receiver.h
+++ b/ecal/core/src/io/ecal_receiver.h
@@ -45,20 +45,11 @@ namespace eCAL
   ////////////////////////////////////////////////////////
   struct SReceiverAttr
   {
-    SReceiverAttr() :
-      port(0),
-      broadcast(false),
-      unicast(false),
-      loopback(true),
-      rcvbuf(1024 * 1024)
-    {};
-
     std::string ipaddr;
-    int         port;
-    bool        broadcast;
-    bool        unicast;
-    bool        loopback;
-    int         rcvbuf;
+    int         port      = 0;
+    bool        localhost = false;
+    bool        loopback  = true;
+    int         rcvbuf    = 1024 * 1024;
   };
 
   class CReceiver

--- a/ecal/core/src/io/ecal_receiver.h
+++ b/ecal/core/src/io/ecal_receiver.h
@@ -45,9 +45,9 @@ namespace eCAL
   ////////////////////////////////////////////////////////
   struct SReceiverAttr
   {
-    std::string ipaddr;
+    std::string address;
     int         port      = 0;
-    bool        localhost = false;
+    bool        broadcast = false;
     bool        loopback  = true;
     int         rcvbuf    = 1024 * 1024;
   };

--- a/ecal/core/src/io/snd_sample.cpp
+++ b/ecal/core/src/io/snd_sample.cpp
@@ -52,7 +52,7 @@ namespace eCAL
     if (data_size > 0)
     {
       // and send it
-      sent_sum = SendSampleBuffer(m_payload.data(), data_size, bandwidth_, std::bind(TransmitToUDP, std::placeholders::_1, std::placeholders::_2, m_udp_sender, m_attr.ipaddr));
+      sent_sum = SendSampleBuffer(m_payload.data(), data_size, bandwidth_, std::bind(TransmitToUDP, std::placeholders::_1, std::placeholders::_2, m_udp_sender, m_attr.address));
 
 #ifndef NDEBUG
       // log it

--- a/ecal/core/src/io/udp_configurations.cpp
+++ b/ecal/core/src/io/udp_configurations.cpp
@@ -1,36 +1,62 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
 #include "io/udp_configurations.h"
 
 #include <ecal/ecal_config.h>
 #include "topic2mcast.h"
 
-const std::string localhost_udp_address{ "127.255.255.255" };
-
-
-std::string eCAL::UDP::GetRegistrationMulticastAddress()
+namespace eCAL
 {
-  const bool local_only = !Config::IsNetworkEnabled();
-  if (local_only)
+  namespace UDP
   {
-    return localhost_udp_address;
-  }
-  else
-  {
-    // both in v1 and v2, the mulicast group is returned as the adress for the registration layer
-    return Config::GetUdpMulticastGroup();
-  }
-}
+    std::string LocalHost()
+    {
+      return "127.255.255.255";
+    }
 
-std::string eCAL::UDP::GetLoggingMulticastAddress()
-{
-  //TODO: At the moment, both logging and monitoring addresses seem to be the same
-  // Should it be kept or changed?
-  return GetRegistrationMulticastAddress();
-}
+    std::string GetRegistrationMulticastAddress()
+    {
+      const bool local_only = !Config::IsNetworkEnabled();
+      if (local_only)
+      {
+        return LocalHost();
+      }
+      else
+      {
+        // both in v1 and v2, the mulicast group is returned as the adress for the registration layer
+        return Config::GetUdpMulticastGroup();
+      }
+    }
 
-std::string eCAL::UDP::GetTopicMulticastAddress(const std::string& topic_name)
-{
-  if (Config::GetUdpMulticastConfigVersion() == Config::UdpConfigVersion::V1)
-    return UDP::V1::topic2mcast(topic_name, Config::GetUdpMulticastGroup(), Config::GetUdpMulticastMask());
-  // v2
-  return  UDP::V2::topic2mcast(topic_name, Config::GetUdpMulticastGroup(), Config::GetUdpMulticastMask());
+    std::string GetLoggingMulticastAddress()
+    {
+      // both logging and monitoring use the same addresses but different ports
+      return GetRegistrationMulticastAddress();
+    }
+
+    std::string GetTopicMulticastAddress(const std::string& topic_name)
+    {
+      if (Config::GetUdpMulticastConfigVersion() == Config::UdpConfigVersion::V1)
+        return UDP::V1::topic2mcast(topic_name, Config::GetUdpMulticastGroup(), Config::GetUdpMulticastMask());
+      // v2
+      return  UDP::V2::topic2mcast(topic_name, Config::GetUdpMulticastGroup(), Config::GetUdpMulticastMask());
+    }
+  }
 }

--- a/ecal/core/src/io/udp_configurations.cpp
+++ b/ecal/core/src/io/udp_configurations.cpp
@@ -28,7 +28,7 @@ namespace eCAL
 {
   namespace UDP
   {
-    std::string LocalHost()
+    std::string LocalBroadcastAddress()
     {
       // the specific address 127.255.255.255 is the broadcast address within the loopback range (127.0.0.0 to 127.255.255.255)
       return "127.255.255.255";
@@ -39,7 +39,7 @@ namespace eCAL
       const bool local_only = !Config::IsNetworkEnabled();
       if (local_only)
       {
-        return LocalHost();
+        return LocalBroadcastAddress();
       }
       else
       {

--- a/ecal/core/src/io/udp_configurations.cpp
+++ b/ecal/core/src/io/udp_configurations.cpp
@@ -66,18 +66,6 @@ namespace eCAL
 
     std::string GetPayloadMulticastAddress(const std::string& topic_name)
     {
-      // local host only
-      const bool local_only = !Config::IsNetworkEnabled();
-      if (local_only)
-      {
-        return LocalHost();
-      }
-
-      if (topic_name.empty())
-      {
-        return Config::GetUdpMulticastGroup();
-      }
-
       // v1
       if (Config::GetUdpMulticastConfigVersion() == Config::UdpConfigVersion::V1)
       {
@@ -98,7 +86,7 @@ namespace eCAL
       const bool local_only = !Config::IsNetworkEnabled();
       if (local_only)
       {
-        return 0;
+        return 1;
       }
       else
       {

--- a/ecal/core/src/io/udp_configurations.h
+++ b/ecal/core/src/io/udp_configurations.h
@@ -29,13 +29,19 @@ namespace eCAL
 {
   namespace UDP
   {
-    // return the multicast adress used for sending/receiving the registration information
+    // return the multicast adress/port used for sending/receiving the registration information
     std::string GetRegistrationMulticastAddress();
+    int GetRegistrationPort();
 
-    // return the multicast adress used for sending/receiving the logging information
+    // return the multicast adress/port used for sending/receiving the logging information
     std::string GetLoggingMulticastAddress();
+    int GetLoggingPort();
 
-    // return the multicast adress used for sending/receiving the topic payload
-    std::string GetTopicMulticastAddress(const std::string& topic_name);
+    // return the multicast adress/port used for sending/receiving the topic payload
+    std::string GetPayloadMulticastAddress(const std::string& topic_name);
+    int GetPayloadPort();
+
+    // return multicast udp package time to live setting
+    int GetMulticastTtl();
   }
 }

--- a/ecal/core/src/io/udp_configurations.h
+++ b/ecal/core/src/io/udp_configurations.h
@@ -29,12 +29,13 @@ namespace eCAL
 {
   namespace UDP
   {
-    // Return the Multicast Adress used for sending Registration information
+    // return the multicast adress used for sending/receiving the registration information
     std::string GetRegistrationMulticastAddress();
 
+    // return the multicast adress used for sending/receiving the logging information
     std::string GetLoggingMulticastAddress();
 
+    // return the multicast adress used for sending/receiving the topic payload
     std::string GetTopicMulticastAddress(const std::string& topic_name);
   }
-
 }

--- a/ecal/core/src/io/udp_configurations.h
+++ b/ecal/core/src/io/udp_configurations.h
@@ -29,6 +29,9 @@ namespace eCAL
 {
   namespace UDP
   {
+    // return local broadcast address
+    std::string LocalBroadcastAddress();
+
     // return the multicast adress/port used for sending/receiving the registration information
     std::string GetRegistrationMulticastAddress();
     int GetRegistrationPort();

--- a/ecal/core/src/io/udp_receiver_asio.cpp
+++ b/ecal/core/src/io/udp_receiver_asio.cpp
@@ -32,16 +32,9 @@ namespace eCAL
   CUDPReceiverAsio::CUDPReceiverAsio(const SReceiverAttr& attr_) :
     CUDPReceiverBase(attr_),
     m_created(false),
-    m_broadcast(attr_.broadcast),
-    m_unicast(attr_.unicast),
+    m_localhost(attr_.localhost),
     m_socket(m_iocontext)
   {
-    if (m_broadcast && m_unicast)
-    {
-      std::cerr << "CUDPReceiverAsio: Setting broadcast and unicast option true is not allowed." << std::endl;
-      return;
-    }
-
     // create socket
     const asio::ip::udp::endpoint listen_endpoint(asio::ip::udp::v4(), static_cast<unsigned short>(attr_.port));
     {
@@ -75,9 +68,8 @@ namespace eCAL
       }
     }
 
-    if (!m_unicast)
+    // set loopback option
     {
-      // set loopback option
       const asio::ip::multicast::enable_loopback loopback(attr_.loopback);
       asio::error_code ec;
       m_socket.set_option(loopback, ec);
@@ -109,7 +101,7 @@ namespace eCAL
 
   bool CUDPReceiverAsio::AddMultiCastGroup(const char* ipaddr_)
   {
-    if (!m_broadcast && !m_unicast)
+    if (!m_localhost)
     {
       // join multicast group
 #ifdef __linux__
@@ -145,7 +137,7 @@ namespace eCAL
 
   bool CUDPReceiverAsio::RemMultiCastGroup(const char* ipaddr_)
   {
-    if (!m_broadcast && !m_unicast)
+    if (!m_localhost)
     {
       // Leave multicast group
 #ifdef __linux__

--- a/ecal/core/src/io/udp_receiver_asio.cpp
+++ b/ecal/core/src/io/udp_receiver_asio.cpp
@@ -32,7 +32,7 @@ namespace eCAL
   CUDPReceiverAsio::CUDPReceiverAsio(const SReceiverAttr& attr_) :
     CUDPReceiverBase(attr_),
     m_created(false),
-    m_localhost(attr_.localhost),
+    m_broadcast(attr_.broadcast),
     m_socket(m_iocontext)
   {
     // create socket
@@ -93,7 +93,7 @@ namespace eCAL
     }
 
     // join multicast group
-    AddMultiCastGroup(attr_.ipaddr.c_str());
+    AddMultiCastGroup(attr_.address.c_str());
 
     // state successful creation
     m_created = true;
@@ -101,7 +101,7 @@ namespace eCAL
 
   bool CUDPReceiverAsio::AddMultiCastGroup(const char* ipaddr_)
   {
-    if (!m_localhost)
+    if (!m_broadcast)
     {
       // join multicast group
 #ifdef __linux__
@@ -137,7 +137,7 @@ namespace eCAL
 
   bool CUDPReceiverAsio::RemMultiCastGroup(const char* ipaddr_)
   {
-    if (!m_localhost)
+    if (!m_broadcast)
     {
       // Leave multicast group
 #ifdef __linux__

--- a/ecal/core/src/io/udp_receiver_asio.h
+++ b/ecal/core/src/io/udp_receiver_asio.h
@@ -48,7 +48,7 @@ namespace eCAL
     void RunIOContext(const asio::chrono::steady_clock::duration& timeout);
 
     bool                    m_created;
-    bool                    m_localhost;
+    bool                    m_broadcast;
     asio::io_context        m_iocontext;
     asio::ip::udp::socket   m_socket;
     asio::ip::udp::endpoint m_sender_endpoint;

--- a/ecal/core/src/io/udp_receiver_asio.h
+++ b/ecal/core/src/io/udp_receiver_asio.h
@@ -48,8 +48,7 @@ namespace eCAL
     void RunIOContext(const asio::chrono::steady_clock::duration& timeout);
 
     bool                    m_created;
-    bool                    m_broadcast;
-    bool                    m_unicast;
+    bool                    m_localhost;
     asio::io_context        m_iocontext;
     asio::ip::udp::socket   m_socket;
     asio::ip::udp::endpoint m_sender_endpoint;

--- a/ecal/core/src/io/udp_receiver_npcap.cpp
+++ b/ecal/core/src/io/udp_receiver_npcap.cpp
@@ -26,7 +26,7 @@ namespace eCAL
   CUDPReceiverPcap::CUDPReceiverPcap(const SReceiverAttr& attr_)
     : CUDPReceiverBase(attr_)
     , m_created(false)
-    , m_unicast(attr_.unicast)
+    , m_localhost(attr_.localhost)
   {
     // set receive buffer size (default = 1 MB)
     int rcvbuf = 1024 * 1024;
@@ -46,11 +46,8 @@ namespace eCAL
       return;
     }
 
-    if (!m_unicast)
-    {
-      // set loopback option
-      m_socket.setMulticastLoopbackEnabled(attr_.loopback);
-    }
+    // set loopback option
+    m_socket.setMulticastLoopbackEnabled(attr_.loopback);
 
     // join multicast group
     AddMultiCastGroup(attr_.ipaddr.c_str());
@@ -61,7 +58,7 @@ namespace eCAL
 
   bool CUDPReceiverPcap::AddMultiCastGroup(const char* ipaddr_)
   {
-    if (!m_unicast)
+    if (!m_localhost)
     {
       // join multicast group
       if (!m_socket.joinMulticastGroup(Udpcap::HostAddress(ipaddr_)))
@@ -75,7 +72,7 @@ namespace eCAL
 
   bool CUDPReceiverPcap::RemMultiCastGroup(const char* ipaddr_)
   {
-    if (!m_unicast)
+    if (!m_localhost)
     {
       // leave multicast group
       if (!m_socket.leaveMulticastGroup(Udpcap::HostAddress(ipaddr_)))

--- a/ecal/core/src/io/udp_receiver_npcap.cpp
+++ b/ecal/core/src/io/udp_receiver_npcap.cpp
@@ -47,7 +47,10 @@ namespace eCAL
     }
 
     // set loopback option
-    m_socket.setMulticastLoopbackEnabled(attr_.loopback);
+    if (!m_localhost)
+    {
+      m_socket.setMulticastLoopbackEnabled(attr_.loopback);
+    }
 
     // join multicast group
     AddMultiCastGroup(attr_.ipaddr.c_str());

--- a/ecal/core/src/io/udp_receiver_npcap.cpp
+++ b/ecal/core/src/io/udp_receiver_npcap.cpp
@@ -26,7 +26,7 @@ namespace eCAL
   CUDPReceiverPcap::CUDPReceiverPcap(const SReceiverAttr& attr_)
     : CUDPReceiverBase(attr_)
     , m_created(false)
-    , m_localhost(attr_.localhost)
+    , m_broadcast(attr_.broadcast)
   {
     // set receive buffer size (default = 1 MB)
     int rcvbuf = 1024 * 1024;
@@ -47,13 +47,13 @@ namespace eCAL
     }
 
     // set loopback option
-    if (!m_localhost)
+    if (!m_broadcast)
     {
       m_socket.setMulticastLoopbackEnabled(attr_.loopback);
     }
 
     // join multicast group
-    AddMultiCastGroup(attr_.ipaddr.c_str());
+    AddMultiCastGroup(attr_.address.c_str());
 
     // state successful creation
     m_created = true;
@@ -61,7 +61,7 @@ namespace eCAL
 
   bool CUDPReceiverPcap::AddMultiCastGroup(const char* ipaddr_)
   {
-    if (!m_localhost)
+    if (!m_broadcast)
     {
       // join multicast group
       if (!m_socket.joinMulticastGroup(Udpcap::HostAddress(ipaddr_)))
@@ -75,7 +75,7 @@ namespace eCAL
 
   bool CUDPReceiverPcap::RemMultiCastGroup(const char* ipaddr_)
   {
-    if (!m_localhost)
+    if (!m_broadcast)
     {
       // leave multicast group
       if (!m_socket.leaveMulticastGroup(Udpcap::HostAddress(ipaddr_)))

--- a/ecal/core/src/io/udp_receiver_npcap.h
+++ b/ecal/core/src/io/udp_receiver_npcap.h
@@ -43,7 +43,7 @@ namespace eCAL
 
   protected:
     bool                 m_created;
-    bool                 m_unicast;
+    bool                 m_localhost;
     Udpcap::UdpcapSocket m_socket;
   };
 

--- a/ecal/core/src/io/udp_receiver_npcap.h
+++ b/ecal/core/src/io/udp_receiver_npcap.h
@@ -43,7 +43,7 @@ namespace eCAL
 
   protected:
     bool                 m_created;
-    bool                 m_localhost;
+    bool                 m_broadcast;
     Udpcap::UdpcapSocket m_socket;
   };
 

--- a/ecal/core/src/io/udp_sender.cpp
+++ b/ecal/core/src/io/udp_sender.cpp
@@ -47,7 +47,7 @@ namespace eCAL
     size_t Send(const void* buf_, size_t len_, const char* ipaddr_ = nullptr);
 
   protected:
-    bool                    m_localhost;
+    bool                    m_broadcast;
     asio::io_context        m_iocontext;
     asio::ip::udp::endpoint m_endpoint;
     asio::ip::udp::socket   m_socket;
@@ -55,12 +55,12 @@ namespace eCAL
   };
 
   CUDPSenderImpl::CUDPSenderImpl(const SSenderAttr& attr_) :
-    m_localhost(attr_.localhost),
-    m_endpoint(asio::ip::make_address(attr_.ipaddr), static_cast<unsigned short>(attr_.port)),
+    m_broadcast(attr_.broadcast),
+    m_endpoint(asio::ip::make_address(attr_.address), static_cast<unsigned short>(attr_.port)),
     m_socket(m_iocontext, m_endpoint.protocol()),
     m_port(static_cast<unsigned short>(attr_.port))
   {
-    if (m_localhost)
+    if (m_broadcast)
     {
       // set unicast packet TTL
       const asio::ip::unicast::hops ttl(attr_.ttl);
@@ -90,7 +90,7 @@ namespace eCAL
       }
     }
 
-    if (m_localhost)
+    if (m_broadcast)
     {
       asio::error_code ec;
       m_socket.set_option(asio::socket_base::broadcast(true), ec);

--- a/ecal/core/src/io/udp_sender.cpp
+++ b/ecal/core/src/io/udp_sender.cpp
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -48,7 +48,6 @@ namespace eCAL
 
   protected:
     bool                    m_localhost;
-    bool                    m_unicast;
     asio::io_context        m_iocontext;
     asio::ip::udp::endpoint m_endpoint;
     asio::ip::udp::socket   m_socket;

--- a/ecal/core/src/io/udp_sender.cpp
+++ b/ecal/core/src/io/udp_sender.cpp
@@ -47,7 +47,7 @@ namespace eCAL
     size_t Send(const void* buf_, size_t len_, const char* ipaddr_ = nullptr);
 
   protected:
-    bool                    m_broadcast;
+    bool                    m_localhost;
     bool                    m_unicast;
     asio::io_context        m_iocontext;
     asio::ip::udp::endpoint m_endpoint;
@@ -56,19 +56,12 @@ namespace eCAL
   };
 
   CUDPSenderImpl::CUDPSenderImpl(const SSenderAttr& attr_) :
-    m_broadcast(attr_.broadcast),
-    m_unicast(attr_.unicast),
+    m_localhost(attr_.localhost),
     m_endpoint(asio::ip::make_address(attr_.ipaddr), static_cast<unsigned short>(attr_.port)),
     m_socket(m_iocontext, m_endpoint.protocol()),
     m_port(static_cast<unsigned short>(attr_.port))
   {
-    if (m_broadcast && m_unicast)
-    {
-      std::cerr << "CUDPSender: Setting broadcast and unicast option true is not allowed." << std::endl;
-      return;
-    }
-
-    if (m_broadcast || m_unicast)
+    if (m_localhost)
     {
       // set unicast packet TTL
       const asio::ip::unicast::hops ttl(attr_.ttl);
@@ -98,7 +91,7 @@ namespace eCAL
       }
     }
 
-    if (m_broadcast)
+    if (m_localhost)
     {
       asio::error_code ec;
       m_socket.set_option(asio::socket_base::broadcast(true), ec);

--- a/ecal/core/src/io/udp_sender.h
+++ b/ecal/core/src/io/udp_sender.h
@@ -30,10 +30,10 @@ namespace eCAL
 {
   struct SSenderAttr
   {
-    std::string ipaddr;
+    std::string address;
     int         port      = 0;
     int         ttl       = 0;
-    bool        localhost = false;
+    bool        broadcast = false;
     bool        loopback  = true;
     int         sndbuf    = 1024 * 1024;
   };

--- a/ecal/core/src/io/udp_sender.h
+++ b/ecal/core/src/io/udp_sender.h
@@ -33,8 +33,7 @@ namespace eCAL
     std::string ipaddr;
     int         port      = 0;
     int         ttl       = 0;
-    bool        broadcast = false;
-    bool        unicast   = false;
+    bool        localhost = false;
     bool        loopback  = true;
     int         sndbuf    = 1024 * 1024;
   };

--- a/ecal/core/src/mon/ecal_monitoring_threads.cpp
+++ b/ecal/core/src/mon/ecal_monitoring_threads.cpp
@@ -44,9 +44,9 @@ namespace eCAL
     m_network_mode(false), m_log_cb(log_cb_)
   {
     SReceiverAttr attr;
-    attr.ipaddr    = UDP::GetLoggingMulticastAddress();
+    attr.address   = UDP::GetLoggingMulticastAddress();
     attr.port      = UDP::GetLoggingPort();
-    attr.localhost = !Config::IsNetworkEnabled();
+    attr.broadcast = !Config::IsNetworkEnabled();
     attr.loopback  = true;
     attr.rcvbuf    = Config::GetUdpMulticastRcvBufSizeBytes();
 

--- a/ecal/core/src/mon/ecal_monitoring_threads.cpp
+++ b/ecal/core/src/mon/ecal_monitoring_threads.cpp
@@ -28,9 +28,7 @@
 #include "io/msg_type.h"
 #include "io/udp_configurations.h"
 
-#include "ecal_config_reader_hlp.h"
 #include "ecal_monitoring_threads.h"
-#include "ecal_global_accessors.h"
 
 namespace eCAL
 {
@@ -47,7 +45,7 @@ namespace eCAL
   {
     SReceiverAttr attr;
     attr.ipaddr    = UDP::GetLoggingMulticastAddress();
-    attr.port      = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_LOG_OFF;
+    attr.port      = UDP::GetLoggingPort();
     attr.localhost = !Config::IsNetworkEnabled();
     attr.loopback  = true;
     attr.rcvbuf    = Config::GetUdpMulticastRcvBufSizeBytes();

--- a/ecal/core/src/mon/ecal_monitoring_threads.cpp
+++ b/ecal/core/src/mon/ecal_monitoring_threads.cpp
@@ -46,20 +46,11 @@ namespace eCAL
     m_network_mode(false), m_log_cb(log_cb_)
   {
     SReceiverAttr attr;
-    bool local_only = !Config::IsNetworkEnabled();
-    // for local only communication we switch to local broadcasting to bypass vpn's or firewalls
-    if (local_only)
-    {
-      attr.broadcast = true;
-    }
-    else
-    {
-      attr.broadcast = false;
-    }
-    attr.ipaddr   = UDP::GetLoggingMulticastAddress();
-    attr.port     = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_LOG_OFF;
-    attr.loopback = true;
-    attr.rcvbuf   = Config::GetUdpMulticastRcvBufSizeBytes();
+    attr.ipaddr    = UDP::GetLoggingMulticastAddress();
+    attr.port      = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_LOG_OFF;
+    attr.localhost = !Config::IsNetworkEnabled();
+    attr.loopback  = true;
+    attr.rcvbuf    = Config::GetUdpMulticastRcvBufSizeBytes();
 
     m_log_rcv.Create(attr);
     m_log_rcv_thread.Start(0, std::bind(&CLoggingReceiveThread::ThreadFun, this));

--- a/ecal/core/src/readwrite/ecal_reader_udp_mc.cpp
+++ b/ecal/core/src/readwrite/ecal_reader_udp_mc.cpp
@@ -60,7 +60,7 @@ namespace eCAL
   void CUDPReaderLayer::Initialize()
   {
     SReceiverAttr attr;
-    attr.ipaddr    = UDP::GetPayloadMulticastAddress("");
+    attr.ipaddr    = Config::GetUdpMulticastGroup();
     attr.port      = UDP::GetPayloadPort();
     attr.localhost = false;
     attr.loopback  = true;

--- a/ecal/core/src/readwrite/ecal_reader_udp_mc.cpp
+++ b/ecal/core/src/readwrite/ecal_reader_udp_mc.cpp
@@ -60,9 +60,9 @@ namespace eCAL
   void CUDPReaderLayer::Initialize()
   {
     SReceiverAttr attr;
-    attr.ipaddr    = Config::GetUdpMulticastGroup();
+    attr.address   = Config::GetUdpMulticastGroup();
     attr.port      = UDP::GetPayloadPort();
-    attr.localhost = false;
+    attr.broadcast = false;
     attr.loopback  = true;
     attr.rcvbuf    = Config::GetUdpMulticastRcvBufSizeBytes();
     rcv.Create(attr);

--- a/ecal/core/src/readwrite/ecal_reader_udp_mc.cpp
+++ b/ecal/core/src/readwrite/ecal_reader_udp_mc.cpp
@@ -60,11 +60,11 @@ namespace eCAL
   void CUDPReaderLayer::Initialize()
   {
     SReceiverAttr attr;
-    attr.ipaddr = Config::GetUdpMulticastGroup();
-    attr.port = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_SAMPLE_OFF;
-    attr.unicast = false;
-    attr.loopback = true;
-    attr.rcvbuf = Config::GetUdpMulticastRcvBufSizeBytes();
+    attr.ipaddr    = Config::GetUdpMulticastGroup();
+    attr.port      = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_SAMPLE_OFF;
+    attr.localhost = false;
+    attr.loopback  = true;
+    attr.rcvbuf    = Config::GetUdpMulticastRcvBufSizeBytes();
     rcv.Create(attr);
   }
 

--- a/ecal/core/src/readwrite/ecal_reader_udp_mc.cpp
+++ b/ecal/core/src/readwrite/ecal_reader_udp_mc.cpp
@@ -60,8 +60,8 @@ namespace eCAL
   void CUDPReaderLayer::Initialize()
   {
     SReceiverAttr attr;
-    attr.ipaddr    = Config::GetUdpMulticastGroup();
-    attr.port      = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_SAMPLE_OFF;
+    attr.ipaddr    = UDP::GetPayloadMulticastAddress("");
+    attr.port      = UDP::GetPayloadPort();
     attr.localhost = false;
     attr.loopback  = true;
     attr.rcvbuf    = Config::GetUdpMulticastRcvBufSizeBytes();
@@ -76,7 +76,7 @@ namespace eCAL
       started = true;
     }
     // add topic name based multicast address
-    const std::string mcast_address = UDP::GetTopicMulticastAddress(topic_name_);
+    const std::string mcast_address = UDP::GetPayloadMulticastAddress(topic_name_);
     if (topic_name_mcast_map.find(mcast_address) == topic_name_mcast_map.end())
     {
       topic_name_mcast_map.emplace(std::pair<std::string, int>(mcast_address, 0));
@@ -87,7 +87,7 @@ namespace eCAL
 
   void CUDPReaderLayer::RemSubscription(const std::string& /*host_name_*/, const std::string& topic_name_, const std::string& /*topic_id_*/)
   {
-    const std::string mcast_address = UDP::GetTopicMulticastAddress(topic_name_);
+    const std::string mcast_address = UDP::GetPayloadMulticastAddress(topic_name_);
     if (topic_name_mcast_map.find(mcast_address) == topic_name_mcast_map.end())
     {
       // this should never happen

--- a/ecal/core/src/readwrite/ecal_writer_udp_mc.cpp
+++ b/ecal/core/src/readwrite/ecal_writer_udp_mc.cpp
@@ -62,10 +62,10 @@ namespace eCAL
 
     // set network attributes
     SSenderAttr attr;
-    attr.ipaddr = UDP::GetPayloadMulticastAddress(topic_name_);
-    attr.port   = UDP::GetPayloadPort();
-    attr.ttl    = UDP::GetMulticastTtl();
-    attr.sndbuf = Config::GetUdpMulticastSndBufSizeBytes();
+    attr.address = UDP::GetPayloadMulticastAddress(topic_name_);
+    attr.port    = UDP::GetPayloadPort();
+    attr.ttl     = UDP::GetMulticastTtl();
+    attr.sndbuf  = Config::GetUdpMulticastSndBufSizeBytes();
 
     // create udp/sample sender with activated loop-back
     attr.loopback   = true;

--- a/ecal/core/src/readwrite/ecal_writer_udp_mc.cpp
+++ b/ecal/core/src/readwrite/ecal_writer_udp_mc.cpp
@@ -24,9 +24,7 @@
 #include <ecal/ecal_log.h>
 #include <ecal/ecal_config.h>
 
-#include "ecal_def.h"
 #include "ecal_writer_udp_mc.h"
-
 #include "io/udp_configurations.h"
 
 namespace eCAL
@@ -62,14 +60,12 @@ namespace eCAL
     m_topic_name  = topic_name_;
     m_topic_id    = topic_id_;
 
-    m_udp_ipaddr = UDP::GetTopicMulticastAddress(topic_name_);
-
     // set network attributes
     SSenderAttr attr;
-    attr.ipaddr     = m_udp_ipaddr;
-    attr.port       = Config::GetUdpMulticastPort() + NET_UDP_MULTICAST_PORT_SAMPLE_OFF;
-    attr.ttl        = Config::GetUdpMulticastTtl();
-    attr.sndbuf     = Config::GetUdpMulticastSndBufSizeBytes();
+    attr.ipaddr = UDP::GetPayloadMulticastAddress(topic_name_);
+    attr.port   = UDP::GetPayloadPort();
+    attr.ttl    = UDP::GetMulticastTtl();
+    attr.sndbuf = Config::GetUdpMulticastSndBufSizeBytes();
 
     // create udp/sample sender with activated loop-back
     attr.loopback   = true;

--- a/ecal/core/src/readwrite/ecal_writer_udp_mc.h
+++ b/ecal/core/src/readwrite/ecal_writer_udp_mc.h
@@ -56,7 +56,6 @@ namespace eCAL
     bool Write(const void* buf_, const SWriterAttr& attr_) override;
 
   protected:
-    std::string                    m_udp_ipaddr;
     eCAL::pb::Sample               m_ecal_sample;
 
     std::shared_ptr<CSampleSender> m_sample_sender_loopback;


### PR DESCRIPTION
### Description
<!-- What does your PR change? -->
In preparation for a new udp communication layer implementation there are some cleanups made in udp_confiuration and the sender and receiver udp attribute structures. Test under Windows and Ubuntu with local and network mode and for Windows with and without npcap.

### Related issues
Is not fixing any issue, should behave as before.

### Cherry-pick to
- _none_
