### PR TITLE
Python: Fix client remove response callback

### DIFF
--- a/lang/python/core/ecal/core/core.py
+++ b/lang/python/core/ecal/core/core.py
@@ -478,7 +478,7 @@ def client_add_response_callback(client_handle, callback):
   return _ecal.client_add_response_callback(client_handle, callback)
 
 
-def client_rem_method_callback(client_handle):
+def client_rem_response_callback(client_handle):
   """ remove response callback from client
 
   :param client_handle: the client handle

--- a/lang/python/core/ecal/core/service.py
+++ b/lang/python/core/ecal/core/service.py
@@ -100,7 +100,7 @@ class Client(object):
     """
     return ecal_core.client_add_response_callback(self.shandle, callback)
 
-  def rem_response_callback(self, method_name):
+  def rem_response_callback(self):
     """ remove response callback from client
     """
     return ecal_core.client_rem_response_callback(self.shandle)

--- a/lang/python/core/src/ecal_wrap.cxx
+++ b/lang/python/core/src/ecal_wrap.cxx
@@ -1634,7 +1634,7 @@ static PyMethodDef _ecal_methods[] =
   {"client_call_method",            client_call_method,            METH_VARARGS,  "client_call_method(client_handle, method_name, request, timeout)" },
 
   {"client_add_response_callback",  client_add_response_callback,  METH_VARARGS,  "client_add_response_callback(client_handle, callback)" },
-  {"client_rem_response_callback",  client_add_response_callback,  METH_VARARGS,  "client_rem_response_callback(client_handle)" },
+  {"client_rem_response_callback",  client_rem_response_callback,  METH_VARARGS,  "client_rem_response_callback(client_handle)" },
   
   {"mon_initialize",                mon_initialize,                METH_NOARGS,   "mon_initialize()"},
   {"mon_finalize",                  mon_finalize,                  METH_NOARGS,   "mon_finalize()"},


### PR DESCRIPTION
### Description
Fixed the python bindings for removing a response callback from a service client:

`ecal.core.service.py` :
- Client had `rem_response_callback` taking a method name parameter (which was unused) and calling non-existant `ecal.core.core.client_rem_response_callback`.

`ecal.core.core.py`:
- `client_rem_response_callback` doesn't exist because it was typoed in as `client_rem_method_callback`.

`ecal_wrap.cxx`:
- Implementation of `client_rem_response_callback` does exist
- Unfortunately, the `_ecal_methods` mapping binds the python API function `client_rem_response_callback` to the C++ function `client_add_response_callback`!

### Related issues
<!-- Type "Fixes #123" to automatically close that issue, when this PR is merged -->
- None

### Cherry-pick to
- 5.11 (old stable)
- 5.12 (current stable)
