### PR TITLE
CUDPReceiver socket protected by mutex

### DIFF
--- a/ecal/core/src/io/udp/udp_receiver.cpp
+++ b/ecal/core/src/io/udp/udp_receiver.cpp
@@ -73,25 +73,34 @@ namespace eCAL
   bool CUDPReceiver::Destroy()
   {
     if (!m_socket_impl) return(false);
+
+    const std::lock_guard<std::mutex> lock(m_socket_mtx);
     m_socket_impl.reset();
+
     return(true);
   }
 
   bool CUDPReceiver::AddMultiCastGroup(const char* ipaddr_)
   {
     if (!m_socket_impl) return(false);
+
+    const std::lock_guard<std::mutex> lock(m_socket_mtx);
     return(m_socket_impl->AddMultiCastGroup(ipaddr_));
   }
 
   bool CUDPReceiver::RemMultiCastGroup(const char* ipaddr_)
   {
     if (!m_socket_impl) return(false);
+
+    const std::lock_guard<std::mutex> lock(m_socket_mtx);
     return(m_socket_impl->RemMultiCastGroup(ipaddr_));
   }
 
   size_t CUDPReceiver::Receive(char* buf_, size_t len_, int timeout_, ::sockaddr_in* address_ /* = nullptr */)
   {
     if (!m_socket_impl) return(0);
+
+    const std::lock_guard<std::mutex> lock(m_socket_mtx);
     return(m_socket_impl->Receive(buf_, len_, timeout_, address_));
   }
 }

--- a/ecal/core/src/io/udp/udp_receiver.h
+++ b/ecal/core/src/io/udp/udp_receiver.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 #include "ecal_receiver.h"
 
 namespace eCAL
@@ -45,6 +46,7 @@ namespace eCAL
 
   protected:
     bool m_use_npcap;
+    std::mutex                        m_socket_mtx;
     std::shared_ptr<CUDPReceiverBase> m_socket_impl;
   };
 }


### PR DESCRIPTION
### Description
Base UDP receive socket handling (ASIO/NPCAP) is not thread safe. On Destruction it may happen that we are still in Receive state and the socket implementation (shared_ptr) is destroyed.

### Related issues
Fixes #1212 (probably)

### Cherry-pick to
- 5.11 (old stable)
- 5.12 (current stable)
