### PR TITLE
fixed segfault on udp receiver destruction

### DIFF
--- a/ecal/core/src/io/udp/ecal_udp_sample_receiver.cpp
+++ b/ecal/core/src/io/udp/ecal_udp_sample_receiver.cpp
@@ -117,7 +117,11 @@ namespace eCAL
 
     CSampleReceiver::~CSampleReceiver()
     {
+      // stop receiver thread
       m_udp_receiver_thread->stop();
+
+      // destroy udp receiver
+      m_udp_receiver.Destroy();
     }
 
     bool CSampleReceiver::AddMultiCastGroup(const char* ipaddr_)


### PR DESCRIPTION
### Description
Fix a segfault in eCAL::Finalize phase based on the wrong order of stopping udp sample receiver.

### Related issues
Even it's closed, Fixes #1212

### Cherry-pick to
- _none_
