### PR TITLE
fix wrapper function miss matching

### DIFF
--- a/lang/python/core/ecal/core/core.py
+++ b/lang/python/core/ecal/core/core.py
@@ -465,7 +465,7 @@ def client_set_hostname(client_handle, host_name):
   :type host_name:      string
 
   """
-  return _ecal.client_set_host_name(client_handle, host_name)
+  return _ecal.client_set_hostname(client_handle, host_name)
 
 
 def client_add_response_callback(client_handle, callback):

--- a/lang/python/core/ecal/core/service.py
+++ b/lang/python/core/ecal/core/service.py
@@ -90,7 +90,7 @@ class Client(object):
     :type host_name:  string
 
     """
-    return ecal_core.client_set_host_name(self.shandle, host_name)
+    return ecal_core.client_set_hostname(self.shandle, host_name)
 
   def add_response_callback(self, callback):
     """ add response callback to client


### PR DESCRIPTION
### Description
Fix python wrapper function name
`client_set_host_name` to `client_set_hostname`

the method defined here:
https://github.com/eclipse-ecal/ecal/blob/28ef1a150bf7e27d0748c124d42a7381f72c4862/lang/python/core/src/ecal_wrap.cxx#L1633C22-L1633C22

### Related issues
- 

### Cherry-pick to
