### PR TITLE
Doc: Fixed compatibility issue with empy

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,7 +3,7 @@ sphinx-book-theme==0.3.3
 sphinx-tabs==3.3.1
 PyGithub
 autodoc
-empy
+empy<=3.3.4
 semantic-version 
 exhale
 Jinja2


### PR DESCRIPTION
At the moment it seems to be the case that the recently released version 4.0.0 (end of nov) of python package empy is not compatible with our sphinx documentation build. As short-term fix the package version can be pinned to the previous version 3.3.4 so that the documentation build on the master branch works again.