### PR TITLE
Doc: Downgraded applehelp in requirements.txt

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -9,5 +9,8 @@ exhale
 Jinja2
 sphinxcontrib-youtube<=1.2
 sphinxcontrib-apidoc
-sphinxcontrib-applehelp<=1.0.7 # 2024-01-15: applehelp 1.0.8 needs Sphinx 5 or up, but our old sphinx-book-theme 0.3.3 requires Sphinx 4
-sphinxcontrib-devhelp<=1.0.5  # 2024-01-15: devhelp 1.0.6 needs Sphinx 5 or up, but our old sphinx-book-theme 0.3.3 requires Sphinx 4
+sphinxcontrib-applehelp<=1.0.7        # 2024-01-15: Newer packages needs Sphinx 5 or up, but our old sphinx-book-theme 0.3.3 requires Sphinx 4
+sphinxcontrib-devhelp<=1.0.5          # 2024-01-15: Newer packages need Sphinx 5 or up, but our old sphinx-book-theme 0.3.3 requires Sphinx 4
+sphinxcontrib-htmlhelp<=2.0.4         # 2024-01-15: Newer packages (probably) need Sphinx 5 or up, but our old sphinx-book-theme 0.3.3 requires Sphinx 4
+sphinxcontrib-qthelp<=1.0.6           # 2024-01-15: Newer packages (probably) need Sphinx 5 or up, but our old sphinx-book-theme 0.3.3 requires Sphinx 4
+sphinxcontrib-serializinghtml<=1.1.9  # 2024-01-15: Newer packages (probably) need Sphinx 5 or up, but our old sphinx-book-theme 0.3.3 requires Sphinx 4

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -9,4 +9,4 @@ exhale
 Jinja2
 sphinxcontrib-youtube<=1.2
 sphinxcontrib-apidoc
-
+sphinxcontrib-applehelp<=1.0.7 # 2024-01-15: applehelp 1.0.8 needs Sphinx 5 or up, but our old sphinx-book-theme 0.3.3 requires Sphinx 4

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -10,3 +10,4 @@ Jinja2
 sphinxcontrib-youtube<=1.2
 sphinxcontrib-apidoc
 sphinxcontrib-applehelp<=1.0.7 # 2024-01-15: applehelp 1.0.8 needs Sphinx 5 or up, but our old sphinx-book-theme 0.3.3 requires Sphinx 4
+sphinxcontrib-devhelp<=1.0.5  # 2024-01-15: devhelp 1.0.6 needs Sphinx 5 or up, but our old sphinx-book-theme 0.3.3 requires Sphinx 4


### PR DESCRIPTION
### Description
sphinxcontrib-applehelp 1.0.8 needs Sphinx 5 or up, but our old sphinx-book-theme 0.3.3 requires Sphinx 4

Fixes #1301

### Cherry-pick to
- 5.11 (old stable)
- 5.12 (current stable)
