### PR TITLE
Doc: Downgraded sphinx related packages in requirements.txt (#1302)

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -9,4 +9,8 @@ exhale
 Jinja2
 sphinxcontrib-youtube<=1.2
 sphinxcontrib-apidoc
-
+sphinxcontrib-applehelp<=1.0.7        # 2024-01-15: Newer packages needs Sphinx 5 or up, but our old sphinx-book-theme 0.3.3 requires Sphinx 4
+sphinxcontrib-devhelp<=1.0.5          # 2024-01-15: Newer packages need Sphinx 5 or up, but our old sphinx-book-theme 0.3.3 requires Sphinx 4
+sphinxcontrib-htmlhelp<=2.0.4         # 2024-01-15: Newer packages (probably) need Sphinx 5 or up, but our old sphinx-book-theme 0.3.3 requires Sphinx 4
+sphinxcontrib-qthelp<=1.0.6           # 2024-01-15: Newer packages (probably) need Sphinx 5 or up, but our old sphinx-book-theme 0.3.3 requires Sphinx 4
+sphinxcontrib-serializinghtml<=1.1.9  # 2024-01-15: Newer packages (probably) need Sphinx 5 or up, but our old sphinx-book-theme 0.3.3 requires Sphinx 4


### PR DESCRIPTION
* The most recent release of various sphinx related packages need Sphinx 5 or up, but our old sphinx-book-theme 0.3.3 requires Sphinx 4 For a proper solution see #1303

### Description
Fix documentation build.
