### PR TITLE
[Core] Remove unnecessary `new` operators ... 

### DIFF
--- a/ecal/core/include/ecal/ecal_timer.h
+++ b/ecal/core/include/ecal/ecal_timer.h
@@ -37,13 +37,13 @@ namespace eCAL
    *
    * The CTimer class is used to realize simple time triggered callbacks.
   **/
-  class ECAL_API CTimer 
+  class CTimer 
   {
   public:
     /**
      * @brief Constructor. 
     **/
-    CTimer();
+    ECAL_API CTimer();
 
     /**
      * @brief Constructor. 
@@ -52,12 +52,12 @@ namespace eCAL
      * @param callback_   The callback function. 
      * @param delay_      Timer callback delay for first call in ms.
     **/
-    CTimer(int timeout_, TimerCallbackT callback_, int delay_ = 0);
+    ECAL_API CTimer(int timeout_, TimerCallbackT callback_, int delay_ = 0);
 
     /**
      * @brief Destructor. 
     **/
-    virtual ~CTimer();
+    ECAL_API virtual ~CTimer();
 
     /**
      * @brief Start the timer. 
@@ -68,18 +68,18 @@ namespace eCAL
      *
      * @return  True if timer could be started. 
     **/
-    bool Start(int timeout_, TimerCallbackT callback_, int delay_ = 0);
+    ECAL_API bool Start(int timeout_, TimerCallbackT callback_, int delay_ = 0);
 
     /**
      * @brief Stop the timer. 
      *
      * @return  True if timer could be stopped. 
     **/
-    bool Stop();
+    ECAL_API bool Stop();
 
   protected:
     // class members
-    CTimerImpl*  m_timer;
+    std::unique_ptr<CTimerImpl> m_timer;
 
   private:
     // this object must not be copied.

--- a/ecal/core/include/ecal/ecal_timer.h
+++ b/ecal/core/include/ecal/ecal_timer.h
@@ -26,6 +26,7 @@
 
 #include <ecal/ecal_os.h>
 #include <functional>
+#include <memory>
 
 namespace eCAL
 {
@@ -59,6 +60,20 @@ namespace eCAL
     **/
     ECAL_API virtual ~CTimer();
 
+    // Object not copyable
+    CTimer(const CTimer&) = delete;
+    CTimer& operator=(const CTimer&) = delete;
+
+    /**
+     * @brief Move constructor
+    **/
+    ECAL_API CTimer(CTimer&& rhs);
+
+    /**
+     * @brief Move assignment
+    **/
+    ECAL_API CTimer& operator=(CTimer&& rhs);
+
     /**
      * @brief Start the timer. 
      *
@@ -80,10 +95,5 @@ namespace eCAL
   protected:
     // class members
     std::unique_ptr<CTimerImpl> m_timer;
-
-  private:
-    // this object must not be copied.
-    CTimer(const CTimer&);
-    CTimer& operator=(const CTimer&);
   };
 }

--- a/ecal/core/include/ecal/ecal_timer.h
+++ b/ecal/core/include/ecal/ecal_timer.h
@@ -60,19 +60,11 @@ namespace eCAL
     **/
     ECAL_API virtual ~CTimer();
 
-    // Object not copyable
+    // Object not copyable / moveable
     CTimer(const CTimer&) = delete;
     CTimer& operator=(const CTimer&) = delete;
-
-    /**
-     * @brief Move constructor
-    **/
-    ECAL_API CTimer(CTimer&& rhs) noexcept;
-
-    /**
-     * @brief Move assignment
-    **/
-    ECAL_API CTimer& operator=(CTimer&& rhs) noexcept;
+    CTimer(CTimer&& rhs) = delete;
+    CTimer& operator=(CTimer&& rhs) = delete;
 
     /**
      * @brief Start the timer. 

--- a/ecal/core/include/ecal/ecal_timer.h
+++ b/ecal/core/include/ecal/ecal_timer.h
@@ -67,12 +67,12 @@ namespace eCAL
     /**
      * @brief Move constructor
     **/
-    ECAL_API CTimer(CTimer&& rhs);
+    ECAL_API CTimer(CTimer&& rhs) noexcept;
 
     /**
      * @brief Move assignment
     **/
-    ECAL_API CTimer& operator=(CTimer&& rhs);
+    ECAL_API CTimer& operator=(CTimer&& rhs) noexcept;
 
     /**
      * @brief Start the timer. 

--- a/ecal/core/include/ecal/msg/protobuf/dynamic_json_subscriber.h
+++ b/ecal/core/include/ecal/msg/protobuf/dynamic_json_subscriber.h
@@ -63,12 +63,12 @@ namespace eCAL
       /**
        * @brief Move constructor
       **/
-      ECAL_API CDynamicJSONSubscriber(CDynamicJSONSubscriber&& rhs);
+      ECAL_API CDynamicJSONSubscriber(CDynamicJSONSubscriber&& rhs) noexcept;
 
       /**
        * @brief Move assignment
       **/
-      ECAL_API CDynamicJSONSubscriber& operator=(CDynamicJSONSubscriber&& rhs);
+      ECAL_API CDynamicJSONSubscriber& operator=(CDynamicJSONSubscriber&& rhs) noexcept;
 
       /**
        * @brief Creates this object.

--- a/ecal/core/include/ecal/msg/protobuf/dynamic_json_subscriber.h
+++ b/ecal/core/include/ecal/msg/protobuf/dynamic_json_subscriber.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <ecal/ecal.h>
+#include <memory>
 
 namespace eCAL
 {
@@ -55,6 +56,19 @@ namespace eCAL
        * @brief Destructor.
       **/
       ECAL_API ~CDynamicJSONSubscriber();
+
+      CDynamicJSONSubscriber(const CDynamicJSONSubscriber&) = delete;
+      CDynamicJSONSubscriber& operator=(const CDynamicJSONSubscriber&) = delete;
+
+      /**
+       * @brief Move constructor
+      **/
+      ECAL_API CDynamicJSONSubscriber(CDynamicJSONSubscriber&& rhs);
+
+      /**
+       * @brief Move assignment
+      **/
+      ECAL_API CDynamicJSONSubscriber& operator=(CDynamicJSONSubscriber&& rhs);
 
       /**
        * @brief Creates this object.
@@ -98,11 +112,6 @@ namespace eCAL
     protected:
       bool                                        created;
       std::unique_ptr<CDynamicJSONSubscriberImpl> proto_dyn_sub_impl;
-
-    private:
-      // this object must not be copied.
-      CDynamicJSONSubscriber(const CDynamicJSONSubscriber&);
-      CDynamicJSONSubscriber& operator=(const CDynamicJSONSubscriber&);
     };
     /** @example proto_dyn_json.cpp
     * This is an example how to use CDynamicJSONSubscriber to receive dynamic google::protobuf data as a JSON string with eCAL.

--- a/ecal/core/include/ecal/msg/protobuf/dynamic_json_subscriber.h
+++ b/ecal/core/include/ecal/msg/protobuf/dynamic_json_subscriber.h
@@ -36,25 +36,25 @@ namespace eCAL
     /**
      * @brief eCAL dynamic protobuf to json subscriber.
     **/
-    class ECAL_API CDynamicJSONSubscriber
+    class CDynamicJSONSubscriber
     {
     public:
       /**
        * @brief Constructor.
       **/
-      CDynamicJSONSubscriber();
+      ECAL_API CDynamicJSONSubscriber();
 
       /**
        * @brief Constructor.
        *
        * @param topic_name_  Unique topic name.
       **/
-      CDynamicJSONSubscriber(const std::string& topic_name_);
+      ECAL_API CDynamicJSONSubscriber(const std::string& topic_name_);
 
       /**
        * @brief Destructor.
       **/
-      ~CDynamicJSONSubscriber();
+      ECAL_API ~CDynamicJSONSubscriber();
 
       /**
        * @brief Creates this object.
@@ -63,21 +63,21 @@ namespace eCAL
        *
        * @return  true if it succeeds, false if it fails.
       **/
-      void Create(const std::string& topic_name_);
+      ECAL_API void Create(const std::string& topic_name_);
 
       /**
        * @brief Destroys this object.
        *
        * @return  true if it succeeds, false if it fails.
       **/
-      void Destroy();
+      ECAL_API void Destroy();
 
       /**
        * @brief Query if this object is created.
        *
        * @return  true if created, false if not.
       **/
-      bool IsCreated() { return(created); }
+      ECAL_API bool IsCreated() { return(created); }
 
       /**
        * @brief Add callback function for incoming receives.
@@ -86,18 +86,18 @@ namespace eCAL
        *
        * @return  True if succeeded, false if not.
       **/
-      bool AddReceiveCallback(ReceiveCallbackT callback_);
+      ECAL_API bool AddReceiveCallback(ReceiveCallbackT callback_);
 
       /**
        * @brief Remove callback function for incoming receives.
        *
        * @return  True if succeeded, false if not.
       **/
-      bool RemReceiveCallback();
+      ECAL_API bool RemReceiveCallback();
 
     protected:
-      bool                          created;
-      CDynamicJSONSubscriberImpl*   proto_dyn_sub_impl;
+      bool                                        created;
+      std::unique_ptr<CDynamicJSONSubscriberImpl> proto_dyn_sub_impl;
 
     private:
       // this object must not be copied.

--- a/ecal/core/include/ecal/msg/protobuf/dynamic_json_subscriber.h
+++ b/ecal/core/include/ecal/msg/protobuf/dynamic_json_subscriber.h
@@ -59,16 +59,8 @@ namespace eCAL
 
       CDynamicJSONSubscriber(const CDynamicJSONSubscriber&) = delete;
       CDynamicJSONSubscriber& operator=(const CDynamicJSONSubscriber&) = delete;
-
-      /**
-       * @brief Move constructor
-      **/
-      ECAL_API CDynamicJSONSubscriber(CDynamicJSONSubscriber&& rhs) noexcept;
-
-      /**
-       * @brief Move assignment
-      **/
-      ECAL_API CDynamicJSONSubscriber& operator=(CDynamicJSONSubscriber&& rhs) noexcept;
+      CDynamicJSONSubscriber(CDynamicJSONSubscriber&& rhs) = delete;
+      CDynamicJSONSubscriber& operator=(CDynamicJSONSubscriber&& rhs) = delete;
 
       /**
        * @brief Creates this object.

--- a/ecal/core/include/ecal/msg/protobuf/dynamic_subscriber.h
+++ b/ecal/core/include/ecal/msg/protobuf/dynamic_subscriber.h
@@ -153,13 +153,13 @@ namespace eCAL
 
       std::shared_ptr<google::protobuf::Message> CreateMessagePointer(const std::string& topic_name_);
 
-      bool                                        created;
-      std::string                                 topic_name;
-      eCAL::protobuf::CProtoDynDecoder*           msg_decoder;
-      std::shared_ptr<google::protobuf::Message>  msg_ptr;
-      eCAL::CSubscriber                           msg_sub;
-      ProtoMsgCallbackT                           msg_callback;
-      ProtoErrorCallbackT                         err_callback;
+      bool                                              created;
+      std::string                                       topic_name;
+      std::unique_ptr<eCAL::protobuf::CProtoDynDecoder> msg_decoder;
+      std::shared_ptr<google::protobuf::Message>        msg_ptr;
+      eCAL::CSubscriber                                 msg_sub;
+      ProtoMsgCallbackT                                 msg_callback;
+      ProtoErrorCallbackT                               err_callback;
 
     private:
       // this object must not be copied.
@@ -196,7 +196,7 @@ namespace eCAL
       topic_name = topic_name_;
 
       // create message decoder
-      msg_decoder = new eCAL::protobuf::CProtoDynDecoder();
+      msg_decoder = std::make_unique<eCAL::protobuf::CProtoDynDecoder>();
 
       // create subscriber
       msg_sub.Create(topic_name_);
@@ -215,7 +215,7 @@ namespace eCAL
       msg_ptr = nullptr;
 
       // delete message decoder
-      delete msg_decoder;
+      msg_decoder.reset();
 
       created = false;
     }

--- a/ecal/core/src/config/ecal_config_reader.cpp
+++ b/ecal/core/src/config/ecal_config_reader.cpp
@@ -352,14 +352,10 @@ namespace eCAL
   CConfig::CConfig() :
     m_impl(nullptr)
   {
-    m_impl = new CConfigImpl();
+    m_impl = std::make_unique<CConfigImpl>();
   }
 
-  CConfig::~CConfig()
-  {
-    delete m_impl;
-    m_impl = nullptr;
-  }
+  CConfig::~CConfig() = default;
 
   void CConfig::OverwriteKeys(const std::vector<std::string>& key_vec_)
   {

--- a/ecal/core/src/config/ecal_config_reader.h
+++ b/ecal/core/src/config/ecal_config_reader.h
@@ -27,6 +27,7 @@
 
 #include <string>
 #include <vector>
+#include <memory>
 
 namespace eCAL
 {
@@ -49,7 +50,7 @@ namespace eCAL
     std::string get(const std::string& section_, const std::string& key_, const char* default_);
 
   private:
-    CConfigImpl* m_impl;
+    std::unique_ptr<CConfigImpl> m_impl;
   };
 
   ECAL_API bool        CfgGetBool  (const std::string& section_, const std::string& key_, bool        default_ = false);

--- a/ecal/core/src/ecal_descgate.h
+++ b/ecal/core/src/ecal_descgate.h
@@ -103,7 +103,7 @@ namespace eCAL
     struct STopicInfoMap
     {
       explicit STopicInfoMap(const std::chrono::milliseconds& timeout_) :
-        map(new TopicInfoMap(timeout_))
+        map(std::make_unique<TopicInfoMap>(timeout_))
       {
       };
       mutable std::shared_timed_mutex sync;                                        //!< Mutex protecting the map
@@ -116,7 +116,7 @@ namespace eCAL
     struct SServiceMethodInfoMap
     {
       explicit SServiceMethodInfoMap(const std::chrono::milliseconds& timeout_) :
-        map(new ServiceMethodInfoMap(timeout_))
+        map(std::make_unique<ServiceMethodInfoMap>(timeout_))
       {
       };
       mutable std::shared_timed_mutex       sync;                                  //!< Mutex protecting the map

--- a/ecal/core/src/monitoring/ecal_monitoring_def.cpp
+++ b/ecal/core/src/monitoring/ecal_monitoring_def.cpp
@@ -30,13 +30,12 @@ namespace eCAL
 {
   CMonitoring::CMonitoring()
   {
-    m_monitoring_impl = new CMonitoringImpl;
+    m_monitoring_impl = std::make_unique<CMonitoringImpl>();
   }
 
   CMonitoring::~CMonitoring()
   {
-    delete m_monitoring_impl;
-    m_monitoring_impl = nullptr;
+    m_monitoring_impl.reset();
   }
 
   void CMonitoring::Create()

--- a/ecal/core/src/monitoring/ecal_monitoring_def.h
+++ b/ecal/core/src/monitoring/ecal_monitoring_def.h
@@ -58,7 +58,7 @@ namespace eCAL
     void GetMonitoring(eCAL::Monitoring::SMonitoring& monitoring_, unsigned int entities_ = Monitoring::Entity::All);
 
   protected:
-    CMonitoringImpl* m_monitoring_impl = nullptr;
+    std::unique_ptr<CMonitoringImpl> m_monitoring_impl;
 
   private:
     CMonitoring(const CMonitoring&);                 // prevent copy-construction

--- a/ecal/core/src/monitoring/ecal_monitoring_impl.h
+++ b/ecal/core/src/monitoring/ecal_monitoring_impl.h
@@ -87,7 +87,7 @@ namespace eCAL
     struct STopicMonMap
     {
       explicit STopicMonMap(const std::chrono::milliseconds& timeout_) :
-        map(new TopicMonMapT(timeout_))
+        map(std::make_unique<TopicMonMapT>(timeout_))
       {
       };
       std::mutex                     sync;
@@ -98,7 +98,7 @@ namespace eCAL
     struct SProcessMonMap
     {
       explicit SProcessMonMap(const std::chrono::milliseconds& timeout_) :
-        map(new ProcessMonMapT(timeout_))
+        map(std::make_unique<ProcessMonMapT>(timeout_))
       {
       };
       std::mutex                       sync;
@@ -109,7 +109,7 @@ namespace eCAL
     struct SServerMonMap
     {
       explicit SServerMonMap(const std::chrono::milliseconds& timeout_) :
-        map(new ServerMonMapT(timeout_))
+        map(std::make_unique<ServerMonMapT>(timeout_))
       {
       };
       std::mutex                      sync;
@@ -120,7 +120,7 @@ namespace eCAL
     struct SClientMonMap
     {
       explicit SClientMonMap(const std::chrono::milliseconds& timeout_) :
-        map(new ClientMonMapT(timeout_))
+        map(std::make_unique<ClientMonMapT>(timeout_))
       {
       };
       std::mutex                      sync;

--- a/ecal/core/src/pubsub/ecal_proto_dyn_json_sub.cpp
+++ b/ecal/core/src/pubsub/ecal_proto_dyn_json_sub.cpp
@@ -209,6 +209,12 @@ namespace eCAL
       Destroy();
     }
 
+    CDynamicJSONSubscriber::CDynamicJSONSubscriber(CDynamicJSONSubscriber&& rhs)
+      = default;
+
+    CDynamicJSONSubscriber& CDynamicJSONSubscriber::operator=(CDynamicJSONSubscriber&& rhs)
+      = default;
+
     void CDynamicJSONSubscriber::Create(const std::string& topic_name_)
     {
       if (created) return;

--- a/ecal/core/src/pubsub/ecal_proto_dyn_json_sub.cpp
+++ b/ecal/core/src/pubsub/ecal_proto_dyn_json_sub.cpp
@@ -209,12 +209,6 @@ namespace eCAL
       Destroy();
     }
 
-    CDynamicJSONSubscriber::CDynamicJSONSubscriber(CDynamicJSONSubscriber&& rhs) noexcept
-      = default;
-
-    CDynamicJSONSubscriber& CDynamicJSONSubscriber::operator=(CDynamicJSONSubscriber&& rhs) noexcept
-      = default;
-
     void CDynamicJSONSubscriber::Create(const std::string& topic_name_)
     {
       if (created) return;

--- a/ecal/core/src/pubsub/ecal_proto_dyn_json_sub.cpp
+++ b/ecal/core/src/pubsub/ecal_proto_dyn_json_sub.cpp
@@ -79,7 +79,7 @@ namespace eCAL
         if (created) return;
 
         // create message decoder
-        msg_decoder = new eCAL::protobuf::CProtoDynDecoder();
+        msg_decoder = std::make_unique<eCAL::protobuf::CProtoDynDecoder>();
 
         // create subscriber
         msg_sub.Create(topic_name_);
@@ -101,7 +101,7 @@ namespace eCAL
         msg_sub.Destroy();
 
         // delete message decoder
-        delete msg_decoder;
+        msg_decoder.reset();
 
         created = false;
       }
@@ -173,11 +173,11 @@ namespace eCAL
         }
       }
 
-      bool                              created;
-      eCAL::protobuf::CProtoDynDecoder* msg_decoder;
-      std::string                       msg_string;
-      eCAL::CSubscriber                 msg_sub;
-      ReceiveCallbackT                  msg_callback;
+      bool                                              created;
+      std::unique_ptr<eCAL::protobuf::CProtoDynDecoder> msg_decoder;
+      std::string                                       msg_string;
+      eCAL::CSubscriber                                 msg_sub;
+      ReceiveCallbackT                                  msg_callback;
 
       std::string topic_type;
       std::string topic_type_full;
@@ -212,7 +212,7 @@ namespace eCAL
     void CDynamicJSONSubscriber::Create(const std::string& topic_name_)
     {
       if (created) return;
-      proto_dyn_sub_impl = new CDynamicJSONSubscriberImpl(topic_name_);
+      proto_dyn_sub_impl = std::make_unique<CDynamicJSONSubscriberImpl>(topic_name_);
       proto_dyn_sub_impl->Create(topic_name_);
       created = true;
     }
@@ -221,8 +221,7 @@ namespace eCAL
     {
       if (!created) return;
       proto_dyn_sub_impl->Destroy();
-      delete proto_dyn_sub_impl;
-      proto_dyn_sub_impl = nullptr;
+      proto_dyn_sub_impl.reset();
       created = false;
     }
 

--- a/ecal/core/src/pubsub/ecal_proto_dyn_json_sub.cpp
+++ b/ecal/core/src/pubsub/ecal_proto_dyn_json_sub.cpp
@@ -209,10 +209,10 @@ namespace eCAL
       Destroy();
     }
 
-    CDynamicJSONSubscriber::CDynamicJSONSubscriber(CDynamicJSONSubscriber&& rhs)
+    CDynamicJSONSubscriber::CDynamicJSONSubscriber(CDynamicJSONSubscriber&& rhs) noexcept
       = default;
 
-    CDynamicJSONSubscriber& CDynamicJSONSubscriber::operator=(CDynamicJSONSubscriber&& rhs)
+    CDynamicJSONSubscriber& CDynamicJSONSubscriber::operator=(CDynamicJSONSubscriber&& rhs) noexcept
       = default;
 
     void CDynamicJSONSubscriber::Create(const std::string& topic_name_)

--- a/ecal/core/src/time/ecal_timer.cpp
+++ b/ecal/core/src/time/ecal_timer.cpp
@@ -146,6 +146,12 @@ namespace eCAL
     m_timer.reset();
   }
 
+  CTimer::CTimer(CTimer&& rhs)
+    = default;
+
+  CTimer& CTimer::operator=(CTimer&& rhs)
+    = default;
+
   bool CTimer::Start(const int timeout_, TimerCallbackT callback_, const int delay_ /*= 0*/)
   {
     return(m_timer->Start(timeout_, callback_, delay_));

--- a/ecal/core/src/time/ecal_timer.cpp
+++ b/ecal/core/src/time/ecal_timer.cpp
@@ -146,10 +146,10 @@ namespace eCAL
     m_timer.reset();
   }
 
-  CTimer::CTimer(CTimer&& rhs)
+  CTimer::CTimer(CTimer&& rhs) noexcept
     = default;
 
-  CTimer& CTimer::operator=(CTimer&& rhs)
+  CTimer& CTimer::operator=(CTimer&& rhs) noexcept
     = default;
 
   bool CTimer::Start(const int timeout_, TimerCallbackT callback_, const int delay_ /*= 0*/)

--- a/ecal/core/src/time/ecal_timer.cpp
+++ b/ecal/core/src/time/ecal_timer.cpp
@@ -131,19 +131,19 @@ namespace eCAL
 
   CTimer::CTimer() : m_timer(nullptr)
   {
-    m_timer = new CTimerImpl();
+    m_timer = std::make_unique<CTimerImpl>();
   }
 
   CTimer::CTimer(const int timeout_, TimerCallbackT callback_, const int delay_ /*= 0*/) : m_timer(nullptr)
   { 
-    m_timer = new CTimerImpl();
+    m_timer = std::make_unique<CTimerImpl>();
     m_timer->Start(timeout_, callback_, delay_);
   }
 
   CTimer::~CTimer()
   {
     Stop();
-    delete m_timer;
+    m_timer.reset();
   }
 
   bool CTimer::Start(const int timeout_, TimerCallbackT callback_, const int delay_ /*= 0*/)

--- a/ecal/core/src/time/ecal_timer.cpp
+++ b/ecal/core/src/time/ecal_timer.cpp
@@ -146,12 +146,6 @@ namespace eCAL
     m_timer.reset();
   }
 
-  CTimer::CTimer(CTimer&& rhs) noexcept
-    = default;
-
-  CTimer& CTimer::operator=(CTimer&& rhs) noexcept
-    = default;
-
   bool CTimer::Start(const int timeout_, TimerCallbackT callback_, const int delay_ /*= 0*/)
   {
     return(m_timer->Start(timeout_, callback_, delay_));


### PR DESCRIPTION
and replace with `make_shared` or `make_unique`.

### Description
There is really need for explicit use of `new` so replace with creation of shared/unique pointers.

### Cherry-pick to:
- None (changes public API slightly and will therefore be ABI compatible)