### PR TITLE
fix: yaml-cpp compatability with CMake < 3.18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@
 #
 # ========================= eCAL LICENSE =================================
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.15)
 
 include(CMakeDependentOption)
 

--- a/app/meas_cutter/CMakeLists.txt
+++ b/app/meas_cutter/CMakeLists.txt
@@ -24,7 +24,9 @@ find_package(yaml-cpp REQUIRED)
 
 #compatibility with yaml-cpp < 0.8.0
 if (NOT TARGET yaml-cpp::yaml-cpp AND TARGET yaml-cpp)
-  add_library(yaml-cpp::yaml-cpp ALIAS yaml-cpp)
+  # ALIASing a imported non-global library requires CMake 3.18 so we do this
+  add_library(yaml-cpp::yaml-cpp INTERFACE IMPORTED)
+  target_link_libraries(yaml-cpp::yaml-cpp INTERFACE yaml-cpp)
 endif()
 
 


### PR DESCRIPTION
### Description
- Fixes yaml-cpp compatability with CMake < 3.18
  - See #1322 for details
- Corrects the minimum required version to 3.15
  - Required for `list(APPEND)`

### Related issues
<!-- Type "Fixes #123" to automatically close that issue, when this PR is merged -->
closes #1322

### Cherry-pick to
- none

