### PR TITLE
[Core] Check validity of event callbacks before actually calling them.

### DIFF
--- a/ecal/core/src/readwrite/ecal_reader.cpp
+++ b/ecal/core/src/readwrite/ecal_reader.cpp
@@ -728,7 +728,7 @@ namespace eCAL
       {
         const std::lock_guard<std::mutex> lock(m_event_callback_map_sync);
         auto iter = m_event_callback_map.find(sub_event_connected);
-        if (iter != m_event_callback_map.end())
+        if (iter != m_event_callback_map.end() && iter->second)
         {
           data.type  = sub_event_connected;
           data.tid   = tid_;
@@ -745,7 +745,7 @@ namespace eCAL
     {
       const std::lock_guard<std::mutex> lock(m_event_callback_map_sync);
       auto iter = m_event_callback_map.find(sub_event_update_connection);
-      if (iter != m_event_callback_map.end())
+      if (iter != m_event_callback_map.end() && iter->second)
       {
         data.type  = sub_event_update_connection;
         data.tid   = tid_;
@@ -767,7 +767,7 @@ namespace eCAL
       {
         const std::lock_guard<std::mutex> lock(m_event_callback_map_sync);
         auto iter = m_event_callback_map.find(sub_event_disconnected);
-        if (iter != m_event_callback_map.end())
+        if (iter != m_event_callback_map.end() && iter->second)
         {
           SSubEventCallbackData data;
           data.type  = sub_event_disconnected;
@@ -958,7 +958,7 @@ namespace eCAL
       {
         const std::lock_guard<std::mutex> lock(m_event_callback_map_sync);
         auto iter = m_event_callback_map.find(sub_event_timeout);
-        if(iter != m_event_callback_map.end())
+        if(iter != m_event_callback_map.end() && iter->second)
         {
           SSubEventCallbackData data;
           data.type  = sub_event_timeout;

--- a/ecal/core/src/readwrite/ecal_writer.cpp
+++ b/ecal/core/src/readwrite/ecal_writer.cpp
@@ -1007,7 +1007,7 @@ namespace eCAL
       {
         const std::lock_guard<std::mutex> lock(m_event_callback_map_sync);
         auto iter = m_event_callback_map.find(pub_event_connected);
-        if (iter != m_event_callback_map.end())
+        if (iter != m_event_callback_map.end() && iter->second)
         {
           data.type = pub_event_connected;
           (iter->second)(m_topic_name.c_str(), &data);
@@ -1019,7 +1019,7 @@ namespace eCAL
     {
       const std::lock_guard<std::mutex> lock(m_event_callback_map_sync);
       auto iter = m_event_callback_map.find(pub_event_update_connection);
-      if (iter != m_event_callback_map.end())
+      if (iter != m_event_callback_map.end() && iter->second)
       {
         data.type  = pub_event_update_connection;
         data.tid   = tid_;
@@ -1042,7 +1042,7 @@ namespace eCAL
       {
         const std::lock_guard<std::mutex> lock(m_event_callback_map_sync);
         auto iter = m_event_callback_map.find(pub_event_disconnected);
-        if (iter != m_event_callback_map.end())
+        if (iter != m_event_callback_map.end() && iter->second)
         {
           SPubEventCallbackData data;
           data.type  = pub_event_disconnected;


### PR DESCRIPTION
### Description
Sometimes callbacks which are stored in the event callback map do not exist anymore.
Nobody knows why. And we should rather fix the root.
However, this prevents eCAL from crashing.

### Cherry-pick to
- 5.12 (current stable)
