### PR TITLE
[Core] Fix race condition in CSampleSender::Send() #1332

### DIFF
--- a/ecal/core/src/io/udp/ecal_udp_sample_sender.cpp
+++ b/ecal/core/src/io/udp/ecal_udp_sample_sender.cpp
@@ -47,7 +47,7 @@ namespace eCAL
     {
       if (!m_udp_sender) return(0);
 
-      std::lock_guard<std::mutex> send_lock(m_payload_mutex);
+      std::lock_guard<std::mutex> const send_lock(m_payload_mutex);
       // return value
       size_t sent_sum(0);
 

--- a/ecal/core/src/io/udp/ecal_udp_sample_sender.cpp
+++ b/ecal/core/src/io/udp/ecal_udp_sample_sender.cpp
@@ -47,6 +47,7 @@ namespace eCAL
     {
       if (!m_udp_sender) return(0);
 
+      std::lock_guard<std::mutex> send_lock(m_payload_mutex);
       // return value
       size_t sent_sum(0);
 

--- a/ecal/core/src/io/udp/ecal_udp_sample_sender.h
+++ b/ecal/core/src/io/udp/ecal_udp_sample_sender.h
@@ -35,6 +35,7 @@
 #endif
 
 #include <memory>
+#include <mutex>
 #include <vector>
 
 namespace eCAL
@@ -51,6 +52,7 @@ namespace eCAL
       IO::UDP::SSenderAttr                 m_attr;
       std::shared_ptr<IO::UDP::CUDPSender> m_udp_sender;
 
+      std::mutex                           m_payload_mutex;
       std::vector<char>                    m_payload;
     };
   }


### PR DESCRIPTION
### Description
This PR protects the `m_payload` member variable and thus makes the `Send()` function reentrant, as it may be called simultaneously from different threads.

### Related issues
Fixes #1332

### Cherry-pick to
- 5.12 (current stable) - Cherry picking might require making manual changes as files have been renamed betwween 5.12 and master.
