### PR TITLE
[Core] Fix: proper destructors / rule of 5 for everything involving std::thread

### DIFF
--- a/ecal/core/include/ecal/ecal_timed_cb.h
+++ b/ecal/core/include/ecal/ecal_timed_cb.h
@@ -68,6 +68,11 @@ namespace eCAL
     **/
     virtual ~CTimedCB() { Stop(); }
 
+    CTimedCB(const CTimedCB&) = delete;
+    CTimedCB& operator=(const CTimedCB&) = delete;
+    CTimedCB(CTimedCB&& rhs) = delete;
+    CTimedCB& operator=(CTimedCB&& rhs) = delete;
+
     /**
      * @brief Start the timer.
      *
@@ -97,7 +102,10 @@ namespace eCAL
     {
       if (!m_running) return(false);
       m_stop = true;
-      m_thread.join();
+      // Wait for the callback thread to finish
+      if (m_thread.joinable()) {
+        m_thread.join();
+      }
       m_running = false;
       return(true);
     }

--- a/ecal/core/src/io/shm/ecal_memfile_pool.cpp
+++ b/ecal/core/src/io/shm/ecal_memfile_pool.cpp
@@ -309,7 +309,10 @@ namespace eCAL
   {
   }
 
-  CMemFileThreadPool::~CMemFileThreadPool() = default;
+  CMemFileThreadPool::~CMemFileThreadPool()
+  {
+    Destroy();
+  }
 
   void CMemFileThreadPool::Create()
   {

--- a/ecal/core/src/io/shm/ecal_memfile_pool.h
+++ b/ecal/core/src/io/shm/ecal_memfile_pool.h
@@ -50,6 +50,11 @@ namespace eCAL
     CMemFileObserver();
     ~CMemFileObserver();
 
+    CMemFileObserver(const CMemFileObserver&) = delete;
+    CMemFileObserver& operator=(const CMemFileObserver&) = delete;
+    CMemFileObserver(CMemFileObserver&& rhs) = delete;
+    CMemFileObserver& operator=(CMemFileObserver&& rhs) = delete;
+
     bool Create(const std::string& memfile_name_, const std::string& memfile_event_);
     bool Destroy();
 

--- a/ecal/core/src/time/ecal_timer.cpp
+++ b/ecal/core/src/time/ecal_timer.cpp
@@ -38,6 +38,10 @@ namespace eCAL
     CTimerImpl(const int timeout_, TimerCallbackT callback_, const int delay_) : m_stop(false), m_running(false) { Start(timeout_, callback_, delay_); }
 
     virtual ~CTimerImpl() { Stop(); }
+    CTimerImpl(const CTimerImpl&) = delete;
+    CTimerImpl& operator=(const CTimerImpl&) = delete;
+    CTimerImpl(CTimerImpl&& rhs) = delete;
+    CTimerImpl& operator=(CTimerImpl&& rhs) = delete;
 
     bool Start(const int timeout_, TimerCallbackT callback_, const int delay_)
     {

--- a/ecal/core/src/util/ecal_thread.h
+++ b/ecal/core/src/util/ecal_thread.h
@@ -44,6 +44,16 @@ namespace eCAL
     CCallbackThread(std::function<void()> callback)
       : callback_(callback) {}
 
+    ~CCallbackThread()
+    {
+      stop();
+    }
+
+    CCallbackThread(const CCallbackThread&) = delete;
+    CCallbackThread& operator=(const CCallbackThread&) = delete;
+    CCallbackThread(CCallbackThread&& rhs) = delete;
+    CCallbackThread& operator=(CCallbackThread&& rhs) = delete;
+
     /**
      * @brief Start the callback thread with a specified timeout.
      * @param timeout The timeout duration for waiting in the callback thread.


### PR DESCRIPTION
### Related issues
Fixes #1329  

### Cherry-pick to
- 5.11 (old stable)
- 5.12 (current stable)
(might not be easily cherry-pickable)