### PR TITLE
[CMake] CROSS_COMPILING builds should be able to locate hdf5.

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -25,7 +25,7 @@ jobs:
         target: 'desktop'
 
     - name: Install Dependencies
-      run: brew install ninja doxygen graphviz protobuf hdf5 pkg-config
+      run: brew install ninja doxygen graphviz protobuf hdf5@1.10 pkg-config
 
     - name: Install Cap’n Proto
       run: |
@@ -85,6 +85,7 @@ jobs:
         -DECAL_THIRDPARTY_BUILD_QWT=ON \
         -DECAL_THIRDPARTY_BUILD_YAML-CPP=ON \
         -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_PREFIX_PATH=/usr/local/opt/hdf5@1.10 \
         -DCMAKE_CXX_STANDARD=17 \
         -DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON \
         -DPython_FIND_STRATEGY=LOCATION \

--- a/contrib/ecalhdf5/CMakeLists.txt
+++ b/contrib/ecalhdf5/CMakeLists.txt
@@ -18,15 +18,8 @@
 
 project(hdf5 LANGUAGES C CXX)
 
-if(NOT CMAKE_CROSSCOMPILING)
-  find_package(HDF5 COMPONENTS C REQUIRED)
-  find_package(Threads REQUIRED)
-else()
-  find_library(hdf5_path NAMES hdf5 REQUIRED PATH_SUFFIXES hdf5/serial)
-  find_path(hdf5_include NAMES hdf5.h PATH_SUFFIXES hdf5/serial REQUIRED)  
-  set(HDF5_LIBRARIES "${hdf5_path};m;dl;z;sz;pthread")
-  set(HDF5_INCLUDE_DIRS "${hdf5_include}")
-endif()
+find_package(HDF5 COMPONENTS C REQUIRED)
+find_package(Threads REQUIRED)
 
 set(ecalhdf5_src
     src/eh5_meas.cpp

--- a/contrib/ecalhdf5/CMakeLists.txt
+++ b/contrib/ecalhdf5/CMakeLists.txt
@@ -18,8 +18,15 @@
 
 project(hdf5 LANGUAGES C CXX)
 
-find_package(HDF5 COMPONENTS C REQUIRED)
-find_package(Threads REQUIRED)
+if(NOT CMAKE_CROSSCOMPILING)
+  find_package(HDF5 COMPONENTS C REQUIRED)
+  find_package(Threads REQUIRED)
+else()
+  find_library(hdf5_path NAMES hdf5 REQUIRED PATH_SUFFIXES hdf5/serial)
+  find_path(hdf5_include NAMES hdf5.h PATH_SUFFIXES hdf5/serial REQUIRED)  
+  set(HDF5_LIBRARIES "${hdf5_path};m;dl;z;sz;pthread")
+  set(HDF5_INCLUDE_DIRS "${hdf5_include}")
+endif()
 
 set(ecalhdf5_src
     src/eh5_meas.cpp


### PR DESCRIPTION
This "hack" was added to enable cross compile builds.
However it's a bad hack, and it's not working for Macos runners, which somehow (some of them) are considered to be cross-compiling?

Alternatively, we could call find_package, and if it fails resort to finding it manually?