### PR TITLE
Core: Fixed missing include

### DIFF
--- a/ecal/core/src/ecal_registration_receiver.h
+++ b/ecal/core/src/ecal_registration_receiver.h
@@ -41,6 +41,7 @@
 
 #include <string>
 #include <atomic>
+#include <mutex>
 
 #ifdef _MSC_VER
 #pragma warning(push)


### PR DESCRIPTION
### Description
Added #include <mutex> to registration_provider.h. This is required for Ubuntu 18.04