### PR TITLE
hotfix/asio udp receiver destruction

### DIFF
--- a/ecal/core/src/io/udp_receiver_asio.cpp
+++ b/ecal/core/src/io/udp_receiver_asio.cpp
@@ -107,6 +107,23 @@ namespace eCAL
     m_created = true;
   }
 
+  CUDPReceiverAsio::~CUDPReceiverAsio()
+  {
+    // prepare for destruction
+    m_created = false;
+
+    // interrupt running asio io context
+    m_iocontext.stop();
+
+    // shut down socket
+    asio::error_code ec;
+    m_socket.shutdown(asio::ip::udp::socket::shutdown_receive, ec);
+    if (ec)
+    {
+      std::cerr << "CUDPReceiverAsio: Shutdown asio socket failed: " << ec.message() << std::endl;
+    }
+  }
+
   bool CUDPReceiverAsio::AddMultiCastGroup(const char* ipaddr_)
   {
     if (!m_broadcast && !m_unicast)

--- a/ecal/core/src/io/udp_receiver_asio.h
+++ b/ecal/core/src/io/udp_receiver_asio.h
@@ -36,6 +36,7 @@ namespace eCAL
   {
   public:
     CUDPReceiverAsio(const SReceiverAttr& attr_);
+    ~CUDPReceiverAsio();
 
     // this virtual function is called during construction/destruction,
     // so, mark it as final to ensure that no derived classes override it.

--- a/ecal/core/src/io/udp_receiver_asio.h
+++ b/ecal/core/src/io/udp_receiver_asio.h
@@ -36,7 +36,7 @@ namespace eCAL
   {
   public:
     CUDPReceiverAsio(const SReceiverAttr& attr_);
-    ~CUDPReceiverAsio();
+    ~CUDPReceiverAsio() override;
 
     // this virtual function is called during construction/destruction,
     // so, mark it as final to ensure that no derived classes override it.


### PR DESCRIPTION
Destructor added to shutdown socket ..

```cpp
CUDPReceiverAsio::~CUDPReceiverAsio()
{
  // prepare for destruction
  m_created = false;

  // interrupt running asio io context
  m_iocontext.stop();

  // shut down socket
  asio::error_code ec;
  m_socket.shutdown(asio::ip::udp::socket::shutdown_receive, ec);
  if (ec)
  {
    std::cerr << "CUDPReceiverAsio: Shutdown asio socket failed: " << ec.message() << std::endl;
  }
}
```