### PR TITLE
[measurement] GetChannelDataTypeInformation / SetChannelDataTypeInformation

### DIFF
--- a/app/meas_cutter/src/measurement_exporter.cpp
+++ b/app/meas_cutter/src/measurement_exporter.cpp
@@ -54,15 +54,18 @@ MeasurementExporter::~MeasurementExporter()
 void MeasurementExporter::createChannel(const std::string& channel_name, const eCALMeasCutterUtils::ChannelInfo& channel_info)
 {
   _current_channel_name = channel_name;
+  eCAL::experimental::measurement::base::DataTypeInformation data_type_info;
   if (channel_info.format == eCALMeasCutterUtils::SerializationFormat::PROTOBUF)
   {
-    _writer->SetChannelType(channel_name, "proto:" + channel_info.type);
+    data_type_info.encoding = "proto";
   }
   else
   {
-    _writer->SetChannelType(channel_name, channel_info.type);
+    data_type_info.encoding = "";
   }
-  _writer->SetChannelDescription(channel_name, channel_info.description);
+  data_type_info.name = channel_info.type;
+  data_type_info.descriptor = channel_info.description;
+  _writer->SetChannelDataTypeInformation(channel_name, data_type_info);
 }
 
 void MeasurementExporter::setData(eCALMeasCutterUtils::Timestamp timestamp, const eCALMeasCutterUtils::MetaData& meta_data, const std::string& payload)

--- a/app/meas_cutter/src/measurement_importer.cpp
+++ b/app/meas_cutter/src/measurement_importer.cpp
@@ -67,17 +67,17 @@ void MeasurementImporter::openChannel(const std::string& channel_name)
   _current_opened_channel_data._timestamps.clear();
   _current_opened_channel_data._timestamp_entry_info_map.clear();
 
-  if (isProtoChannel(_reader->GetChannelType(channel_name)))
+  auto channel_information = _reader->GetChannelDataTypeInformation(channel_name);
+  if (isProtoChannel(channel_information))
   {
     _current_opened_channel_data._channel_info.format = eCALMeasCutterUtils::SerializationFormat::PROTOBUF;
-    _current_opened_channel_data._channel_info.type   = _reader->GetChannelType(channel_name).substr(6); // remove "proto:" from type string
   }
   else
   {
     _current_opened_channel_data._channel_info.format = eCALMeasCutterUtils::SerializationFormat::UNKNOWN;
-    _current_opened_channel_data._channel_info.type   = _reader->GetChannelType(channel_name);
   }
-  _current_opened_channel_data._channel_info.description = _reader->GetChannelDescription(channel_name);
+  _current_opened_channel_data._channel_info.type = channel_information.name;
+  _current_opened_channel_data._channel_info.description = channel_information.descriptor;
   _current_opened_channel_data._channel_info.name = channel_name;
 
   eCAL::experimental::measurement::base::EntryInfoSet entry_info_set;
@@ -177,10 +177,9 @@ bool MeasurementImporter::isEcalMeasFile(const std::string& path)
   return false;
 }
 
-bool MeasurementImporter::isProtoChannel(const std::string& channel_type)
+bool MeasurementImporter::isProtoChannel(const eCAL::experimental::measurement::base::DataTypeInformation& channel_info)
 {
-  std::string space = channel_type.substr(0, channel_type.find_first_of(':'));
-  return (space.compare("proto") == 0);
+  return (channel_info.encoding.compare("proto") == 0);
 }
 
 std::string MeasurementImporter::getLoadedPath()

--- a/app/meas_cutter/src/measurement_importer.cpp
+++ b/app/meas_cutter/src/measurement_importer.cpp
@@ -179,7 +179,7 @@ bool MeasurementImporter::isEcalMeasFile(const std::string& path)
 
 bool MeasurementImporter::isProtoChannel(const eCAL::experimental::measurement::base::DataTypeInformation& channel_info)
 {
-  return (channel_info.encoding.compare("proto") == 0);
+  return (channel_info.encoding == "proto");
 }
 
 std::string MeasurementImporter::getLoadedPath()

--- a/app/meas_cutter/src/measurement_importer.h
+++ b/app/meas_cutter/src/measurement_importer.h
@@ -52,7 +52,7 @@ public:
 
 private:
   bool                                 isEcalMeasFile(const std::string& path);
-  bool                                 isProtoChannel(const std::string& channel_type);
+  bool                                 isProtoChannel(const eCAL::experimental::measurement::base::DataTypeInformation& channel_info);
   std::unique_ptr<eCAL::experimental::measurement::base::Reader>      _reader;
   eCALMeasCutterUtils::ChannelData                      _current_opened_channel_data;
   std::string                                           _loaded_path;

--- a/app/play/play_core/src/measurement_container.cpp
+++ b/app/play/play_core/src/measurement_container.cpp
@@ -129,10 +129,12 @@ void MeasurementContainer::CreatePublishers(const std::map<std::string, std::str
   // Create new publishers
   for (const auto& channel_mapping : publisher_map)
   {
-    auto topic_type        = hdf5_meas_->GetChannelType(channel_mapping.first);
-    auto topic_description = hdf5_meas_->GetChannelDescription(channel_mapping.first);
-
-    publisher_map_.emplace(channel_mapping.first, PublisherInfo(channel_mapping.second, topic_type, topic_description));
+    auto topic_info        = hdf5_meas_->GetChannelDataTypeInformation(channel_mapping.first);
+    eCAL::SDataTypeInformation data_type_info;
+    data_type_info.name = topic_info.name;
+    data_type_info.encoding = topic_info.encoding;
+    data_type_info.descriptor = topic_info.descriptor;
+    publisher_map_.emplace(channel_mapping.first, PublisherInfo(channel_mapping.second, data_type_info));
   }
 
   // Assign publishers to entries
@@ -307,7 +309,9 @@ double MeasurementContainer::GetMaxTimestampOfChannel(const std::string& channel
 
 std::string MeasurementContainer::GetChannelType(const std::string& channel_name) const
 {
-  return hdf5_meas_->GetChannelType(channel_name);
+  // This function needs to also return the proper datatypes information! To clean up.
+  auto datatype_information = hdf5_meas_->GetChannelDataTypeInformation(channel_name);
+  return eCAL::Util::CombinedTopicEncodingAndType(datatype_information.encoding, datatype_information.name);
 }
 
 size_t MeasurementContainer::GetChannelCumulativeEstimatedSize(const std::string& channel_name) const

--- a/app/play/play_core/src/measurement_container.h
+++ b/app/play/play_core/src/measurement_container.h
@@ -92,8 +92,8 @@ private:
     eCAL::CPublisher publisher_;
     long long message_counter_;
 
-    PublisherInfo(const std::string& topic_name, const std::string& topic_type = "", const std::string& topic_description = "")
-      : publisher_(topic_name, topic_type, topic_description)
+    PublisherInfo(const std::string& topic_name, eCAL::SDataTypeInformation info_)
+      : publisher_(topic_name, info_)
       , message_counter_(0)
     {}
   };

--- a/app/play/play_core/src/measurement_container.h
+++ b/app/play/play_core/src/measurement_container.h
@@ -92,7 +92,7 @@ private:
     eCAL::CPublisher publisher_;
     long long message_counter_;
 
-    PublisherInfo(const std::string& topic_name, eCAL::SDataTypeInformation info_)
+    PublisherInfo(const std::string& topic_name, const eCAL::SDataTypeInformation& info_)
       : publisher_(topic_name, info_)
       , message_counter_(0)
     {}

--- a/app/rec/rec_client_core/include/rec_client_core/topic_info.h
+++ b/app/rec/rec_client_core/include/rec_client_core/topic_info.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <set>
 #include <map>
+#include <ecal/ecal_types.h>
 
 namespace eCAL
 {
@@ -29,17 +30,48 @@ namespace eCAL
   {
     struct TopicInfo
     {
-      TopicInfo(const std::string& type, const std::string& description)
-        : type_(type), description_(description), description_quality_(0)
+      TopicInfo(const eCAL::SDataTypeInformation& tinfo)
+        : tinfo_(tinfo)
       {}
+
+      TopicInfo(const std::string& type, const std::string& encoding, const std::string& description)
+        : tinfo_{ type, encoding, description }
+      {}
+
       TopicInfo() 
-        : description_quality_(0)
       {}
 
-      std::string type_;
-      std::string description_;
+      eCAL::SDataTypeInformation tinfo_;
 
-      int description_quality_;
+      //  This should be removed once internally SDatatypeInformation is saved alongside with the publisher ID..
+      std::string GetLegacyType()
+      {
+        if (tinfo_.encoding.empty())
+        {
+          return tinfo_.name;
+        }
+        else
+        {
+          return tinfo_.encoding + ":" + tinfo_.name;
+        }
+      }
+
+      void SetLegacyType(const std::string& combined_topic_type_)
+      {
+        auto pos = combined_topic_type_.find(':');
+        if (pos == std::string::npos)
+        {
+          tinfo_.encoding = "";
+          tinfo_.name = combined_topic_type_;
+        }
+        else
+        {
+          tinfo_.encoding = combined_topic_type_.substr(0, pos);
+          tinfo_.name = combined_topic_type_.substr(pos + 1);
+        }
+      }
+
+      int description_quality_ = 0;
 
       std::map<std::string, std::set<std::string>> publishers_;
     };

--- a/app/rec/rec_client_core/include/rec_client_core/topic_info.h
+++ b/app/rec/rec_client_core/include/rec_client_core/topic_info.h
@@ -44,7 +44,7 @@ namespace eCAL
       eCAL::SDataTypeInformation tinfo_;
 
       //  This should be removed once internally SDatatypeInformation is saved alongside with the publisher ID..
-      std::string GetLegacyType()
+      std::string GetLegacyType() const
       {
         if (tinfo_.encoding.empty())
         {

--- a/app/rec/rec_client_core/src/job/hdf5_writer_thread.cpp
+++ b/app/rec/rec_client_core/src/job/hdf5_writer_thread.cpp
@@ -169,8 +169,8 @@ namespace eCAL
 
           for (const auto& topic : topic_info_map_to_set)
           {
-            hdf5_writer_->SetChannelType(topic.first, topic.second.type_);
-            hdf5_writer_->SetChannelDescription(topic.first, topic.second.description_);
+            eCAL::experimental::measurement::base::DataTypeInformation topic_info{ topic.second.tinfo_.name, topic.second.tinfo_.encoding, topic.second.tinfo_.descriptor };
+            hdf5_writer_->SetChannelDataTypeInformation(topic.first, topic_info);
           }
         }
         else if (frame)

--- a/app/rec/rec_client_core/src/job/hdf5_writer_thread.cpp
+++ b/app/rec/rec_client_core/src/job/hdf5_writer_thread.cpp
@@ -169,7 +169,7 @@ namespace eCAL
 
           for (const auto& topic : topic_info_map_to_set)
           {
-            eCAL::experimental::measurement::base::DataTypeInformation topic_info{ topic.second.tinfo_.name, topic.second.tinfo_.encoding, topic.second.tinfo_.descriptor };
+            eCAL::experimental::measurement::base::DataTypeInformation const topic_info{ topic.second.tinfo_.name, topic.second.tinfo_.encoding, topic.second.tinfo_.descriptor };
             hdf5_writer_->SetChannelDataTypeInformation(topic.first, topic_info);
           }
         }

--- a/app/rec/rec_client_core/src/monitoring_thread.cpp
+++ b/app/rec/rec_client_core/src/monitoring_thread.cpp
@@ -84,7 +84,7 @@ namespace eCAL
             if (topic_info_map_it == topic_info_map_.end())
             {
               // Create a new topic entry
-              topic_info_map_.emplace(topic.tname(), eCAL::rec::TopicInfo("", ""));
+              topic_info_map_.emplace(topic.tname(), eCAL::rec::TopicInfo("", "", ""));
               topic_info_map_it = topic_info_map_.find(topic.tname());
             }
 
@@ -166,18 +166,18 @@ namespace eCAL
             if ((channel_descriptor_entry_it != channel_descriptor_map.end())
               && (channel_descriptor_entry_it->second.first >= topic_info_map_entry.second.description_quality_))
             {
-              topic_info_map_entry.second.type_                = channel_descriptor_entry_it->second.second.first;
-              topic_info_map_entry.second.description_         = channel_descriptor_entry_it->second.second.second;
+              topic_info_map_entry.second.SetLegacyType(channel_descriptor_entry_it->second.second.first);
+              topic_info_map_entry.second.tinfo_.descriptor    = channel_descriptor_entry_it->second.second.second;
               topic_info_map_entry.second.description_quality_ = channel_descriptor_entry_it->second.first;
             }
 
-            if (!topic_info_map_entry.second.type_.empty())
+            if (!topic_info_map_entry.second.GetLegacyType().empty())
             {
-              auto type_descriptor_entry_it = type_descriptor_map.find(topic_info_map_entry.second.type_);
+              auto type_descriptor_entry_it = type_descriptor_map.find(topic_info_map_entry.second.GetLegacyType());
               if ((type_descriptor_entry_it != type_descriptor_map.end())
                 && (type_descriptor_entry_it->second.first >= topic_info_map_entry.second.description_quality_)) 
               {
-                topic_info_map_entry.second.description_         = type_descriptor_entry_it->second.second;
+                topic_info_map_entry.second.tinfo_.descriptor    = type_descriptor_entry_it->second.second;
                 topic_info_map_entry.second.description_quality_ = type_descriptor_entry_it->second.first;
               }
             }

--- a/contrib/ecalhdf5/include/ecalhdf5/eh5_meas.h
+++ b/contrib/ecalhdf5/include/ecalhdf5/eh5_meas.h
@@ -214,6 +214,9 @@ namespace eCAL
       **/
       void SetChannelType(const std::string& channel_name, const std::string& type);
 
+
+
+
       /**
        * @brief Gets minimum timestamp for specified channel
        *

--- a/contrib/ecalhdf5/include/ecalhdf5/eh5_meas.h
+++ b/contrib/ecalhdf5/include/ecalhdf5/eh5_meas.h
@@ -187,6 +187,7 @@ namespace eCAL
        *
        * @return              channel description
       **/
+      [[deprecated("Please use GetChannelDataTypeInformation instead")]]
       std::string GetChannelDescription(const std::string& channel_name) const;
 
       /**
@@ -195,6 +196,7 @@ namespace eCAL
        * @param channel_name    channel name
        * @param description     description of the channel
       **/
+      [[deprecated("Please use SetChannelDataTypeInformation instead")]]
       void SetChannelDescription(const std::string& channel_name, const std::string& description);
 
       /**
@@ -204,6 +206,7 @@ namespace eCAL
        *
        * @return              channel type
       **/
+      [[deprecated("Please use GetChannelDataTypeInformation instead")]]
       std::string GetChannelType(const std::string& channel_name) const;
 
       /**
@@ -212,10 +215,27 @@ namespace eCAL
        * @param channel_name  channel name
        * @param type          type of the channel
       **/
+      [[deprecated("Please use SetChannelDataTypeInformation instead")]]
       void SetChannelType(const std::string& channel_name, const std::string& type);
 
+      /**
+       * @brief Get data type information of the given channel
+       *
+       * @param channel_name  channel name
+       *
+       * @return              channel type
+      **/
+      DataTypeInformation GetChannelDataTypeInformation(const std::string& channel_name) const;
 
-
+      /**
+       * @brief Set data type information of the given channel
+       *
+       * @param channel_name  channel name
+       * @param info          datatype info of the channel
+       *
+       * @return              channel type
+      **/
+      void SetChannelDataTypeInformation(const std::string& channel_name, const DataTypeInformation& info);
 
       /**
        * @brief Gets minimum timestamp for specified channel

--- a/contrib/ecalhdf5/include/ecalhdf5/eh5_types.h
+++ b/contrib/ecalhdf5/include/ecalhdf5/eh5_types.h
@@ -49,6 +49,8 @@ namespace eCAL
     using eAccessType = eCAL::experimental::measurement::base::AccessType;
     using eCAL::experimental::measurement::base::RDONLY;
     using eCAL::experimental::measurement::base::CREATE;
+   
+    using eCAL::experimental::measurement::base::DataTypeInformation;
     //!< @endcond
   }  // namespace eh5
 }  // namespace eCAL

--- a/contrib/ecalhdf5/src/eh5_meas.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas.cpp
@@ -233,41 +233,54 @@ bool eCAL::eh5::HDF5Meas::HasChannel(const std::string& channel_name) const
   return ret_val;
 }
 
+// deprecated
 std::string eCAL::eh5::HDF5Meas::GetChannelDescription(const std::string& channel_name) const
 {
-  std::string ret_val;
-  if (hdf_meas_impl_)
-  {
-    ret_val = hdf_meas_impl_->GetChannelDescription(GetEscapedTopicname(channel_name));
-  }
-
-  return ret_val;
+  auto datatype_info = GetChannelDataTypeInformation(channel_name);
+  return datatype_info.descriptor;
 }
 
+// deprecated
 void eCAL::eh5::HDF5Meas::SetChannelDescription(const std::string& channel_name, const std::string& description)
 {
-  if (hdf_meas_impl_)
-  {
-    hdf_meas_impl_->SetChannelDescription(GetEscapedTopicname(channel_name), description);
-  }
+  auto current_info = GetChannelDataTypeInformation(channel_name);
+  current_info.descriptor = description;
+  SetChannelDataTypeInformation(channel_name, current_info);
 }
 
+// deprecated
 std::string eCAL::eh5::HDF5Meas::GetChannelType(const std::string& channel_name) const
 {
   std::string ret_val;
+  auto datatype_info = GetChannelDataTypeInformation(channel_name);
+  std::tie(ret_val, std::ignore) = FromInfo(datatype_info);
+  return ret_val;
+}
+
+// deprecated
+void eCAL::eh5::HDF5Meas::SetChannelType(const std::string& channel_name, const std::string& type)
+{
+  auto current_info = GetChannelDataTypeInformation(channel_name);
+  auto new_info = CreateInfo(type, current_info.descriptor);
+  SetChannelDataTypeInformation(channel_name, new_info);
+}
+
+eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5Meas::GetChannelDataTypeInformation(const std::string& channel_name) const
+{
+  eCAL::eh5::DataTypeInformation ret_val;
   if (hdf_meas_impl_)
   {
-    ret_val = hdf_meas_impl_->GetChannelType(GetEscapedTopicname(channel_name));
+    ret_val = hdf_meas_impl_->GetChannelDataTypeInformation(GetEscapedTopicname(channel_name));
   }
 
   return ret_val;
 }
 
-void eCAL::eh5::HDF5Meas::SetChannelType(const std::string& channel_name, const std::string& type)
+void eCAL::eh5::HDF5Meas::SetChannelDataTypeInformation(const std::string& channel_name, const eCAL::eh5::DataTypeInformation& info)
 {
   if (hdf_meas_impl_)
   {
-    hdf_meas_impl_->SetChannelType(GetEscapedTopicname(channel_name), type);
+    hdf_meas_impl_->SetChannelDataTypeInformation(GetEscapedTopicname(channel_name), info);
   }
 }
 

--- a/contrib/ecalhdf5/src/eh5_meas_dir.h
+++ b/contrib/ecalhdf5/src/eh5_meas_dir.h
@@ -143,38 +143,23 @@ namespace eCAL
       bool HasChannel(const std::string& channel_name) const override;
 
       /**
-      * @brief Get the channel description for the given channel
-      *
-      * @param channel_name  channel name
-      *
-      * @return              channel description
+       * @brief Get data type information of the given channel
+       *
+       * @param channel_name  channel name
+       *
+       * @return              channel type
       **/
-      std::string GetChannelDescription(const std::string& channel_name) const override;
+      DataTypeInformation GetChannelDataTypeInformation(const std::string& channel_name) const override;
 
       /**
-      * @brief Set description of the given channel
-      *
-      * @param channel_name    channel name
-      * @param description     description of the channel
+       * @brief Set data type information of the given channel
+       *
+       * @param channel_name  channel name
+       * @param info          datatype info of the channel
+       *
+       * @return              channel type
       **/
-      void SetChannelDescription(const std::string& channel_name, const std::string& description) override;
-
-      /**
-      * @brief Gets the channel type of the given channel
-      *
-      * @param channel_name  channel name
-      *
-      * @return              channel type
-      **/
-      std::string GetChannelType(const std::string& channel_name) const override;
-
-      /**
-      * @brief Set type of the given channel
-      *
-      * @param channel_name  channel name
-      * @param type          type of the channel
-      **/
-      void SetChannelType(const std::string& channel_name, const std::string& type) override;
+      void SetChannelDataTypeInformation(const std::string& channel_name, const DataTypeInformation& info) override;
 
       /**
       * @brief Gets minimum timestamp for specified channel
@@ -280,14 +265,12 @@ namespace eCAL
     protected:
       struct ChannelInfo
       {
-        std::string type;
-        std::string description;
+        DataTypeInformation info;
         std::list<const eCAL::eh5::HDF5Meas*> files;
 
         ChannelInfo() = default;
-        ChannelInfo(const std::string& type_, const std::string& description_)
-          : type(type_)
-          , description(description_)
+        ChannelInfo(const DataTypeInformation& info_)
+          : info(info_)
         {}
       };
 

--- a/contrib/ecalhdf5/src/eh5_meas_file_v1.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v1.cpp
@@ -164,32 +164,22 @@ bool eCAL::eh5::HDF5MeasFileV1::HasChannel(const std::string& channel_name) cons
   return std::find(channels.cbegin(), channels.cend(), channel_name) != channels.end();
 }
 
-std::string eCAL::eh5::HDF5MeasFileV1::GetChannelDescription(const std::string& channel_name) const
-{
-  std::string description;
-
-  if (EcalUtils::String::Icompare(channel_name, channel_name_))
-    GetAttributeValue(file_id_, kChnDescAttrTitle, description);
-
-  return  description;
-}
-
-void eCAL::eh5::HDF5MeasFileV1::SetChannelDescription(const std::string& /*channel_name*/, const std::string& /*description*/)
-{
-  ReportUnsupportedAction();
-}
-
-std::string eCAL::eh5::HDF5MeasFileV1::GetChannelType(const std::string& channel_name) const
+eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5MeasFileV1::GetChannelDataTypeInformation(const std::string& channel_name) const
 {
   std::string type;
 
   if (EcalUtils::String::Icompare(channel_name, channel_name_))
     GetAttributeValue(file_id_, kChnTypeAttrTitle, type);
 
-  return type;
+  std::string description;
+
+  if (EcalUtils::String::Icompare(channel_name, channel_name_))
+    GetAttributeValue(file_id_, kChnDescAttrTitle, description);
+
+  return CreateInfo(type, description);
 }
 
-void eCAL::eh5::HDF5MeasFileV1::SetChannelType(const std::string& /*channel_name*/, const std::string& /*type*/)
+void eCAL::eh5::HDF5MeasFileV1::SetChannelDataTypeInformation(const std::string& /*channel_name*/, const eCAL::eh5::DataTypeInformation& /*info*/)
 {
   ReportUnsupportedAction();
 }

--- a/contrib/ecalhdf5/src/eh5_meas_file_v1.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v1.h
@@ -135,38 +135,23 @@ namespace eCAL
       bool HasChannel(const std::string& channel_name) const override;
 
       /**
-      * @brief Get the channel description for the given channel
-      *
-      * @param channel_name  channel name
-      *
-      * @return              channel description
+       * @brief Get data type information of the given channel
+       *
+       * @param channel_name  channel name
+       *
+       * @return              channel type
       **/
-      std::string GetChannelDescription(const std::string& channel_name) const override;
+      DataTypeInformation GetChannelDataTypeInformation(const std::string& channel_name) const override;
 
       /**
-      * @brief Set description of the given channel
-      *
-      * @param channel_name    channel name
-      * @param description     description of the channel
+       * @brief Set data type information of the given channel
+       *
+       * @param channel_name  channel name
+       * @param info          datatype info of the channel
+       *
+       * @return              channel type
       **/
-      void SetChannelDescription(const std::string& channel_name, const std::string& description) override;
-
-      /**
-      * @brief Gets the channel type of the given channel
-      *
-      * @param channel_name  channel name
-      *
-      * @return              channel type
-      **/
-      std::string GetChannelType(const std::string& channel_name) const override;
-
-      /**
-      * @brief Set type of the given channel
-      *
-      * @param channel_name  channel name
-      * @param type          type of the channel
-      **/
-      void SetChannelType(const std::string& channel_name, const std::string& type) override;
+      void SetChannelDataTypeInformation(const std::string& channel_name, const DataTypeInformation& info) override;
 
       /**
       * @brief Gets minimum timestamp for specified channel

--- a/contrib/ecalhdf5/src/eh5_meas_file_v2.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v2.cpp
@@ -144,8 +144,9 @@ bool eCAL::eh5::HDF5MeasFileV2::HasChannel(const std::string& channel_name) cons
   return std::find(channels.cbegin(), channels.cend(), channel_name) != channels.end();
 }
 
-std::string eCAL::eh5::HDF5MeasFileV2::GetChannelDescription(const std::string& channel_name) const
+eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5MeasFileV2::GetChannelDataTypeInformation(const std::string& channel_name) const
 {
+  std::string type;
   std::string description;
 
   if (this->IsOk())
@@ -153,38 +154,19 @@ std::string eCAL::eh5::HDF5MeasFileV2::GetChannelDescription(const std::string& 
     auto dataset_id = H5Dopen(file_id_, channel_name.c_str(), H5P_DEFAULT);
     if (dataset_id >= 0)
     {
+      GetAttributeValue(dataset_id, kChnTypeAttrTitle, type);
       GetAttributeValue(dataset_id, kChnDescAttrTitle, description);
       H5Dclose(dataset_id);
     }
   }
 
-  return description;
+  return CreateInfo(type, description);
 }
 
-void eCAL::eh5::HDF5MeasFileV2::SetChannelDescription(const std::string& /*channel_name*/, const std::string& /*description*/)
+void eCAL::eh5::HDF5MeasFileV2::SetChannelDataTypeInformation(const std::string& /*channel_name*/, const eCAL::eh5::DataTypeInformation& /*info*/)
 {
 }
 
-std::string eCAL::eh5::HDF5MeasFileV2::GetChannelType(const std::string& channel_name) const
-{
-  std::string type;
-
-  if (this->IsOk())
-  {
-    auto dataset_id = H5Dopen(file_id_, channel_name.c_str(), H5P_DEFAULT);
-    if (dataset_id >= 0)
-    {
-      GetAttributeValue(dataset_id, kChnTypeAttrTitle, type);
-      H5Dclose(dataset_id);
-    }
-  }
-
-  return type;
-}
-
-void eCAL::eh5::HDF5MeasFileV2::SetChannelType(const std::string& /*channel_name*/, const std::string& /*type*/)
-{
-}
 
 long long eCAL::eh5::HDF5MeasFileV2::GetMinTimestamp(const std::string& channel_name) const
 {

--- a/contrib/ecalhdf5/src/eh5_meas_file_v2.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v2.h
@@ -135,38 +135,23 @@ namespace eCAL
       bool HasChannel(const std::string& channel_name) const override;
 
       /**
-      * @brief Get the channel description for the given channel
-      *
-      * @param channel_name  channel name
-      *
-      * @return              channel description
+       * @brief Get data type information of the given channel
+       *
+       * @param channel_name  channel name
+       *
+       * @return              channel type
       **/
-      std::string GetChannelDescription(const std::string& channel_name) const override;
+      DataTypeInformation GetChannelDataTypeInformation(const std::string& channel_name) const override;
 
       /**
-      * @brief Set description of the given channel
-      *
-      * @param channel_name    channel name
-      * @param description     description of the channel
+       * @brief Set data type information of the given channel
+       *
+       * @param channel_name  channel name
+       * @param info          datatype info of the channel
+       *
+       * @return              channel type
       **/
-      void SetChannelDescription(const std::string& channel_name, const std::string& description) override;
-
-      /**
-      * @brief Gets the channel type of the given channel
-      *
-      * @param channel_name  channel name
-      *
-      * @return              channel type
-      **/
-      std::string GetChannelType(const std::string& channel_name) const override;
-
-      /**
-      * @brief Set type of the given channel
-      *
-      * @param channel_name  channel name
-      * @param type          type of the channel
-      **/
-      void SetChannelType(const std::string& channel_name, const std::string& type) override;
+      void SetChannelDataTypeInformation(const std::string& channel_name, const DataTypeInformation& info) override;
 
       /**
       * @brief Gets minimum timestamp for specified channel

--- a/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.cpp
@@ -139,7 +139,7 @@ bool eCAL::eh5::HDF5MeasFileWriterV5::HasChannel(const std::string& /*channel_na
 }
 
 
-eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5MeasFileWriterV5::GetChannelDataTypeInformation(const std::string& channel_name) const
+eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5MeasFileWriterV5::GetChannelDataTypeInformation(const std::string&  /*channel_name*/) const
 {
   // UNSUPPORTED FUNCTION
   return eCAL::eh5::DataTypeInformation{};

--- a/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.cpp
@@ -138,26 +138,18 @@ bool eCAL::eh5::HDF5MeasFileWriterV5::HasChannel(const std::string& /*channel_na
   return false;
 }
 
-std::string eCAL::eh5::HDF5MeasFileWriterV5::GetChannelDescription(const std::string& /*channel_name*/) const
+
+eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5MeasFileWriterV5::GetChannelDataTypeInformation(const std::string& channel_name) const
 {
   // UNSUPPORTED FUNCTION
-  return "";
+  return eCAL::eh5::DataTypeInformation{};
 }
 
-void eCAL::eh5::HDF5MeasFileWriterV5::SetChannelDescription(const std::string& channel_name, const std::string& description)
+void eCAL::eh5::HDF5MeasFileWriterV5::SetChannelDataTypeInformation(const std::string& channel_name, const eCAL::eh5::DataTypeInformation& info)
 {
-  channels_[channel_name].Description = description;
-}
-
-std::string eCAL::eh5::HDF5MeasFileWriterV5::GetChannelType(const std::string& /*channel_name*/) const
-{
-  // UNSUPPORTED FUNCTION
-  return "";
-}
-
-void eCAL::eh5::HDF5MeasFileWriterV5::SetChannelType(const std::string& channel_name, const std::string& type)
-{
-  channels_[channel_name].Type = type;
+  auto type_descriptor = FromInfo(info);
+  channels_[channel_name].Type = type_descriptor.first;
+  channels_[channel_name].Description = type_descriptor.second;
 }
 
 long long eCAL::eh5::HDF5MeasFileWriterV5::GetMinTimestamp(const std::string& /*channel_name*/) const

--- a/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.h
@@ -141,38 +141,23 @@ namespace eCAL
       bool HasChannel(const std::string& channel_name) const override;
 
       /**
-      * @brief Get the channel description for the given channel
-      *
-      * @param channel_name  channel name
-      *
-      * @return              channel description
+       * @brief Get data type information of the given channel
+       *
+       * @param channel_name  channel name
+       *
+       * @return              channel type
       **/
-      std::string GetChannelDescription(const std::string& channel_name) const override;
+      DataTypeInformation GetChannelDataTypeInformation(const std::string & channel_name) const override;
 
       /**
-      * @brief Set description of the given channel
-      *
-      * @param channel_name    channel name
-      * @param description     description of the channel
+       * @brief Set data type information of the given channel
+       *
+       * @param channel_name  channel name
+       * @param info          datatype info of the channel
+       *
+       * @return              channel type
       **/
-      void SetChannelDescription(const std::string& channel_name, const std::string& description) override;
-
-      /**
-      * @brief Gets the channel type of the given channel
-      *
-      * @param channel_name  channel name
-      *
-      * @return              channel type
-      **/
-      std::string GetChannelType(const std::string& channel_name) const override;
-
-      /**
-      * @brief Set type of the given channel
-      *
-      * @param channel_name  channel name
-      * @param type          type of the channel
-      **/
-      void SetChannelType(const std::string& channel_name, const std::string& type) override;
+      void SetChannelDataTypeInformation(const std::string & channel_name, const DataTypeInformation & info) override;
 
       /**
       * @brief Gets minimum timestamp for specified channel

--- a/contrib/ecalhdf5/src/eh5_meas_impl.h
+++ b/contrib/ecalhdf5/src/eh5_meas_impl.h
@@ -29,6 +29,39 @@
 
 #include "ecalhdf5/eh5_types.h"
 
+inline eCAL::eh5::DataTypeInformation CreateInfo(const std::string& combined_topic_type_, const std::string& descriptor_)
+{
+  eCAL::eh5::DataTypeInformation info;
+  auto pos = combined_topic_type_.find(':');
+  if (pos == std::string::npos)
+  {
+    info.name     = combined_topic_type_;
+    info.encoding = "";
+  }
+  else
+  {
+    info.name     = combined_topic_type_.substr(pos + 1);
+    info.encoding = combined_topic_type_.substr(0, pos);
+  }
+  info.descriptor = descriptor_;
+  return info;
+}
+
+inline std::pair<std::string, std::string> FromInfo(const eCAL::eh5::DataTypeInformation& datatype_info_)
+{
+  std::string combined_topic_type;
+  if (datatype_info_.encoding.empty())
+  {
+    combined_topic_type = datatype_info_.name;
+  }
+  else
+  {
+    combined_topic_type = datatype_info_.encoding + ":" + datatype_info_.name;
+  }
+
+  return std::make_pair(combined_topic_type, datatype_info_.descriptor);
+}
+
 namespace eCAL
 {
   namespace eh5
@@ -126,38 +159,23 @@ namespace eCAL
       virtual bool HasChannel(const std::string& channel_name) const = 0;
 
       /**
-      * @brief Get the channel description for the given channel
-      *
-      * @param channel_name  channel name
-      *
-      * @return              channel description
+       * @brief Get data type information of the given channel
+       *
+       * @param channel_name  channel name
+       *
+       * @return              channel type
       **/
-      virtual std::string GetChannelDescription(const std::string& channel_name) const = 0;
+      virtual DataTypeInformation GetChannelDataTypeInformation(const std::string& channel_name) const = 0;
 
       /**
-      * @brief Set description of the given channel
-      *
-      * @param channel_name    channel name
-      * @param description     description of the channel
+       * @brief Set data type information of the given channel
+       *
+       * @param channel_name  channel name
+       * @param info          datatype info of the channel
+       *
+       * @return              channel type
       **/
-      virtual void SetChannelDescription(const std::string& channel_name, const std::string& description) = 0;
-
-      /**
-      * @brief Gets the channel type of the given channel
-      *
-      * @param channel_name  channel name
-      *
-      * @return              channel type
-      **/
-      virtual std::string GetChannelType(const std::string& channel_name) const = 0;
-
-      /**
-      * @brief Set type of the given channel
-      *
-      * @param channel_name  channel name
-      * @param type          type of the channel
-      **/
-      virtual void SetChannelType(const std::string& channel_name, const std::string& type) = 0;
+      virtual void SetChannelDataTypeInformation(const std::string& channel_name, const DataTypeInformation& info) = 0;
 
       /**
       * @brief Gets minimum timestamp for specified channel

--- a/contrib/measurement/base/include/ecal/measurement/base/reader.h
+++ b/contrib/measurement/base/include/ecal/measurement/base/reader.h
@@ -126,22 +126,14 @@ namespace eCAL
           virtual bool HasChannel(const std::string& channel_name) const = 0;
 
           /**
-           * @brief Get the channel description for the given channel
-           *
-           * @param channel_name  channel name
-           *
-           * @return              channel description
-          **/
-          virtual std::string GetChannelDescription(const std::string& channel_name) const = 0;
-
-          /**
-           * @brief Gets the channel type of the given channel
+           * @brief Get data type information of the given channel
            *
            * @param channel_name  channel name
            *
            * @return              channel type
           **/
-          virtual std::string GetChannelType(const std::string& channel_name) const = 0;
+          virtual DataTypeInformation GetChannelDataTypeInformation(const std::string & channel_name) const = 0;
+
 
           /**
            * @brief Gets minimum timestamp for specified channel

--- a/contrib/measurement/base/include/ecal/measurement/base/types.h
+++ b/contrib/measurement/base/include/ecal/measurement/base/types.h
@@ -37,6 +37,29 @@ namespace eCAL
       namespace base
       {
         /**
+         * @brief Optional compile time information associated with a given topic
+         *        (necessary for reflection / runtime type checking)
+        **/
+        struct DataTypeInformation
+        {
+          std::string name;          //!< name of the datatype
+          std::string encoding;      //!< encoding of the datatype (e.g. protobuf, flatbuffers, capnproto)
+          std::string descriptor;    //!< descriptor information of the datatype (necessary for reflection)
+
+          //!< @cond
+          bool operator==(const DataTypeInformation& other) const
+          {
+            return name == other.name && encoding == other.encoding && descriptor == other.descriptor;
+          }
+
+          bool operator!=(const DataTypeInformation& other) const
+          {
+            return !(*this == other);
+          }
+          //!< @endcond
+        };
+
+        /**
          * @brief Info struct for a single measurement entry
         **/
         struct EntryInfo

--- a/contrib/measurement/base/include/ecal/measurement/base/writer.h
+++ b/contrib/measurement/base/include/ecal/measurement/base/writer.h
@@ -139,20 +139,14 @@ namespace eCAL
           virtual void SetOneFilePerChannelEnabled(bool enabled) = 0;
 
           /**
-           * @brief Set description of the given channel
-           *
-           * @param channel_name    channel name
-           * @param description     description of the channel
-          **/
-          virtual void SetChannelDescription(const std::string& channel_name, const std::string& description) = 0;
-
-          /**
-           * @brief Set type of the given channel
+           * @brief Set data type information of the given channel
            *
            * @param channel_name  channel name
-           * @param type          type of the channel
+           * @param info          datatype info of the channel
+           *
+           * @return              channel type
           **/
-          virtual void SetChannelType(const std::string& channel_name, const std::string& type) = 0;
+          virtual void SetChannelDataTypeInformation(const std::string & channel_name, const DataTypeInformation& info) = 0;
 
           /**
            * @brief Set measurement file base name (desired name for the actual hdf5 files that will be created)

--- a/contrib/measurement/base/include/ecal/measurement/omeasurement.h
+++ b/contrib/measurement/base/include/ecal/measurement/omeasurement.h
@@ -132,7 +132,7 @@ namespace eCAL
     inline OChannel<T> OMeasurement::Create(const std::string& channel) const
     {
       static T msg;
-      eCAL::experimental::measurement::base::DataTypeInformation datatype_info;
+      eCAL::experimental::measurement::base::DataTypeInformation const datatype_info;
       datatype_info.name = eCAL::message::GetTypeName(msg);
       datatype_info.encoding = eCAL::message::GetEncoding(msg);
       datatype_info.descriptor = eCAL::message::GetDescription(msg);

--- a/contrib/measurement/base/include/ecal/measurement/omeasurement.h
+++ b/contrib/measurement/base/include/ecal/measurement/omeasurement.h
@@ -132,8 +132,11 @@ namespace eCAL
     inline OChannel<T> OMeasurement::Create(const std::string& channel) const
     {
       static T msg;
-      meas->SetChannelType(channel, eCAL::message::GetTypeName(msg));
-      meas->SetChannelDescription(channel, eCAL::message::GetDescription(msg));
+      eCAL::experimental::measurement::base::DataTypeInformation datatype_info;
+      datatype_info.name = eCAL::message::GetTypeName(msg);
+      datatype_info.encoding = eCAL::message::GetEncoding(msg);
+      datatype_info.descriptor = eCAL::message::GetDescription(msg);
+      meas->SetChannelDataTypeInformation(channel, datatype_info);
         // Construct a channel based 
       return OChannel<T>{meas, channel};
     }

--- a/contrib/measurement/base/include/ecal/measurement/omeasurement.h
+++ b/contrib/measurement/base/include/ecal/measurement/omeasurement.h
@@ -132,10 +132,11 @@ namespace eCAL
     inline OChannel<T> OMeasurement::Create(const std::string& channel) const
     {
       static T msg;
-      eCAL::experimental::measurement::base::DataTypeInformation const datatype_info;
-      datatype_info.name = eCAL::message::GetTypeName(msg);
-      datatype_info.encoding = eCAL::message::GetEncoding(msg);
-      datatype_info.descriptor = eCAL::message::GetDescription(msg);
+      const eCAL::experimental::measurement::base::DataTypeInformation datatype_info{
+        eCAL::message::GetTypeName(msg),
+        eCAL::message::GetEncoding(msg),
+        eCAL::message::GetDescription(msg)
+      };
       meas->SetChannelDataTypeInformation(channel, datatype_info);
         // Construct a channel based 
       return OChannel<T>{meas, channel};

--- a/contrib/measurement/hdf5/include/ecal/measurement/hdf5/reader.h
+++ b/contrib/measurement/hdf5/include/ecal/measurement/hdf5/reader.h
@@ -136,22 +136,13 @@ namespace eCAL
           bool HasChannel(const std::string& channel_name) const override;
 
           /**
-           * @brief Get the channel description for the given channel
-           *
-           * @param channel_name  channel name
-           *
-           * @return              channel description
-          **/
-          std::string GetChannelDescription(const std::string& channel_name) const override;
-
-          /**
-           * @brief Gets the channel type of the given channel
+           * @brief Get data type information of the given channel
            *
            * @param channel_name  channel name
            *
            * @return              channel type
           **/
-          std::string GetChannelType(const std::string& channel_name) const override;
+          base::DataTypeInformation GetChannelDataTypeInformation(const std::string& channel_name) const override;
 
           /**
            * @brief Gets minimum timestamp for specified channel

--- a/contrib/measurement/hdf5/include/ecal/measurement/hdf5/writer.h
+++ b/contrib/measurement/hdf5/include/ecal/measurement/hdf5/writer.h
@@ -149,20 +149,14 @@ namespace eCAL
           void SetOneFilePerChannelEnabled(bool enabled) override;
 
           /**
-           * @brief Set description of the given channel
-           *
-           * @param channel_name    channel name
-           * @param description     description of the channel
-          **/
-          void SetChannelDescription(const std::string& channel_name, const std::string& description) override;
-
-          /**
-           * @brief Set type of the given channel
+           * @brief Set data type information of the given channel
            *
            * @param channel_name  channel name
-           * @param type          type of the channel
+           * @param info          datatype info of the channel
+           *
+           * @return              channel type
           **/
-          void SetChannelType(const std::string& channel_name, const std::string& type) override;
+          void SetChannelDataTypeInformation(const std::string& channel_name, const base::DataTypeInformation& info) override;
 
           /**
            * @brief Set measurement file base name (desired name for the actual hdf5 files that will be created)

--- a/contrib/measurement/hdf5/src/reader.cpp
+++ b/contrib/measurement/hdf5/src/reader.cpp
@@ -5,27 +5,6 @@
 using namespace eCAL::experimental::measurement::hdf5;
 using namespace eCAL::experimental::measurement;
 
-namespace
-{
-  // To be removed soon-ish!
-  std::pair<std::string, std::string> SplitCombinedTopicType(const std::string& combined_topic_type_)
-  {
-    auto pos = combined_topic_type_.find(':');
-    if (pos == std::string::npos)
-    {
-      std::string encoding;
-      std::string type{ combined_topic_type_ };
-      return std::make_pair(encoding, type);
-    }
-    else
-    {
-      std::string encoding = combined_topic_type_.substr(0, pos);
-      std::string type = combined_topic_type_.substr(pos + 1);
-      return std::make_pair(encoding, type);
-    }
-  }
-}
-
 Reader::Reader() 
   : measurement(std::make_unique<eh5::HDF5Meas>()) 
 {}
@@ -72,13 +51,7 @@ bool Reader::HasChannel(const std::string& channel_name) const
 
 base::DataTypeInformation Reader::GetChannelDataTypeInformation(const std::string& channel_name) const
 {
-  base::DataTypeInformation info;
-  auto type = measurement->GetChannelType(channel_name);
-  auto split_types = SplitCombinedTopicType(type);
-  info.encoding = split_types.first;
-  info.name = split_types.second;
-  info.descriptor = measurement->GetChannelDescription(channel_name);
-  return info;
+  return measurement->GetChannelDataTypeInformation(channel_name);
 }
 
 long long Reader::GetMinTimestamp(const std::string& channel_name) const

--- a/contrib/measurement/hdf5/src/writer.cpp
+++ b/contrib/measurement/hdf5/src/writer.cpp
@@ -4,21 +4,6 @@
 using namespace eCAL::experimental::measurement::hdf5;
 using namespace eCAL::experimental::measurement;
 
-namespace {
-  //To be removed soon - ish
-  std::string CombinedTopicEncodingAndType(const std::string & topic_encoding_, const std::string & topic_type_)
-  {
-    if (topic_encoding_.empty())
-    {
-      return topic_type_;
-    }
-    else
-    {
-      return topic_encoding_ + ":" + topic_type_;
-    }
-  }
-}
-
 Writer::Writer() 
   : measurement(std::make_unique<eh5::HDF5Meas>()) 
 {}
@@ -70,9 +55,7 @@ void Writer::SetOneFilePerChannelEnabled(bool enabled)
 
 void Writer::SetChannelDataTypeInformation(const std::string& channel_name, const base::DataTypeInformation& info)
 {
-
-  measurement->SetChannelType(channel_name, CombinedTopicEncodingAndType(info.encoding, info.name));
-  measurement->SetChannelDescription(channel_name, info.descriptor);
+  measurement->SetChannelDataTypeInformation(channel_name, info);
 }
 
 void Writer::SetFileBaseName(const std::string& base_name)

--- a/contrib/measurement/hdf5/src/writer.cpp
+++ b/contrib/measurement/hdf5/src/writer.cpp
@@ -4,6 +4,21 @@
 using namespace eCAL::experimental::measurement::hdf5;
 using namespace eCAL::experimental::measurement;
 
+namespace {
+  //To be removed soon - ish
+  std::string CombinedTopicEncodingAndType(const std::string & topic_encoding_, const std::string & topic_type_)
+  {
+    if (topic_encoding_.empty())
+    {
+      return topic_type_;
+    }
+    else
+    {
+      return topic_encoding_ + ":" + topic_type_;
+    }
+  }
+}
+
 Writer::Writer() 
   : measurement(std::make_unique<eh5::HDF5Meas>()) 
 {}
@@ -53,14 +68,11 @@ void Writer::SetOneFilePerChannelEnabled(bool enabled)
   return measurement->SetOneFilePerChannelEnabled(enabled);
 }
 
-void Writer::SetChannelDescription(const std::string& channel_name, const std::string& description)
+void Writer::SetChannelDataTypeInformation(const std::string& channel_name, const base::DataTypeInformation& info)
 {
-  return measurement->SetChannelDescription(channel_name, description);
-}
 
-void Writer::SetChannelType(const std::string& channel_name, const std::string& type)
-{
-  return measurement->SetChannelType(channel_name, type);
+  measurement->SetChannelType(channel_name, CombinedTopicEncodingAndType(info.encoding, info.name));
+  measurement->SetChannelDescription(channel_name, info.descriptor);
 }
 
 void Writer::SetFileBaseName(const std::string& base_name)

--- a/contrib/message/include/ecal/msg/message.h
+++ b/contrib/message/include/ecal/msg/message.h
@@ -30,6 +30,10 @@ namespace eCAL
     //// unfortunately, we need an actual object for this :/
     //template<typename T>
     //std::string GetTypeName(const T& message);
+    
+    //// unfortunately, we need an actual object for this :/
+    //template<typename T>
+    //std::string GetEncoding(const T& message);
   
     //// unfortunately, we need an actual object for this :/
     //template<typename T>

--- a/contrib/message/include/ecal/msg/proto/message.h
+++ b/contrib/message/include/ecal/msg/proto/message.h
@@ -38,7 +38,13 @@ namespace eCAL
     // unfortunately, we need an actual object for this :/
     inline std::string GetTypeName(const google::protobuf::Message& message)
     {
-      return("proto:" + message.GetTypeName());
+      return(message.GetTypeName());
+    }
+    
+    // unfortunately, we need an actual object for this :/
+    inline std::string GetEncoding(const google::protobuf::Message& /*message*/)
+    {
+      return("proto");
     }
 
     // unfortunately, we need an actual object for this :/

--- a/contrib/message/include/ecal/msg/string/message.h
+++ b/contrib/message/include/ecal/msg/string/message.h
@@ -30,14 +30,21 @@ namespace eCAL
     // unfortunately, we need an actual object for this :/
     inline std::string GetTypeName(const std::string& /*message*/)
     {
-      return("base:std::string");
+      return("std::string");
     }
 
+    // unfortunately, we need an actual object for this :/
+    inline std::string GetEncoding(const std::string& /*message*/)
+    {
+      return("base");
+    }
+    
     // unfortunately, we need an actual object for this :/
     inline std::string GetDescription(const std::string& /*message*/)
     {
       return("");
     }
+
 
     inline bool Serialize(const std::string& message, std::string& buffer)
     {


### PR DESCRIPTION
### Description
Provides an API to get/set ChannelDatatypeInformation atomically.

### Related issues
https://github.com/eclipse-ecal/ecal/issues/1076

I'd wait for this to be merged until after a branch for 5.13 has been created.

