### PR TITLE
5.12: Revert "ensure correct udp socket concurrent handling by mutex (#1289)"

### DIFF
--- a/ecal/core/src/io/udp_receiver.cpp
+++ b/ecal/core/src/io/udp_receiver.cpp
@@ -78,34 +78,25 @@ namespace eCAL
   bool CUDPReceiver::Destroy()
   {
     if (!m_socket_impl) return(false);
-
-    const std::lock_guard<std::mutex> lock(m_socket_mtx);
     m_socket_impl.reset();
-
     return(true);
   }
 
   bool CUDPReceiver::AddMultiCastGroup(const char* ipaddr_)
   {
     if (!m_socket_impl) return(false);
-    
-    const std::lock_guard<std::mutex> lock(m_socket_mtx);
     return(m_socket_impl->AddMultiCastGroup(ipaddr_));
   }
 
   bool CUDPReceiver::RemMultiCastGroup(const char* ipaddr_)
   {
     if (!m_socket_impl) return(false);
-
-    const std::lock_guard<std::mutex> lock(m_socket_mtx);
     return(m_socket_impl->RemMultiCastGroup(ipaddr_));
   }
 
   size_t CUDPReceiver::Receive(char* buf_, size_t len_, int timeout_, ::sockaddr_in* address_ /* = nullptr */)
   {
     if (!m_socket_impl) return(0);
-
-    const std::lock_guard<std::mutex> lock(m_socket_mtx);
     return(m_socket_impl->Receive(buf_, len_, timeout_, address_));
   }
 }

--- a/ecal/core/src/io/udp_receiver.h
+++ b/ecal/core/src/io/udp_receiver.h
@@ -24,7 +24,6 @@
 #pragma once
 
 #include <memory>
-#include <mutex>
 #include "ecal_receiver.h"
 
 namespace eCAL
@@ -51,8 +50,7 @@ namespace eCAL
     size_t Receive(char* buf_, size_t len_, int timeout_, ::sockaddr_in* address_ = nullptr) override;
 
   protected:
-    bool                              m_use_npcap;
-    std::mutex                        m_socket_mtx;
+    bool m_use_npcap;
     std::shared_ptr<CUDPReceiverBase> m_socket_impl;
   };
 }


### PR DESCRIPTION
This reverts commit 771280e603494e57d6f817374d087b0a38a049e2.

### Description
The commit attempted to fix a racecondition. The result however are deadlocks and / or timeouts somewhere, which leads to ctest tests taking 40 minutes (instead of 5). Also, we were not able to reproduce the racecondition anymore, so this commit has be reverted.

### Related issues
- Fixes #1350