### PR TITLE
[new-core-alignment] service includes cleaned up

### DIFF
--- a/ecal/service/ecal_service/include/ecal/service/client_manager.h
+++ b/ecal/service/ecal_service/include/ecal/service/client_manager.h
@@ -19,10 +19,14 @@
 
 #pragma once
 
-#include <memory>
+#include <cstddef>
+#include <cstdint>
 #include <map>
+#include <memory>
 
 #include <ecal/service/client_session.h>
+#include <mutex>
+#include <string>
 
 namespace eCAL
 {

--- a/ecal/service/ecal_service/include/ecal/service/client_session.h
+++ b/ecal/service/ecal_service/include/ecal/service/client_session.h
@@ -19,7 +19,10 @@
 
 #pragma once
 
+#include <cstdint>
+#include <functional>
 #include <memory>
+#include <string>
 
 #ifdef _MSC_VER
 #pragma warning(push)

--- a/ecal/service/ecal_service/include/ecal/service/server.h
+++ b/ecal/service/ecal_service/include/ecal/service/server.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <cstdint>
+#include <functional>
 #include <memory>
 
 #include <asio.hpp>

--- a/ecal/service/ecal_service/include/ecal/service/server_manager.h
+++ b/ecal/service/ecal_service/include/ecal/service/server_manager.h
@@ -19,10 +19,13 @@
 
 #pragma once
 
-#include <memory>
+#include <cstddef>
+#include <cstdint>
 #include <map>
+#include <memory>
 
 #include <ecal/service/server.h>
+#include <mutex>
 
 namespace eCAL
 {

--- a/ecal/service/ecal_service/src/client_manager.cpp
+++ b/ecal/service/ecal_service/src/client_manager.cpp
@@ -17,7 +17,13 @@
  * ========================= eCAL LICENSE =================================
 */
 
+#include <cstddef>
+#include <cstdint>
 #include <ecal/service/client_manager.h>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
 
 namespace eCAL
 {

--- a/ecal/service/ecal_service/src/client_session.cpp
+++ b/ecal/service/ecal_service/src/client_session.cpp
@@ -17,7 +17,11 @@
  * ========================= eCAL LICENSE =================================
 */
 
+#include <cstdint>
 #include <ecal/service/client_session.h>
+#include <memory>
+#include <mutex>
+#include <string>
 
 #include "client_session_impl_v1.h"
 #include "client_session_impl_v0.h"

--- a/ecal/service/ecal_service/src/client_session_impl_base.h
+++ b/ecal/service/ecal_service/src/client_session_impl_base.h
@@ -19,6 +19,10 @@
 
 #pragma once
 
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4834)

--- a/ecal/service/ecal_service/src/client_session_impl_v0.cpp
+++ b/ecal/service/ecal_service/src/client_session_impl_v0.cpp
@@ -23,7 +23,13 @@
 #include "log_helpers.h"
 #include "log_defs.h"
 
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
 
 namespace eCAL
 {

--- a/ecal/service/ecal_service/src/client_session_impl_v0.h
+++ b/ecal/service/ecal_service/src/client_session_impl_v0.h
@@ -20,10 +20,13 @@
 #pragma once
 
 #include "client_session_impl_base.h"
+#include <cstdint>
 #include <ecal/service/logger.h>
 
 #include <deque>
+#include <memory>
 #include <mutex>
+#include <string>
 
 namespace eCAL
 {

--- a/ecal/service/ecal_service/src/client_session_impl_v1.cpp
+++ b/ecal/service/ecal_service/src/client_session_impl_v1.cpp
@@ -23,7 +23,14 @@
 #include "log_helpers.h"
 #include "log_defs.h"
 
+#include <cstddef>
+#include <cstdint>
 #include <iostream>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace eCAL
 {

--- a/ecal/service/ecal_service/src/client_session_impl_v1.h
+++ b/ecal/service/ecal_service/src/client_session_impl_v1.h
@@ -20,10 +20,14 @@
 #pragma once
 
 #include "client_session_impl_base.h"
+#include <atomic>
+#include <cstdint>
 #include <ecal/service/logger.h>
 
 #include <deque>
+#include <memory>
 #include <mutex>
+#include <string>
 
 namespace eCAL
 {

--- a/ecal/service/ecal_service/src/log_helpers.h
+++ b/ecal/service/ecal_service/src/log_helpers.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <asio.hpp>
+#include <string>
 
 namespace eCAL
 {

--- a/ecal/service/ecal_service/src/protocol_v0.cpp
+++ b/ecal/service/ecal_service/src/protocol_v0.cpp
@@ -20,6 +20,11 @@
 #include "protocol_v0.h"
 
 #include "protocol_layout.h"
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
 
 namespace eCAL
 {

--- a/ecal/service/ecal_service/src/protocol_v0.h
+++ b/ecal/service/ecal_service/src/protocol_v0.h
@@ -19,11 +19,10 @@
 
 #pragma once
 
-#include <memory>
-#include <string>
-#include <vector>
 #include <functional>
+#include <memory>
 #include <mutex>
+#include <string>
 
 #include <asio.hpp>
 

--- a/ecal/service/ecal_service/src/protocol_v1.cpp
+++ b/ecal/service/ecal_service/src/protocol_v1.cpp
@@ -20,6 +20,12 @@
 #include "protocol_v1.h"
 
 #include "protocol_layout.h"
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
 
 namespace eCAL
 {

--- a/ecal/service/ecal_service/src/server.cpp
+++ b/ecal/service/ecal_service/src/server.cpp
@@ -17,9 +17,11 @@
  * ========================= eCAL LICENSE =================================
 */
 
+#include <cstdint>
 #include <ecal/service/server.h>
 
 #include <algorithm>
+#include <memory>
 
 #include "server_impl.h"
 

--- a/ecal/service/ecal_service/src/server_impl.cpp
+++ b/ecal/service/ecal_service/src/server_impl.cpp
@@ -20,6 +20,9 @@
 #include "server_impl.h"
 
 #include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <mutex>
 
 #include "server_session_impl_v1.h"
 #include "server_session_impl_v0.h"

--- a/ecal/service/ecal_service/src/server_impl.h
+++ b/ecal/service/ecal_service/src/server_impl.h
@@ -19,11 +19,13 @@
 
 #pragma once
 
-#include <functional>
-#include <string>
-#include <memory>
 #include <atomic>
+#include <cstdint>
+#include <functional>
+#include <memory>
 #include <mutex>
+#include <string>
+#include <vector>
 
 #ifdef _MSC_VER
 #pragma warning(push)

--- a/ecal/service/ecal_service/src/server_manager.cpp
+++ b/ecal/service/ecal_service/src/server_manager.cpp
@@ -17,7 +17,12 @@
  * ========================= eCAL LICENSE =================================
 */
 
+#include <cstddef>
+#include <cstdint>
 #include <ecal/service/server_manager.h>
+#include <map>
+#include <memory>
+#include <mutex>
 
 namespace eCAL
 {

--- a/ecal/service/ecal_service/src/server_session_impl_base.h
+++ b/ecal/service/ecal_service/src/server_session_impl_base.h
@@ -22,7 +22,7 @@
 #include <memory>
 #include <functional>
 
-#include <string>
+#include <mutex>
 #include <sstream>
 
 #ifdef _MSC_VER

--- a/ecal/service/ecal_service/src/server_session_impl_v0.cpp
+++ b/ecal/service/ecal_service/src/server_session_impl_v0.cpp
@@ -23,6 +23,12 @@
 #include "log_defs.h"
 
 #include "protocol_layout.h"
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
 
 ///////////////////////////////////////////////
 // Create, Constructor, Destructor

--- a/ecal/service/ecal_service/src/server_session_impl_v0.h
+++ b/ecal/service/ecal_service/src/server_session_impl_v0.h
@@ -20,10 +20,14 @@
 #pragma once
 
 #include "server_session_impl_base.h"
+#include <atomic>
+#include <cstddef>
 #include <ecal/service/logger.h>
 #include <ecal/service/server_session_types.h>
 
 #include <ecal/service/state.h>
+#include <memory>
+#include <string>
 
 namespace eCAL
 {

--- a/ecal/service/ecal_service/src/server_session_impl_v1.cpp
+++ b/ecal/service/ecal_service/src/server_session_impl_v1.cpp
@@ -21,8 +21,14 @@
 
 #include "protocol_v1.h"
 
-#include "log_helpers.h"
 #include "log_defs.h"
+#include "log_helpers.h"
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
 
 ///////////////////////////////////////////////
 // Create, Constructor, Destructor

--- a/ecal/service/ecal_service/src/server_session_impl_v1.h
+++ b/ecal/service/ecal_service/src/server_session_impl_v1.h
@@ -20,10 +20,14 @@
 #pragma once
 
 #include "server_session_impl_base.h"
+#include <atomic>
+#include <cstdint>
 #include <ecal/service/logger.h>
 #include <ecal/service/server_session_types.h>
 
 #include <ecal/service/state.h>
+#include <memory>
+#include <string>
 
 namespace eCAL
 {

--- a/ecal/service/test/src/ecal_tcp_service_test.cpp
+++ b/ecal/service/test/src/ecal_tcp_service_test.cpp
@@ -21,10 +21,11 @@
 
 #include <asio.hpp>
 
-#include <iostream>
 #include <atomic>
-#include <thread>
 #include <chrono>
+#include <iostream>
+#include <string>
+#include <thread>
 
 #include <ecal/service/server.h> // Should not be needed, when I use the server manager / client manager
 #include <ecal/service/client_session.h> // Should not be needed, when I use the server manager / client manager


### PR DESCRIPTION
### Description
Service header clean up, see  see https://github.com/eclipse-ecal/ecal-core/pull/15.

Based on changes by @FlorianReimold):

_I tried to apply the IWYU pragma. I mainly focused on std headers, as those don't come with umbrella headers._

### Cherry-pick to
- None
