### PR TITLE
[CMake] Fixed Qt Discovery

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -48,7 +48,7 @@ jobs:
         cd "${{ runner.workspace }}/_build"
         cmake $GITHUB_WORKSPACE -G "Ninja" \
         -DHAS_HDF5=ON \
-        -DHAS_QT=OFF \
+        -DHAS_QT5=OFF \
         -DHAS_CURL=OFF \
         -DHAS_CAPNPROTO=OFF \
         -DHAS_FTXUI=ON \

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -48,7 +48,7 @@ jobs:
         cd "${{ runner.workspace }}/_build"
         cmake $GITHUB_WORKSPACE -G "Ninja" \
         -DHAS_HDF5=ON \
-        -DHAS_QT5=OFF \
+        -DHAS_QT=OFF \
         -DHAS_CURL=OFF \
         -DHAS_CAPNPROTO=OFF \
         -DHAS_FTXUI=ON \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,13 +69,14 @@ endif()
 # use it that way cmake .. -DBUILD_APPS=ON -DBUILD_SAMPLES=ON
 # --------------------------------------------------------
 option(HAS_HDF5                                "Platform supports HDF5 library"                                    ON)
-option(HAS_QT                                  "Platform supports Qt 5 / 6 library."                               ON)
 
 # If the user set the legacy HAS_QT5 option, but didn't set the new HAS_QT option, set it to the value of HAS_QT5
 if(DEFINED HAS_QT5 AND NOT DEFINED HAS_QT)
   set(HAS_QT ${HAS_QT5})
   message(WARNING "The option HAS_QT5 is deprecated and may be removed at any time. Please use HAS_QT instead.")
 endif()
+
+option(HAS_QT                                  "Platform supports Qt 5 / 6 library."                               ON)
 
 option(HAS_CURL                                "Build with CURL (i.e. upload support in the recorder app)"         ON)
 option(HAS_CAPNPROTO                           "Platform supports Cap'n Proto library"                            OFF)

--- a/thirdparty/cmakefunctions/cmake_functions/qt/qt_msvc_path.cmake
+++ b/thirdparty/cmakefunctions/cmake_functions/qt/qt_msvc_path.cmake
@@ -112,8 +112,14 @@ macro(autodetect_qt_msvc_dir)
 		endif()
 
 		message(STATUS "Using Qt ${BEST_QT_MAJOR}.${BEST_QT_MINOR}.${BEST_QT_PATCH} MSVC ${BEST_QT_MSVC_YEAR} from ${BEST_QT_DIRECTORY}")
+		
+		# Dirs for legacy targets with version:
 		SET(Qt${BEST_QT_MAJOR}_DIR "${BEST_QT_DIRECTORY}/lib/cmake/Qt${BEST_QT_MAJOR}/")
 		SET(Qt${BEST_QT_MAJOR}Test_DIR "${BEST_QT_DIRECTORY}/lib/cmake/Qt${BEST_QT_MAJOR}Test")
+		
+		# Dirs for modern version-less targets
+		SET(QT_DIR "${BEST_QT_DIRECTORY}/lib/cmake/Qt${BEST_QT_MAJOR}/")
+		SET(QTTest_DIR "${BEST_QT_DIRECTORY}/lib/cmake/Qt${BEST_QT_MAJOR}Test")
 	
 	endif()
 endmacro()


### PR DESCRIPTION
### Description
- Fixed handling of legacy HAS_QT5 option
- qt_msvc_path now sets the legacy Qt5 / Qt6 variables (with version) as well.

### Cherry-pick to
- master-v5 (master for eCAL 5 feature backporting)