### PR TITLE
[GH Actions] Documentation workflow now uses the modern HAS_QT option

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -48,7 +48,7 @@ jobs:
         cd "${{ runner.workspace }}/_build"
         cmake $GITHUB_WORKSPACE -G "Ninja" \
         -DHAS_HDF5=ON \
-        -DHAS_QT5=OFF \
+        -DHAS_QT=OFF \
         -DHAS_CURL=OFF \
         -DHAS_CAPNPROTO=OFF \
         -DHAS_FTXUI=ON \


### PR DESCRIPTION
### Description
Documentation workflow now uses the modern `HAS_QT` option

### Cherry-pick to
- master-v5 (master for eCAL 5 feature backporting)
- 5.12 (old stable)
- 5.13 (current stable)

_Cherry pick to all support branches, even though they don't use Qt6, as the support branches still trigger the Qt6-enabled master for building the documentation_
