### PR TITLE
[Core] Added missing includes

### DIFF
--- a/ecal/core/include/ecal/ecal_config.h
+++ b/ecal/core/include/ecal/ecal_config.h
@@ -19,9 +19,10 @@
 
 #pragma once
 
+#include <cstddef>
+#include <ecal/ecal_log_level.h>
 #include <ecal/ecal_os.h>
 #include <ecal/ecal_tlayer.h>
-#include <ecal/ecal_log_level.h>
 
 #include <string>
 

--- a/ecal/core/include/ecal/ecal_publisher.h
+++ b/ecal/core/include/ecal/ecal_publisher.h
@@ -24,9 +24,10 @@
 
 #pragma once
 
-#include <ecal/ecal_os.h>
-#include <ecal/ecal_deprecate.h>
+#include <cstddef>
 #include <ecal/ecal_callback.h>
+#include <ecal/ecal_deprecate.h>
+#include <ecal/ecal_os.h>
 #include <ecal/ecal_payload_writer.h>
 #include <ecal/ecal_qos.h>
 #include <ecal/ecal_tlayer.h>

--- a/ecal/core/include/ecal/ecal_subscriber.h
+++ b/ecal/core/include/ecal/ecal_subscriber.h
@@ -24,9 +24,10 @@
 
 #pragma once
 
-#include <ecal/ecal_os.h>
-#include <ecal/ecal_deprecate.h>
+#include <cstddef>
 #include <ecal/ecal_callback.h>
+#include <ecal/ecal_deprecate.h>
+#include <ecal/ecal_os.h>
 #include <ecal/ecal_qos.h>
 #include <ecal/ecal_types.h>
 

--- a/ecal/core/include/ecal/ecal_util.h
+++ b/ecal/core/include/ecal/ecal_util.h
@@ -30,11 +30,11 @@
 #include <ecal/ecal_types.h>
 
 #include <map>
-#include <unordered_map>
 #include <string>
 #include <tuple>
+#include <unordered_map>
+#include <utility>
 #include <vector>
-
 
 namespace eCAL
 {

--- a/ecal/core/include/ecal/msg/flatbuffers/publisher.h
+++ b/ecal/core/include/ecal/msg/flatbuffers/publisher.h
@@ -24,7 +24,9 @@
 
 #pragma once
 
+#include <cstddef>
 #include <ecal/msg/publisher.h>
+#include <string>
 
 namespace eCAL
 {

--- a/ecal/core/include/ecal/msg/flatbuffers/subscriber.h
+++ b/ecal/core/include/ecal/msg/flatbuffers/subscriber.h
@@ -24,7 +24,10 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <ecal/msg/subscriber.h>
+#include <string>
 
 namespace eCAL
 {

--- a/ecal/core/include/ecal/msg/protobuf/dynamic_publisher.h
+++ b/ecal/core/include/ecal/msg/protobuf/dynamic_publisher.h
@@ -24,11 +24,16 @@
 
 #pragma once
 
+#include <cassert>
+#include <cstddef>
+#include <memory>
 #include <sstream>
 
 #include <ecal/ecal.h>
 #include <ecal/msg/publisher.h>
 #include <ecal/protobuf/ecal_proto_hlp.h>
+#include <stdexcept>
+#include <string>
 
 #ifdef _MSC_VER
 #pragma warning(push, 0) // disable proto warnings

--- a/ecal/core/include/ecal/msg/protobuf/dynamic_subscriber.h
+++ b/ecal/core/include/ecal/msg/protobuf/dynamic_subscriber.h
@@ -24,12 +24,15 @@
 
 #pragma once
 
-#include <exception>
-#include <sstream>
 #include <ecal/ecal.h>
 #include <ecal/ecal_deprecate.h>
-#include <ecal/protobuf/ecal_proto_dyn.h>
 #include <ecal/msg/dynamic.h>
+#include <ecal/protobuf/ecal_proto_dyn.h>
+#include <exception>
+#include <functional>
+#include <memory>
+#include <sstream>
+#include <string>
 
 #ifdef _MSC_VER
 #pragma warning(push, 0) // disable proto warnings

--- a/ecal/core/include/ecal/msg/protobuf/publisher.h
+++ b/ecal/core/include/ecal/msg/protobuf/publisher.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <ecal/ecal_deprecate.h>
 #include <ecal/msg/publisher.h>
 #include <ecal/protobuf/ecal_proto_hlp.h>

--- a/ecal/core/include/ecal/msg/protobuf/server.h
+++ b/ecal/core/include/ecal/msg/protobuf/server.h
@@ -25,8 +25,9 @@
 #pragma once
 
 #include <ecal/ecal_server.h>
-#include <ecal/protobuf/ecal_proto_dyn.h>
 #include <ecal/msg/dynamic.h>
+#include <ecal/protobuf/ecal_proto_dyn.h>
+#include <functional>
 
 // protobuf includes
 #ifdef _MSC_VER

--- a/ecal/core/include/ecal/msg/protobuf/subscriber.h
+++ b/ecal/core/include/ecal/msg/protobuf/subscriber.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <ecal/msg/subscriber.h>
 #include <ecal/protobuf/ecal_proto_hlp.h>
 

--- a/ecal/core/include/ecal/msg/string/publisher.h
+++ b/ecal/core/include/ecal/msg/string/publisher.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <ecal/ecal_deprecate.h>
 #include <ecal/msg/publisher.h>
 

--- a/ecal/core/include/ecal/msg/string/subscriber.h
+++ b/ecal/core/include/ecal/msg/string/subscriber.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <ecal/msg/subscriber.h>
 
 #include <string>

--- a/ecal/core/src/config/ecal_config.cpp
+++ b/ecal/core/src/config/ecal_config.cpp
@@ -17,8 +17,11 @@
  * ========================= eCAL LICENSE =================================
 */
 
+#include <cstddef>
 #include <ecal/ecal_config.h>
 #include <ecal/ecal_log_level.h>
+#include <string>
+#include <vector>
 
 #include "ecal_config_reader.h"
 #include "ecal_config_reader_hlp.h"

--- a/ecal/core/src/config/ecal_config_reader.cpp
+++ b/ecal/core/src/config/ecal_config_reader.cpp
@@ -21,19 +21,25 @@
  * @brief  Global config class
 **/
 
-#include <ecal/ecal_os.h>
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
 #include <ecal/ecal_defs.h>
+#include <ecal/ecal_os.h>
 
 #include "ecal_def.h"
 #include "ecal_config_reader.h"
 #include "ecal_global_accessors.h"
 #include "util/getenvvar.h"
 
-#include <iostream>
-#include <fstream>
 #include <cassert>
+#include <fstream>
+#include <iostream>
 
 #include <ecal_utils/filesystem.h>
+#include <memory>
+#include <string>
+#include <vector>
 
 #ifdef ECAL_OS_WINDOWS
 #include "ecal_win_main.h"

--- a/ecal/core/src/ecal.cpp
+++ b/ecal/core/src/ecal.cpp
@@ -23,8 +23,12 @@
 
 #include "ecal_globals.h"
 
-#include <tclap/CmdLine.h>
 #include "util/advanced_tclap_output.h"
+#include <algorithm>
+#include <cstddef>
+#include <string>
+#include <tclap/CmdLine.h>
+#include <vector>
 
 namespace eCAL
 {

--- a/ecal/core/src/ecal_clang.cpp
+++ b/ecal/core/src/ecal_clang.cpp
@@ -21,6 +21,9 @@
  * @brief  eCAL C language interface
 **/
 
+#include <cstddef>
+#include <cstdlib>
+#include <cstring>
 #include <ecal/ecal.h>
 #include <ecal/ecal_clang.h>
 #include <ecal/msg/protobuf/dynamic_json_subscriber.h>

--- a/ecal/core/src/ecal_descgate.cpp
+++ b/ecal/core/src/ecal_descgate.cpp
@@ -21,13 +21,18 @@
  * @brief  eCAL description gateway class
 **/
 
-#include <ecal/ecal_log.h>
+#include <chrono>
 #include <ecal/ecal_config.h>
+#include <ecal/ecal_log.h>
 
 #include "ecal_descgate.h"
-#include <cassert>
 #include <algorithm>
+#include <cassert>
+#include <map>
 #include <mutex>
+#include <shared_mutex>
+#include <string>
+#include <tuple>
 
 namespace eCAL
 {

--- a/ecal/core/src/ecal_descgate.h
+++ b/ecal/core/src/ecal_descgate.h
@@ -23,21 +23,22 @@
 
 #pragma once
 
-#include <ecal/ecal_util.h>
+#include <chrono>
 #include <ecal/ecal_types.h>
+#include <ecal/ecal_util.h>
 
 #include "ecal_global_accessors.h"
 #include "ecal_def.h"
 #include "util/ecal_expmap.h"
 
+#include <map>
+#include <memory>
 #include <shared_mutex>
 #include <string>
-#include <map>
-#include <unordered_map>
-#include <memory>
 #include <tuple>
+#include <type_traits>
+#include <unordered_map>
 #include <vector>
-
 
 namespace eCAL
 {

--- a/ecal/core/src/ecal_event.cpp
+++ b/ecal/core/src/ecal_event.cpp
@@ -26,9 +26,10 @@
 
 #include <ecal/ecal_event.h>
 
-#include <sstream>
-#include <memory>
 #include <chrono>
+#include <memory>
+#include <sstream>
+#include <string>
 #include <thread>
 
 #ifdef ECAL_OS_WINDOWS

--- a/ecal/core/src/ecal_global_accessors.cpp
+++ b/ecal/core/src/ecal_global_accessors.cpp
@@ -23,6 +23,9 @@
 
 #include "ecal_global_accessors.h"
 #include "ecal_globals.h"
+#include <atomic>
+#include <string>
+#include <vector>
 
 namespace eCAL
 {

--- a/ecal/core/src/ecal_globals.cpp
+++ b/ecal/core/src/ecal_globals.cpp
@@ -25,7 +25,11 @@
 
 #include "config/ecal_config_reader.h"
 
+#include <iostream>
+#include <memory>
 #include <stdexcept>
+#include <string>
+#include <vector>
 
 #include "service/ecal_service_singleton_manager.h"
 

--- a/ecal/core/src/ecal_globals.h
+++ b/ecal/core/src/ecal_globals.h
@@ -38,6 +38,8 @@
 #include "io/shm/ecal_memfile_db.h"
 
 #include <memory>
+#include <string>
+#include <vector>
 
 namespace eCAL
 {

--- a/ecal/core/src/ecal_process.cpp
+++ b/ecal/core/src/ecal_process.cpp
@@ -39,7 +39,6 @@
 #include <iostream>
 #include <memory>
 #include <sstream>
-#include <stdio.h>
 #include <thread>
 
 #include "util/sys_usage.h"

--- a/ecal/core/src/ecal_process.cpp
+++ b/ecal/core/src/ecal_process.cpp
@@ -21,6 +21,7 @@
 * @brief  eCAL process interface
 **/
 
+#include <cerrno>
 #include <ecal/ecal.h>
 #include <ecal/ecal_config.h>
 
@@ -31,22 +32,25 @@
 #include "ecal_process.h"
 #include "io/udp/ecal_udp_configurations.h"
 
+#include <algorithm>
 #include <array>
 #include <chrono>
-#include <thread>
-#include <iostream>
-#include <sstream>
-#include <algorithm>
-#include <memory>
 #include <fstream>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <stdio.h>
+#include <thread>
 
 #include "util/sys_usage.h"
 
-#include <cstdlib>
-#include <cstdio>
-#include <string>
-#include <cstring>
 #include <atomic>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <utility>
+#include <vector>
 
 #ifdef ECAL_OS_WINDOWS
 #include "ecal_win_main.h"

--- a/ecal/core/src/ecal_process_stub.cpp
+++ b/ecal/core/src/ecal_process_stub.cpp
@@ -18,7 +18,7 @@
 */
 
 #include <cstdlib>
-#include <errno.h>
+#include <cerrno>
 #include <fcntl.h>
 #include <string>
 #include <sys/file.h>

--- a/ecal/core/src/ecal_process_stub.cpp
+++ b/ecal/core/src/ecal_process_stub.cpp
@@ -17,10 +17,13 @@
  * ========================= eCAL LICENSE =================================
 */
 
+#include <cstdlib>
+#include <errno.h>
+#include <fcntl.h>
+#include <string>
 #include <sys/file.h>
 #include <sys/stat.h>
 #include <unistd.h>
-#include <errno.h>
 
 #include <string.h>
 #include <iostream>

--- a/ecal/core/src/ecal_util.cpp
+++ b/ecal/core/src/ecal_util.cpp
@@ -29,12 +29,17 @@
 #include "pubsub/ecal_pubgate.h"
 #include "monitoring/ecal_monitoring_def.h"
 
-#include <stdio.h>
-#include <stdlib.h>
 #include <cstdlib>
 #include <iostream>
 #include <list>
+#include <map>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 #ifdef ECAL_OS_WINDOWS
 #include "ecal_win_main.h"

--- a/ecal/core/src/ecal_util.cpp
+++ b/ecal/core/src/ecal_util.cpp
@@ -33,8 +33,7 @@
 #include <iostream>
 #include <list>
 #include <map>
-#include <stdio.h>
-#include <stdlib.h>
+#include <cstdio>
 #include <string>
 #include <tuple>
 #include <unordered_map>

--- a/ecal/core/src/ecalc.cpp
+++ b/ecal/core/src/ecalc.cpp
@@ -21,11 +21,17 @@
  * @brief  Implementation of the eCAL dll interface
 **/
 
+#include <cstddef>
+#include <cstdlib>
+#include <cstring>
+#include <functional>
 #include <mutex>
 
 #include <ecal/ecal.h>
-#include <ecal/msg/protobuf/dynamic_json_subscriber.h>
 #include <ecal/ecalc.h>
+#include <ecal/msg/protobuf/dynamic_json_subscriber.h>
+#include <set>
+#include <string>
 
 #include "ecal_process.h"
 

--- a/ecal/core/src/io/mtx/ecal_named_mutex.cpp
+++ b/ecal/core/src/io/mtx/ecal_named_mutex.cpp
@@ -21,7 +21,10 @@
  * @brief  eCAL named mutex
 **/
 
+#include <cstdint>
 #include <ecal/ecal_os.h>
+#include <memory>
+#include <string>
 
 #include "ecal_named_mutex.h"
 

--- a/ecal/core/src/io/mtx/linux/ecal_named_mutex_impl.cpp
+++ b/ecal/core/src/io/mtx/linux/ecal_named_mutex_impl.cpp
@@ -21,6 +21,7 @@
  * @brief  eCAL named mutex
 **/
 
+#include <ctime>
 #include <ecal/ecal_os.h>
 
 #include "ecal_named_mutex_impl.h"

--- a/ecal/core/src/io/mtx/linux/ecal_named_mutex_impl.h
+++ b/ecal/core/src/io/mtx/linux/ecal_named_mutex_impl.h
@@ -24,6 +24,8 @@
 #pragma once
 
 #include "io/mtx/ecal_named_mutex_base.h"
+#include <cstdint>
+#include <string>
 
 typedef struct named_mutex named_mutex_t;
 

--- a/ecal/core/src/io/mtx/linux/ecal_named_mutex_robust_clocklock_impl.cpp
+++ b/ecal/core/src/io/mtx/linux/ecal_named_mutex_robust_clocklock_impl.cpp
@@ -23,15 +23,16 @@
 
 #include "ecal_named_mutex_robust_clocklock_impl.h"
 
+#include <cstdint>
+#include <ctime>
+#include <fcntl.h>
+#include <pthread.h>
+#include <string>
+#include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/types.h>
-#include <sys/mman.h>
-#include <fcntl.h>
-#include <pthread.h>
 #include <unistd.h>
-#include <cstdint>
-#include <string>
 
 struct alignas(8) named_mutex
 {

--- a/ecal/core/src/io/mtx/linux/ecal_named_mutex_robust_clocklock_impl.h
+++ b/ecal/core/src/io/mtx/linux/ecal_named_mutex_robust_clocklock_impl.h
@@ -24,6 +24,8 @@
 #pragma once
 
 #include "io/mtx/ecal_named_mutex_base.h"
+#include <cstdint>
+#include <string>
 
 typedef struct named_mutex named_mutex_t;
 

--- a/ecal/core/src/io/shm/ecal_memfile.cpp
+++ b/ecal/core/src/io/shm/ecal_memfile.cpp
@@ -26,10 +26,11 @@
 #include "ecal_memfile_info.h"
 #include "ecal_memfile_db.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cstdint>
+#include <cstdio>
 #include <cstring>
-#include <algorithm>
 #include <random>
 
 #define SIZEOF_PARTIAL_STRUCT(_STRUCT_NAME_, _FIELD_NAME_) (reinterpret_cast<std::size_t>(&(reinterpret_cast<_STRUCT_NAME_*>(0)->_FIELD_NAME_)) + sizeof(_STRUCT_NAME_::_FIELD_NAME_)) //NOLINT

--- a/ecal/core/src/io/shm/ecal_memfile.h
+++ b/ecal/core/src/io/shm/ecal_memfile.h
@@ -23,9 +23,10 @@
 
 #pragma once
 
-#include <string>
 #include <array>
+#include <cstddef>
 #include <cstdint>
+#include <string>
 
 #include <ecal/ecal_payload_writer.h>
 

--- a/ecal/core/src/io/shm/ecal_memfile_broadcast.cpp
+++ b/ecal/core/src/io/shm/ecal_memfile_broadcast.cpp
@@ -27,8 +27,12 @@
 #include "ecal_memfile.h"
 #include "ecal_global_accessors.h"
 
-#include <iostream>
 #include <array>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <string>
 
 namespace eCAL
 {

--- a/ecal/core/src/io/shm/ecal_memfile_broadcast.h
+++ b/ecal/core/src/io/shm/ecal_memfile_broadcast.h
@@ -23,11 +23,12 @@
 
 #pragma once
 
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <memory>
 #include <string>
 #include <vector>
-#include <memory>
-#include <cstring>
-#include <cstdint>
 
 #include "io/shm/relocatable_circular_queue.h"
 

--- a/ecal/core/src/io/shm/ecal_memfile_broadcast_reader.cpp
+++ b/ecal/core/src/io/shm/ecal_memfile_broadcast_reader.cpp
@@ -22,8 +22,13 @@
 **/
 
 #include "ecal_memfile_broadcast_reader.h"
-#include "ecal_memfile.h"
 #include "ecal_def.h"
+#include "ecal_memfile.h"
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <set>
+#include <tuple>
 
 namespace eCAL
 {

--- a/ecal/core/src/io/shm/ecal_memfile_broadcast_reader.h
+++ b/ecal/core/src/io/shm/ecal_memfile_broadcast_reader.h
@@ -25,10 +25,11 @@
 
 #include "ecal_memfile_broadcast.h"
 
+#include <cstddef>
 #include <cstdint>
-#include <vector>
-#include <unordered_map>
 #include <memory>
+#include <unordered_map>
+#include <vector>
 
 namespace eCAL
 {

--- a/ecal/core/src/io/shm/ecal_memfile_broadcast_writer.cpp
+++ b/ecal/core/src/io/shm/ecal_memfile_broadcast_writer.cpp
@@ -22,8 +22,12 @@
 **/
 
 #include "ecal_memfile_broadcast_writer.h"
-#include "ecal_memfile.h"
 #include "ecal_def.h"
+#include "ecal_memfile.h"
+#include <cstddef>
+#include <iostream>
+#include <memory>
+#include <utility>
 
 namespace eCAL
 {

--- a/ecal/core/src/io/shm/ecal_memfile_broadcast_writer.h
+++ b/ecal/core/src/io/shm/ecal_memfile_broadcast_writer.h
@@ -25,6 +25,7 @@
 
 #include "ecal_memfile_broadcast.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 

--- a/ecal/core/src/io/shm/ecal_memfile_db.cpp
+++ b/ecal/core/src/io/shm/ecal_memfile_db.cpp
@@ -26,6 +26,9 @@
 #include "ecal_memfile_db.h"
 
 #include <cassert>
+#include <cstddef>
+#include <mutex>
+#include <string>
 
 namespace eCAL
 {

--- a/ecal/core/src/io/shm/ecal_memfile_db.h
+++ b/ecal/core/src/io/shm/ecal_memfile_db.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <mutex>
 #include <string>
 #include <unordered_map>

--- a/ecal/core/src/io/shm/ecal_memfile_info.h
+++ b/ecal/core/src/io/shm/ecal_memfile_info.h
@@ -23,8 +23,9 @@
 
 #pragma once
 
-#include <string>
+#include <cstddef>
 #include <memory>
+#include <string>
 
 #include <ecal/ecal_os.h>
 

--- a/ecal/core/src/io/shm/ecal_memfile_naming.cpp
+++ b/ecal/core/src/io/shm/ecal_memfile_naming.cpp
@@ -20,9 +20,11 @@
 #include "io/shm/ecal_memfile_naming.h"
 
 #include <cstdint>
+#include <ios>
 #include <limits>
 #include <random>
 #include <sstream>
+#include <string>
 
 namespace eCAL
 {

--- a/ecal/core/src/io/shm/ecal_memfile_os.h
+++ b/ecal/core/src/io/shm/ecal_memfile_os.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <string>
 
 #include "ecal_memfile.h"

--- a/ecal/core/src/io/shm/ecal_memfile_pool.cpp
+++ b/ecal/core/src/io/shm/ecal_memfile_pool.cpp
@@ -26,7 +26,16 @@
 #include "ecal_event_internal.h"
 #include "ecal_memfile_pool.h"
 
+#include <algorithm>
 #include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
 
 namespace eCAL
 {

--- a/ecal/core/src/io/shm/ecal_memfile_pool.h
+++ b/ecal/core/src/io/shm/ecal_memfile_pool.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include <chrono>
+#include <cstddef>
 #include <ecal/ecal_event.h>
 #include <ecal/ecal_log.h>
 
@@ -35,6 +37,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <string>
 #include <thread>
 
 namespace eCAL

--- a/ecal/core/src/io/shm/ecal_memfile_sync.cpp
+++ b/ecal/core/src/io/shm/ecal_memfile_sync.cpp
@@ -21,6 +21,8 @@
  * @brief  synchronized memory file interface
 **/
 
+#include <cstddef>
+#include <cstdint>
 #include <ecal/ecal_event.h>
 #include <ecal/ecal_log.h>
 
@@ -30,7 +32,11 @@
 #include "ecal_memfile_sync.h"
 
 #include <chrono>
+#include <mutex>
 #include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace eCAL
 {

--- a/ecal/core/src/io/shm/ecal_memfile_sync.h
+++ b/ecal/core/src/io/shm/ecal_memfile_sync.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <ecal/ecal_eventhandle.h>
 #include <ecal/ecal_payload_writer.h>
 

--- a/ecal/core/src/io/shm/relocatable_circular_queue.h
+++ b/ecal/core/src/io/shm/relocatable_circular_queue.h
@@ -23,11 +23,12 @@
 
 #pragma once
 
-#include <cstdint>
-#include <stdexcept>
-#include <limits>
-#include <iterator>
 #include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <limits>
+#include <stdexcept>
 
 template<class T>
 class RelocatableCircularQueue{

--- a/ecal/core/src/io/udp/ecal_udp_configurations.cpp
+++ b/ecal/core/src/io/udp/ecal_udp_configurations.cpp
@@ -23,6 +23,7 @@
 #include "ecal_udp_topic2mcast.h"
 
 #include <ecal/ecal_config.h>
+#include <string>
 
 namespace eCAL
 {

--- a/ecal/core/src/io/udp/ecal_udp_logging_receiver.cpp
+++ b/ecal/core/src/io/udp/ecal_udp_logging_receiver.cpp
@@ -25,6 +25,10 @@
 
 #include "ecal_def.h"
 #include "io/udp/fragmentation/msg_type.h"
+#include <chrono>
+#include <cstddef>
+#include <functional>
+#include <memory>
 
 namespace eCAL
 {

--- a/ecal/core/src/io/udp/ecal_udp_logging_sender.cpp
+++ b/ecal/core/src/io/udp/ecal_udp_logging_sender.cpp
@@ -22,6 +22,8 @@
 **/
 
 #include "ecal_udp_logging_sender.h"
+#include <cstddef>
+#include <memory>
 
 namespace eCAL
 {

--- a/ecal/core/src/io/udp/ecal_udp_logging_sender.h
+++ b/ecal/core/src/io/udp/ecal_udp_logging_sender.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "io/udp/sendreceive/udp_sender.h"
+#include <cstddef>
 
 #ifdef _MSC_VER
 #pragma warning(push, 0) // disable proto warnings

--- a/ecal/core/src/io/udp/ecal_udp_sample_receiver.cpp
+++ b/ecal/core/src/io/udp/ecal_udp_sample_receiver.cpp
@@ -24,7 +24,14 @@
 #include "ecal_udp_sample_receiver.h"
 #include "io/udp/fragmentation/msg_type.h"
 
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
 #include <ecal/ecal_log.h>
+#include <memory>
+#include <string>
+#include <vector>
 
 namespace eCAL
 {

--- a/ecal/core/src/io/udp/ecal_udp_sample_receiver.h
+++ b/ecal/core/src/io/udp/ecal_udp_sample_receiver.h
@@ -28,6 +28,8 @@
 #include "util/ecal_thread.h"
 
 #include <chrono>
+#include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>

--- a/ecal/core/src/io/udp/ecal_udp_sample_sender.cpp
+++ b/ecal/core/src/io/udp/ecal_udp_sample_sender.cpp
@@ -24,7 +24,12 @@
 #include "ecal_udp_sample_sender.h"
 #include "io/udp/fragmentation/snd_fragments.h"
 
+#include <cstddef>
 #include <ecal/ecal_log.h>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
 
 namespace
 {

--- a/ecal/core/src/io/udp/ecal_udp_sample_sender.h
+++ b/ecal/core/src/io/udp/ecal_udp_sample_sender.h
@@ -24,7 +24,8 @@
 #pragma once
 
 #include "io/udp/sendreceive/udp_sender.h"
-
+#include <cstddef>
+#include <string>
 
 #ifdef _MSC_VER
 #pragma warning(push, 0) // disable proto warnings

--- a/ecal/core/src/io/udp/ecal_udp_topic2mcast.h
+++ b/ecal/core/src/io/udp/ecal_udp_topic2mcast.h
@@ -23,11 +23,13 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
-#include <sstream>
+#include <cstdlib>
 #include <iostream>
+#include <sstream>
 #include <string>
- 
+
 namespace eCAL
 {
   namespace UDP

--- a/ecal/core/src/io/udp/fragmentation/rcv_fragments.cpp
+++ b/ecal/core/src/io/udp/fragmentation/rcv_fragments.cpp
@@ -25,9 +25,12 @@
 #include "rcv_fragments.h"
 #include "msg_type.h"
 
+#include <chrono>
 #include <ecal/ecal_log.h>
 
 #include <cstring>
+#include <string>
+#include <utility>
 
 namespace IO
 {

--- a/ecal/core/src/io/udp/fragmentation/rcv_fragments.h
+++ b/ecal/core/src/io/udp/fragmentation/rcv_fragments.h
@@ -26,6 +26,7 @@
 #include "ecal_def.h"
 
 #include <chrono>
+#include <cstdint>
 #include <vector>
 
 namespace IO

--- a/ecal/core/src/io/udp/fragmentation/snd_fragments.cpp
+++ b/ecal/core/src/io/udp/fragmentation/snd_fragments.cpp
@@ -25,8 +25,13 @@
 #include "msg_type.h"
 
 #include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
 #include <mutex>
+#include <string>
 #include <thread>
+#include <vector>
 
 namespace
 {

--- a/ecal/core/src/io/udp/fragmentation/snd_fragments.h
+++ b/ecal/core/src/io/udp/fragmentation/snd_fragments.h
@@ -21,8 +21,10 @@
  * @brief  raw message buffer handling
 **/
 
+#include <cstddef>
 #include <functional>
 #include <string>
+#include <vector>
 
 #ifdef _MSC_VER
 #pragma warning(push, 0) // disable proto warnings

--- a/ecal/core/src/io/udp/sendreceive/linux/socket_os.h
+++ b/ecal/core/src/io/udp/sendreceive/linux/socket_os.h
@@ -19,14 +19,14 @@
 
 #pragma once
 
+#include <arpa/inet.h>
+#include <cerrno>
 #include <cstring>
 #include <ifaddrs.h>
 #include <iostream>
 #include <net/if.h>
 #include <netinet/in.h>
-#include <arpa/inet.h>
 #include <vector>
-
 
 namespace IO
 {

--- a/ecal/core/src/io/udp/sendreceive/udp_receiver.cpp
+++ b/ecal/core/src/io/udp/sendreceive/udp_receiver.cpp
@@ -25,6 +25,9 @@
 #include "io/udp/ecal_udp_configurations.h"
 
 #include "udp_receiver_asio.h"
+#include <cstddef>
+#include <memory>
+#include <mutex>
 #ifdef ECAL_NPCAP_SUPPORT
 #include "udp_receiver_npcap.h"
 #endif

--- a/ecal/core/src/io/udp/sendreceive/udp_receiver.h
+++ b/ecal/core/src/io/udp/sendreceive/udp_receiver.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <ecal/ecal_os.h>
 
 #ifdef ECAL_OS_WINDOWS

--- a/ecal/core/src/io/udp/sendreceive/udp_receiver_asio.cpp
+++ b/ecal/core/src/io/udp/sendreceive/udp_receiver_asio.cpp
@@ -21,6 +21,8 @@
 #include "udp_receiver_asio.h"
 
 #include "io/udp/ecal_udp_configurations.h"
+#include <cstddef>
+#include <cstring>
 
 #ifdef __linux__
 #include "linux/socket_os.h"

--- a/ecal/core/src/io/udp/sendreceive/udp_receiver_asio.h
+++ b/ecal/core/src/io/udp/sendreceive/udp_receiver_asio.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "udp_receiver.h"
+#include <cstddef>
 
 #ifdef _MSC_VER
 #pragma warning(push)

--- a/ecal/core/src/io/udp/sendreceive/udp_sender.cpp
+++ b/ecal/core/src/io/udp/sendreceive/udp_sender.cpp
@@ -23,7 +23,9 @@
 
 #include "udp_sender.h"
 
+#include <cstddef>
 #include <iostream>
+#include <memory>
 
 #ifdef _MSC_VER
 #pragma warning(push)

--- a/ecal/core/src/io/udp/sendreceive/udp_sender.h
+++ b/ecal/core/src/io/udp/sendreceive/udp_sender.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <ecal/ecal_os.h>
 
 #ifdef ECAL_OS_WINDOWS

--- a/ecal/core/src/logging/ecal_log.cpp
+++ b/ecal/core/src/logging/ecal_log.cpp
@@ -27,6 +27,7 @@
 
 #include <atomic>
 #include <memory>
+#include <string>
 
 namespace eCAL
 {

--- a/ecal/core/src/logging/ecal_log_impl.cpp
+++ b/ecal/core/src/logging/ecal_log_impl.cpp
@@ -28,8 +28,9 @@
 #include "ecal_log_impl.h"
 #include "io/udp/ecal_udp_configurations.h"
 
-#include <mutex>
 #include <cstdio>
+#include <functional>
+#include <mutex>
 
 #include <iostream>
 #include <sstream>

--- a/ecal/core/src/logging/ecal_log_impl.h
+++ b/ecal/core/src/logging/ecal_log_impl.h
@@ -26,6 +26,7 @@
 #include "io/udp/ecal_udp_logging_receiver.h"
 #include "io/udp/ecal_udp_logging_sender.h"
 
+#include <cstdio>
 #include <ecal/ecal.h>
 #include <ecal/ecal_os.h>
 
@@ -34,10 +35,11 @@
 #include "ecal_global_accessors.h"
 
 #include <atomic>
-#include <list>
-#include <mutex>
-#include <memory>
 #include <chrono>
+#include <list>
+#include <memory>
+#include <mutex>
+#include <string>
 
 namespace eCAL
 {

--- a/ecal/core/src/monitoring/ecal_monitoring_def.cpp
+++ b/ecal/core/src/monitoring/ecal_monitoring_def.cpp
@@ -22,9 +22,10 @@
 **/
 
 #include "ecal_monitoring_def.h"
+#include "ecal_global_accessors.h"
 #include "ecal_monitoring_impl.h"
 #include "logging/ecal_log_impl.h"
-#include "ecal_global_accessors.h"
+#include <string>
 
 namespace eCAL
 {

--- a/ecal/core/src/monitoring/ecal_monitoring_def.h
+++ b/ecal/core/src/monitoring/ecal_monitoring_def.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <ecal/types/monitoring.h>
+#include <memory>
 #include <string>
 
 #ifdef _MSC_VER

--- a/ecal/core/src/monitoring/ecal_monitoring_impl.cpp
+++ b/ecal/core/src/monitoring/ecal_monitoring_impl.cpp
@@ -21,14 +21,20 @@
  * @brief  Global monitoring class (implementation)
 **/
 
+#include <chrono>
+#include <cstddef>
 #include <ecal/ecal.h>
 #include <ecal/ecal_config.h>
 
-#include "io/udp/ecal_udp_configurations.h"
 #include "config/ecal_config_reader_hlp.h"
 #include "ecal_monitoring_impl.h"
+#include "io/udp/ecal_udp_configurations.h"
 
+#include <map>
+#include <mutex>
 #include <regex>
+#include <string>
+#include <utility>
 
 #include "registration/ecal_registration_receiver.h"
 

--- a/ecal/core/src/monitoring/ecal_monitoring_impl.h
+++ b/ecal/core/src/monitoring/ecal_monitoring_impl.h
@@ -23,7 +23,10 @@
 
 #pragma once
 
+#include <chrono>
 #include <ecal/types/monitoring.h>
+#include <set>
+#include <strings.h>
 
 #include "ecal_def.h"
 #include "util/ecal_expmap.h"

--- a/ecal/core/src/monitoring/ecal_monitoring_impl.h
+++ b/ecal/core/src/monitoring/ecal_monitoring_impl.h
@@ -26,7 +26,6 @@
 #include <chrono>
 #include <ecal/types/monitoring.h>
 #include <set>
-#include <strings.h>
 
 #include "ecal_def.h"
 #include "util/ecal_expmap.h"

--- a/ecal/core/src/pubsub/ecal_proto_dyn_json_sub.cpp
+++ b/ecal/core/src/pubsub/ecal_proto_dyn_json_sub.cpp
@@ -30,7 +30,7 @@
 #include <iostream>
 #include <memory>
 #include <sstream>
-#include <stdio.h>
+#include <cstdio>
 #include <string>
 
 #ifdef _MSC_VER

--- a/ecal/core/src/pubsub/ecal_proto_dyn_json_sub.cpp
+++ b/ecal/core/src/pubsub/ecal_proto_dyn_json_sub.cpp
@@ -25,11 +25,13 @@
 #include <ecal/msg/protobuf/dynamic_json_subscriber.h>
 #include <ecal/msg/protobuf/dynamic_subscriber.h>
 
-#include <stdio.h>
-#include <iostream>
-#include <sstream>
 #include <fstream>
+#include <functional>
+#include <iostream>
 #include <memory>
+#include <sstream>
+#include <stdio.h>
+#include <string>
 
 #ifdef _MSC_VER
 #pragma warning(push, 0) // disable proto warnings

--- a/ecal/core/src/pubsub/ecal_pubgate.cpp
+++ b/ecal/core/src/pubsub/ecal_pubgate.cpp
@@ -26,8 +26,12 @@
 #include "ecal_descgate.h"
 #include "ecal_sample_to_topicinfo.h"
 
-#include <iterator>
 #include <atomic>
+#include <iterator>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <string>
 
 namespace eCAL
 {

--- a/ecal/core/src/pubsub/ecal_pubgate.h
+++ b/ecal/core/src/pubsub/ecal_pubgate.h
@@ -28,9 +28,11 @@
 
 #include "readwrite/ecal_writer.h"
 
-#include <shared_mutex>
 #include <atomic>
-#include <unordered_map>
+#include <map>
+#include <memory>
+#include <shared_mutex>
+#include <string>
 
 namespace eCAL
 {

--- a/ecal/core/src/pubsub/ecal_publisher.cpp
+++ b/ecal/core/src/pubsub/ecal_publisher.cpp
@@ -21,9 +21,10 @@
  * @brief  common data publisher based on eCAL
 **/
 
+#include <cstddef>
 #include <ecal/ecal.h>
-#include <ecal/ecal_tlayer.h>
 #include <ecal/ecal_config.h>
+#include <ecal/ecal_tlayer.h>
 
 #include "config/ecal_config_reader_hlp.h"
 #include "readwrite/ecal_buffer_payload_writer.h"
@@ -31,8 +32,10 @@
 
 #include "readwrite/ecal_writer.h"
 
-#include <sstream>
 #include <iostream>
+#include <memory>
+#include <sstream>
+#include <string>
 #include <utility>
 
 namespace eCAL

--- a/ecal/core/src/pubsub/ecal_subgate.cpp
+++ b/ecal/core/src/pubsub/ecal_subgate.cpp
@@ -22,9 +22,19 @@
 **/
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 
+#include <cstddef>
 #include <ecal/ecal.h>
+#include <functional>
+#include <iterator>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <string>
+#include <thread>
+#include <vector>
 
 #ifdef ECAL_OS_LINUX
 //#include <sys/types.h>

--- a/ecal/core/src/pubsub/ecal_subgate.h
+++ b/ecal/core/src/pubsub/ecal_subgate.h
@@ -27,8 +27,9 @@
 #include "util/ecal_thread.h"
 
 #include <atomic>
-#include <shared_mutex>
+#include <cstddef>
 #include <memory>
+#include <shared_mutex>
 #include <string>
 #include <unordered_map>
 

--- a/ecal/core/src/pubsub/ecal_subscriber.cpp
+++ b/ecal/core/src/pubsub/ecal_subscriber.cpp
@@ -21,14 +21,17 @@
  * @brief  common data subscriber for eCAL
 **/
 
+#include <cstddef>
 #include <ecal/ecal.h>
 
 #include "ecal_globals.h"
 #include "readwrite/ecal_reader.h"
 
-#include <sstream>
 #include <iostream>
-
+#include <memory>
+#include <sstream>
+#include <string>
+#include <utility>
 
 namespace eCAL
 {

--- a/ecal/core/src/readwrite/ecal_reader.cpp
+++ b/ecal/core/src/readwrite/ecal_reader.cpp
@@ -21,6 +21,8 @@
  * @brief  common eCAL data reader
 **/
 
+#include <chrono>
+#include <cstddef>
 #include <ecal/ecal.h>
 #include <ecal/ecal_config.h>
 
@@ -34,11 +36,16 @@
 #include "readwrite/shm/ecal_reader_shm.h"
 #include "readwrite/tcp/ecal_reader_tcp.h"
 
-#include <iterator>
-#include <sstream>
-#include <iostream>
-#include <utility>
 #include <algorithm>
+#include <iostream>
+#include <iterator>
+#include <list>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <sstream>
+#include <string>
+#include <utility>
 
 namespace eCAL
 {

--- a/ecal/core/src/readwrite/ecal_reader.h
+++ b/ecal/core/src/readwrite/ecal_reader.h
@@ -23,9 +23,13 @@
 
 #pragma once
 
+#include <chrono>
+#include <cstddef>
+#include <deque>
 #include <ecal/ecal.h>
 #include <ecal/ecal_callback.h>
 #include <ecal/ecal_types.h>
+#include <map>
 
 #ifdef _MSC_VER
 #pragma warning(push, 0) // disable proto warnings

--- a/ecal/core/src/readwrite/ecal_writer.cpp
+++ b/ecal/core/src/readwrite/ecal_writer.cpp
@@ -21,6 +21,7 @@
  * @brief  common eCAL data writer
 **/
 
+#include <cstddef>
 #include <ecal/ecal.h>
 #include <ecal/ecal_config.h>
 #include <ecal/ecal_payload_writer.h>
@@ -38,9 +39,11 @@
 
 #include "pubsub/ecal_pubgate.h"
 
-#include <sstream>
 #include <chrono>
 #include <functional>
+#include <mutex>
+#include <sstream>
+#include <string>
 
 struct SSndHash
 {

--- a/ecal/core/src/readwrite/ecal_writer.h
+++ b/ecal/core/src/readwrite/ecal_writer.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <ecal/ecal_callback.h>
 #include <ecal/ecal_payload_writer.h>
 #include <ecal/ecal_tlayer.h>
@@ -36,10 +37,11 @@
 #include "tcp/ecal_writer_tcp.h"
 #include "inproc/ecal_writer_inproc.h"
 
-#include <mutex>
-#include <string>
 #include <atomic>
 #include <map>
+#include <mutex>
+#include <string>
+#include <tuple>
 #include <vector>
 
 namespace eCAL

--- a/ecal/core/src/readwrite/inproc/ecal_writer_inproc.cpp
+++ b/ecal/core/src/readwrite/inproc/ecal_writer_inproc.cpp
@@ -23,6 +23,7 @@
 
 #include <ecal/ecal.h>
 #include <ecal/ecal_log.h>
+#include <string>
 
 #include "ecal_global_accessors.h"
 #include "pubsub/ecal_subgate.h"

--- a/ecal/core/src/readwrite/inproc/ecal_writer_inproc.h
+++ b/ecal/core/src/readwrite/inproc/ecal_writer_inproc.h
@@ -37,12 +37,10 @@
 #include "readwrite/ecal_writer_base.h"
 
 #include <string>
-#include <vector>
 
-namespace eCAL
+namespace eCAL {
+class CDataWriterInProc : public CDataWriterBase
 {
-  class CDataWriterInProc : public CDataWriterBase
-  {
   public:
     ~CDataWriterInProc() override;
 
@@ -57,4 +55,4 @@ namespace eCAL
 
   protected:
   };
-}
+  } // namespace eCAL

--- a/ecal/core/src/readwrite/shm/ecal_reader_shm.cpp
+++ b/ecal/core/src/readwrite/shm/ecal_reader_shm.cpp
@@ -21,7 +21,11 @@
  * @brief  shared memory layer
 **/
 
+#include <cstddef>
 #include <ecal/ecal.h>
+#include <functional>
+#include <string>
+#include <vector>
 
 #ifdef _MSC_VER
 #pragma warning(push, 0) // disable proto warnings

--- a/ecal/core/src/readwrite/shm/ecal_reader_shm.h
+++ b/ecal/core/src/readwrite/shm/ecal_reader_shm.h
@@ -26,7 +26,9 @@
 #include "ecal_def.h"
 #include "readwrite/ecal_reader_layer.h"
 
+#include <cstddef>
 #include <memory>
+#include <string>
 
 namespace eCAL
 {

--- a/ecal/core/src/readwrite/shm/ecal_writer_shm.cpp
+++ b/ecal/core/src/readwrite/shm/ecal_writer_shm.cpp
@@ -21,9 +21,13 @@
  * @brief  memory file data writer
 **/
 
+#include <cstddef>
 #include <ecal/ecal.h>
 #include <ecal/ecal_config.h>
 #include <ecal/ecal_log.h>
+#include <memory>
+#include <mutex>
+#include <string>
 
 #ifdef _MSC_VER
 #pragma warning(push, 0) // disable proto warnings

--- a/ecal/core/src/readwrite/shm/ecal_writer_shm.h
+++ b/ecal/core/src/readwrite/shm/ecal_writer_shm.h
@@ -26,9 +26,11 @@
 #include "readwrite/ecal_writer_base.h"
 #include "io/shm/ecal_memfile_sync.h"
 
+#include <cstddef>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <vector>
 
 namespace eCAL
 {

--- a/ecal/core/src/readwrite/tcp/ecal_reader_tcp.cpp
+++ b/ecal/core/src/readwrite/tcp/ecal_reader_tcp.cpp
@@ -23,7 +23,13 @@
 
 #include "ecal_global_accessors.h"
 
+#include <cstdint>
 #include <ecal/ecal_config.h>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <string>
 
 #include "pubsub/ecal_subgate.h"
 

--- a/ecal/core/src/readwrite/tcp/ecal_reader_tcp.h
+++ b/ecal/core/src/readwrite/tcp/ecal_reader_tcp.h
@@ -25,8 +25,13 @@
 
 #include "readwrite/ecal_reader_layer.h"
 
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
 #include <tcp_pubsub/executor.h>
 #include <tcp_pubsub/subscriber.h>
+#include <unordered_map>
 
 #ifdef _MSC_VER
 #pragma warning(push, 0) // disable proto warnings

--- a/ecal/core/src/readwrite/tcp/ecal_tcp_pubsub_logger.h
+++ b/ecal/core/src/readwrite/tcp/ecal_tcp_pubsub_logger.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <ecal/ecal_log.h>
+#include <string>
 #include <tcp_pubsub/tcp_pubsub_logger.h>
 
 namespace eCAL

--- a/ecal/core/src/readwrite/tcp/ecal_writer_tcp.cpp
+++ b/ecal/core/src/readwrite/tcp/ecal_writer_tcp.cpp
@@ -21,6 +21,13 @@
  * @brief  tcp writer
 **/
 
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
 #ifdef _MSC_VER
 #pragma warning(push, 0) // disable proto warnings
 #endif

--- a/ecal/core/src/readwrite/tcp/ecal_writer_tcp.h
+++ b/ecal/core/src/readwrite/tcp/ecal_writer_tcp.h
@@ -25,6 +25,8 @@
 
 #include "readwrite/ecal_writer_base.h"
 
+#include <cstdint>
+#include <memory>
 #include <tcp_pubsub/executor.h>
 #include <tcp_pubsub/publisher.h>
 

--- a/ecal/core/src/readwrite/udp/ecal_reader_udp_mc.cpp
+++ b/ecal/core/src/readwrite/udp/ecal_reader_udp_mc.cpp
@@ -27,6 +27,9 @@
 #include "pubsub/ecal_subgate.h"
 
 #include "io/udp/ecal_udp_configurations.h"
+#include <functional>
+#include <string>
+#include <utility>
 
 namespace eCAL
 {

--- a/ecal/core/src/readwrite/udp/ecal_writer_udp_mc.cpp
+++ b/ecal/core/src/readwrite/udp/ecal_writer_udp_mc.cpp
@@ -21,8 +21,11 @@
  * @brief  udp data writer
 **/
 
-#include <ecal/ecal_log.h>
+#include <cstddef>
 #include <ecal/ecal_config.h>
+#include <ecal/ecal_log.h>
+#include <memory>
+#include <string>
 
 #include "ecal_writer_udp_mc.h"
 #include "io/udp/ecal_udp_configurations.h"

--- a/ecal/core/src/readwrite/udp/ecal_writer_udp_mc.h
+++ b/ecal/core/src/readwrite/udp/ecal_writer_udp_mc.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "ecal_def.h"
+#include <memory>
 
 #ifdef _MSC_VER
 #pragma warning(push, 0) // disable proto warnings

--- a/ecal/core/src/registration/ecal_registration_provider.cpp
+++ b/ecal/core/src/registration/ecal_registration_provider.cpp
@@ -26,6 +26,7 @@
  * 
 **/
 
+#include <atomic>
 #include <ecal/ecal_config.h>
 
 #include "ecal_def.h"
@@ -37,6 +38,10 @@
 #include "io/udp/ecal_udp_sample_sender.h"
 
 #include <chrono>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <string>
 
 namespace eCAL
 {

--- a/ecal/core/src/registration/ecal_registration_receiver.cpp
+++ b/ecal/core/src/registration/ecal_registration_receiver.cpp
@@ -35,7 +35,12 @@
 #include "io/udp/ecal_udp_configurations.h"
 #include "ecal_sample_to_topicinfo.h"
 
+#include <atomic>
 #include <chrono>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
 
 namespace eCAL
 {

--- a/ecal/core/src/registration/ecal_registration_receiver.h
+++ b/ecal/core/src/registration/ecal_registration_receiver.h
@@ -37,6 +37,7 @@
 #include "io/shm/ecal_memfile_broadcast_reader.h"
 
 #include <atomic>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <string>

--- a/ecal/core/src/service/ecal_clientgate.cpp
+++ b/ecal/core/src/service/ecal_clientgate.cpp
@@ -24,6 +24,11 @@
 #include "ecal_clientgate.h"
 #include "ecal_descgate.h"
 #include "service/ecal_service_client_impl.h"
+#include <atomic>
+#include <mutex>
+#include <shared_mutex>
+#include <string>
+#include <vector>
 
 namespace eCAL
 {

--- a/ecal/core/src/service/ecal_clientgate.h
+++ b/ecal/core/src/service/ecal_clientgate.h
@@ -27,6 +27,8 @@
 #include "util/ecal_expmap.h"
 
 #include <ecal/ecal_callback.h>
+#include <string>
+#include <vector>
 
 #ifdef _MSC_VER
 #pragma warning(push, 0) // disable proto warnings

--- a/ecal/core/src/service/ecal_service_client.cpp
+++ b/ecal/core/src/service/ecal_service_client.cpp
@@ -22,6 +22,7 @@
 **/
 
 #include <ecal/ecal.h>
+#include <string>
 
 #include "ecal_clientgate.h"
 #include "ecal_global_accessors.h"

--- a/ecal/core/src/service/ecal_service_client_impl.cpp
+++ b/ecal/core/src/service/ecal_service_client_impl.cpp
@@ -28,8 +28,15 @@
 #include "ecal_service_client_impl.h"
 
 #include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
 #include <sstream>
+#include <string>
 #include <utility>
+#include <vector>
 
 #include "ecal_service_singleton_manager.h"
 

--- a/ecal/core/src/service/ecal_service_server.cpp
+++ b/ecal/core/src/service/ecal_service_server.cpp
@@ -22,6 +22,7 @@
 **/
 
 #include <ecal/ecal.h>
+#include <string>
 
 #include "ecal_servicegate.h"
 #include "ecal_global_accessors.h"

--- a/ecal/core/src/service/ecal_service_server_impl.cpp
+++ b/ecal/core/src/service/ecal_service_server_impl.cpp
@@ -31,7 +31,10 @@
 
 #include <chrono>
 #include <iostream>
+#include <memory>
+#include <mutex>
 #include <sstream>
+#include <string>
 #include <utility>
 
 #include "ecal_service_singleton_manager.h"

--- a/ecal/core/src/service/ecal_service_server_impl.h
+++ b/ecal/core/src/service/ecal_service_server_impl.h
@@ -25,6 +25,8 @@
 
 #include <ecal/ecal.h>
 #include <ecal/ecal_callback.h>
+#include <memory>
+#include <string>
 
 #ifdef _MSC_VER
 #pragma warning(push, 0) // disable proto warnings

--- a/ecal/core/src/service/ecal_service_singleton_manager.cpp
+++ b/ecal/core/src/service/ecal_service_singleton_manager.cpp
@@ -19,7 +19,12 @@
 
 #include "ecal_service_singleton_manager.h"
 
+#include <cstddef>
 #include <ecal/ecal_log.h>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
 
 namespace eCAL
 {

--- a/ecal/core/src/service/ecal_service_singleton_manager.h
+++ b/ecal/core/src/service/ecal_service_singleton_manager.h
@@ -19,10 +19,15 @@
 
 #pragma once
 
-#include <ecal/service/server_manager.h>
+#include <atomic>
+#include <cstddef>
 #include <ecal/service/client_manager.h>
+#include <ecal/service/server_manager.h>
 
 #include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
 
 namespace eCAL
 {

--- a/ecal/core/src/service/ecal_servicegate.cpp
+++ b/ecal/core/src/service/ecal_servicegate.cpp
@@ -23,6 +23,9 @@
 
 #include "ecal_servicegate.h"
 #include "service/ecal_service_server_impl.h"
+#include <atomic>
+#include <mutex>
+#include <shared_mutex>
 
 namespace eCAL
 {

--- a/ecal/core/src/time/ecal_time.cpp
+++ b/ecal/core/src/time/ecal_time.cpp
@@ -24,6 +24,7 @@
 #include <ecal/ecal.h>
 
 #include <chrono>
+#include <string>
 #include <thread>
 
 #include "ecal_timegate.h"

--- a/ecal/core/src/time/ecal_timegate.cpp
+++ b/ecal/core/src/time/ecal_timegate.cpp
@@ -21,6 +21,7 @@
  * @brief  eCAL time gateway class
 **/
 
+#include <atomic>
 #include <ecal/ecal.h>
 #include <ecal/ecal_os.h>
 
@@ -32,8 +33,9 @@
 #include "ecal_timegate.h"
 #include "util/getenvvar.h"
 
-#include <iostream>
 #include <chrono>
+#include <iostream>
+#include <string>
 #include <thread>
 
 #define etime_initialize_name            "etime_initialize"

--- a/ecal/core/src/time/ecal_timegate.h
+++ b/ecal/core/src/time/ecal_timegate.h
@@ -28,6 +28,7 @@
 #include "ecal_global_accessors.h"
 
 #include <atomic>
+#include <string>
 
 #ifdef ECAL_OS_WINDOWS
 

--- a/ecal/core/src/time/ecal_timer.cpp
+++ b/ecal/core/src/time/ecal_timer.cpp
@@ -23,8 +23,8 @@
 
 #include <ecal/ecal.h>
 
-#include <assert.h>
 #include <atomic>
+#include <cassert>
 #include <chrono>
 #include <memory>
 #include <thread>

--- a/ecal/core/src/time/ecal_timer.cpp
+++ b/ecal/core/src/time/ecal_timer.cpp
@@ -23,10 +23,11 @@
 
 #include <ecal/ecal.h>
 
+#include <assert.h>
 #include <atomic>
 #include <chrono>
+#include <memory>
 #include <thread>
-#include <assert.h>
 
 namespace eCAL
 {

--- a/ecal/core/src/util/advanced_tclap_output.cpp
+++ b/ecal/core/src/util/advanced_tclap_output.cpp
@@ -19,7 +19,13 @@
 
 #include "advanced_tclap_output.h"
 
+#include <cstddef>
+#include <list>
+#include <ostream>
 #include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace CustomTclap
 {

--- a/ecal/core/src/util/ecal_expmap.h
+++ b/ecal/core/src/util/ecal_expmap.h
@@ -23,13 +23,14 @@
 
 #pragma once
 
+#include <chrono>
 #include <functional>
+#include <iterator>
 #include <list>
 #include <map>
 #include <memory>
 #include <utility>
 #include <vector>
-#include <chrono>
 
 namespace eCAL
 {

--- a/ecal/service/ecal_service/src/client_session.cpp
+++ b/ecal/service/ecal_service/src/client_session.cpp
@@ -17,6 +17,7 @@
  * ========================= eCAL LICENSE =================================
 */
 
+#include <condition_variable>
 #include <cstdint>
 #include <ecal/service/client_session.h>
 #include <memory>

--- a/ecal/service/ecal_service/src/client_session_impl_v0.cpp
+++ b/ecal/service/ecal_service/src/client_session_impl_v0.cpp
@@ -29,6 +29,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace eCAL

--- a/ecal/service/sample/src/main.cpp
+++ b/ecal/service/sample/src/main.cpp
@@ -17,12 +17,15 @@
  * ========================= eCAL LICENSE =================================
 */
 
-#include <ecal/service/server_manager.h>
+#include "asio/io_context.hpp"
 #include <ecal/service/client_manager.h>
+#include <ecal/service/server_manager.h>
 
-#include <iostream>
-#include <thread>
 #include <chrono>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
 
 int main(int /*argc*/, char** /*argv*/)
 {

--- a/ecal/service/test/src/ecal_tcp_service_test.cpp
+++ b/ecal/service/test/src/ecal_tcp_service_test.cpp
@@ -17,6 +17,8 @@
  * ========================= eCAL LICENSE =================================
 */
 
+#include <cstddef>
+#include <cstdint>
 #include <gtest/gtest.h>
 
 #include <asio.hpp>
@@ -24,6 +26,7 @@
 #include <atomic>
 #include <chrono>
 #include <iostream>
+#include <memory>
 #include <string>
 #include <thread>
 
@@ -32,6 +35,7 @@
 
 #include <ecal/service/client_manager.h>
 #include <ecal/service/server_manager.h>
+#include <vector>
 
 #include "atomic_signalable.h"
 


### PR DESCRIPTION
### Description
Added many missing includes by Clang tidy include cleaner. I focused on STL headers and only added missing headres, but didn't remove unnecessary headers.

### Cherry-pick to
- ~master-v5 (master for eCAL 5 feature backporting)~ _(this PR goes to that branch already)_
- 5.13 (current stable)