### PR TITLE
[measurement] HDF5 v6 - Store channel ID in measurement

### DIFF
--- a/app/meas_cutter/CMakeLists.txt
+++ b/app/meas_cutter/CMakeLists.txt
@@ -55,7 +55,7 @@ target_include_directories(${PROJECT_NAME}
 target_link_libraries(${PROJECT_NAME}   yaml-cpp::yaml-cpp
                                         tclap::tclap
                                         eCAL::ecal-utils
-                                        eCAL::measurement_hdf5
+                                        eCAL::hdf5
                                         Threads::Threads)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14) 

--- a/app/meas_cutter/src/measurement_exporter.cpp
+++ b/app/meas_cutter/src/measurement_exporter.cpp
@@ -76,12 +76,12 @@ void MeasurementExporter::setData(eCALMeasCutterUtils::Timestamp timestamp, cons
   const auto sender_timestamp = (iter != meta_data.end()) ? iter->second.sender_timestamp : static_cast<eCALMeasCutterUtils::Timestamp>(0);
 
   iter = meta_data.find(eCALMeasCutterUtils::MetaDatumKey::SENDER_ID);
-  const auto sender_id = (iter != meta_data.end()) ? iter->second.sender_id : static_cast<uint64_t>(0);
+  const auto sender_id = (iter != meta_data.end()) ? iter->second.sender_id : 0;
 
   iter = meta_data.find(eCALMeasCutterUtils::MetaDatumKey::SENDER_CLOCK);
-  const auto sender_clock = (iter != meta_data.end()) ? iter->second.sender_clock : static_cast<uint64_t>(0);
+  const auto sender_clock = (iter != meta_data.end()) ? iter->second.sender_clock : 0;
 
-  if (!_writer->AddEntryToFile(payload.data(), payload.size(), sender_timestamp, timestamp, _current_channel_name, sender_id, sender_clock))
+  if (!_writer->AddEntryToFile(payload.data(), payload.size(), sender_timestamp, timestamp, eCAL::experimental::measurement::base::Channel{ _current_channel_name, sender_id }, sender_clock))
   {
     throw ExporterException("Unable to export protobuf message.");
   }

--- a/app/meas_cutter/src/measurement_exporter.cpp
+++ b/app/meas_cutter/src/measurement_exporter.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,9 @@
 */
 
 #include "measurement_exporter.h"
-#include <ecal/measurement/hdf5/writer.h>
 
 MeasurementExporter::MeasurementExporter():
-  _writer(std::make_unique<eCAL::experimental::measurement::hdf5::Writer>())
+  _writer(std::make_unique<eCAL::eh5::v2::HDF5Meas>())
 {
 }
 
@@ -29,7 +28,7 @@ void MeasurementExporter::setPath(const std::string& path, const std::string& ba
 {
   _root_output_path = EcalUtils::Filesystem::CleanPath(path);
   _output_path = EcalUtils::Filesystem::CleanPath(_root_output_path + EcalUtils::Filesystem::NativeSeparator(EcalUtils::Filesystem::OsStyle::Current) + eCALMeasCutterUtils::kDefaultFolderOutput, EcalUtils::Filesystem::OsStyle::Current);
-  if (!_writer->Open(_output_path))
+  if (!_writer->Open(_output_path, eCAL::eh5::v2::eAccessType::CREATE))
   {
     throw ExporterException("Unable to create HDF5 protobuf output path " + path + ".");
   }
@@ -81,7 +80,7 @@ void MeasurementExporter::setData(eCALMeasCutterUtils::Timestamp timestamp, cons
   iter = meta_data.find(eCALMeasCutterUtils::MetaDatumKey::SENDER_CLOCK);
   const auto sender_clock = (iter != meta_data.end()) ? iter->second.sender_clock : 0;
 
-  if (!_writer->AddEntryToFile(payload.data(), payload.size(), sender_timestamp, timestamp, eCAL::experimental::measurement::base::Channel{ _current_channel_name, sender_id }, sender_clock))
+  if (!_writer->AddEntryToFile(payload.data(), payload.size(), sender_timestamp, timestamp, _current_channel_name, sender_id, sender_clock))
   {
     throw ExporterException("Unable to export protobuf message.");
   }

--- a/app/meas_cutter/src/measurement_exporter.h
+++ b/app/meas_cutter/src/measurement_exporter.h
@@ -18,9 +18,12 @@
 */
 
 #pragma once
+
 #include <iostream>
-#include <unordered_map>
 #include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
 
 #include <ecalhdf5/eh5_meas.h>
 #include <ecal_utils/filesystem.h>

--- a/app/meas_cutter/src/measurement_exporter.h
+++ b/app/meas_cutter/src/measurement_exporter.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 #include <unordered_map>
 #include <map>
 
-#include <ecal/measurement/base/writer.h>
+#include <ecalhdf5/eh5_meas.h>
 #include <ecal_utils/filesystem.h>
 #include "utils.h"
 
@@ -43,7 +43,7 @@ public:
   std::string getRootOutputPath() const;
 
 private:
-  std::unique_ptr<eCAL::experimental::measurement::base::Writer>      _writer;
+  std::unique_ptr<eCAL::eh5::v2::HDF5Meas>              _writer;
   std::string                                           _current_channel_name;
   std::string                                           _output_path;
   std::string                                           _root_output_path;

--- a/app/meas_cutter/src/measurement_importer.cpp
+++ b/app/meas_cutter/src/measurement_importer.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,10 @@
 */
 
 #include "measurement_importer.h"
-#include <ecal/measurement/hdf5/reader.h>
+#include <ecalhdf5/eh5_meas.h>
 
 MeasurementImporter::MeasurementImporter() :
-  _reader(std::make_unique<eCAL::experimental::measurement::hdf5::Reader>()),
+  _reader(std::make_unique<eCAL::eh5::v2::HDF5Meas>()),
   _current_opened_channel_data()
 {
 }

--- a/app/meas_cutter/src/measurement_importer.h
+++ b/app/meas_cutter/src/measurement_importer.h
@@ -18,11 +18,13 @@
 */
 
 #pragma once
-#include <iostream>
 #include <algorithm>
-#include <regex>
 #include <cctype>
-#include <array>
+#include <iostream>
+#include <memory>
+#include <list>
+#include <regex>
+#include <utility>
 
 #include <ecal_utils/filesystem.h>
 #include <ecalhdf5/eh5_meas.h>

--- a/app/meas_cutter/src/measurement_importer.h
+++ b/app/meas_cutter/src/measurement_importer.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@
 #include <array>
 
 #include <ecal_utils/filesystem.h>
-#include <ecal/measurement/base/reader.h>
+#include <ecalhdf5/eh5_meas.h>
 
 #include "utils.h"
 
@@ -53,7 +53,7 @@ public:
 private:
   bool                                 isEcalMeasFile(const std::string& path);
   bool                                 isProtoChannel(const eCAL::experimental::measurement::base::DataTypeInformation& channel_info);
-  std::unique_ptr<eCAL::experimental::measurement::base::Reader>      _reader;
+  std::unique_ptr<eCAL::eh5::v2::HDF5Meas>              _reader;
   eCALMeasCutterUtils::ChannelData                      _current_opened_channel_data;
   std::string                                           _loaded_path;
   eCALMeasCutterUtils::ChannelNameSet                   _channel_names;

--- a/app/meas_cutter/src/utils.h
+++ b/app/meas_cutter/src/utils.h
@@ -312,10 +312,10 @@ namespace eCALMeasCutterUtils
   {
     Timestamp receiver_timestamp;
     Timestamp sender_timestamp;
-    uint64_t sender_id;
-    uint64_t sender_clock;
+    int64_t sender_id;
+    int64_t sender_clock;
 
-      std::array<char,64> __union_size;
+    std::array<char,64> __union_size;
   };
 
   typedef std::unordered_map<MetaDatumKey, MetaDatumValue, MetaDatumHash> MetaData;

--- a/app/play/play_core/CMakeLists.txt
+++ b/app/play/play_core/CMakeLists.txt
@@ -1,6 +1,6 @@
 # ========================= eCAL LICENSE =================================
 #
-# Copyright (C) 2016 - 2019 Continental Corporation
+# Copyright (C) 2016 - 2024 Continental Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
   eCAL::core_protobuf
   eCAL::app_pb
   eCAL::ecaltime_pb
-  eCAL::measurement_hdf5
+  eCAL::hdf5
 )
 
 target_link_libraries(${PROJECT_NAME} PRIVATE

--- a/app/play/play_core/src/ecal_play.cpp
+++ b/app/play/play_core/src/ecal_play.cpp
@@ -19,11 +19,12 @@
 
 #include "ecal_play.h"
 
-#include <iostream>
-#include <fstream>
-#include <sstream>
-#include <clocale>
 #include <chrono>
+#include <clocale>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <sstream>
 
 #include "ecal_play_logger.h"
 #include "play_thread.h"

--- a/app/play/play_core/src/ecal_play.cpp
+++ b/app/play/play_core/src/ecal_play.cpp
@@ -29,7 +29,6 @@
 #include "ecal_play_logger.h"
 #include "play_thread.h"
 #include <ecalhdf5/eh5_meas.h>
-
 #include <ecal_utils/string.h>
 #include <ecal_utils/filesystem.h>
 #include <ecal_utils/str_convert.h>

--- a/app/play/play_core/src/ecal_play.cpp
+++ b/app/play/play_core/src/ecal_play.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@
 
 #include "ecal_play_logger.h"
 #include "play_thread.h"
-#include <ecal/measurement/hdf5/reader.h>
+#include <ecalhdf5/eh5_meas.h>
 
 #include <ecal_utils/string.h>
 #include <ecal_utils/filesystem.h>
@@ -58,7 +58,7 @@ bool EcalPlay::LoadMeasurement(const std::string& path)
 {
   EcalPlayLogger::Instance()->info("Loading measurement...");
 
-  std::shared_ptr<eCAL::experimental::measurement::base::Reader> measurement(std::make_shared<eCAL::experimental::measurement::hdf5::Reader>());
+  std::shared_ptr<eCAL::eh5::v2::HDF5Meas> measurement(std::make_shared<eCAL::eh5::v2::HDF5Meas>());
 
   std::string meas_dir;               // The directory of the measurement
   std::string path_to_load;           // The actual path we load the measurement from. May be a directory or a .hdf5 file
@@ -129,7 +129,7 @@ bool EcalPlay::LoadMeasurement(const std::string& path)
 void EcalPlay::CloseMeasurement()
 {
   description_ = "";
-  play_thread_->SetMeasurement(std::shared_ptr<eCAL::experimental::measurement::base::Reader>(nullptr));
+  play_thread_->SetMeasurement(std::shared_ptr<eCAL::eh5::v2::HDF5Meas>(nullptr));
   measurement_path_ = "";
   clearScenariosPath();
   channel_mapping_path_ = "";

--- a/app/play/play_core/src/measurement_container.cpp
+++ b/app/play/play_core/src/measurement_container.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,13 +20,13 @@
 #include "measurement_container.h"
 
 #include <ecal/ecal_util.h>
-#include <ecal/measurement/hdf5/reader.h>
+#include <ecalhdf5/eh5_meas.h>
 
 #include <algorithm>
 #include <math.h>
 #include <stdlib.h>
 
-MeasurementContainer::MeasurementContainer(std::shared_ptr<eCAL::experimental::measurement::base::Reader> hdf5_meas, const std::string& meas_dir, bool use_receive_timestamp)
+MeasurementContainer::MeasurementContainer(std::shared_ptr<eCAL::eh5::v2::HDF5Meas> hdf5_meas, const std::string& meas_dir, bool use_receive_timestamp)
   : hdf5_meas_             (hdf5_meas)
   , meas_dir_              (meas_dir)
   , use_receive_timestamp_ (use_receive_timestamp)

--- a/app/play/play_core/src/measurement_container.h
+++ b/app/play/play_core/src/measurement_container.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,14 +24,14 @@
 #include <memory>
 
 #include <ecal/ecal.h>
-#include <ecal/measurement/base/reader.h>
+#include <ecalhdf5/eh5_meas.h>
 
 #include "continuity_report.h"
 
 class MeasurementContainer
 {
 public:
-  MeasurementContainer(std::shared_ptr<eCAL::experimental::measurement::base::Reader> hdf5_meas, const std::string& meas_dir = "", bool use_receive_timestamp = true);
+  MeasurementContainer(std::shared_ptr<eCAL::eh5::v2::HDF5Meas> hdf5_meas, const std::string& meas_dir = "", bool use_receive_timestamp = true);
   ~MeasurementContainer();
 
   void CreatePublishers();
@@ -108,7 +108,7 @@ private:
     PublisherInfo*                     publisher_info_;
   };
 
-  std::shared_ptr<eCAL::experimental::measurement::base::Reader>      hdf5_meas_;
+  std::shared_ptr<eCAL::eh5::v2::HDF5Meas>              hdf5_meas_;
   std::string                                           meas_dir_;
   bool                                                  use_receive_timestamp_;
 

--- a/app/play/play_core/src/play_thread.cpp
+++ b/app/play/play_core/src/play_thread.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -576,7 +576,7 @@ void PlayThread::LogChannelMapping(const std::map<std::string, std::string>& cha
 //// Measurement                                                            ////
 ////////////////////////////////////////////////////////////////////////////////
 
-void PlayThread::SetMeasurement(const std::shared_ptr<eCAL::experimental::measurement::base::Reader>& measurement, const std::string& path)
+void PlayThread::SetMeasurement(const std::shared_ptr<eCAL::eh5::v2::HDF5Meas>& measurement, const std::string& path)
 {
   std::unique_ptr<MeasurementContainer> new_measurment_container;
 

--- a/app/play/play_core/src/play_thread.h
+++ b/app/play/play_core/src/play_thread.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,7 +79,7 @@ public:
    * @param measurement    The new measurement
    * @param path           The (optional) path from where the measurement was loaded
    */
-  void SetMeasurement(const std::shared_ptr<eCAL::experimental::measurement::base::Reader>& measurement, const std::string& path = "");
+  void SetMeasurement(const std::shared_ptr<eCAL::eh5::v2::HDF5Meas>& measurement, const std::string& path = "");
 
   /**
    * @brief Returns whether a measurement has successfully been loaded

--- a/app/rec/rec_client_core/CMakeLists.txt
+++ b/app/rec/rec_client_core/CMakeLists.txt
@@ -1,6 +1,6 @@
 # ========================= eCAL LICENSE =================================
 #
-# Copyright (C) 2016 - 2019 Continental Corporation
+# Copyright (C) 2016 - 2024 Continental Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -98,7 +98,7 @@ target_link_libraries(${PROJECT_NAME}
     eCAL::core_pb
     eCAL::app_pb
   PRIVATE
-    eCAL::measurement_hdf5
+    eCAL::hdf5
     ThreadingUtils
     Threads::Threads
     eCAL::ecal-utils

--- a/app/rec/rec_client_core/src/job/hdf5_writer_thread.cpp
+++ b/app/rec/rec_client_core/src/job/hdf5_writer_thread.cpp
@@ -186,8 +186,7 @@ namespace eCAL
             frame->data_.size(),
             std::chrono::duration_cast<std::chrono::microseconds>(frame->ecal_publish_time_.time_since_epoch()).count(),
             std::chrono::duration_cast<std::chrono::microseconds>(frame->ecal_receive_time_.time_since_epoch()).count(),
-            frame->topic_name_,
-            frame->id_,
+            eCAL::experimental::measurement::base::Channel{ frame->topic_name_, frame->id_ },
             frame->clock_
           ))
           {

--- a/app/rec/rec_client_core/src/job/hdf5_writer_thread.cpp
+++ b/app/rec/rec_client_core/src/job/hdf5_writer_thread.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@
 */
 
 #include "hdf5_writer_thread.h"
-#include <ecal/measurement/hdf5/writer.h>
 
 #include "rec_client_core/ecal_rec_logger.h"
 
@@ -42,7 +41,7 @@ namespace eCAL
       , new_topic_info_map_available_(true)
       , flushing_                    (false)
     {
-      hdf5_writer_ = std::make_unique<eCAL::experimental::measurement::hdf5::Writer>();
+      hdf5_writer_ = std::make_unique<eCAL::eh5::v2::HDF5Meas>();
     }
 
     Hdf5WriterThread::~Hdf5WriterThread()
@@ -186,7 +185,8 @@ namespace eCAL
             frame->data_.size(),
             std::chrono::duration_cast<std::chrono::microseconds>(frame->ecal_publish_time_.time_since_epoch()).count(),
             std::chrono::duration_cast<std::chrono::microseconds>(frame->ecal_receive_time_.time_since_epoch()).count(),
-            eCAL::experimental::measurement::base::Channel{ frame->topic_name_, frame->id_ },
+            frame->topic_name_, 
+            frame->id_,
             frame->clock_
           ))
           {
@@ -264,7 +264,7 @@ namespace eCAL
 #endif // NDEBUG
       std::unique_lock<decltype(hdf5_writer_mutex_)> hdf5_writer_lock(hdf5_writer_mutex_);
 
-      if (hdf5_writer_->Open(hdf5_dir))
+      if (hdf5_writer_->Open(hdf5_dir, eCAL::eh5::v2::eAccessType::CREATE))
       {
 #ifndef NDEBUG
         EcalRecLogger::Instance()->debug("Hdf5WriterThread::Open(): Successfully opened HDF5-Writer with path \"" + hdf5_dir + "\"");

--- a/app/rec/rec_client_core/src/job/hdf5_writer_thread.h
+++ b/app/rec/rec_client_core/src/job/hdf5_writer_thread.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 #pragma once
 #include <ThreadingUtils/InterruptibleThread.h>
 
-#include <ecal/measurement/base/writer.h>
+#include <ecalhdf5/eh5_meas.h>
 
 #include <mutex>
 #include <deque>
@@ -94,7 +94,7 @@ namespace eCAL
       mutable RecHdf5JobStatus              last_status_;
 
       mutable std::mutex                                    hdf5_writer_mutex_;
-      std::unique_ptr<eCAL::experimental::measurement::base::Writer>      hdf5_writer_;
+      std::unique_ptr<eCAL::eh5::v2::HDF5Meas>              hdf5_writer_;
 
 
       std::atomic<bool> flushing_;

--- a/contrib/ecalhdf5/CMakeLists.txt
+++ b/contrib/ecalhdf5/CMakeLists.txt
@@ -42,9 +42,15 @@ set(ecalhdf5_src
     src/eh5_meas_file_v4.h
     src/eh5_meas_file_v5.cpp
     src/eh5_meas_file_v5.h
+    src/eh5_meas_file_v6.cpp
+    src/eh5_meas_file_v6.h
     src/eh5_meas_file_writer_v5.cpp
     src/eh5_meas_file_writer_v5.h
+    src/eh5_meas_file_writer_v6.cpp
+    src/eh5_meas_file_writer_v6.h
     src/eh5_meas_impl.h
+    src/hdf5_helper.h
+    src/hdf5_helper.cpp
     src/escape.cpp
     src/escape.h
 )

--- a/contrib/ecalhdf5/CMakeLists.txt
+++ b/contrib/ecalhdf5/CMakeLists.txt
@@ -1,6 +1,6 @@
 # ========================= eCAL LICENSE =================================
 #
-# Copyright (C) 2016 - 2019 Continental Corporation
+# Copyright (C) 2016 - 2024 Continental Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,7 +29,10 @@ else()
 endif()
 
 set(ecalhdf5_src
-    src/eh5_meas.cpp
+    src/datatype_helper.cpp
+    src/datatype_helper.h
+    src/eh5_meas_api_v2.cpp
+    src/eh5_meas_api_v3.cpp
     src/eh5_meas_dir.cpp
     src/eh5_meas_dir.h
     src/eh5_meas_file_v1.cpp
@@ -58,6 +61,8 @@ set(ecalhdf5_src
 set(ecalhdf5_header_base
     include/ecalhdf5/eh5_defs.h
     include/ecalhdf5/eh5_meas.h
+    include/ecalhdf5/eh5_meas_api_v2.h
+    include/ecalhdf5/eh5_meas_api_v3.h
     include/ecalhdf5/eh5_types.h
 )
 
@@ -73,7 +78,10 @@ target_include_directories(${PROJECT_NAME}
 
 target_compile_definitions(${PROJECT_NAME}
   PRIVATE
-    $<$<BOOL:${MSVC}>:_UNICODE>)
+    $<$<BOOL:${MSVC}>:_UNICODE>
+  PUBLIC
+    ECAL_EH5_API_VERSION=2
+  )
 
 target_compile_options(${PROJECT_NAME}
   PRIVATE

--- a/contrib/ecalhdf5/include/ecalhdf5/eh5_defs.h
+++ b/contrib/ecalhdf5/include/ecalhdf5/eh5_defs.h
@@ -1,6 +1,6 @@
 ;/* ========================= eCAL LICENSE =================================
 ; *
-; * Copyright (C) 2016 - 2019 Continental Corporation
+; * Copyright (C) 2016 - 2024 Continental Corporation
 ; *
 ; * Licensed under the Apache License, Version 2.0 (the "License");
 ; * you may not use this file except in compliance with the License.
@@ -25,13 +25,13 @@
 #pragma once
 
 ;/* version parsed out into numeric values */
-#define ECAL_HDF5_VERSION_MAJOR              2                   //!< eCAL HDF5 major version
-#define ECAL_HDF5_VERSION_MINOR              1                   //!< eCAL HDF5 minor version
+#define ECAL_HDF5_VERSION_MAJOR              3                   //!< eCAL HDF5 major version
+#define ECAL_HDF5_VERSION_MINOR              0                   //!< eCAL HDF5 minor version
 #define ECAL_HDF5_VERSION_PATCH              0                   //!< eCAL HDF5 patch version
 
 ;/* version as string */
-#define ECAL_HDF5_VERSION                    "v.2.1.0.20180329"  //!< eCAL HDF5 version string
-#define ECAL_HDF5_DATE                       "29.03.2018"        //!< eCAL HDF5 version date
+#define ECAL_HDF5_VERSION                    "v.3.0.0.20241203"  //!< eCAL HDF5 version string
+#define ECAL_HDF5_DATE                       "03.12.2024"        //!< eCAL HDF5 version date
 
 ;/* name as string */
 #define ECAL_HDF5_NAME                       "eCALHDF5"          //!< eCAL HDF5 library name

--- a/contrib/ecalhdf5/include/ecalhdf5/eh5_meas.h
+++ b/contrib/ecalhdf5/include/ecalhdf5/eh5_meas.h
@@ -24,12 +24,19 @@
 
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <set>
 #include <string>
 #include <memory>
 
 #include "eh5_types.h"
+
+#if defined(ECAL_EH5_NO_DEPRECATION_WARNINGS)
+#define ECAL_EH5_DEPRECATE(__message__)                             //!< Don't print deprecation warnigns
+#else 
+#define ECAL_EH5_DEPRECATE(__message__) [[deprecated(__message__)]] //!< Deprecate the following function 
+#endif
 
 namespace eCAL
 {
@@ -172,6 +179,21 @@ namespace eCAL
       std::set<std::string> GetChannelNames() const;
 
       /**
+       * @brief Get the available channel names of the current opened file / measurement
+       *
+       * @return Channels (channel name & id)
+      **/
+      std::set<SChannel> GetChannels() const;
+
+      /**
+       * @brief Get the available channel names of the current opened file / measurement
+       *
+       * @param   channel_name   name of the channel
+       * @return                 channel names & ids
+      **/
+      std::set<eCAL::eh5::SChannel> GetChannels(const std::string & channel_name) const;
+
+      /**
        * @brief Check if channel exists in measurement
        *
        * @param channel_name   name of the channel
@@ -187,7 +209,7 @@ namespace eCAL
        *
        * @return              channel description
       **/
-      [[deprecated("Please use GetChannelDataTypeInformation instead")]]
+      ECAL_EH5_DEPRECATE("Please use GetChannelDataTypeInformation instead")
       std::string GetChannelDescription(const std::string& channel_name) const;
 
       /**
@@ -196,7 +218,7 @@ namespace eCAL
        * @param channel_name    channel name
        * @param description     description of the channel
       **/
-      [[deprecated("Please use SetChannelDataTypeInformation instead")]]
+      ECAL_EH5_DEPRECATE("Please use SetChannelDataTypeInformation instead")
       void SetChannelDescription(const std::string& channel_name, const std::string& description);
 
       /**
@@ -206,7 +228,7 @@ namespace eCAL
        *
        * @return              channel type
       **/
-      [[deprecated("Please use GetChannelDataTypeInformation instead")]]
+      ECAL_EH5_DEPRECATE("Please use GetChannelDataTypeInformation instead")
       std::string GetChannelType(const std::string& channel_name) const;
 
       /**
@@ -215,7 +237,7 @@ namespace eCAL
        * @param channel_name  channel name
        * @param type          type of the channel
       **/
-      [[deprecated("Please use SetChannelDataTypeInformation instead")]]
+      ECAL_EH5_DEPRECATE("Please use SetChannelDataTypeInformation instead")
       void SetChannelType(const std::string& channel_name, const std::string& type);
 
       /**
@@ -225,7 +247,7 @@ namespace eCAL
        *
        * @return              channel type
       **/
-      DataTypeInformation GetChannelDataTypeInformation(const std::string& channel_name) const;
+      DataTypeInformation GetChannelDataTypeInformation(const SChannel& channel) const;
 
       /**
        * @brief Set data type information of the given channel
@@ -235,7 +257,7 @@ namespace eCAL
        *
        * @return              channel type
       **/
-      void SetChannelDataTypeInformation(const std::string& channel_name, const DataTypeInformation& info);
+      void SetChannelDataTypeInformation(const SChannel& channel, const DataTypeInformation& info);
 
       /**
        * @brief Gets minimum timestamp for specified channel
@@ -244,7 +266,17 @@ namespace eCAL
        *
        * @return                minimum timestamp value
       **/
+      ECAL_EH5_DEPRECATE("Please use the overload GetMinTimestamp(const SChannel&)")
       long long GetMinTimestamp(const std::string& channel_name) const;
+
+      /**
+        * @brief Gets minimum timestamp for specified channel
+        *
+        * @param channel         channel (name & id)
+        *
+        * @return                minimum timestamp value
+      **/
+      long long GetMinTimestamp(const SChannel& channel) const;
 
       /**
        * @brief Gets maximum timestamp for specified channel
@@ -253,7 +285,17 @@ namespace eCAL
        *
        * @return                maximum timestamp value
       **/
+      ECAL_EH5_DEPRECATE("Please use the overload GetMaxTimestamp(const SChannel&)")
       long long GetMaxTimestamp(const std::string& channel_name) const;
+
+      /**
+       * @brief Gets maximum timestamp for specified channel
+       *
+       * @param channel         channel (name & id)
+       *
+       * @return                maximum timestamp value
+      **/
+      long long GetMaxTimestamp(const SChannel& channel) const;
 
       /**
        * @brief Gets the header info for all data entries for the given channel
@@ -264,7 +306,20 @@ namespace eCAL
        *
        * @return                    true if succeeds, false if it fails
       **/
+      ECAL_EH5_DEPRECATE("Please use the overload GetEntriesInfo(const SChannel&, EntryInfoSet&)")
       bool GetEntriesInfo(const std::string& channel_name, EntryInfoSet& entries) const;
+      
+      /**
+       * @brief Gets the header info for all data entries for the given channel
+       *        Header = timestamp + entry id
+       *
+       * @param [in]  channel       channel (name & id)
+       * @param [out] entries       header info for all data entries
+       *
+       * @return                    true if succeeds, false if it fails
+      **/
+      bool GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const;
+
 
       /**
        * @brief Gets the header info for data entries for the given channel included in given time range (begin->end)
@@ -277,7 +332,21 @@ namespace eCAL
        *
        * @return                   true if succeeds, false if it fails
       **/
+      ECAL_EH5_DEPRECATE("Please use the overload GetEntriesInfoRange(const SChannel&, long long, long long, EntryInfoSet&)")
       bool GetEntriesInfoRange(const std::string& channel_name, long long begin, long long end, EntryInfoSet& entries) const;
+
+      /**
+       * @brief Gets the header info for data entries for the given channel included in given time range (begin->end)
+       *        Header = timestamp + entry id
+       *
+       * @param [in]  channel      channel (name & id)
+       * @param [in]  begin        time range begin timestamp
+       * @param [in]  end          time range end timestamp
+       * @param [out] entries      header info for data entries in given range
+       *
+       * @return                   true if succeeds, false if it fails
+      **/
+      bool GetEntriesInfoRange(const SChannel& channel, long long begin, long long end, EntryInfoSet& entries) const;
 
       /**
        * @brief Gets data size of a specific entry
@@ -319,7 +388,23 @@ namespace eCAL
        *
        * @return              true if succeeds, false if it fails
       **/
+      ECAL_EH5_DEPRECATE("Please use the overload AddEntryToFile(const void*, const unsigned long long&, const long long, const long long&, const SChannel&, long long)")
       bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const std::string& channel_name, long long id, long long clock);
+
+      /**
+       * @brief Add entry to file
+       *
+       * @param data           data to be added
+       * @param size           size of the data
+       * @param snd_timestamp  send time stamp
+       * @param rcv_timestamp  receive time stamp
+       * @param channel        channel channel (name & id)
+       * @param id             message id
+       * @param clock          message clock
+       *
+       * @return              true if succeeds, false if it fails
+      **/
+      bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long clock);
 
       /**
        * @brief Callback function type for pre file split notification

--- a/contrib/ecalhdf5/include/ecalhdf5/eh5_meas.h
+++ b/contrib/ecalhdf5/include/ecalhdf5/eh5_meas.h
@@ -191,7 +191,7 @@ namespace eCAL
        * @param   channel_name   name of the channel
        * @return                 channel names & ids
       **/
-      std::set<eCAL::eh5::SChannel> GetChannels(const std::string & channel_name) const;
+      std::set<SChannel> GetChannels(const std::string & channel_name) const;
 
       /**
        * @brief Check if channel exists in measurement
@@ -201,6 +201,15 @@ namespace eCAL
        * @return       true if exists, false otherwise
       **/
       bool HasChannel(const std::string& channel_name) const;
+
+      /**
+       * @brief Check if channel exists in measurement
+       *
+       * @param channel   channel name & id
+       *
+       * @return       true if exists, false otherwise
+      **/
+      bool HasChannel(const eCAL::eh5::SChannel& channel) const;
 
       /**
        * @brief Get the channel description for the given channel

--- a/contrib/ecalhdf5/include/ecalhdf5/eh5_meas.h
+++ b/contrib/ecalhdf5/include/ecalhdf5/eh5_meas.h
@@ -40,18 +40,3 @@
 
 #include "eh5_meas_api_v2.h"
 #include "eh5_meas_api_v3.h"
-
-namespace eCAL
-{
-  namespace eh5
-  {
-   
-#if ECAL_EH5_API_VERSION == 2
-    using HDF5Meas = v2::HDF5Meas;
-    using eAccessType = v2::eAccessType;
-#else
-    using HDF5Meas = v3::HDF5Meas;
-    using eAccessType = v3::eAccessType;
-#endif
-  }  // namespace eh5
-}  // namespace eCAL

--- a/contrib/ecalhdf5/include/ecalhdf5/eh5_meas_api_v2.h
+++ b/contrib/ecalhdf5/include/ecalhdf5/eh5_meas_api_v2.h
@@ -1,0 +1,351 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2024 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+/**
+ * @file   eh5_meas.h
+ * @brief  eCALHDF5 measurement class
+**/
+
+#pragma once
+
+#include <functional>
+#include <set>
+#include <string>
+#include <memory>
+
+#include "eh5_types.h"
+
+namespace eCAL
+{
+  namespace eh5
+  {
+    namespace v3
+    {
+      class HDF5Meas;
+    }
+
+    namespace v2
+    {
+    /**
+     * @brief eCAL HDF5 measurement API
+    **/
+    class HDF5Meas
+    {
+    public:
+      /**
+       * @brief Constructor
+      **/
+      HDF5Meas();
+
+      /**
+       * @brief Constructor
+       *
+       * @param path     Input file path / measurement directory path (see meas directory structure description bellow, in Open method).
+       * @param access   Access type
+       *
+      **/
+      explicit HDF5Meas(const std::string& path, eAccessType access = RDONLY);
+
+      /**
+       * @brief Destructor
+      **/
+      ~HDF5Meas();
+
+      /**
+       * @brief Copy constructor deleted
+      **/
+      HDF5Meas(const HDF5Meas& other) = delete;
+      /**
+       * @brief Move assignemnt deleted
+      **/
+      HDF5Meas& operator=(const HDF5Meas& other) = delete;
+
+      /**
+      * @brief Move constructor
+      **/
+      HDF5Meas(HDF5Meas&&) = default;
+      /**
+       * @brief Move assignment
+      **/
+      HDF5Meas& operator=(HDF5Meas&&) = default;
+
+      /**
+       * @brief Open file
+       *
+       * @param path     Input file path / measurement directory path.
+       *
+       *                 Default measurement directory structure:
+       *                  - root directory e.g.: M:\measurement_directory\measurement01
+       *                  - documents directory:                                |_doc
+       *                  - hosts directories:                                  |_Host1 (e.g.: CARPC01)
+       *                                                                        |_Host2 (e.g.: CARPC02)
+       *
+       *                 File path as input (eAccessType::RDONLY):
+       *                  - root directory (e.g.: M:\measurement_directory\measurement01) in this case all hosts subdirectories will be iterated,
+       *                  - host directory (e.g.: M:\measurement_directory\measurement01\CARPC01),
+       *                  - file path, path to file from measurement (e.g.: M:\measurement_directory\measurement01\CARPC01\meas01_05.hdf5).
+       *
+       *                 File path as output (eAccessType::CREATE):
+       *                  - full path to  measurement directory (recommended with host name) (e.g.: M:\measurement_directory\measurement01\CARPC01),
+       *                  - to set the name of the actual hdf5 file use SetFileBaseName method.
+       *
+       * @param access   Access type
+       *
+       * @return         true if output (eAccessType::CREATE) measurement directory structure can be accessed/created, false otherwise.
+       *                 true if input (eAccessType::RDONLY) measurement/file path was opened, false otherwise.
+      **/
+      bool Open(const std::string& path, eAccessType access = RDONLY);
+
+      /**
+       * @brief Close file
+       *
+       * @return         true if succeeds, false if it fails
+      **/
+      bool Close();
+
+      /**
+       * @brief Checks if file/measurement is ok
+       *
+       * @return  true if meas can be opened(read) or location is accessible(write), false otherwise
+      **/
+      bool IsOk() const;
+
+      /**
+       * @brief Get the File Type Version of the current opened file
+       *
+       * @return       file version
+      **/
+      std::string GetFileVersion() const;
+
+      /**
+       * @brief Gets maximum allowed size for an individual file
+       *
+       * @return       maximum size in MB
+      **/
+      size_t GetMaxSizePerFile() const;
+
+      /**
+       * @brief Sets maximum allowed size for an individual file
+       *
+       * @param size   maximum size in MB
+      **/
+      void SetMaxSizePerFile(size_t size);
+
+      /**
+      * @brief Whether each Channel shall be writte in its own file
+      * 
+      * When enabled, data is clustered by channel and each channel is written
+      * to its own file. The filenames will consist of the basename and the 
+      * channel name.
+      * 
+      * @return true, if one file per channel is enabled
+      */
+      bool IsOneFilePerChannelEnabled() const;
+
+      /**
+      * @brief Enable / disable the creation of one individual file per channel
+      * 
+      * When enabled, data is clustered by channel and each channel is written
+      * to its own file. The filenames will consist of the basename and the 
+      * channel name.
+      * 
+      * @param enabled   Whether one file shall be created per channel
+      */
+      void SetOneFilePerChannelEnabled(bool enabled);
+
+      /**
+       * @brief Get the available channel names of the current opened file / measurement
+       *
+       * @return       channel names
+      **/
+      std::set<std::string> GetChannelNames() const;
+
+      /**
+       * @brief Check if channel exists in measurement
+       *
+       * @param channel_name   name of the channel
+       *
+       * @return       true if exists, false otherwise
+      **/
+      bool HasChannel(const std::string& channel_name) const;
+
+      /**
+       * @brief Get the channel description for the given channel
+       *
+       * @param channel_name  channel name
+       *
+       * @return              channel description
+      **/
+      [[deprecated("Please use GetChannelDataTypeInformation instead")]]
+      std::string GetChannelDescription(const std::string& channel_name) const;
+
+      /**
+       * @brief Set description of the given channel
+       *
+       * @param channel_name    channel name
+       * @param description     description of the channel
+      **/
+      [[deprecated("Please use SetChannelDataTypeInformation instead")]]
+      void SetChannelDescription(const std::string& channel_name, const std::string& description);
+
+      /**
+       * @brief Gets the channel type of the given channel
+       *
+       * @param channel_name  channel name
+       *
+       * @return              channel type
+      **/
+      [[deprecated("Please use GetChannelDataTypeInformation instead")]]
+      std::string GetChannelType(const std::string& channel_name) const;
+
+      /**
+       * @brief Set type of the given channel
+       *
+       * @param channel_name  channel name
+       * @param type          type of the channel
+      **/
+      [[deprecated("Please use SetChannelDataTypeInformation instead")]]
+      void SetChannelType(const std::string& channel_name, const std::string& type);
+
+      /**
+       * @brief Get data type information of the given channel
+       *
+       * @param channel_name  channel name
+       *
+       * @return              channel type
+      **/
+      DataTypeInformation GetChannelDataTypeInformation(const std::string& channel_name) const;
+
+      /**
+       * @brief Set data type information of the given channel
+       *
+       * @param channel_name  channel name
+       * @param info          datatype info of the channel
+       *
+       * @return              channel type
+      **/
+      void SetChannelDataTypeInformation(const std::string& channel_name, const DataTypeInformation& info);
+
+      /**
+       * @brief Gets minimum timestamp for specified channel
+       *
+       * @param channel_name    channel name
+       *
+       * @return                minimum timestamp value
+      **/
+      long long GetMinTimestamp(const std::string& channel_name) const;
+
+      /**
+       * @brief Gets maximum timestamp for specified channel
+       *
+       * @param channel_name    channel name
+       *
+       * @return                maximum timestamp value
+      **/
+      long long GetMaxTimestamp(const std::string& channel_name) const;
+
+      /**
+       * @brief Gets the header info for all data entries for the given channel
+       *        Header = timestamp + entry id
+       *
+       * @param [in]  channel_name  channel name
+       * @param [out] entries       header info for all data entries
+       *
+       * @return                    true if succeeds, false if it fails
+      **/
+      bool GetEntriesInfo(const std::string& channel_name, EntryInfoSet& entries) const;
+
+      /**
+       * @brief Gets the header info for data entries for the given channel included in given time range (begin->end)
+       *        Header = timestamp + entry id
+       *
+       * @param [in]  channel_name channel name
+       * @param [in]  begin        time range begin timestamp
+       * @param [in]  end          time range end timestamp
+       * @param [out] entries      header info for data entries in given range
+       *
+       * @return                   true if succeeds, false if it fails
+      **/
+      bool GetEntriesInfoRange(const std::string& channel_name, long long begin, long long end, EntryInfoSet& entries) const;
+
+      /**
+       * @brief Gets data size of a specific entry
+       *
+       * @param [in]  entry_id   Entry ID
+       * @param [out] size       Entry data size
+       *
+       * @return                 true if succeeds, false if it fails
+      **/
+      bool GetEntryDataSize(long long entry_id, size_t& size) const;
+
+      /**
+       * @brief Gets data from a specific entry
+       *
+       * @param [in]  entry_id   Entry ID
+       * @param [out] data       Entry data
+       *
+       * @return                 true if succeeds, false if it fails
+      **/
+      bool GetEntryData(long long entry_id, void* data) const;
+
+      /**
+       * @brief Set measurement file base name (desired name for the actual hdf5 files that will be created)
+       *
+       * @param base_name        Name of the hdf5 files that will be created.
+      **/
+      void SetFileBaseName(const std::string& base_name);
+
+      /**
+       * @brief Add entry to file
+       *
+       * @param data           data to be added
+       * @param size           size of the data
+       * @param snd_timestamp  send time stamp
+       * @param rcv_timestamp  receive time stamp
+       * @param channel_name   channel name
+       * @param id             message id
+       * @param clock          message clock
+       *
+       * @return              true if succeeds, false if it fails
+      **/
+      bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const std::string& channel_name, long long id, long long clock);
+
+      /**
+       * @brief Callback function type for pre file split notification
+      **/
+      typedef std::function<void(void)> CallbackFunction;
+
+      /**
+       * @brief Connect callback for pre file split notification
+       *
+       * @param cb   callback function
+      **/
+      void ConnectPreSplitCallback(CallbackFunction cb);
+
+      /**
+       * @brief Disconnect pre file split callback
+      **/
+      void DisconnectPreSplitCallback();
+
+     private:
+      std::unique_ptr<v3::HDF5Meas> hdf_meas_impl_;
+    };
+    } // namespace v1
+  }  // namespace eh5
+}  // namespace eCAL

--- a/contrib/ecalhdf5/include/ecalhdf5/eh5_meas_api_v2.h
+++ b/contrib/ecalhdf5/include/ecalhdf5/eh5_meas_api_v2.h
@@ -25,9 +25,10 @@
 #pragma once
 
 #include <functional>
+#include <map>
+#include <memory>
 #include <set>
 #include <string>
-#include <memory>
 
 #include "eh5_types.h"
 
@@ -345,6 +346,9 @@ namespace eCAL
 
      private:
       std::unique_ptr<v3::HDF5Meas> hdf_meas_impl_;
+      // this map saves all datatype infos that have been set, so that the api can still
+      // support setting type and descriptor separately
+      std::map<std::string, DataTypeInformation> data_type_info_map;
     };
     } // namespace v1
   }  // namespace eh5

--- a/contrib/ecalhdf5/include/ecalhdf5/eh5_meas_api_v2.h
+++ b/contrib/ecalhdf5/include/ecalhdf5/eh5_meas_api_v2.h
@@ -36,7 +36,7 @@ namespace eCAL
 {
   namespace eh5
   {
-    namespace v3
+    inline namespace v3
     {
       class HDF5Meas;
     }
@@ -193,7 +193,6 @@ namespace eCAL
        *
        * @return              channel description
       **/
-      [[deprecated("Please use GetChannelDataTypeInformation instead")]]
       std::string GetChannelDescription(const std::string& channel_name) const;
 
       /**
@@ -202,7 +201,6 @@ namespace eCAL
        * @param channel_name    channel name
        * @param description     description of the channel
       **/
-      [[deprecated("Please use SetChannelDataTypeInformation instead")]]
       void SetChannelDescription(const std::string& channel_name, const std::string& description);
 
       /**
@@ -212,7 +210,6 @@ namespace eCAL
        *
        * @return              channel type
       **/
-      [[deprecated("Please use GetChannelDataTypeInformation instead")]]
       std::string GetChannelType(const std::string& channel_name) const;
 
       /**
@@ -221,7 +218,6 @@ namespace eCAL
        * @param channel_name  channel name
        * @param type          type of the channel
       **/
-      [[deprecated("Please use SetChannelDataTypeInformation instead")]]
       void SetChannelType(const std::string& channel_name, const std::string& type);
 
       /**

--- a/contrib/ecalhdf5/include/ecalhdf5/eh5_meas_api_v3.h
+++ b/contrib/ecalhdf5/include/ecalhdf5/eh5_meas_api_v3.h
@@ -285,7 +285,7 @@ namespace eCAL
        *
        * @return              true if succeeds, false if it fails
       **/
-      bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long id, long long clock);
+      bool AddEntryToFile(const SWriteEntry& entry);
 
       /**
        * @brief Callback function type for pre file split notification

--- a/contrib/ecalhdf5/include/ecalhdf5/eh5_meas_api_v3.h
+++ b/contrib/ecalhdf5/include/ecalhdf5/eh5_meas_api_v3.h
@@ -1,0 +1,317 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2024 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+/**
+ * @file   eh5_meas.h
+ * @brief  eCALHDF5 measurement class
+**/
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <set>
+#include <string>
+#include <memory>
+
+#include "eh5_types.h"
+
+#if defined(ECAL_EH5_NO_DEPRECATION_WARNINGS)
+#define ECAL_EH5_DEPRECATE(__message__)                             //!< Don't print deprecation warnigns
+#else 
+#define ECAL_EH5_DEPRECATE(__message__) [[deprecated(__message__)]] //!< Deprecate the following function 
+#endif
+
+namespace eCAL
+{
+  namespace eh5
+  {
+    class HDF5MeasImpl;
+
+    namespace v3{
+      
+    /**
+     * @brief eCAL HDF5 measurement API
+    **/
+    class HDF5Meas
+    {
+    public:
+      /**
+       * @brief Constructor
+      **/
+      HDF5Meas();
+
+      /**
+       * @brief Constructor
+       *
+       * @param path     Input file path / measurement directory path (see meas directory structure description bellow, in Open method).
+       * @param access   Access type
+       *
+      **/
+      explicit HDF5Meas(const std::string& path, v3::eAccessType access = v3::eAccessType::RDONLY);
+
+      /**
+       * @brief Destructor
+      **/
+      ~HDF5Meas();
+
+      /**
+       * @brief Copy constructor deleted
+      **/
+      HDF5Meas(const HDF5Meas& other) = delete;
+      /**
+       * @brief Move assignemnt deleted
+      **/
+      HDF5Meas& operator=(const HDF5Meas& other) = delete;
+
+      /**
+      * @brief Move constructor
+      **/
+      HDF5Meas(HDF5Meas&&) = default;
+      /**
+       * @brief Move assignment
+      **/
+      HDF5Meas& operator=(HDF5Meas&&) = default;
+
+      /**
+       * @brief Open file
+       *
+       * @param path     Input file path / measurement directory path.
+       *
+       *                 Default measurement directory structure:
+       *                  - root directory e.g.: M:\measurement_directory\measurement01
+       *                  - documents directory:                                |_doc
+       *                  - hosts directories:                                  |_Host1 (e.g.: CARPC01)
+       *                                                                        |_Host2 (e.g.: CARPC02)
+       *
+       *                 File path as input (eAccessType::RDONLY):
+       *                  - root directory (e.g.: M:\measurement_directory\measurement01) in this case all hosts subdirectories will be iterated,
+       *                  - host directory (e.g.: M:\measurement_directory\measurement01\CARPC01),
+       *                  - file path, path to file from measurement (e.g.: M:\measurement_directory\measurement01\CARPC01\meas01_05.hdf5).
+       *
+       *                 File path as output (eAccessType::CREATE):
+       *                  - full path to  measurement directory (recommended with host name) (e.g.: M:\measurement_directory\measurement01\CARPC01),
+       *                  - to set the name of the actual hdf5 file use SetFileBaseName method.
+       *
+       * @param access   Access type
+       *
+       * @return         true if output (eAccessType::CREATE) measurement directory structure can be accessed/created, false otherwise.
+       *                 true if input (eAccessType::RDONLY) measurement/file path was opened, false otherwise.
+      **/
+      bool Open(const std::string& path, v3::eAccessType access = v3::eAccessType::RDONLY);
+
+      /**
+       * @brief Close file
+       *
+       * @return         true if succeeds, false if it fails
+      **/
+      bool Close();
+
+      /**
+       * @brief Checks if file/measurement is ok
+       *
+       * @return  true if meas can be opened(read) or location is accessible(write), false otherwise
+      **/
+      bool IsOk() const;
+
+      /**
+       * @brief Get the File Type Version of the current opened file
+       *
+       * @return       file version
+      **/
+      std::string GetFileVersion() const;
+
+      /**
+       * @brief Gets maximum allowed size for an individual file
+       *
+       * @return       maximum size in MB
+      **/
+      size_t GetMaxSizePerFile() const;
+
+      /**
+       * @brief Sets maximum allowed size for an individual file
+       *
+       * @param size   maximum size in MB
+      **/
+      void SetMaxSizePerFile(size_t size);
+
+      /**
+      * @brief Whether each Channel shall be writte in its own file
+      * 
+      * When enabled, data is clustered by channel and each channel is written
+      * to its own file. The filenames will consist of the basename and the 
+      * channel name.
+      * 
+      * @return true, if one file per channel is enabled
+      */
+      bool IsOneFilePerChannelEnabled() const;
+
+      /**
+      * @brief Enable / disable the creation of one individual file per channel
+      * 
+      * When enabled, data is clustered by channel and each channel is written
+      * to its own file. The filenames will consist of the basename and the 
+      * channel name.
+      * 
+      * @param enabled   Whether one file shall be created per channel
+      */
+      void SetOneFilePerChannelEnabled(bool enabled);
+
+      /**
+       * @brief Get the available channel names of the current opened file / measurement
+       *
+       * @return Channels (channel name & id)
+      **/
+      std::set<SChannel> GetChannels() const;
+
+      /**
+       * @brief Check if channel exists in measurement
+       *
+       * @param channel   channel name & id
+       *
+       * @return       true if exists, false otherwise
+      **/
+      bool HasChannel(const eCAL::eh5::SChannel& channel) const;
+
+      /**
+       * @brief Get data type information of the given channel
+       *
+       * @param channel_name  channel name
+       *
+       * @return              channel type
+      **/
+      DataTypeInformation GetChannelDataTypeInformation(const SChannel& channel) const;
+
+      /**
+       * @brief Set data type information of the given channel
+       *
+       * @param channel_name  channel name
+       * @param info          datatype info of the channel
+       *
+       * @return              channel type
+      **/
+      void SetChannelDataTypeInformation(const SChannel& channel, const DataTypeInformation& info);
+
+      /**
+        * @brief Gets minimum timestamp for specified channel
+        *
+        * @param channel         channel (name & id)
+        *
+        * @return                minimum timestamp value
+      **/
+      long long GetMinTimestamp(const SChannel& channel) const;
+
+      /**
+       * @brief Gets maximum timestamp for specified channel
+       *
+       * @param channel         channel (name & id)
+       *
+       * @return                maximum timestamp value
+      **/
+      long long GetMaxTimestamp(const SChannel& channel) const;
+     
+      /**
+       * @brief Gets the header info for all data entries for the given channel
+       *        Header = timestamp + entry id
+       *
+       * @param [in]  channel       channel (name & id)
+       * @param [out] entries       header info for all data entries
+       *
+       * @return                    true if succeeds, false if it fails
+      **/
+      bool GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const;
+
+      /**
+       * @brief Gets the header info for data entries for the given channel included in given time range (begin->end)
+       *        Header = timestamp + entry id
+       *
+       * @param [in]  channel      channel (name & id)
+       * @param [in]  begin        time range begin timestamp
+       * @param [in]  end          time range end timestamp
+       * @param [out] entries      header info for data entries in given range
+       *
+       * @return                   true if succeeds, false if it fails
+      **/
+      bool GetEntriesInfoRange(const SChannel& channel, long long begin, long long end, EntryInfoSet& entries) const;
+
+      /**
+       * @brief Gets data size of a specific entry
+       *
+       * @param [in]  entry_id   Entry ID
+       * @param [out] size       Entry data size
+       *
+       * @return                 true if succeeds, false if it fails
+      **/
+      bool GetEntryDataSize(long long entry_id, size_t& size) const;
+
+      /**
+       * @brief Gets data from a specific entry
+       *
+       * @param [in]  entry_id   Entry ID
+       * @param [out] data       Entry data
+       *
+       * @return                 true if succeeds, false if it fails
+      **/
+      bool GetEntryData(long long entry_id, void* data) const;
+
+      /**
+       * @brief Set measurement file base name (desired name for the actual hdf5 files that will be created)
+       *
+       * @param base_name        Name of the hdf5 files that will be created.
+      **/
+      void SetFileBaseName(const std::string& base_name);
+
+      /**
+       * @brief Add entry to file
+       *
+       * @param data           data to be added
+       * @param size           size of the data
+       * @param snd_timestamp  send time stamp
+       * @param rcv_timestamp  receive time stamp
+       * @param channel        channel channel (name & id)
+       * @param id             message id
+       * @param clock          message clock
+       *
+       * @return              true if succeeds, false if it fails
+      **/
+      bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long id, long long clock);
+
+      /**
+       * @brief Callback function type for pre file split notification
+      **/
+      typedef std::function<void(void)> CallbackFunction;
+
+      /**
+       * @brief Connect callback for pre file split notification
+       *
+       * @param cb   callback function
+      **/
+      void ConnectPreSplitCallback(CallbackFunction cb);
+
+      /**
+       * @brief Disconnect pre file split callback
+      **/
+      void DisconnectPreSplitCallback();
+
+     private:
+      std::unique_ptr<HDF5MeasImpl> hdf_meas_impl_;
+    };
+    }
+  }  // namespace eh5
+}  // namespace eCAL

--- a/contrib/ecalhdf5/include/ecalhdf5/eh5_meas_api_v3.h
+++ b/contrib/ecalhdf5/include/ecalhdf5/eh5_meas_api_v3.h
@@ -32,11 +32,6 @@
 
 #include "eh5_types.h"
 
-#if defined(ECAL_EH5_NO_DEPRECATION_WARNINGS)
-#define ECAL_EH5_DEPRECATE(__message__)                             //!< Don't print deprecation warnigns
-#else 
-#define ECAL_EH5_DEPRECATE(__message__) [[deprecated(__message__)]] //!< Deprecate the following function 
-#endif
 
 namespace eCAL
 {
@@ -44,7 +39,7 @@ namespace eCAL
   {
     class HDF5MeasImpl;
 
-    namespace v3{
+    inline namespace v3{
       
     /**
      * @brief eCAL HDF5 measurement API

--- a/contrib/ecalhdf5/include/ecalhdf5/eh5_types.h
+++ b/contrib/ecalhdf5/include/ecalhdf5/eh5_types.h
@@ -38,11 +38,16 @@ namespace eCAL
     const std::string kChnNameAttribTitle ("Channel Name");
     const std::string kChnDescAttrTitle   ("Channel Description");
     const std::string kChnTypeAttrTitle   ("Channel Type");
+    const std::string kChnIdTypename      ("TypeName");
+    const std::string kChnIdEncoding      ("TypeEncoding");
+    const std::string kChnIdDescriptor    ("TypeDescriptor");
+    const std::string kChnIdData          ("DataTable");
     const std::string kFileVerAttrTitle   ("Version");
     const std::string kTimestampAttrTitle ("Timestamps");
     const std::string kChnAttrTitle       ("Channels");
 
     // Remove @eCAL6 -> backwards compatibility with old interface!
+    using SChannel = eCAL::experimental::measurement::base::Channel;
     using SEntryInfo = eCAL::experimental::measurement::base::EntryInfo;
     using EntryInfoSet = eCAL::experimental::measurement::base::EntryInfoSet;
     using EntryInfoVect = eCAL::experimental::measurement::base::EntryInfoVect;

--- a/contrib/ecalhdf5/include/ecalhdf5/eh5_types.h
+++ b/contrib/ecalhdf5/include/ecalhdf5/eh5_types.h
@@ -61,7 +61,7 @@ namespace eCAL
       };
     }
 
-    namespace v3
+    inline namespace v3
     {
       enum class eAccessType
       {

--- a/contrib/ecalhdf5/include/ecalhdf5/eh5_types.h
+++ b/contrib/ecalhdf5/include/ecalhdf5/eh5_types.h
@@ -51,9 +51,13 @@ namespace eCAL
     using SEntryInfo = eCAL::experimental::measurement::base::EntryInfo;
     using EntryInfoSet = eCAL::experimental::measurement::base::EntryInfoSet;
     using EntryInfoVect = eCAL::experimental::measurement::base::EntryInfoVect;
-    using eAccessType = eCAL::experimental::measurement::base::AccessType;
-    using eCAL::experimental::measurement::base::RDONLY;
-    using eCAL::experimental::measurement::base::CREATE;
+
+    enum eAccessType
+    {
+      RDONLY,    //!< ReadOnly - the measurement can only be read
+      CREATE,    //!< Create   - a new measurement will be created
+      CREATE_V5  //!< Create a legacy V5 hdf5 measurement (For testing purpose only!)
+    };
    
     using eCAL::experimental::measurement::base::DataTypeInformation;
     //!< @endcond

--- a/contrib/ecalhdf5/include/ecalhdf5/eh5_types.h
+++ b/contrib/ecalhdf5/include/ecalhdf5/eh5_types.h
@@ -51,6 +51,7 @@ namespace eCAL
     using SEntryInfo = eCAL::experimental::measurement::base::EntryInfo;
     using EntryInfoSet = eCAL::experimental::measurement::base::EntryInfoSet;
     using EntryInfoVect = eCAL::experimental::measurement::base::EntryInfoVect;
+    using SWriteEntry = eCAL::experimental::measurement::base::WriteEntry;
 
     namespace v2
     {

--- a/contrib/ecalhdf5/include/ecalhdf5/eh5_types.h
+++ b/contrib/ecalhdf5/include/ecalhdf5/eh5_types.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,13 +52,25 @@ namespace eCAL
     using EntryInfoSet = eCAL::experimental::measurement::base::EntryInfoSet;
     using EntryInfoVect = eCAL::experimental::measurement::base::EntryInfoVect;
 
-    enum eAccessType
+    namespace v2
     {
-      RDONLY,    //!< ReadOnly - the measurement can only be read
-      CREATE,    //!< Create   - a new measurement will be created
-      CREATE_V5  //!< Create a legacy V5 hdf5 measurement (For testing purpose only!)
-    };
-   
+      enum eAccessType
+      {
+        RDONLY,    //!< ReadOnly - the measurement can only be read
+        CREATE,    //!< Create   - a new measurement will be created
+      };
+    }
+
+    namespace v3
+    {
+      enum class eAccessType
+      {
+        RDONLY,    //!< ReadOnly - the measurement can only be read
+        CREATE,    //!< Create   - a new measurement will be created
+        CREATE_V5  //!< Create a legacy V5 hdf5 measurement (For testing purpose only!)
+      };
+    }
+  
     using eCAL::experimental::measurement::base::DataTypeInformation;
     //!< @endcond
   }  // namespace eh5

--- a/contrib/ecalhdf5/src/datatype_helper.cpp
+++ b/contrib/ecalhdf5/src/datatype_helper.cpp
@@ -1,0 +1,60 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2024 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+#include "datatype_helper.h"
+
+namespace eCAL
+{
+  namespace eh5
+  {
+    DataTypeInformation CreateInfo(const std::string& combined_topic_type_, const std::string& descriptor_)
+    {
+    eCAL::eh5::DataTypeInformation info;
+    auto pos = combined_topic_type_.find(':');
+    if (pos == std::string::npos)
+    {
+      info.name = combined_topic_type_;
+      info.encoding = "";
+    }
+    else
+    {
+      info.name = combined_topic_type_.substr(pos + 1);
+      info.encoding = combined_topic_type_.substr(0, pos);
+    }
+    info.descriptor = descriptor_;
+    return info;
+  }
+
+  std::pair<std::string, std::string> FromInfo(const eCAL::eh5::DataTypeInformation& datatype_info_)
+  {
+    std::string combined_topic_type;
+    if (datatype_info_.encoding.empty())
+    {
+      combined_topic_type = datatype_info_.name;
+    }
+    else
+    {
+      combined_topic_type = datatype_info_.encoding + ":" + datatype_info_.name;
+    }
+
+    return std::make_pair(combined_topic_type, datatype_info_.descriptor);
+  }
+    
+  }
+}

--- a/contrib/ecalhdf5/src/datatype_helper.h
+++ b/contrib/ecalhdf5/src/datatype_helper.h
@@ -17,41 +17,18 @@
  * ========================= eCAL LICENSE =================================
 */
 
-/**
- * @file   eh5_meas.h
- * @brief  eCALHDF5 measurement class
-**/
-
 #pragma once
 
-#include <cstdint>
-#include <functional>
-#include <set>
 #include <string>
-#include <memory>
+#include <utility>
+#include <ecalhdf5/eh5_types.h>
 
-#include "eh5_types.h"
-
-#if defined(ECAL_EH5_NO_DEPRECATION_WARNINGS)
-#define ECAL_EH5_DEPRECATE(__message__)                             //!< Don't print deprecation warnigns
-#else 
-#define ECAL_EH5_DEPRECATE(__message__) [[deprecated(__message__)]] //!< Deprecate the following function 
-#endif
-
-#include "eh5_meas_api_v2.h"
-#include "eh5_meas_api_v3.h"
 
 namespace eCAL
 {
   namespace eh5
   {
-   
-#if ECAL_EH5_API_VERSION == 2
-    using HDF5Meas = v2::HDF5Meas;
-    using eAccessType = v2::eAccessType;
-#else
-    using HDF5Meas = v3::HDF5Meas;
-    using eAccessType = v3::eAccessType;
-#endif
-  }  // namespace eh5
-}  // namespace eCAL
+    DataTypeInformation CreateInfo(const std::string& combined_topic_type_, const std::string& descriptor_);
+    std::pair<std::string, std::string> FromInfo(const DataTypeInformation& datatype_info_);   
+  }
+}

--- a/contrib/ecalhdf5/src/eh5_meas.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas.cpp
@@ -62,7 +62,7 @@ bool eCAL::eh5::HDF5Meas::Open(const std::string& path, eAccessType access /*= e
     Close();
   }
 
-  if (access == eAccessType::CREATE)
+  if (access == eAccessType::CREATE || access == eAccessType::CREATE_V5)
   {
     EcalUtils::Filesystem::MkPath(path, EcalUtils::Filesystem::OsStyle::Current);
   }
@@ -135,7 +135,7 @@ bool eCAL::eh5::HDF5Meas::Open(const std::string& path, eAccessType access /*= e
     break;
   }
 
-  if (access == eAccessType::CREATE)
+  if (access == eAccessType::CREATE || access == eAccessType::CREATE_V5)
   {
     return hdf_meas_impl_ ? EcalUtils::Filesystem::IsDir(path, EcalUtils::Filesystem::OsStyle::Current) : false;
   }
@@ -272,6 +272,17 @@ bool eCAL::eh5::HDF5Meas::HasChannel(const std::string& channel_name) const
   return ret_val;
 }
 
+bool eCAL::eh5::HDF5Meas::HasChannel(const eCAL::eh5::SChannel& channel) const
+{
+  bool ret_val = false;
+  if (hdf_meas_impl_)
+  {
+    ret_val = hdf_meas_impl_->HasChannel(eCAL::eh5::SChannel{ GetEscapedTopicname(channel.name), channel.id });
+  }
+
+  return ret_val;
+}
+
 // deprecated
 // Return FIRST non-empty Datatype Information from a channel that contains channel_name
 std::string eCAL::eh5::HDF5Meas::GetChannelDescription(const std::string& channel_name) const
@@ -377,10 +388,10 @@ long long eCAL::eh5::HDF5Meas::GetMinTimestamp(const SChannel& channel) const
 long long eCAL::eh5::HDF5Meas::GetMaxTimestamp(const std::string& channel_name) const
 {
   auto channels = GetChannels(channel_name);
-  std::vector<long long> min_timestamps_per_channel;
-  std::transform(channels.begin(), channels.end(), std::back_inserter(min_timestamps_per_channel),
+  std::vector<long long> max_timestamps_per_channel;
+  std::transform(channels.begin(), channels.end(), std::back_inserter(max_timestamps_per_channel),
     [this](const eCAL::eh5::SChannel& channel) { return GetMaxTimestamp(channel); });
-  return *std::max_element(min_timestamps_per_channel.begin(), min_timestamps_per_channel.end());
+  return *std::max_element(max_timestamps_per_channel.begin(), max_timestamps_per_channel.end());
 }
 
 long long eCAL::eh5::HDF5Meas::GetMaxTimestamp(const SChannel& channel) const

--- a/contrib/ecalhdf5/src/eh5_meas.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -495,7 +495,13 @@ void eCAL::eh5::HDF5Meas::SetFileBaseName(const std::string& base_name)
 
 bool eCAL::eh5::HDF5Meas::AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const std::string& channel_name, long long id, long long clock)
 {
-  return AddEntryToFile(data, size, snd_timestamp, rcv_timestamp, eCAL::eh5::SChannel{ channel_name, id }, clock);
+  bool ret_val = false;
+  if (hdf_meas_impl_)
+  {
+    return hdf_meas_impl_->AddEntryToFile(data, size, snd_timestamp, rcv_timestamp, GetEscapedTopicname(channel_name), id, clock);
+  }
+
+  return ret_val;
 }
 
 bool eCAL::eh5::HDF5Meas::AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const eCAL::eh5::SChannel& channel, long long clock)
@@ -503,7 +509,7 @@ bool eCAL::eh5::HDF5Meas::AddEntryToFile(const void* data, const unsigned long l
   bool ret_val = false;
   if (hdf_meas_impl_)
   {
-    return hdf_meas_impl_->AddEntryToFile(data, size, snd_timestamp, rcv_timestamp, GetEscapedTopicname(channel.name), channel.id, clock);
+    return hdf_meas_impl_->AddEntryToFile(data, size, snd_timestamp, rcv_timestamp, eCAL::eh5::SChannel(GetEscapedTopicname(channel.name), channel.id), clock);
   }
 
   return ret_val;

--- a/contrib/ecalhdf5/src/eh5_meas.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas.cpp
@@ -237,7 +237,7 @@ std::set<eCAL::eh5::SChannel> eCAL::eh5::HDF5Meas::GetChannels() const
     auto escaped_channels = hdf_meas_impl_->GetChannels();
     for (const auto& escaped_channel : escaped_channels)
     {
-      ret_val.emplace(eCAL::eh5::SChannel{ GetUnescapedString(escaped_channel.name), escaped_channel.id });
+      ret_val.emplace(GetUnescapedString(escaped_channel.name), escaped_channel.id);
     }
   }
 
@@ -253,7 +253,7 @@ std::set<eCAL::eh5::SChannel> eCAL::eh5::HDF5Meas::GetChannels(const std::string
     for (const auto& escaped_channel : escaped_channels)
     {
       if (GetUnescapedString(escaped_channel.name) == channel_name)
-        ret_val.emplace(eCAL::eh5::SChannel{ channel_name, escaped_channel.id });
+        ret_val.emplace(channel_name, escaped_channel.id);
     }
   }
 
@@ -363,11 +363,13 @@ void eCAL::eh5::HDF5Meas::SetChannelDataTypeInformation(const SChannel& channel,
 // deprecated
 long long eCAL::eh5::HDF5Meas::GetMinTimestamp(const std::string& channel_name) const
 {
-  auto channels = GetChannels(channel_name);
-  std::vector<long long> min_timestamps_per_channel;
-  std::transform(channels.begin(), channels.end(), std::back_inserter(min_timestamps_per_channel),
-      [this](const eCAL::eh5::SChannel& channel) { return GetMinTimestamp(channel); });
-  return *std::min_element(min_timestamps_per_channel.begin(), min_timestamps_per_channel.end());
+  long long ret_val = 0;
+  if (hdf_meas_impl_)
+  {
+    ret_val = hdf_meas_impl_->GetMinTimestamp(GetEscapedTopicname(channel_name));
+  }
+
+  return ret_val;
 }
 
 
@@ -387,11 +389,13 @@ long long eCAL::eh5::HDF5Meas::GetMinTimestamp(const SChannel& channel) const
 // deprecated
 long long eCAL::eh5::HDF5Meas::GetMaxTimestamp(const std::string& channel_name) const
 {
-  auto channels = GetChannels(channel_name);
-  std::vector<long long> max_timestamps_per_channel;
-  std::transform(channels.begin(), channels.end(), std::back_inserter(max_timestamps_per_channel),
-    [this](const eCAL::eh5::SChannel& channel) { return GetMaxTimestamp(channel); });
-  return *std::max_element(max_timestamps_per_channel.begin(), max_timestamps_per_channel.end());
+  long long ret_val = 0;
+  if (hdf_meas_impl_)
+  {
+    ret_val = hdf_meas_impl_->GetMaxTimestamp(GetEscapedTopicname(channel_name));
+  }
+
+  return ret_val;
 }
 
 long long eCAL::eh5::HDF5Meas::GetMaxTimestamp(const SChannel& channel) const
@@ -410,15 +414,12 @@ long long eCAL::eh5::HDF5Meas::GetMaxTimestamp(const SChannel& channel) const
 // deprecated
 bool eCAL::eh5::HDF5Meas::GetEntriesInfo(const std::string& channel_name, EntryInfoSet& entries) const
 {
-  entries.clear();
-  bool ret_val = true;
-  auto channels = GetChannels(channel_name);
-  for (const auto& channel : channels)
+  bool ret_val = false;
+  if (hdf_meas_impl_)
   {
-    EntryInfoSet channel_entries;
-    ret_val &= GetEntriesInfo(channel, channel_entries);
-    entries.insert(channel_entries.begin(), channel_entries.end());
+    ret_val = hdf_meas_impl_->GetEntriesInfo(GetEscapedTopicname(channel_name), entries);
   }
+
   return ret_val;
 }
 
@@ -438,15 +439,12 @@ bool eCAL::eh5::HDF5Meas::GetEntriesInfo(const SChannel& channel, EntryInfoSet& 
 // deprecated
 bool eCAL::eh5::HDF5Meas::GetEntriesInfoRange(const std::string& channel_name, long long begin, long long end, EntryInfoSet& entries) const
 {
-  entries.clear();
-  bool ret_val = true;
-  auto channels = GetChannels(channel_name);
-  for (const auto& channel : channels)
+  bool ret_val = false;
+  if (hdf_meas_impl_ && begin < end)
   {
-    EntryInfoSet channel_entries;
-    ret_val &= GetEntriesInfoRange(channel, begin, end, channel_entries);
-    entries.insert(channel_entries.begin(), channel_entries.end());
+    ret_val = hdf_meas_impl_->GetEntriesInfoRange(GetEscapedTopicname(channel_name), begin, end, entries);
   }
+
   return ret_val;
 }
 

--- a/contrib/ecalhdf5/src/eh5_meas_api_v2.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_api_v2.cpp
@@ -22,8 +22,12 @@
 **/
 
 #include <ecalhdf5/eh5_meas_api_v2.h>
+
+#include <limits>
+
 #include <ecalhdf5/eh5_meas_api_v3.h>
 #include "datatype_helper.h"
+
 
 namespace {
   using namespace eCAL::eh5;

--- a/contrib/ecalhdf5/src/eh5_meas_api_v2.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_api_v2.cpp
@@ -1,0 +1,205 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2024 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+/**
+ * @brief  eCALHDF5 measurement class <TODO>
+**/
+
+#include <ecalhdf5/eh5_meas_api_v2.h>
+#include <ecalhdf5/eh5_meas_api_v3.h>
+#include "datatype_helper.h"
+
+namespace {
+  using namespace eCAL::eh5;
+
+  v3::eAccessType convert(v2::eAccessType v2_access)
+  {
+    switch (v2_access)
+    {
+    case v2::RDONLY:
+      return v3::eAccessType::RDONLY;
+    case v2::CREATE:
+      return v3::eAccessType::CREATE_V5;
+    default:
+      return v3::eAccessType::RDONLY;
+    }
+  }
+
+  SChannel createChannel(const std::string& channel_name)
+  {
+    return SChannel(channel_name, 0);
+  }
+}
+
+using namespace eCAL::eh5::v2;
+
+eCAL::eh5::v2::HDF5Meas::HDF5Meas()
+: hdf_meas_impl_(std::make_unique<eCAL::eh5::v3::HDF5Meas>())
+{}
+
+// TODO restrict to V5 due to API
+eCAL::eh5::v2::HDF5Meas::HDF5Meas(const std::string& path, eAccessType access /*= eAccessType::RDONLY*/)
+: hdf_meas_impl_(std::make_unique<eCAL::eh5::v3::HDF5Meas>(path, convert(access)))
+{}
+
+eCAL::eh5::v2::HDF5Meas::~HDF5Meas()
+= default;
+
+bool eCAL::eh5::v2::HDF5Meas::Open(const std::string& path, eAccessType access /*= eAccessType::RDONLY*/)
+{
+  return hdf_meas_impl_->Open(path, convert(access));
+}
+
+bool eCAL::eh5::v2::HDF5Meas::Close()
+{
+  return hdf_meas_impl_->Close();
+}
+
+bool eCAL::eh5::v2::HDF5Meas::IsOk() const
+{
+  return hdf_meas_impl_->IsOk();
+}
+
+std::string eCAL::eh5::v2::HDF5Meas::GetFileVersion() const
+{
+  return hdf_meas_impl_->GetFileVersion();
+}
+
+size_t eCAL::eh5::v2::HDF5Meas::GetMaxSizePerFile() const
+{
+  return hdf_meas_impl_->GetMaxSizePerFile();
+}
+
+void eCAL::eh5::v2::HDF5Meas::SetMaxSizePerFile(size_t size)
+{
+  return hdf_meas_impl_->SetMaxSizePerFile(size);
+}
+
+bool eCAL::eh5::v2::HDF5Meas::IsOneFilePerChannelEnabled() const
+{
+  return hdf_meas_impl_->IsOneFilePerChannelEnabled();
+}
+
+void eCAL::eh5::v2::HDF5Meas::SetOneFilePerChannelEnabled(bool enabled)
+{
+  return hdf_meas_impl_->SetOneFilePerChannelEnabled(enabled);
+}
+
+std::set<std::string> eCAL::eh5::v2::HDF5Meas::GetChannelNames() const
+{
+  auto channels = hdf_meas_impl_->GetChannels();
+  std::set<std::string> channel_names;
+  for (const auto& channel : channels) {
+    channel_names.insert(channel.name);
+  }
+  return channel_names;
+}
+
+bool eCAL::eh5::v2::HDF5Meas::HasChannel(const std::string& channel_name) const
+{
+  return hdf_meas_impl_->HasChannel(createChannel(channel_name));
+}
+
+std::string eCAL::eh5::v2::HDF5Meas::GetChannelDescription(const std::string& channel_name) const
+{
+  auto datatype_info = GetChannelDataTypeInformation(channel_name);
+  return datatype_info.descriptor;
+}
+
+void eCAL::eh5::v2::HDF5Meas::SetChannelDescription(const std::string& channel_name, const std::string& description)
+{
+  auto current_info = GetChannelDataTypeInformation(channel_name);
+  current_info.descriptor = description;
+  SetChannelDataTypeInformation(channel_name, current_info);
+}
+
+std::string eCAL::eh5::v2::HDF5Meas::GetChannelType(const std::string& channel_name) const
+{
+  std::string ret_val;
+  auto datatype_info = GetChannelDataTypeInformation(channel_name);
+  std::tie(ret_val, std::ignore) = FromInfo(datatype_info);
+  return ret_val;
+}
+
+void eCAL::eh5::v2::HDF5Meas::SetChannelType(const std::string& channel_name, const std::string& type)
+{
+  auto current_info = GetChannelDataTypeInformation(channel_name);
+  auto new_info = CreateInfo(type, current_info.descriptor);
+  SetChannelDataTypeInformation(channel_name, new_info);
+}
+
+eCAL::eh5::DataTypeInformation eCAL::eh5::v2::HDF5Meas::GetChannelDataTypeInformation(const std::string& channel_name) const
+{
+  return hdf_meas_impl_->GetChannelDataTypeInformation(createChannel(channel_name));
+}
+
+void eCAL::eh5::v2::HDF5Meas::SetChannelDataTypeInformation(const std::string& channel_name, const eCAL::eh5::DataTypeInformation& info)
+{
+  return hdf_meas_impl_->SetChannelDataTypeInformation(createChannel(channel_name), info);
+}
+
+long long eCAL::eh5::v2::HDF5Meas::GetMinTimestamp(const std::string& channel_name) const
+{
+  return hdf_meas_impl_->GetMinTimestamp(createChannel(channel_name));
+}
+
+long long eCAL::eh5::v2::HDF5Meas::GetMaxTimestamp(const std::string& channel_name) const
+{
+  return hdf_meas_impl_->GetMaxTimestamp(createChannel(channel_name));
+}
+
+bool eCAL::eh5::v2::HDF5Meas::GetEntriesInfo(const std::string& channel_name, EntryInfoSet& entries) const
+{
+  return hdf_meas_impl_->GetEntriesInfo(createChannel(channel_name), entries);
+}
+
+bool eCAL::eh5::v2::HDF5Meas::GetEntriesInfoRange(const std::string& channel_name, long long begin, long long end, EntryInfoSet& entries) const
+{
+  return hdf_meas_impl_->GetEntriesInfoRange(createChannel(channel_name), begin, end, entries);
+}
+
+bool eCAL::eh5::v2::HDF5Meas::GetEntryDataSize(long long entry_id, size_t& size) const
+{
+  return hdf_meas_impl_->GetEntryDataSize(entry_id, size);
+}
+
+bool eCAL::eh5::v2::HDF5Meas::GetEntryData(long long entry_id, void* data) const
+{
+  return hdf_meas_impl_->GetEntryData(entry_id, data);
+}
+
+void eCAL::eh5::v2::HDF5Meas::SetFileBaseName(const std::string& base_name)
+{
+  return hdf_meas_impl_->SetFileBaseName(base_name);
+}
+
+bool eCAL::eh5::v2::HDF5Meas::AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const std::string& channel_name, long long id, long long clock)
+{
+  return hdf_meas_impl_->AddEntryToFile(data, size, snd_timestamp, rcv_timestamp, createChannel(channel_name), id, clock);
+}
+
+void eCAL::eh5::v2::HDF5Meas::ConnectPreSplitCallback(CallbackFunction cb)
+{
+  return hdf_meas_impl_->ConnectPreSplitCallback(std::move(cb));
+}
+
+void eCAL::eh5::v2::HDF5Meas::DisconnectPreSplitCallback()
+{
+  return hdf_meas_impl_->DisconnectPreSplitCallback();
+}

--- a/contrib/ecalhdf5/src/eh5_meas_api_v2.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_api_v2.cpp
@@ -146,7 +146,7 @@ std::string eCAL::eh5::v2::HDF5Meas::GetChannelDescription(const std::string& ch
 void eCAL::eh5::v2::HDF5Meas::SetChannelDescription(const std::string& channel_name, const std::string& description)
 {
   const auto& channel = createChannel(channel_name);
-  auto current_info = hdf_meas_impl_->GetChannelDataTypeInformation(channel);
+  auto& current_info = data_type_info_map[channel_name];
   current_info.descriptor = description;
   hdf_meas_impl_->SetChannelDataTypeInformation(channel, current_info);
 }
@@ -162,8 +162,8 @@ std::string eCAL::eh5::v2::HDF5Meas::GetChannelType(const std::string& channel_n
 void eCAL::eh5::v2::HDF5Meas::SetChannelType(const std::string& channel_name, const std::string& type)
 {
   const auto& channel = createChannel(channel_name);
-  auto current_info = hdf_meas_impl_->GetChannelDataTypeInformation(channel);
-  auto new_info = CreateInfo(type, current_info.descriptor);
+  auto& current_info = data_type_info_map[channel_name];
+  current_info = CreateInfo(type, current_info.descriptor);
   hdf_meas_impl_->SetChannelDataTypeInformation(channel, current_info);
 }
 
@@ -180,6 +180,7 @@ eCAL::eh5::DataTypeInformation eCAL::eh5::v2::HDF5Meas::GetChannelDataTypeInform
 
 void eCAL::eh5::v2::HDF5Meas::SetChannelDataTypeInformation(const std::string& channel_name, const eCAL::eh5::DataTypeInformation& info)
 {
+  data_type_info_map[channel_name] = info;
   return hdf_meas_impl_->SetChannelDataTypeInformation(createChannel(channel_name), info);
 }
 

--- a/contrib/ecalhdf5/src/eh5_meas_api_v2.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_api_v2.cpp
@@ -261,7 +261,15 @@ void eCAL::eh5::v2::HDF5Meas::SetFileBaseName(const std::string& base_name)
 
 bool eCAL::eh5::v2::HDF5Meas::AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const std::string& channel_name, long long id, long long clock)
 {
-  return hdf_meas_impl_->AddEntryToFile(data, size, snd_timestamp, rcv_timestamp, createChannel(channel_name), id, clock);
+  SWriteEntry entry;
+  entry.channel = createChannel(channel_name);
+  entry.data = data;
+  entry.size = size;
+  entry.snd_timestamp = snd_timestamp;
+  entry.rcv_timestamp = rcv_timestamp;
+  entry.sender_id = id;
+  entry.clock = clock;
+  return hdf_meas_impl_->AddEntryToFile(entry);
 }
 
 void eCAL::eh5::v2::HDF5Meas::ConnectPreSplitCallback(CallbackFunction cb)

--- a/contrib/ecalhdf5/src/eh5_meas_api_v3.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_api_v3.cpp
@@ -21,7 +21,7 @@
  * @brief  eCALHDF5 measurement class <TODO>
 **/
 
-#include <ecalhdf5/eh5_meas.h>
+#include <ecalhdf5/eh5_meas_api_v2.h>
 
 #include <ecal_utils/filesystem.h>
 
@@ -44,18 +44,20 @@ namespace
   const double file_version_max(6.0);
 }
 
-eCAL::eh5::HDF5Meas::HDF5Meas()
+using namespace eCAL::eh5::v3;
+
+eCAL::eh5::v3::HDF5Meas::HDF5Meas()
 = default;
 
-eCAL::eh5::HDF5Meas::HDF5Meas(const std::string& path, eAccessType access /*= eAccessType::RDONLY*/)
+eCAL::eh5::v3::HDF5Meas::HDF5Meas(const std::string& path, eAccessType access /*= eAccessType::RDONLY*/)
 {
   Open(path, access);
 }
 
-eCAL::eh5::HDF5Meas::~HDF5Meas()
+eCAL::eh5::v3::HDF5Meas::~HDF5Meas()
 = default;
 
-bool eCAL::eh5::HDF5Meas::Open(const std::string& path, eAccessType access /*= eAccessType::RDONLY*/)
+bool eCAL::eh5::v3::HDF5Meas::Open(const std::string& path, eAccessType access /*= eAccessType::RDONLY*/)
 {
   if (hdf_meas_impl_)
   {
@@ -145,7 +147,7 @@ bool eCAL::eh5::HDF5Meas::Open(const std::string& path, eAccessType access /*= e
   }
 }
 
-bool eCAL::eh5::HDF5Meas::Close()
+bool eCAL::eh5::v3::HDF5Meas::Close()
 {
   bool ret_val = false;
   if (hdf_meas_impl_)
@@ -156,7 +158,7 @@ bool eCAL::eh5::HDF5Meas::Close()
   return ret_val;
 }
 
-bool eCAL::eh5::HDF5Meas::IsOk() const
+bool eCAL::eh5::v3::HDF5Meas::IsOk() const
 {
   bool ret_val = false;
   if (hdf_meas_impl_)
@@ -167,7 +169,7 @@ bool eCAL::eh5::HDF5Meas::IsOk() const
   return ret_val;
 }
 
-std::string eCAL::eh5::HDF5Meas::GetFileVersion() const
+std::string eCAL::eh5::v3::HDF5Meas::GetFileVersion() const
 {
   std::string ret_val;
   if (hdf_meas_impl_)
@@ -178,7 +180,7 @@ std::string eCAL::eh5::HDF5Meas::GetFileVersion() const
   return ret_val;
 }
 
-size_t eCAL::eh5::HDF5Meas::GetMaxSizePerFile() const
+size_t eCAL::eh5::v3::HDF5Meas::GetMaxSizePerFile() const
 {
   size_t ret_val = 0;
   if (hdf_meas_impl_)
@@ -189,7 +191,7 @@ size_t eCAL::eh5::HDF5Meas::GetMaxSizePerFile() const
   return ret_val;
 }
 
-void eCAL::eh5::HDF5Meas::SetMaxSizePerFile(size_t size)
+void eCAL::eh5::v3::HDF5Meas::SetMaxSizePerFile(size_t size)
 {
   if (hdf_meas_impl_)
   {
@@ -197,7 +199,7 @@ void eCAL::eh5::HDF5Meas::SetMaxSizePerFile(size_t size)
   }
 }
 
-bool eCAL::eh5::HDF5Meas::IsOneFilePerChannelEnabled() const
+bool eCAL::eh5::v3::HDF5Meas::IsOneFilePerChannelEnabled() const
 {
   if (hdf_meas_impl_ != nullptr)
   {
@@ -206,7 +208,7 @@ bool eCAL::eh5::HDF5Meas::IsOneFilePerChannelEnabled() const
   return false;
 }
 
-void eCAL::eh5::HDF5Meas::SetOneFilePerChannelEnabled(bool enabled)
+void eCAL::eh5::v3::HDF5Meas::SetOneFilePerChannelEnabled(bool enabled)
 {
   if (hdf_meas_impl_ != nullptr)
   {
@@ -214,22 +216,7 @@ void eCAL::eh5::HDF5Meas::SetOneFilePerChannelEnabled(bool enabled)
   }
 }
 
-std::set<std::string> eCAL::eh5::HDF5Meas::GetChannelNames() const
-{
-  std::set<std::string> ret_val;
-  if (hdf_meas_impl_)
-  {
-    std::set<std::string> escaped_channel_names = hdf_meas_impl_->GetChannelNames();
-    for (const std::string& escaped_name : escaped_channel_names)
-    {
-      ret_val.emplace(GetUnescapedString(escaped_name));
-    }
-  }
-
-  return ret_val;
-}
-
-std::set<eCAL::eh5::SChannel> eCAL::eh5::HDF5Meas::GetChannels() const
+std::set<eCAL::eh5::SChannel> eCAL::eh5::v3::HDF5Meas::GetChannels() const
 {
   std::set<eCAL::eh5::SChannel> ret_val;
   if (hdf_meas_impl_)
@@ -244,35 +231,7 @@ std::set<eCAL::eh5::SChannel> eCAL::eh5::HDF5Meas::GetChannels() const
   return ret_val;
 }
 
-std::set<eCAL::eh5::SChannel> eCAL::eh5::HDF5Meas::GetChannels(const std::string& channel_name) const
-{
-  std::set<eCAL::eh5::SChannel> ret_val;
-  if (hdf_meas_impl_)
-  {
-    auto escaped_channels = hdf_meas_impl_->GetChannels();
-    for (const auto& escaped_channel : escaped_channels)
-    {
-      if (GetUnescapedString(escaped_channel.name) == channel_name)
-        ret_val.emplace(channel_name, escaped_channel.id);
-    }
-  }
-
-  return ret_val;
-}
-
-
-bool eCAL::eh5::HDF5Meas::HasChannel(const std::string& channel_name) const
-{
-  bool ret_val = false;
-  if (hdf_meas_impl_)
-  {
-    ret_val = hdf_meas_impl_->HasChannel(GetEscapedTopicname(channel_name));
-  }
-
-  return ret_val;
-}
-
-bool eCAL::eh5::HDF5Meas::HasChannel(const eCAL::eh5::SChannel& channel) const
+bool eCAL::eh5::v3::HDF5Meas::HasChannel(const eCAL::eh5::SChannel& channel) const
 {
   bool ret_val = false;
   if (hdf_meas_impl_)
@@ -283,61 +242,7 @@ bool eCAL::eh5::HDF5Meas::HasChannel(const eCAL::eh5::SChannel& channel) const
   return ret_val;
 }
 
-// deprecated
-// Return FIRST non-empty Datatype Information from a channel that contains channel_name
-std::string eCAL::eh5::HDF5Meas::GetChannelDescription(const std::string& channel_name) const
-{
-  auto channels = GetChannels(channel_name);
-  DataTypeInformation info;
-  for (const auto& channel : channels)
-  {
-    info = GetChannelDataTypeInformation(channel);
-    if (info != DataTypeInformation{})
-    {
-      break;
-    }
-  }
-  return info.descriptor;
-}
-
-// deprecated
-void eCAL::eh5::HDF5Meas::SetChannelDescription(const std::string& channel_name, const std::string& description)
-{
-  SChannel channel = eCAL::experimental::measurement::base::CreateChannel(channel_name);
-  auto current_info = GetChannelDataTypeInformation(channel);
-  current_info.descriptor = description;
-  SetChannelDataTypeInformation(channel, current_info);
-}
-
-// deprecated
-// Return FIRST non-empty Datatype Information
-std::string eCAL::eh5::HDF5Meas::GetChannelType(const std::string& channel_name) const
-{
-  auto channels = GetChannels(channel_name);
-  DataTypeInformation info;
-  for (const auto& channel : channels)
-  {
-    info = GetChannelDataTypeInformation(channel);
-    if (info != DataTypeInformation{})
-    {
-      break;
-    }
-  }
-  std::string ret_val;
-  std::tie(ret_val, std::ignore) = FromInfo(info);
-  return ret_val;
-}
-
-// deprecated
-void eCAL::eh5::HDF5Meas::SetChannelType(const std::string& channel_name, const std::string& type)
-{
-  SChannel channel = eCAL::experimental::measurement::base::CreateChannel(channel_name);
-  auto current_info = GetChannelDataTypeInformation(channel);
-  auto new_info = CreateInfo(type, current_info.descriptor);
-  SetChannelDataTypeInformation(channel, new_info);
-}
-
-eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5Meas::GetChannelDataTypeInformation(const SChannel& channel) const
+eCAL::eh5::DataTypeInformation eCAL::eh5::v3::HDF5Meas::GetChannelDataTypeInformation(const SChannel& channel) const
 {
   eCAL::eh5::DataTypeInformation ret_val;
   if (hdf_meas_impl_)
@@ -350,7 +255,7 @@ eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5Meas::GetChannelDataTypeInformatio
   return ret_val;
 }
 
-void eCAL::eh5::HDF5Meas::SetChannelDataTypeInformation(const SChannel& channel, const eCAL::eh5::DataTypeInformation& info)
+void eCAL::eh5::v3::HDF5Meas::SetChannelDataTypeInformation(const SChannel& channel, const eCAL::eh5::DataTypeInformation& info)
 {
   if (hdf_meas_impl_)
   {
@@ -360,20 +265,7 @@ void eCAL::eh5::HDF5Meas::SetChannelDataTypeInformation(const SChannel& channel,
   }
 }
 
-// deprecated
-long long eCAL::eh5::HDF5Meas::GetMinTimestamp(const std::string& channel_name) const
-{
-  long long ret_val = 0;
-  if (hdf_meas_impl_)
-  {
-    ret_val = hdf_meas_impl_->GetMinTimestamp(GetEscapedTopicname(channel_name));
-  }
-
-  return ret_val;
-}
-
-
-long long eCAL::eh5::HDF5Meas::GetMinTimestamp(const SChannel& channel) const
+long long eCAL::eh5::v3::HDF5Meas::GetMinTimestamp(const SChannel& channel) const
 {
   long long ret_val = 0;
   if (hdf_meas_impl_)
@@ -386,19 +278,7 @@ long long eCAL::eh5::HDF5Meas::GetMinTimestamp(const SChannel& channel) const
   return ret_val;
 }
 
-// deprecated
-long long eCAL::eh5::HDF5Meas::GetMaxTimestamp(const std::string& channel_name) const
-{
-  long long ret_val = 0;
-  if (hdf_meas_impl_)
-  {
-    ret_val = hdf_meas_impl_->GetMaxTimestamp(GetEscapedTopicname(channel_name));
-  }
-
-  return ret_val;
-}
-
-long long eCAL::eh5::HDF5Meas::GetMaxTimestamp(const SChannel& channel) const
+long long eCAL::eh5::v3::HDF5Meas::GetMaxTimestamp(const SChannel& channel) const
 {
   long long ret_val = 0;
   if (hdf_meas_impl_)
@@ -411,19 +291,7 @@ long long eCAL::eh5::HDF5Meas::GetMaxTimestamp(const SChannel& channel) const
   return ret_val;
 }
 
-// deprecated
-bool eCAL::eh5::HDF5Meas::GetEntriesInfo(const std::string& channel_name, EntryInfoSet& entries) const
-{
-  bool ret_val = false;
-  if (hdf_meas_impl_)
-  {
-    ret_val = hdf_meas_impl_->GetEntriesInfo(GetEscapedTopicname(channel_name), entries);
-  }
-
-  return ret_val;
-}
-
-bool eCAL::eh5::HDF5Meas::GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const
+bool eCAL::eh5::v3::HDF5Meas::GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const
 {
   bool ret_val = false;
   if (hdf_meas_impl_)
@@ -436,19 +304,7 @@ bool eCAL::eh5::HDF5Meas::GetEntriesInfo(const SChannel& channel, EntryInfoSet& 
   return ret_val;
 }
 
-// deprecated
-bool eCAL::eh5::HDF5Meas::GetEntriesInfoRange(const std::string& channel_name, long long begin, long long end, EntryInfoSet& entries) const
-{
-  bool ret_val = false;
-  if (hdf_meas_impl_ && begin < end)
-  {
-    ret_val = hdf_meas_impl_->GetEntriesInfoRange(GetEscapedTopicname(channel_name), begin, end, entries);
-  }
-
-  return ret_val;
-}
-
-bool eCAL::eh5::HDF5Meas::GetEntriesInfoRange(const SChannel& channel, long long begin, long long end, EntryInfoSet& entries) const
+bool eCAL::eh5::v3::HDF5Meas::GetEntriesInfoRange(const SChannel& channel, long long begin, long long end, EntryInfoSet& entries) const
 {
   bool ret_val = false;
   if (hdf_meas_impl_ && begin < end)
@@ -461,7 +317,7 @@ bool eCAL::eh5::HDF5Meas::GetEntriesInfoRange(const SChannel& channel, long long
   return ret_val;
 }
 
-bool eCAL::eh5::HDF5Meas::GetEntryDataSize(long long entry_id, size_t& size) const
+bool eCAL::eh5::v3::HDF5Meas::GetEntryDataSize(long long entry_id, size_t& size) const
 {
   bool ret_val = false;
   if (hdf_meas_impl_)
@@ -472,7 +328,7 @@ bool eCAL::eh5::HDF5Meas::GetEntryDataSize(long long entry_id, size_t& size) con
   return ret_val;
 }
 
-bool eCAL::eh5::HDF5Meas::GetEntryData(long long entry_id, void* data) const
+bool eCAL::eh5::v3::HDF5Meas::GetEntryData(long long entry_id, void* data) const
 {
   bool ret_val = false;
   if (hdf_meas_impl_)
@@ -483,7 +339,7 @@ bool eCAL::eh5::HDF5Meas::GetEntryData(long long entry_id, void* data) const
   return ret_val;
 }
 
-void eCAL::eh5::HDF5Meas::SetFileBaseName(const std::string& base_name)
+void eCAL::eh5::v3::HDF5Meas::SetFileBaseName(const std::string& base_name)
 {
   if (hdf_meas_impl_)
   {
@@ -491,29 +347,18 @@ void eCAL::eh5::HDF5Meas::SetFileBaseName(const std::string& base_name)
   }
 }
 
-bool eCAL::eh5::HDF5Meas::AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const std::string& channel_name, long long id, long long clock)
+bool eCAL::eh5::v3::HDF5Meas::AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const eCAL::eh5::SChannel& channel, long long id, long long clock)
 {
   bool ret_val = false;
   if (hdf_meas_impl_)
   {
-    return hdf_meas_impl_->AddEntryToFile(data, size, snd_timestamp, rcv_timestamp, GetEscapedTopicname(channel_name), id, clock);
+    return hdf_meas_impl_->AddEntryToFile(data, size, snd_timestamp, rcv_timestamp, eCAL::eh5::SChannel(GetEscapedTopicname(channel.name), channel.id), id, clock);
   }
 
   return ret_val;
 }
 
-bool eCAL::eh5::HDF5Meas::AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const eCAL::eh5::SChannel& channel, long long clock)
-{
-  bool ret_val = false;
-  if (hdf_meas_impl_)
-  {
-    return hdf_meas_impl_->AddEntryToFile(data, size, snd_timestamp, rcv_timestamp, eCAL::eh5::SChannel(GetEscapedTopicname(channel.name), channel.id), clock);
-  }
-
-  return ret_val;
-}
-
-void eCAL::eh5::HDF5Meas::ConnectPreSplitCallback(CallbackFunction cb)
+void eCAL::eh5::v3::HDF5Meas::ConnectPreSplitCallback(CallbackFunction cb)
 {
   if (hdf_meas_impl_)
   {
@@ -521,7 +366,7 @@ void eCAL::eh5::HDF5Meas::ConnectPreSplitCallback(CallbackFunction cb)
   }
 }
 
-void eCAL::eh5::HDF5Meas::DisconnectPreSplitCallback()
+void eCAL::eh5::v3::HDF5Meas::DisconnectPreSplitCallback()
 {
   if (hdf_meas_impl_)
   {

--- a/contrib/ecalhdf5/src/eh5_meas_api_v3.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_api_v3.cpp
@@ -335,12 +335,12 @@ void eCAL::eh5::v3::HDF5Meas::SetFileBaseName(const std::string& base_name)
   }
 }
 
-bool eCAL::eh5::v3::HDF5Meas::AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const eCAL::eh5::SChannel& channel, long long id, long long clock)
+bool eCAL::eh5::v3::HDF5Meas::AddEntryToFile(const SWriteEntry& entry)
 {
   bool ret_val = false;
   if (hdf_meas_impl_)
   {
-    return hdf_meas_impl_->AddEntryToFile(data, size, snd_timestamp, rcv_timestamp, GetEscapedTopicname(channel), id, clock);
+    return hdf_meas_impl_->AddEntryToFile(GetEscapedEntry(entry));
   }
 
   return ret_val;

--- a/contrib/ecalhdf5/src/eh5_meas_api_v3.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_api_v3.cpp
@@ -21,7 +21,7 @@
  * @brief  eCALHDF5 measurement class <TODO>
 **/
 
-#include <ecalhdf5/eh5_meas_api_v2.h>
+#include <ecalhdf5/eh5_meas_api_v3.h>
 
 #include <ecal_utils/filesystem.h>
 

--- a/contrib/ecalhdf5/src/eh5_meas_api_v3.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_api_v3.cpp
@@ -236,7 +236,7 @@ bool eCAL::eh5::v3::HDF5Meas::HasChannel(const eCAL::eh5::SChannel& channel) con
   bool ret_val = false;
   if (hdf_meas_impl_)
   {
-    ret_val = hdf_meas_impl_->HasChannel(eCAL::eh5::SChannel{ GetEscapedTopicname(channel.name), channel.id });
+    ret_val = hdf_meas_impl_->HasChannel(GetEscapedTopicname(channel));
   }
 
   return ret_val;
@@ -247,9 +247,7 @@ eCAL::eh5::DataTypeInformation eCAL::eh5::v3::HDF5Meas::GetChannelDataTypeInform
   eCAL::eh5::DataTypeInformation ret_val;
   if (hdf_meas_impl_)
   {
-    SChannel escaped_channel = channel;
-    escaped_channel.name = GetEscapedTopicname(channel.name);
-    ret_val = hdf_meas_impl_->GetChannelDataTypeInformation(escaped_channel);
+    ret_val = hdf_meas_impl_->GetChannelDataTypeInformation(GetEscapedTopicname(channel));
   }
 
   return ret_val;
@@ -259,9 +257,7 @@ void eCAL::eh5::v3::HDF5Meas::SetChannelDataTypeInformation(const SChannel& chan
 {
   if (hdf_meas_impl_)
   {
-    SChannel escaped_channel = channel;
-    escaped_channel.name = GetEscapedTopicname(channel.name);
-    hdf_meas_impl_->SetChannelDataTypeInformation(escaped_channel, info);
+    hdf_meas_impl_->SetChannelDataTypeInformation(GetEscapedTopicname(channel), info);
   }
 }
 
@@ -270,9 +266,7 @@ long long eCAL::eh5::v3::HDF5Meas::GetMinTimestamp(const SChannel& channel) cons
   long long ret_val = 0;
   if (hdf_meas_impl_)
   {
-    SChannel escaped_channel = channel;
-    escaped_channel.name = GetEscapedTopicname(channel.name);
-    ret_val = hdf_meas_impl_->GetMinTimestamp(escaped_channel);
+    ret_val = hdf_meas_impl_->GetMinTimestamp(GetEscapedTopicname(channel));
   }
 
   return ret_val;
@@ -283,9 +277,7 @@ long long eCAL::eh5::v3::HDF5Meas::GetMaxTimestamp(const SChannel& channel) cons
   long long ret_val = 0;
   if (hdf_meas_impl_)
   {
-    SChannel escaped_channel = channel;
-    escaped_channel.name = GetEscapedTopicname(channel.name);
-    ret_val = hdf_meas_impl_->GetMaxTimestamp(escaped_channel);
+    ret_val = hdf_meas_impl_->GetMaxTimestamp(GetEscapedTopicname(channel));
   }
 
   return ret_val;
@@ -296,9 +288,7 @@ bool eCAL::eh5::v3::HDF5Meas::GetEntriesInfo(const SChannel& channel, EntryInfoS
   bool ret_val = false;
   if (hdf_meas_impl_)
   {
-    SChannel escaped_channel = channel;
-    escaped_channel.name = GetEscapedTopicname(channel.name);
-    ret_val = hdf_meas_impl_->GetEntriesInfo(escaped_channel, entries);
+    ret_val = hdf_meas_impl_->GetEntriesInfo(GetEscapedTopicname(channel), entries);
   }
 
   return ret_val;
@@ -309,9 +299,7 @@ bool eCAL::eh5::v3::HDF5Meas::GetEntriesInfoRange(const SChannel& channel, long 
   bool ret_val = false;
   if (hdf_meas_impl_ && begin < end)
   {
-    SChannel escaped_channel = channel;
-    escaped_channel.name = GetEscapedTopicname(channel.name);
-    ret_val = hdf_meas_impl_->GetEntriesInfoRange(escaped_channel, begin, end, entries);
+    ret_val = hdf_meas_impl_->GetEntriesInfoRange(GetEscapedTopicname(channel), begin, end, entries);
   }
 
   return ret_val;
@@ -352,7 +340,7 @@ bool eCAL::eh5::v3::HDF5Meas::AddEntryToFile(const void* data, const unsigned lo
   bool ret_val = false;
   if (hdf_meas_impl_)
   {
-    return hdf_meas_impl_->AddEntryToFile(data, size, snd_timestamp, rcv_timestamp, eCAL::eh5::SChannel(GetEscapedTopicname(channel.name), channel.id), id, clock);
+    return hdf_meas_impl_->AddEntryToFile(data, size, snd_timestamp, rcv_timestamp, GetEscapedTopicname(channel), id, clock);
   }
 
   return ret_val;

--- a/contrib/ecalhdf5/src/eh5_meas_dir.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_dir.cpp
@@ -31,9 +31,10 @@
 #include <dirent.h>
 #endif //WIN32
 
-#include <string>
-#include <list>
 #include <iostream>
+#include <limits>
+#include <list>
+#include <string>
 
 #include <ecal_utils/filesystem.h>
 #include <ecal_utils/str_convert.h>

--- a/contrib/ecalhdf5/src/eh5_meas_dir.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_dir.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -364,6 +364,22 @@ bool eCAL::eh5::HDF5MeasDir::AddEntryToFile(const void* data, const unsigned lon
   
   // Use the writer that was either found or created to actually write the data
   return file_writer_it->second->AddEntryToFile(data, size, snd_timestamp, rcv_timestamp, channel_name, id, clock);
+}
+
+bool eCAL::eh5::HDF5MeasDir::AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long clock)
+{
+  if ((access_ == RDONLY)
+    || (output_dir_.empty())
+    || (base_name_.empty()))
+  {
+    return false;
+  }
+
+  // Get an existing writer or create a new one
+  auto file_writer_it = GetWriter(channel.name);
+
+  // Use the writer that was either found or created to actually write the data
+  return file_writer_it->second->AddEntryToFile(data, size, snd_timestamp, rcv_timestamp, channel, clock);
 }
 
 void eCAL::eh5::HDF5MeasDir::ConnectPreSplitCallback(CallbackFunction cb)

--- a/contrib/ecalhdf5/src/eh5_meas_dir.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_dir.cpp
@@ -319,7 +319,7 @@ void eCAL::eh5::HDF5MeasDir::SetFileBaseName(const std::string& base_name)
   base_name_ = base_name;
 }
 
-bool eCAL::eh5::HDF5MeasDir::AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long id, long long clock)
+bool eCAL::eh5::HDF5MeasDir::AddEntryToFile(const SWriteEntry& entry)
 {
   if ((access_ == v3::eAccessType::RDONLY)
     || (output_dir_.empty())
@@ -329,10 +329,10 @@ bool eCAL::eh5::HDF5MeasDir::AddEntryToFile(const void* data, const unsigned lon
   }
 
   // Get an existing writer or create a new one
-  auto file_writer_it = GetWriter(channel);
+  auto file_writer_it = GetWriter(entry.channel);
 
   // Use the writer that was either found or created to actually write the data
-  return file_writer_it->second->AddEntryToFile(data, size, snd_timestamp, rcv_timestamp, channel, id, clock);
+  return file_writer_it->second->AddEntryToFile(entry);
 }
 
 void eCAL::eh5::HDF5MeasDir::ConnectPreSplitCallback(CallbackFunction cb)

--- a/contrib/ecalhdf5/src/eh5_meas_dir.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_dir.cpp
@@ -458,33 +458,22 @@ bool eCAL::eh5::HDF5MeasDir::OpenRX(const std::string& path, v3::eAccessType acc
       auto channels = reader->GetChannels();
       for (const auto& channel : channels)
       {
-        auto escaped_name = GetEscapedTopicname(channel.name);
+        auto escaped_channel = GetEscapedTopicname(channel);
         // TODO 
-        auto info = reader->GetChannelDataTypeInformation(channel);
+        auto info = reader->GetChannelDataTypeInformation(escaped_channel);
 
-        auto& channel_info = channels_info_[escaped_name][channel.id];
+        auto& channel_info = channels_info_[escaped_channel.name][escaped_channel.id];
         channel_info.info = info;
         channel_info.files.push_back(reader);
 
         EntryInfoSet entries;
-        if (reader->GetEntriesInfo(channel, entries))
+        if (reader->GetEntriesInfo(escaped_channel, entries))
         {
           for (auto entry : entries)
           {
-            long long index;
-            // Account for the fact that previous to V6, has channel will return false for the given id.
-            if (reader->HasChannel(SChannel{ escaped_name, entry.SndID }))
-            {
-              index = entry.SndID;
-            }
-            else
-            {
-              index = 0;
-            }
-
             entries_by_id_[id] = EntryInfo(entry.ID, reader);
             entry.ID = id;
-            entries_by_chn_[escaped_name][index].insert(entry);
+            entries_by_chn_[escaped_channel.name][escaped_channel.id].insert(entry);
             id++;
           }
         }

--- a/contrib/ecalhdf5/src/eh5_meas_dir.h
+++ b/contrib/ecalhdf5/src/eh5_meas_dir.h
@@ -134,6 +134,13 @@ namespace eCAL
       std::set<std::string> GetChannelNames() const override;
 
       /**
+       * @brief Get the available channel names of the current opened file / measurement
+       *
+       * @return       channel names & ids
+       **/
+      std::set<eCAL::eh5::SChannel> GetChannels() const override;
+
+      /**
       * @brief Check if channel exists in measurement
       *
       * @param channel_name   name of the channel
@@ -149,7 +156,7 @@ namespace eCAL
        *
        * @return              channel type
       **/
-      DataTypeInformation GetChannelDataTypeInformation(const std::string& channel_name) const override;
+      DataTypeInformation GetChannelDataTypeInformation(const SChannel& channel) const override;
 
       /**
        * @brief Set data type information of the given channel
@@ -159,7 +166,7 @@ namespace eCAL
        *
        * @return              channel type
       **/
-      void SetChannelDataTypeInformation(const std::string& channel_name, const DataTypeInformation& info) override;
+      void SetChannelDataTypeInformation(const SChannel& channel, const DataTypeInformation& info) override;
 
       /**
       * @brief Gets minimum timestamp for specified channel
@@ -168,7 +175,7 @@ namespace eCAL
       *
       * @return                minimum timestamp value
       **/
-      long long GetMinTimestamp(const std::string& channel_name) const override;
+      long long GetMinTimestamp(const SChannel& channel) const override;
 
       /**
       * @brief Gets maximum timestamp for specified channel
@@ -177,7 +184,7 @@ namespace eCAL
       *
       * @return                maximum timestamp value
       **/
-      long long GetMaxTimestamp(const std::string& channel_name) const override;
+      long long GetMaxTimestamp(const SChannel& channel) const override;
 
       /**
       * @brief Gets the header info for all data entries for the given channel
@@ -188,7 +195,7 @@ namespace eCAL
       *
       * @return                    true if succeeds, false if it fails
       **/
-      bool GetEntriesInfo(const std::string& channel_name, EntryInfoSet& entries) const override;
+      bool GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const override;
 
       /**
       * @brief Gets the header info for data entries for the given channel included in given time range (begin->end)
@@ -201,7 +208,7 @@ namespace eCAL
       *
       * @return                   true if succeeds, false if it fails
       **/
-      bool GetEntriesInfoRange(const std::string& channel_name, long long begin, long long end, EntryInfoSet& entries) const override;
+      bool GetEntriesInfoRange(const SChannel& channel, long long begin, long long end, EntryInfoSet& entries) const override;
 
       /**
       * @brief Gets data size of a specific entry
@@ -287,10 +294,10 @@ namespace eCAL
         {}
       };
 
-      typedef std::list<eCAL::eh5::HDF5Meas*>               HDF5Files;
-      typedef std::unordered_map<std::string, ChannelInfo>  ChannelInfoUMap;
-      typedef std::unordered_map<long long, EntryInfo>      EntriesByIdUMap;
-      typedef std::unordered_map<std::string, EntryInfoSet> EntriesByChannelUMap;
+      typedef std::list<eCAL::eh5::HDF5Meas*>                                                   HDF5Files;
+      typedef std::unordered_map<std::string, std::unordered_map<SChannel::id_t, ChannelInfo>>  ChannelInfoUMap;
+      typedef std::unordered_map<long long, EntryInfo>                                          EntriesByIdUMap;
+      typedef std::unordered_map<std::string, std::unordered_map<SChannel::id_t, EntryInfoSet>> EntriesByChannelUMap;
 
       HDF5Files              file_readers_;
       ChannelInfoUMap        channels_info_;

--- a/contrib/ecalhdf5/src/eh5_meas_dir.h
+++ b/contrib/ecalhdf5/src/eh5_meas_dir.h
@@ -150,6 +150,15 @@ namespace eCAL
       bool HasChannel(const std::string& channel_name) const override;
 
       /**
+       * @brief Check if channel exists in measurement
+       *
+       * @param channel   channel name & id
+       *
+       * @return       true if exists, false otherwise
+      **/
+      bool HasChannel(const eCAL::eh5::SChannel& channel) const override;
+
+      /**
        * @brief Get data type information of the given channel
        *
        * @param channel_name  channel name

--- a/contrib/ecalhdf5/src/eh5_meas_dir.h
+++ b/contrib/ecalhdf5/src/eh5_meas_dir.h
@@ -52,7 +52,7 @@ namespace eCAL
       *
       * @param path    input file path
       **/
-      explicit HDF5MeasDir(const std::string& path, eAccessType access = eAccessType::RDONLY);
+      explicit HDF5MeasDir(const std::string& path, v3::eAccessType access = v3::eAccessType::RDONLY);
 
       /**
       * @brief Destructor
@@ -67,7 +67,7 @@ namespace eCAL
       *
       * @return         true if succeeds, false if it fails
       **/
-      bool Open(const std::string& path, eAccessType access = eAccessType::RDONLY) override;
+      bool Open(const std::string& path, v3::eAccessType access = v3::eAccessType::RDONLY) override;
 
       /**
       * @brief Close file
@@ -127,27 +127,11 @@ namespace eCAL
       void SetOneFilePerChannelEnabled(bool enabled) override;
 
       /**
-      * @brief Get the available channel names of the current opened file / measurement
-      *
-      * @return       channel names
-      **/
-      std::set<std::string> GetChannelNames() const override;
-
-      /**
        * @brief Get the available channel names of the current opened file / measurement
        *
        * @return       channel names & ids
        **/
       std::set<eCAL::eh5::SChannel> GetChannels() const override;
-
-      /**
-      * @brief Check if channel exists in measurement
-      *
-      * @param channel_name   name of the channel
-      *
-      * @return       true if exists, false otherwise
-      **/
-      bool HasChannel(const std::string& channel_name) const override;
 
       /**
        * @brief Check if channel exists in measurement
@@ -253,15 +237,13 @@ namespace eCAL
       * @param size           size of the data
       * @param snd_timestamp  send timestamp
       * @param rcv_timestamp  receive timestamp
-      * @param channel_name   channel name
+      * @param channel        channel
       * @param id             message id
       * @param clock          message clock
       *
       * @return               true if succeeds, false if it fails
       **/
-      bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const std::string& channel_name, long long id, long long clock) override;
-
-      bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long clock) override;
+      bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long id, long long clock) override;
 
       typedef std::function<void(void)> CallbackFunction;
       /**
@@ -284,7 +266,7 @@ namespace eCAL
       struct ChannelInfo
       {
         DataTypeInformation info;
-        std::list<const eCAL::eh5::HDF5Meas*> files;
+        std::list<const eCAL::eh5::v3::HDF5Meas*> files;
 
         ChannelInfo() = default;
         ChannelInfo(const DataTypeInformation& info_)
@@ -294,18 +276,18 @@ namespace eCAL
 
       struct EntryInfo
       {
-        long long                   file_id;
-        const eCAL::eh5::HDF5Meas* reader;
+        long long                      file_id;
+        const eCAL::eh5::v3::HDF5Meas* reader;
 
         EntryInfo() : file_id(0), reader(nullptr) {}
 
-        EntryInfo(long long file_id_, const eCAL::eh5::HDF5Meas* reader_)
+        EntryInfo(long long file_id_, const eCAL::eh5::v3::HDF5Meas* reader_)
           : file_id(file_id_)
           , reader(reader_)
         {}
       };
 
-      typedef std::list<eCAL::eh5::HDF5Meas*>                                                   HDF5Files;
+      typedef std::list<eCAL::eh5::v3::HDF5Meas*>                                               HDF5Files;
       typedef std::unordered_map<std::string, std::unordered_map<SChannel::id_t, ChannelInfo>>  ChannelInfoUMap;
       typedef std::unordered_map<long long, EntryInfo>                                          EntriesByIdUMap;
       typedef std::unordered_map<std::string, std::unordered_map<SChannel::id_t, EntryInfoSet>> EntriesByChannelUMap;
@@ -325,7 +307,7 @@ namespace eCAL
       typedef std::map<std::string, Channel> Channels;
 
       Channels                 channels_;
-      eAccessType              access_;
+      v3::eAccessType          access_;
 
       std::list<std::string> GetHdfFiles(const std::string& path) const;
 
@@ -336,7 +318,7 @@ namespace eCAL
         return std::equal(end.rbegin(), end.rend(), str.rbegin());
       }
 
-      bool OpenRX(const std::string& path, eAccessType access /*= eAccessType::RDONLY*/);
+      bool OpenRX(const std::string& path, v3::eAccessType access /*= eAccessType::RDONLY*/);
 
 
       // =====================================================================
@@ -368,7 +350,7 @@ namespace eCAL
        * 
        * @return an iterator to the writer
        */
-      FileWriterMap::iterator GetWriter(const std::string& channel_name);
+      FileWriterMap::iterator GetWriter(const SChannel& channel);
     };
   }  //  namespace eh5
 }  //  namespace eCAL

--- a/contrib/ecalhdf5/src/eh5_meas_dir.h
+++ b/contrib/ecalhdf5/src/eh5_meas_dir.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -260,6 +260,8 @@ namespace eCAL
       * @return               true if succeeds, false if it fails
       **/
       bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const std::string& channel_name, long long id, long long clock) override;
+
+      bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long clock) override;
 
       typedef std::function<void(void)> CallbackFunction;
       /**

--- a/contrib/ecalhdf5/src/eh5_meas_dir.h
+++ b/contrib/ecalhdf5/src/eh5_meas_dir.h
@@ -243,7 +243,7 @@ namespace eCAL
       *
       * @return               true if succeeds, false if it fails
       **/
-      bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long id, long long clock) override;
+      bool AddEntryToFile(const SWriteEntry& entry) override;
 
       typedef std::function<void(void)> CallbackFunction;
       /**

--- a/contrib/ecalhdf5/src/eh5_meas_dir.h
+++ b/contrib/ecalhdf5/src/eh5_meas_dir.h
@@ -287,10 +287,10 @@ namespace eCAL
         {}
       };
 
-      typedef std::list<eCAL::eh5::v3::HDF5Meas*>                                               HDF5Files;
-      typedef std::unordered_map<std::string, std::unordered_map<SChannel::id_t, ChannelInfo>>  ChannelInfoUMap;
-      typedef std::unordered_map<long long, EntryInfo>                                          EntriesByIdUMap;
-      typedef std::unordered_map<std::string, std::unordered_map<SChannel::id_t, EntryInfoSet>> EntriesByChannelUMap;
+      typedef std::list<eCAL::eh5::v3::HDF5Meas*>        HDF5Files;
+      typedef std::unordered_map<SChannel, ChannelInfo>  ChannelInfoUMap;
+      typedef std::unordered_map<long long, EntryInfo>   EntriesByIdUMap;
+      typedef std::unordered_map<SChannel, EntryInfoSet> EntriesByChannelUMap;
 
       HDF5Files              file_readers_;
       ChannelInfoUMap        channels_info_;

--- a/contrib/ecalhdf5/src/eh5_meas_file_v1.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v1.cpp
@@ -82,7 +82,7 @@ bool eCAL::eh5::HDF5MeasFileV1::Open(const std::string& path, eAccessType access
     if (channels.size() == 1)
     {
       channel_name_ = *channels.begin();
-      HDF5MeasFileV1::GetEntriesInfo(channel_name_, entries_);
+      HDF5MeasFileV1::GetEntriesInfo(eCAL::experimental::measurement::base::CreateChannel(channel_name_), entries_);
     }
   }
 
@@ -156,6 +156,18 @@ std::set<std::string> eCAL::eh5::HDF5MeasFileV1::GetChannelNames() const
   return channels;
 }
 
+std::set<eCAL::eh5::SChannel> eCAL::eh5::HDF5MeasFileV1::GetChannels() const
+{
+  auto channel_names = GetChannelNames();
+  std::set<eCAL::eh5::SChannel> channels;
+
+  // Transform the vector of strings into a vector of MyStruct
+  std::transform(channel_names.begin(), channel_names.end(), std::inserter(channels, channels.begin()),
+    [](const std::string& str) { return eCAL::experimental::measurement::base::CreateChannel(str); });
+
+  return channels;
+}
+
 
 bool eCAL::eh5::HDF5MeasFileV1::HasChannel(const std::string& channel_name) const
 {
@@ -164,27 +176,27 @@ bool eCAL::eh5::HDF5MeasFileV1::HasChannel(const std::string& channel_name) cons
   return std::find(channels.cbegin(), channels.cend(), channel_name) != channels.end();
 }
 
-eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5MeasFileV1::GetChannelDataTypeInformation(const std::string& channel_name) const
+eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5MeasFileV1::GetChannelDataTypeInformation(const SChannel& channel) const
 {
   std::string type;
 
-  if (EcalUtils::String::Icompare(channel_name, channel_name_))
+  if (EcalUtils::String::Icompare(channel.name, channel_name_))
     GetAttributeValue(file_id_, kChnTypeAttrTitle, type);
 
   std::string description;
 
-  if (EcalUtils::String::Icompare(channel_name, channel_name_))
+  if (EcalUtils::String::Icompare(channel.name, channel_name_))
     GetAttributeValue(file_id_, kChnDescAttrTitle, description);
 
   return CreateInfo(type, description);
 }
 
-void eCAL::eh5::HDF5MeasFileV1::SetChannelDataTypeInformation(const std::string& /*channel_name*/, const eCAL::eh5::DataTypeInformation& /*info*/)
+void eCAL::eh5::HDF5MeasFileV1::SetChannelDataTypeInformation(const SChannel& /*channel*/, const eCAL::eh5::DataTypeInformation& /*info*/)
 {
   ReportUnsupportedAction();
 }
 
-long long eCAL::eh5::HDF5MeasFileV1::GetMinTimestamp(const std::string& /*channel_name*/) const
+long long eCAL::eh5::HDF5MeasFileV1::GetMinTimestamp(const SChannel& /*channel_name*/) const
 {
   long long ret_val = 0;
 
@@ -196,7 +208,7 @@ long long eCAL::eh5::HDF5MeasFileV1::GetMinTimestamp(const std::string& /*channe
   return ret_val;
 }
 
-long long eCAL::eh5::HDF5MeasFileV1::GetMaxTimestamp(const std::string& /*channel_name*/) const
+long long eCAL::eh5::HDF5MeasFileV1::GetMaxTimestamp(const SChannel& /*channel_name*/) const
 {
   long long ret_val = 0;
 
@@ -208,11 +220,11 @@ long long eCAL::eh5::HDF5MeasFileV1::GetMaxTimestamp(const std::string& /*channe
   return ret_val;
 }
 
-bool eCAL::eh5::HDF5MeasFileV1::GetEntriesInfo(const std::string& channel_name, EntryInfoSet& entries) const
+bool eCAL::eh5::HDF5MeasFileV1::GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const
 {
   entries.clear();
 
-  if (!EcalUtils::String::Icompare(channel_name, channel_name_)) return false;
+  if (!EcalUtils::String::Icompare(channel.name, channel_name_)) return false;
 
   if (!HDF5MeasFileV1::IsOk()) return false;
 
@@ -244,7 +256,7 @@ bool eCAL::eh5::HDF5MeasFileV1::GetEntriesInfo(const std::string& channel_name, 
   return (status >= 0);
 }
 
-bool eCAL::eh5::HDF5MeasFileV1::GetEntriesInfoRange(const std::string& /*channel_name*/, long long begin, long long end, EntryInfoSet& entries) const
+bool eCAL::eh5::HDF5MeasFileV1::GetEntriesInfoRange(const SChannel& /*channel_name*/, long long begin, long long end, EntryInfoSet& entries) const
 {
   bool ret_val = false;
 
@@ -377,5 +389,5 @@ bool eCAL::eh5::HDF5MeasFileV1::GetAttributeValue(hid_t obj_id, const std::strin
 
 void eCAL::eh5::HDF5MeasFileV1::ReportUnsupportedAction() 
 {
-  std::cout << "eCALHDF5 file version bellow 2.0 support only readonly access type. Desired action not supported.\n";
+  std::cout << "eCALHDF5 file version below 2.0 support only readonly access type. Desired action not supported.\n";
 }

--- a/contrib/ecalhdf5/src/eh5_meas_file_v1.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v1.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -323,6 +323,12 @@ void eCAL::eh5::HDF5MeasFileV1::SetFileBaseName(const std::string& /*base_name*/
 }
 
 bool eCAL::eh5::HDF5MeasFileV1::AddEntryToFile(const void* /*data*/, const unsigned long long& /*size*/, const long long& /*snd_timestamp*/, const long long& /*rcv_timestamp*/, const std::string& /*channel_name*/, long long /*id*/, long long /*clock*/)
+{
+  ReportUnsupportedAction();
+  return false;
+}
+
+bool eCAL::eh5::HDF5MeasFileV1::AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long clock)
 {
   ReportUnsupportedAction();
   return false;

--- a/contrib/ecalhdf5/src/eh5_meas_file_v1.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v1.cpp
@@ -176,6 +176,11 @@ bool eCAL::eh5::HDF5MeasFileV1::HasChannel(const std::string& channel_name) cons
   return std::find(channels.cbegin(), channels.cend(), channel_name) != channels.end();
 }
 
+bool eCAL::eh5::HDF5MeasFileV1::HasChannel(const eCAL::eh5::SChannel& channel) const
+{
+    return HasChannel(channel.name);
+}
+
 eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5MeasFileV1::GetChannelDataTypeInformation(const SChannel& channel) const
 {
   std::string type;

--- a/contrib/ecalhdf5/src/eh5_meas_file_v1.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v1.cpp
@@ -328,7 +328,7 @@ bool eCAL::eh5::HDF5MeasFileV1::AddEntryToFile(const void* /*data*/, const unsig
   return false;
 }
 
-bool eCAL::eh5::HDF5MeasFileV1::AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long clock)
+bool eCAL::eh5::HDF5MeasFileV1::AddEntryToFile(const void* /*data*/, const unsigned long long& /*size*/, const long long& /*snd_timestamp*/, const long long& /*rcv_timestamp*/, const SChannel& /*channel*/, long long /*clock*/)
 {
   ReportUnsupportedAction();
   return false;

--- a/contrib/ecalhdf5/src/eh5_meas_file_v1.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v1.cpp
@@ -305,7 +305,7 @@ void eCAL::eh5::HDF5MeasFileV1::SetFileBaseName(const std::string& /*base_name*/
   ReportUnsupportedAction();
 }
 
-bool eCAL::eh5::HDF5MeasFileV1::AddEntryToFile(const void* /*data*/, const unsigned long long& /*size*/, const long long& /*snd_timestamp*/, const long long& /*rcv_timestamp*/, const SChannel& /*channel*/, long long id, long long /*clock*/)
+bool eCAL::eh5::HDF5MeasFileV1::AddEntryToFile(const SWriteEntry& /*entry*/)
 {
   ReportUnsupportedAction();
   return false;

--- a/contrib/ecalhdf5/src/eh5_meas_file_v1.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v1.h
@@ -43,7 +43,7 @@ namespace eCAL
       *
       * @param path    input file path
       **/
-      explicit HDF5MeasFileV1(const std::string& path, eAccessType access = eAccessType::RDONLY);
+      explicit HDF5MeasFileV1(const std::string& path, v3::eAccessType access = v3::eAccessType::RDONLY);
 
       /**
       * @brief Destructor
@@ -58,7 +58,7 @@ namespace eCAL
       *
       * @return         true if succeeds, false if it fails
       **/
-      bool Open(const std::string& path, eAccessType access = eAccessType::RDONLY) override;
+      bool Open(const std::string& path, v3::eAccessType access = v3::eAccessType::RDONLY) override;
 
       /**
       * @brief Close file
@@ -117,29 +117,12 @@ namespace eCAL
       */
       void SetOneFilePerChannelEnabled(bool enabled) override;
 
-
-      /**
-      * @brief Get the available channel names of the current opened file / measurement
-      *
-      * @return       channel names
-      **/
-      std::set<std::string> GetChannelNames() const override;
-
       /**
        * @brief Get the available channel names of the current opened file / measurement
        *
        * @return       channel names & ids
       **/
       std::set<eCAL::eh5::SChannel> GetChannels() const override;
-
-      /**
-      * @brief Check if channel exists in measurement
-      *
-      * @param channel_name   name of the channel
-      *
-      * @return       true if exists, false otherwise
-      **/
-      bool HasChannel(const std::string& channel_name) const override;
 
       /**
        * @brief Check if channel exists in measurement
@@ -251,9 +234,7 @@ namespace eCAL
       *
       * @return               true if succeeds, false if it fails
       **/
-      bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const std::string& channel_name, long long id, long long clock) override;
-
-      bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long clock) override;
+      bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long id, long long clock) override;
 
       typedef std::function<void(void)> CallbackFunction;
       /**

--- a/contrib/ecalhdf5/src/eh5_meas_file_v1.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v1.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -252,6 +252,8 @@ namespace eCAL
       * @return               true if succeeds, false if it fails
       **/
       bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const std::string& channel_name, long long id, long long clock) override;
+
+      bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long clock) override;
 
       typedef std::function<void(void)> CallbackFunction;
       /**

--- a/contrib/ecalhdf5/src/eh5_meas_file_v1.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v1.h
@@ -142,6 +142,15 @@ namespace eCAL
       bool HasChannel(const std::string& channel_name) const override;
 
       /**
+       * @brief Check if channel exists in measurement
+       *
+       * @param channel   channel name & id
+       *
+       * @return       true if exists, false otherwise
+      **/
+      bool HasChannel(const eCAL::eh5::SChannel& channel) const override;
+
+      /**
        * @brief Get data type information of the given channel
        *
        * @param channel_name  channel name

--- a/contrib/ecalhdf5/src/eh5_meas_file_v1.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v1.h
@@ -234,7 +234,7 @@ namespace eCAL
       *
       * @return               true if succeeds, false if it fails
       **/
-      bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long id, long long clock) override;
+      bool AddEntryToFile(const SWriteEntry& entry) override;
 
       typedef std::function<void(void)> CallbackFunction;
       /**

--- a/contrib/ecalhdf5/src/eh5_meas_file_v2.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v2.cpp
@@ -317,7 +317,7 @@ bool eCAL::eh5::HDF5MeasFileV2::AddEntryToFile(const void* /*data*/, const unsig
   return false;
 }
 
-bool eCAL::eh5::HDF5MeasFileV2::AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long clock)
+bool eCAL::eh5::HDF5MeasFileV2::AddEntryToFile(const void* /*data*/, const unsigned long long& /*size*/, const long long& /*snd_timestamp*/, const long long& /*rcv_timestamp*/, const SChannel& /*channel*/, long long /*clock*/)
 {
     return false;
 }

--- a/contrib/ecalhdf5/src/eh5_meas_file_v2.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v2.cpp
@@ -158,6 +158,11 @@ bool eCAL::eh5::HDF5MeasFileV2::HasChannel(const std::string& channel_name) cons
   return std::find(channels.cbegin(), channels.cend(), channel_name) != channels.end();
 }
 
+bool eCAL::eh5::HDF5MeasFileV2::HasChannel(const eCAL::eh5::SChannel& channel) const
+{
+  return HasChannel(channel.name);
+}
+
 eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5MeasFileV2::GetChannelDataTypeInformation(const SChannel& channel) const
 {
   std::string type;

--- a/contrib/ecalhdf5/src/eh5_meas_file_v2.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v2.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -315,6 +315,11 @@ void eCAL::eh5::HDF5MeasFileV2::SetFileBaseName(const std::string& /*base_name*/
 bool eCAL::eh5::HDF5MeasFileV2::AddEntryToFile(const void* /*data*/, const unsigned long long& /*size*/, const long long& /*snd_timestamp*/, const long long& /*rcv_timestamp*/, const std::string& /*channel_name*/, long long /*id*/, long long /*clock*/)
 {
   return false;
+}
+
+bool eCAL::eh5::HDF5MeasFileV2::AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long clock)
+{
+    return false;
 }
 
 void eCAL::eh5::HDF5MeasFileV2::ConnectPreSplitCallback(CallbackFunction /*cb*/)

--- a/contrib/ecalhdf5/src/eh5_meas_file_v2.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v2.cpp
@@ -294,7 +294,7 @@ void eCAL::eh5::HDF5MeasFileV2::SetFileBaseName(const std::string& /*base_name*/
 
 }
 
-bool eCAL::eh5::HDF5MeasFileV2::AddEntryToFile(const void* /*data*/, const unsigned long long& /*size*/, const long long& /*snd_timestamp*/, const long long& /*rcv_timestamp*/, const SChannel& /*channel*/, long long /*id*/, long long /*clock*/)
+bool eCAL::eh5::HDF5MeasFileV2::AddEntryToFile(const SWriteEntry& /*entry*/)
 {
     return false;
 }

--- a/contrib/ecalhdf5/src/eh5_meas_file_v2.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v2.cpp
@@ -23,6 +23,7 @@
 
 #include "eh5_meas_file_v2.h"
 #include "hdf5_helper.h"
+#include "datatype_helper.h"
 
 #include "hdf5.h"
 #include <ecal_utils/string.h>
@@ -30,43 +31,6 @@
 #include <iostream>
 #include <list>
 #include <set>
-
-namespace {
-  eCAL::eh5::DataTypeInformation CreateInfo(const std::string& combined_topic_type_, const std::string& descriptor_)
-  {
-    eCAL::eh5::DataTypeInformation info;
-    auto pos = combined_topic_type_.find(':');
-    if (pos == std::string::npos)
-    {
-      info.name = combined_topic_type_;
-      info.encoding = "";
-    }
-    else
-    {
-      info.name = combined_topic_type_.substr(pos + 1);
-      info.encoding = combined_topic_type_.substr(0, pos);
-    }
-    info.descriptor = descriptor_;
-    return info;
-  }
-
-  std::pair<std::string, std::string> FromInfo(const eCAL::eh5::DataTypeInformation& datatype_info_)
-  {
-    std::string combined_topic_type;
-    if (datatype_info_.encoding.empty())
-    {
-      combined_topic_type = datatype_info_.name;
-    }
-    else
-    {
-      combined_topic_type = datatype_info_.encoding + ":" + datatype_info_.name;
-    }
-
-    return std::make_pair(combined_topic_type, datatype_info_.descriptor);
-  }
-
-}
-
 
 eCAL::eh5::HDF5MeasFileV2::HDF5MeasFileV2()
   : file_id_(-1)

--- a/contrib/ecalhdf5/src/eh5_meas_file_v2.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v2.h
@@ -117,13 +117,19 @@ namespace eCAL
       */
       void SetOneFilePerChannelEnabled(bool enabled) override;
 
-
       /**
       * @brief Get the available channel names of the current opened file / measurement
       *
       * @return       channel names
       **/
       std::set<std::string> GetChannelNames() const override;
+
+      /**
+       * @brief Get the available channel names of the current opened file / measurement
+       *
+       * @return       channel names & ids
+      **/
+      std::set<eCAL::eh5::SChannel> GetChannels() const override;
 
       /**
       * @brief Check if channel exists in measurement
@@ -141,7 +147,7 @@ namespace eCAL
        *
        * @return              channel type
       **/
-      DataTypeInformation GetChannelDataTypeInformation(const std::string& channel_name) const override;
+      DataTypeInformation GetChannelDataTypeInformation(const SChannel& channel) const override;
 
       /**
        * @brief Set data type information of the given channel
@@ -151,7 +157,7 @@ namespace eCAL
        *
        * @return              channel type
       **/
-      void SetChannelDataTypeInformation(const std::string& channel_name, const DataTypeInformation& info) override;
+      void SetChannelDataTypeInformation(const SChannel& channel, const DataTypeInformation& info) override;
 
       /**
       * @brief Gets minimum timestamp for specified channel
@@ -160,7 +166,7 @@ namespace eCAL
       *
       * @return                minimum timestamp value
       **/
-      long long GetMinTimestamp(const std::string& channel_name) const override;
+      long long GetMinTimestamp(const SChannel& channel) const override;
 
       /**
       * @brief Gets maximum timestamp for specified channel
@@ -169,7 +175,7 @@ namespace eCAL
       *
       * @return                maximum timestamp value
       **/
-      long long GetMaxTimestamp(const std::string& channel_name) const override;
+      long long GetMaxTimestamp(const SChannel& channel) const override;
 
       /**
       * @brief Gets the header info for all data entries for the given channel
@@ -180,7 +186,7 @@ namespace eCAL
       *
       * @return                    true if succeeds, false if it fails
       **/
-      bool GetEntriesInfo(const std::string& channel_name, EntryInfoSet& entries) const override;
+      bool GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const override;
 
       /**
       * @brief Gets the header info for data entries for the given channel included in given time range (begin->end)
@@ -193,7 +199,7 @@ namespace eCAL
       *
       * @return                   true if succeeds, false if it fails
       **/
-      bool GetEntriesInfoRange(const std::string& channel_name, long long begin, long long end, EntryInfoSet& entries) const override;
+      bool GetEntriesInfoRange(const SChannel& channel, long long begin, long long end, EntryInfoSet& entries) const override;
 
       /**
       * @brief Gets data size of a specific entry
@@ -252,17 +258,6 @@ namespace eCAL
 
     protected:
       hid_t file_id_;
-
-      /**
-      * @brief Gets the value of a string attribute
-      *
-      * @param [in]  obj_id ID of the attribute's parent
-      * @param [in]  name   Name of the attribute
-      * @param [out] value  Value of the attribute
-      *
-      * @return  true if succeeds, false if it fails
-      **/
-      static bool GetAttributeValue(hid_t obj_id, const std::string& name, std::string& value) ;
     };
 
   }  // namespace eh5

--- a/contrib/ecalhdf5/src/eh5_meas_file_v2.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v2.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -251,6 +251,9 @@ namespace eCAL
       * @return               true if succeeds, false if it fails
       **/
       bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const std::string& channel_name, long long id, long long clock) override;
+
+      bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long clock) override;
+
 
       typedef std::function<void(void)> CallbackFunction;
       /**

--- a/contrib/ecalhdf5/src/eh5_meas_file_v2.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v2.h
@@ -141,6 +141,15 @@ namespace eCAL
       bool HasChannel(const std::string& channel_name) const override;
 
       /**
+       * @brief Check if channel exists in measurement
+       *
+       * @param channel   channel name & id
+       *
+       * @return       true if exists, false otherwise
+      **/
+      bool HasChannel(const eCAL::eh5::SChannel& channel) const override;
+
+      /**
        * @brief Get data type information of the given channel
        *
        * @param channel_name  channel name

--- a/contrib/ecalhdf5/src/eh5_meas_file_v2.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v2.h
@@ -43,7 +43,7 @@ namespace eCAL
       *
       * @param path    input file path
       **/
-      explicit HDF5MeasFileV2(const std::string& path, eAccessType access = eAccessType::RDONLY);
+      explicit HDF5MeasFileV2(const std::string& path, v3::eAccessType access = v3::eAccessType::RDONLY);
 
       /**
       * @brief Destructor
@@ -58,7 +58,7 @@ namespace eCAL
       *
       * @return         true if succeeds, false if it fails
       **/
-      bool Open(const std::string& path, eAccessType access = eAccessType::RDONLY) override;
+      bool Open(const std::string& path, v3::eAccessType access = v3::eAccessType::RDONLY) override;
 
       /**
       * @brief Close file
@@ -118,27 +118,11 @@ namespace eCAL
       void SetOneFilePerChannelEnabled(bool enabled) override;
 
       /**
-      * @brief Get the available channel names of the current opened file / measurement
-      *
-      * @return       channel names
-      **/
-      std::set<std::string> GetChannelNames() const override;
-
-      /**
        * @brief Get the available channel names of the current opened file / measurement
        *
        * @return       channel names & ids
       **/
       std::set<eCAL::eh5::SChannel> GetChannels() const override;
-
-      /**
-      * @brief Check if channel exists in measurement
-      *
-      * @param channel_name   name of the channel
-      *
-      * @return       true if exists, false otherwise
-      **/
-      bool HasChannel(const std::string& channel_name) const override;
 
       /**
        * @brief Check if channel exists in measurement
@@ -250,9 +234,7 @@ namespace eCAL
       *
       * @return               true if succeeds, false if it fails
       **/
-      bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const std::string& channel_name, long long id, long long clock) override;
-
-      bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long clock) override;
+      bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long id, long long clock) override;
 
 
       typedef std::function<void(void)> CallbackFunction;

--- a/contrib/ecalhdf5/src/eh5_meas_file_v2.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v2.h
@@ -234,7 +234,7 @@ namespace eCAL
       *
       * @return               true if succeeds, false if it fails
       **/
-      bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long id, long long clock) override;
+      bool AddEntryToFile(const SWriteEntry& entry) override;
 
 
       typedef std::function<void(void)> CallbackFunction;

--- a/contrib/ecalhdf5/src/eh5_meas_file_v3.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v3.cpp
@@ -41,13 +41,13 @@ namespace eCAL
     HDF5MeasFileV3::~HDF5MeasFileV3()
     = default;
 
-    bool HDF5MeasFileV3::GetEntriesInfo(const std::string& channel_name, EntryInfoSet& entries) const
+    bool HDF5MeasFileV3::GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const
     {
       entries.clear();
 
       if (!this->IsOk()) return false;
 
-      hid_t dataset_id = H5Dopen(file_id_, channel_name.c_str(), H5P_DEFAULT);
+      hid_t dataset_id = H5Dopen(file_id_, channel.name.c_str(), H5P_DEFAULT);
 
       if (dataset_id < 0) return false;
 

--- a/contrib/ecalhdf5/src/eh5_meas_file_v3.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v3.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ namespace eCAL
   namespace eh5
   {
 
-    HDF5MeasFileV3::HDF5MeasFileV3(const std::string& path, eAccessType access /*= eAccessType::RDONLY*/)
+    HDF5MeasFileV3::HDF5MeasFileV3(const std::string& path, v3::eAccessType access /*= eAccessType::RDONLY*/)
       : HDF5MeasFileV2(path, access)
     {
     }

--- a/contrib/ecalhdf5/src/eh5_meas_file_v3.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v3.h
@@ -60,7 +60,7 @@ namespace eCAL
       *
       * @return                    true if succeeds, false if it fails
       **/
-      bool GetEntriesInfo(const std::string& channel_name, EntryInfoSet& entries) const override;
+      bool GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const override;
     };
   }  //  namespace eh5
 }  //  namespace eCAL

--- a/contrib/ecalhdf5/src/eh5_meas_file_v3.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v3.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ namespace eCAL
       *
       * @param path    Input file path
       **/
-      explicit HDF5MeasFileV3(const std::string& path, eAccessType access = eAccessType::RDONLY);
+      explicit HDF5MeasFileV3(const std::string& path, v3::eAccessType access = v3::eAccessType::RDONLY);
 
       /**
       * @brief Destructor

--- a/contrib/ecalhdf5/src/eh5_meas_file_v4.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v4.cpp
@@ -41,13 +41,13 @@ namespace eCAL
     HDF5MeasFileV4::~HDF5MeasFileV4()
     = default;
 
-    bool HDF5MeasFileV4::GetEntriesInfo(const std::string& channel_name, EntryInfoSet& entries) const
+    bool HDF5MeasFileV4::GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const
     {
       entries.clear();
 
       if (!this->IsOk()) return false;
 
-      auto dataset_id = H5Dopen(file_id_, channel_name.c_str(), H5P_DEFAULT);
+      auto dataset_id = H5Dopen(file_id_, channel.name.c_str(), H5P_DEFAULT);
 
       if (dataset_id < 0) return false;
 

--- a/contrib/ecalhdf5/src/eh5_meas_file_v4.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v4.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ namespace eCAL
   namespace eh5
   {
 
-    HDF5MeasFileV4::HDF5MeasFileV4(const std::string& path, eAccessType access /*= eAccessType::RDONLY*/)
+    HDF5MeasFileV4::HDF5MeasFileV4(const std::string& path, v3::eAccessType access /*= eAccessType::RDONLY*/)
       : HDF5MeasFileV2(path, access)
     {
     }

--- a/contrib/ecalhdf5/src/eh5_meas_file_v4.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v4.h
@@ -60,7 +60,7 @@ namespace eCAL
       *
       * @return                    true if succeeds, false if it fails
       **/
-      bool GetEntriesInfo(const std::string& channel_name, EntryInfoSet& entries) const override;
+      bool GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const override;
     };
   }  //  namespace eh5
 }  //  namespace eCAL

--- a/contrib/ecalhdf5/src/eh5_meas_file_v4.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v4.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ namespace eCAL
       *
       * @param path    Input file path
       **/
-      explicit HDF5MeasFileV4(const std::string& path, eAccessType access = eAccessType::RDONLY);
+      explicit HDF5MeasFileV4(const std::string& path, v3::eAccessType access = v3::eAccessType::RDONLY);
 
       /**
       * @brief Destructor

--- a/contrib/ecalhdf5/src/eh5_meas_file_v5.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v5.cpp
@@ -41,13 +41,13 @@ namespace eCAL
     HDF5MeasFileV5::~HDF5MeasFileV5()
     = default;
 
-    bool HDF5MeasFileV5::GetEntriesInfo(const std::string& channel_name, EntryInfoSet& entries) const
+    bool HDF5MeasFileV5::GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const
     {
       entries.clear();
 
       if (!this->IsOk()) return false;
 
-      auto dataset_id = H5Dopen(file_id_, channel_name.c_str(), H5P_DEFAULT);
+      auto dataset_id = H5Dopen(file_id_, channel.name.c_str(), H5P_DEFAULT);
 
       if (dataset_id < 0) return false;
 

--- a/contrib/ecalhdf5/src/eh5_meas_file_v5.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v5.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ namespace eCAL
   namespace eh5
   {
 
-    HDF5MeasFileV5::HDF5MeasFileV5(const std::string& path, eAccessType access /*= eAccessType::RDONLY*/)
+    HDF5MeasFileV5::HDF5MeasFileV5(const std::string& path, v3::eAccessType access /*= eAccessType::RDONLY*/)
       : HDF5MeasFileV2(path, access)
     {
     }

--- a/contrib/ecalhdf5/src/eh5_meas_file_v5.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v5.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ namespace eCAL
       *
       * @param path    Input file path
       **/
-      explicit HDF5MeasFileV5(const std::string& path, eAccessType access = eAccessType::RDONLY);
+      explicit HDF5MeasFileV5(const std::string& path, v3::eAccessType access = v3::eAccessType::RDONLY);
 
       /**
       * @brief Destructor

--- a/contrib/ecalhdf5/src/eh5_meas_file_v6.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v6.cpp
@@ -1,0 +1,110 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+/**
+ * @brief  eCALHDF5 reader multiple channels implement
+**/
+
+#include "eh5_meas_file_v6.h"
+
+#include "hdf5.h"
+#include "hdf5_helper.h"
+
+namespace eCAL
+{
+  namespace eh5
+  {
+
+    HDF5MeasFileV6::HDF5MeasFileV6(const std::string& path, eAccessType access /*= eAccessType::RDONLY*/)
+      : HDF5MeasFileV2(path, access)
+    {
+    }
+
+    HDF5MeasFileV6::HDF5MeasFileV6()
+      = default;
+
+    HDF5MeasFileV6::~HDF5MeasFileV6()
+      = default;
+
+    std::set<eCAL::eh5::SChannel> HDF5MeasFileV6::GetChannels() const
+    {
+      std::set<eCAL::eh5::SChannel> channels;
+
+      const auto channel_names = GetChannelNames();
+
+      for (const auto& channel_name : channel_names)
+      {
+        auto group_id = H5Gopen(file_id_, channel_name.c_str(), H5P_DEFAULT);
+        auto groups = ListSubgroups(group_id);
+        H5Gclose(group_id);
+
+        for (const auto& group : groups)
+        {
+          const auto id = parseHexID(group);
+          channels.insert({ channel_name, id });
+        }
+
+      }
+
+      return channels;
+    }
+
+    eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5MeasFileV6::GetChannelDataTypeInformation(const SChannel& channel) const
+    {
+      std::string type_name;
+      std::string type_encoding;
+      std::string type_descriptor;
+
+      auto group_id = H5Gopen(file_id_, channel.name.c_str(), H5P_DEFAULT);
+      auto groups = ListSubgroups(group_id);
+      H5Gclose(group_id);
+
+      if (this->IsOk())
+      {
+        std::string channel_id_key = printHex(channel.id);
+
+        // Read Typename
+        auto type_name_url = v6::GetUrl(channel.name, channel_id_key, eCAL::eh5::kChnIdTypename);
+        ReadStringEntryAsString(file_id_, type_name_url, type_name);
+
+        // Read Encoding
+        auto type_encoding_url = v6::GetUrl(channel.name, channel_id_key, eCAL::eh5::kChnIdEncoding);
+        ReadStringEntryAsString(file_id_, type_encoding_url, type_encoding);
+
+        // Read Descriptor
+        auto type_descriptor_url = v6::GetUrl(channel.name, channel_id_key, eCAL::eh5::kChnIdDescriptor);
+        ReadStringEntryAsString(file_id_, type_descriptor_url, type_descriptor);
+      }
+
+      return eCAL::eh5::DataTypeInformation{ type_name, type_encoding, type_descriptor };
+    }
+
+    bool eCAL::eh5::HDF5MeasFileV6::GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const
+     {
+      if (!this->IsOk()) return false;
+
+      auto hex_id = printHex(channel.id);
+      EntryInfoSet channel_id_entries;
+      auto url = v6::GetUrl(channel.name, hex_id, kChnIdData);
+      GetEntryInfoVector(file_id_, url, entries);
+
+      return true;
+    }
+  }  //  namespace eh5
+}  //  namespace eCAL

--- a/contrib/ecalhdf5/src/eh5_meas_file_v6.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v6.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ namespace eCAL
   namespace eh5
   {
 
-    HDF5MeasFileV6::HDF5MeasFileV6(const std::string& path, eAccessType access /*= eAccessType::RDONLY*/)
+    HDF5MeasFileV6::HDF5MeasFileV6(const std::string& path, v3::eAccessType access /*= eAccessType::RDONLY*/)
       : HDF5MeasFileV2(path, access)
     {
     }
@@ -42,14 +42,18 @@ namespace eCAL
     HDF5MeasFileV6::~HDF5MeasFileV6()
       = default;
 
+    // Channels have to be obtained differently, the names themselves are written in the header
+    // for channel, id, we need to traverse the file format and get them.
     std::set<eCAL::eh5::SChannel> HDF5MeasFileV6::GetChannels() const
     {
       std::set<eCAL::eh5::SChannel> channels;
+      // V2 Channel function will return (channel_name, 0)
+      // so we will take those channel_names
+      const auto channels_v2 = HDF5MeasFileV2::GetChannels();
 
-      const auto channel_names = GetChannelNames();
-
-      for (const auto& channel_name : channel_names)
+      for (const auto& channel_v2 : channels_v2)
       {
+        const auto& channel_name = channel_v2.name;
         auto group_id = H5Gopen(file_id_, channel_name.c_str(), H5P_DEFAULT);
         auto groups = ListSubgroups(group_id);
         H5Gclose(group_id);

--- a/contrib/ecalhdf5/src/eh5_meas_file_v6.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v6.cpp
@@ -65,6 +65,20 @@ namespace eCAL
       return channels;
     }
 
+    bool HDF5MeasFileV6::HasChannel(const eCAL::eh5::SChannel& channel) const
+    {
+      bool has_channel_name = HasGroup(file_id_, channel.name);
+      if (!has_channel_name)
+      {
+        return false;
+      }
+      auto group_id = H5Gopen(file_id_, channel.name.c_str(), H5P_DEFAULT);
+      bool has_channel_id = HasGroup(group_id, printHex(channel.id).c_str());
+      H5Gclose(group_id);
+
+      return has_channel_id;
+    }
+
     eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5MeasFileV6::GetChannelDataTypeInformation(const SChannel& channel) const
     {
       std::string type_name;

--- a/contrib/ecalhdf5/src/eh5_meas_file_v6.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v6.h
@@ -25,41 +25,41 @@
 
 #include <string>
 
-#include "eh5_meas_file_v4.h"
+#include "eh5_meas_file_v5.h"
 
 namespace eCAL
 {
   namespace eh5
   {
-    class HDF5MeasFileV5 : virtual public HDF5MeasFileV4
+    class HDF5MeasFileV6 : virtual public HDF5MeasFileV5
     {
     public:
       /**
       * @brief Constructor
       **/
-      HDF5MeasFileV5();
+      HDF5MeasFileV6();
 
       /**
       * @brief Constructor
       *
       * @param path    Input file path
       **/
-      explicit HDF5MeasFileV5(const std::string& path, eAccessType access = eAccessType::RDONLY);
+      explicit HDF5MeasFileV6(const std::string& path, eAccessType access = eAccessType::RDONLY);
 
       /**
       * @brief Destructor
       **/
-      ~HDF5MeasFileV5() override;
+      ~HDF5MeasFileV6() override;
 
       /**
-      * @brief Gets the header info for all data entries for the given channel
-      *        Header = timestamp + entry id
-      *
-      * @param [in]  channel_name  channel name
-      * @param [out] entries       header info for all data entries
-      *
-      * @return                    true if succeeds, false if it fails
+       * @brief Get the available channel names of the current opened file / measurement
+       *
+       * @return       channel names & ids
       **/
+      std::set<eCAL::eh5::SChannel> GetChannels() const override;
+
+      DataTypeInformation GetChannelDataTypeInformation(const SChannel& channel) const override;
+
       bool GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const override;
     };
   }  //  namespace eh5

--- a/contrib/ecalhdf5/src/eh5_meas_file_v6.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v6.h
@@ -58,6 +58,15 @@ namespace eCAL
       **/
       std::set<eCAL::eh5::SChannel> GetChannels() const override;
 
+      /**
+       * @brief Check if channel exists in measurement
+       *
+       * @param channel   channel name & id
+       *
+       * @return       true if exists, false otherwise
+      **/
+      bool HasChannel(const eCAL::eh5::SChannel& channel) const override;
+
       DataTypeInformation GetChannelDataTypeInformation(const SChannel& channel) const override;
 
       bool GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const override;

--- a/contrib/ecalhdf5/src/eh5_meas_file_v6.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v6.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ namespace eCAL
       *
       * @param path    Input file path
       **/
-      explicit HDF5MeasFileV6(const std::string& path, eAccessType access = eAccessType::RDONLY);
+      explicit HDF5MeasFileV6(const std::string& path, v3::eAccessType access = v3::eAccessType::RDONLY);
 
       /**
       * @brief Destructor

--- a/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.cpp
@@ -139,38 +139,38 @@ bool eCAL::eh5::HDF5MeasFileWriterV5::HasChannel(const std::string& /*channel_na
 }
 
 
-eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5MeasFileWriterV5::GetChannelDataTypeInformation(const std::string&  /*channel_name*/) const
+eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5MeasFileWriterV5::GetChannelDataTypeInformation(const SChannel& /*channel*/) const
 {
   // UNSUPPORTED FUNCTION
   return eCAL::eh5::DataTypeInformation{};
 }
 
-void eCAL::eh5::HDF5MeasFileWriterV5::SetChannelDataTypeInformation(const std::string& channel_name, const eCAL::eh5::DataTypeInformation& info)
+void eCAL::eh5::HDF5MeasFileWriterV5::SetChannelDataTypeInformation(const SChannel& channel, const eCAL::eh5::DataTypeInformation& info)
 {
   auto type_descriptor = FromInfo(info);
-  channels_[channel_name].Type = type_descriptor.first;
-  channels_[channel_name].Description = type_descriptor.second;
+  channels_[channel.name].Type = type_descriptor.first;
+  channels_[channel.name].Description = type_descriptor.second;
 }
 
-long long eCAL::eh5::HDF5MeasFileWriterV5::GetMinTimestamp(const std::string& /*channel_name*/) const
+long long eCAL::eh5::HDF5MeasFileWriterV5::GetMinTimestamp(const SChannel& /*channel*/) const
 {
   // UNSUPPORTED FUNCTION
   return -1;
 }
 
-long long eCAL::eh5::HDF5MeasFileWriterV5::GetMaxTimestamp(const std::string& /*channel_name*/) const
+long long eCAL::eh5::HDF5MeasFileWriterV5::GetMaxTimestamp(const SChannel& /*channel*/) const
 {
   // UNSUPPORTED FUNCTION
   return -1;
 }
 
-bool eCAL::eh5::HDF5MeasFileWriterV5::GetEntriesInfo(const std::string& /*channel_name*/, EntryInfoSet& /*entries*/) const
+bool eCAL::eh5::HDF5MeasFileWriterV5::GetEntriesInfo(const SChannel& /*channel*/, EntryInfoSet& /*entries*/) const
 {
   // UNSUPPORTED FUNCTION
   return false;
 }
 
-bool eCAL::eh5::HDF5MeasFileWriterV5::GetEntriesInfoRange(const std::string& /*channel_name*/, long long /*begin*/, long long /*end*/, EntryInfoSet& /*entries*/) const
+bool eCAL::eh5::HDF5MeasFileWriterV5::GetEntriesInfoRange(const SChannel& /*channel*/, long long /*begin*/, long long /*end*/, EntryInfoSet& /*entries*/) const
 {
   // UNSUPPORTED FUNCTION
   return false;

--- a/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.cpp
@@ -23,6 +23,7 @@
 
 #include "eh5_meas_file_writer_v5.h"
 #include "escape.h"
+#include "datatype_helper.h"
 
 #ifdef WIN32
 #include <windows.h>
@@ -54,7 +55,7 @@ eCAL::eh5::HDF5MeasFileWriterV5::~HDF5MeasFileWriterV5()
   HDF5MeasFileWriterV5::Close();
 }
 
-bool eCAL::eh5::HDF5MeasFileWriterV5::Open(const std::string& output_dir, eAccessType /*access = eAccessType::RDONLY*/)
+bool eCAL::eh5::HDF5MeasFileWriterV5::Open(const std::string& output_dir, v3::eAccessType /*access = eAccessType::RDONLY*/)
 {
   Close();
 
@@ -126,23 +127,10 @@ void eCAL::eh5::HDF5MeasFileWriterV5::SetOneFilePerChannelEnabled(bool /*enabled
 {
 }
 
-std::set<std::string> eCAL::eh5::HDF5MeasFileWriterV5::GetChannelNames() const
-{
-  // UNSUPPORTED FUNCTION
-  return {};
-}
-
 std::set<eCAL::eh5::SChannel> eCAL::eh5::HDF5MeasFileWriterV5::GetChannels() const
 {
   // UNSUPPORTED FUNCTIONs
   return std::set<eCAL::eh5::SChannel>();
-}
-
-
-bool eCAL::eh5::HDF5MeasFileWriterV5::HasChannel(const std::string& /*channel_name*/) const
-{
-  // UNSUPPORTED FUNCTION
-  return false;
 }
 
 bool eCAL::eh5::HDF5MeasFileWriterV5::HasChannel(const eCAL::eh5::SChannel& /*channel*/ ) const
@@ -150,7 +138,6 @@ bool eCAL::eh5::HDF5MeasFileWriterV5::HasChannel(const eCAL::eh5::SChannel& /*ch
   // UNSUPPORTED FUNCTION
   return false;
 }
-
 
 eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5MeasFileWriterV5::GetChannelDataTypeInformation(const SChannel& /*channel*/) const
 {
@@ -206,7 +193,7 @@ void eCAL::eh5::HDF5MeasFileWriterV5::SetFileBaseName(const std::string& base_na
   base_name_ = base_name;
 }
 
-bool eCAL::eh5::HDF5MeasFileWriterV5::AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const std::string& channel_name, long long id, long long clock)
+bool eCAL::eh5::HDF5MeasFileWriterV5::AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long id, long long clock)
 {
   if (!IsOk()) file_id_ = Create();
   if (!IsOk())
@@ -243,17 +230,11 @@ bool eCAL::eh5::HDF5MeasFileWriterV5::AddEntryToFile(const void* data, const uns
   H5Pclose(dsProperty);
   H5Sclose(dataSpace);
 
-  channels_[channel_name].Entries.emplace_back(SEntryInfo(rcv_timestamp, static_cast<long long>(entries_counter_), clock, snd_timestamp, id));
+  channels_[channel.name].Entries.emplace_back(SEntryInfo(rcv_timestamp, static_cast<long long>(entries_counter_), clock, snd_timestamp, id));
 
   entries_counter_++;
 
   return (writeStatus >= 0);
-}
-
-bool eCAL::eh5::HDF5MeasFileWriterV5::AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long clock)
-{
-  // v5 does not support multiple channels per topic. Thus we will only save the name, and no sender ID.
-  return AddEntryToFile(data, size, snd_timestamp, rcv_timestamp, channel.name, 0, clock);
 }
 
 void eCAL::eh5::HDF5MeasFileWriterV5::ConnectPreSplitCallback(CallbackFunction cb)

--- a/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -248,6 +248,12 @@ bool eCAL::eh5::HDF5MeasFileWriterV5::AddEntryToFile(const void* data, const uns
   entries_counter_++;
 
   return (writeStatus >= 0);
+}
+
+bool eCAL::eh5::HDF5MeasFileWriterV5::AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long clock)
+{
+  // v5 does not support multiple channels per topic. Thus we will only save the name, and no sender ID.
+  return AddEntryToFile(data, size, snd_timestamp, rcv_timestamp, channel.name, 0, clock);
 }
 
 void eCAL::eh5::HDF5MeasFileWriterV5::ConnectPreSplitCallback(CallbackFunction cb)

--- a/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.cpp
@@ -145,7 +145,7 @@ bool eCAL::eh5::HDF5MeasFileWriterV5::HasChannel(const std::string& /*channel_na
   return false;
 }
 
-bool eCAL::eh5::HDF5MeasFileWriterV5::HasChannel(const eCAL::eh5::SChannel& channel) const
+bool eCAL::eh5::HDF5MeasFileWriterV5::HasChannel(const eCAL::eh5::SChannel& /*channel*/ ) const
 {
   // UNSUPPORTED FUNCTION
   return false;

--- a/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.cpp
@@ -132,7 +132,20 @@ std::set<std::string> eCAL::eh5::HDF5MeasFileWriterV5::GetChannelNames() const
   return {};
 }
 
+std::set<eCAL::eh5::SChannel> eCAL::eh5::HDF5MeasFileWriterV5::GetChannels() const
+{
+  // UNSUPPORTED FUNCTIONs
+  return std::set<eCAL::eh5::SChannel>();
+}
+
+
 bool eCAL::eh5::HDF5MeasFileWriterV5::HasChannel(const std::string& /*channel_name*/) const
+{
+  // UNSUPPORTED FUNCTION
+  return false;
+}
+
+bool eCAL::eh5::HDF5MeasFileWriterV5::HasChannel(const eCAL::eh5::SChannel& channel) const
 {
   // UNSUPPORTED FUNCTION
   return false;

--- a/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.h
@@ -147,7 +147,7 @@ namespace eCAL
        *
        * @return              channel type
       **/
-      DataTypeInformation GetChannelDataTypeInformation(const std::string & channel_name) const override;
+      DataTypeInformation GetChannelDataTypeInformation(const SChannel& channel) const override;
 
       /**
        * @brief Set data type information of the given channel
@@ -157,7 +157,7 @@ namespace eCAL
        *
        * @return              channel type
       **/
-      void SetChannelDataTypeInformation(const std::string & channel_name, const DataTypeInformation & info) override;
+      void SetChannelDataTypeInformation(const SChannel& channel, const DataTypeInformation & info) override;
 
       /**
       * @brief Gets minimum timestamp for specified channel
@@ -166,7 +166,7 @@ namespace eCAL
       *
       * @return                minimum timestamp value
       **/
-      long long GetMinTimestamp(const std::string& channel_name) const override;
+      long long GetMinTimestamp(const SChannel& channel) const override;
 
       /**
       * @brief Gets maximum timestamp for specified channel
@@ -175,7 +175,7 @@ namespace eCAL
       *
       * @return                maximum timestamp value
       **/
-      long long GetMaxTimestamp(const std::string& channel_name) const override;
+      long long GetMaxTimestamp(const SChannel& channel) const override;
 
       /**
       * @brief Gets the header info for all data entries for the given channel
@@ -186,7 +186,7 @@ namespace eCAL
       *
       * @return                    true if succeeds, false if it fails
       **/
-      bool GetEntriesInfo(const std::string& channel_name, EntryInfoSet& entries) const override;
+      bool GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const override;
 
       /**
       * @brief Gets the header info for data entries for the given channel included in given time range (begin->end)
@@ -199,7 +199,7 @@ namespace eCAL
       *
       * @return                   true if succeeds, false if it fails
       **/
-      bool GetEntriesInfoRange(const std::string& channel_name, long long begin, long long end, EntryInfoSet& entries) const override;
+      bool GetEntriesInfoRange(const SChannel& channel, long long begin, long long end, EntryInfoSet& entries) const override;
 
       /**
       * @brief Gets data size of a specific entry

--- a/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.h
@@ -65,7 +65,7 @@ namespace eCAL
       *
       * @return            true if succeeds, false if it fails
       **/
-      bool Open(const std::string& output_dir, eAccessType access) override;
+      bool Open(const std::string& output_dir, v3::eAccessType access) override;
 
       /**
       * @brief Close file
@@ -125,27 +125,11 @@ namespace eCAL
       void SetOneFilePerChannelEnabled(bool enabled) override;
 
       /**
-      * @brief Get the available channel names of the current opened file / measurement
-      *
-      * @return       channel names
-      **/
-      std::set<std::string> GetChannelNames() const override;
-
-      /**
        * @brief Get the available channel names of the current opened file / measurement
        *
        * @return       channel names & ids
       **/
       std::set<eCAL::eh5::SChannel> GetChannels() const override;
-
-      /**
-      * @brief Check if channel exists in measurement
-      *
-      * @param channel_name   name of the channel
-      *
-      * @return       true if exists, false otherwise
-      **/
-      bool HasChannel(const std::string& channel_name) const override;
 
       /**
        * @brief Check if channel exists in measurement
@@ -257,9 +241,7 @@ namespace eCAL
       *
       * @return               true if succeeds, false if it fails
       **/
-      bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const std::string& channel_name, long long id, long long clock) override;
-
-      bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long clock) override;
+      bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long id, long long clock) override;
 
       using CallbackFunction = std::function<void ()>;
       /**

--- a/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.h
@@ -132,6 +132,13 @@ namespace eCAL
       std::set<std::string> GetChannelNames() const override;
 
       /**
+       * @brief Get the available channel names of the current opened file / measurement
+       *
+       * @return       channel names & ids
+      **/
+      std::set<eCAL::eh5::SChannel> GetChannels() const override;
+
+      /**
       * @brief Check if channel exists in measurement
       *
       * @param channel_name   name of the channel
@@ -139,6 +146,15 @@ namespace eCAL
       * @return       true if exists, false otherwise
       **/
       bool HasChannel(const std::string& channel_name) const override;
+
+      /**
+       * @brief Check if channel exists in measurement
+       *
+       * @param channel   channel name & id
+       *
+       * @return       true if exists, false otherwise
+      **/
+      bool HasChannel(const eCAL::eh5::SChannel & channel) const override;
 
       /**
        * @brief Get data type information of the given channel

--- a/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -258,6 +258,8 @@ namespace eCAL
       * @return               true if succeeds, false if it fails
       **/
       bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const std::string& channel_name, long long id, long long clock) override;
+
+      bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long clock) override;
 
       using CallbackFunction = std::function<void ()>;
       /**

--- a/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.h
@@ -241,7 +241,7 @@ namespace eCAL
       *
       * @return               true if succeeds, false if it fails
       **/
-      bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long id, long long clock) override;
+      bool AddEntryToFile(const SWriteEntry& entry) override;
 
       using CallbackFunction = std::function<void ()>;
       /**

--- a/contrib/ecalhdf5/src/eh5_meas_file_writer_v6.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_writer_v6.cpp
@@ -1,0 +1,344 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+/**
+ * @brief  eCALHDF5 directory reader
+**/
+
+#include "eh5_meas_file_writer_v6.h"
+#include "escape.h"
+
+#ifdef WIN32
+#include <windows.h>
+#else
+#include <dirent.h>
+#endif //WIN32
+
+#include <string>
+#include <list>
+#include <iostream>
+
+#include <ecal_utils/filesystem.h>
+#include <ecal_utils/str_convert.h>
+
+#include "hdf5_helper.h"
+
+constexpr unsigned int kDefaultMaxFileSizeMB = 1000;
+
+eCAL::eh5::HDF5MeasFileWriterV6::HDF5MeasFileWriterV6()
+  : cb_pre_split_      (nullptr)
+  , file_id_           (-1)
+  , file_split_counter_(-1)
+  , entries_counter_   (0)
+  , max_size_per_file_ (kDefaultMaxFileSizeMB * 1024 * 1024)
+{}
+
+eCAL::eh5::HDF5MeasFileWriterV6::~HDF5MeasFileWriterV6()
+{
+  // call the function via its class becase it's a virtual function that is called in constructor/destructor,-
+  // where the vtable is not created yet or it's destructed.
+  HDF5MeasFileWriterV6::Close();
+}
+
+bool eCAL::eh5::HDF5MeasFileWriterV6::Open(const std::string& output_dir, eAccessType /*access = eAccessType::RDONLY*/)
+{
+  Close();
+
+  // Check if the given path points to a directory
+  if (!EcalUtils::Filesystem::IsDir(output_dir, EcalUtils::Filesystem::Current))
+    return false;
+
+  output_dir_ = output_dir;
+
+  return true;
+}
+
+bool eCAL::eh5::HDF5MeasFileWriterV6::Close()
+{
+  if (!this->IsOk())  return false;
+
+  std::string channels_with_entries;
+
+  for (const auto& channel_per_name : channels_)
+  {
+    for (const auto& channel_per_id : channel_per_name.second)
+    {
+      std::ignore = CreateEntriesTableOfContentsFor(channel_per_name.first, channel_per_id.first, channel_per_id.second.Info, channel_per_id.second.Entries);
+    }
+    channels_with_entries += channel_per_name.first + ",";
+  }
+
+  if ((!channels_with_entries.empty())  && (channels_with_entries.back() == ','))
+    channels_with_entries.pop_back();
+
+  SetAttribute(file_id_, kChnAttrTitle, channels_with_entries);
+
+  for (auto& channel_per_name : channels_)
+    for (auto& channel_per_id : channel_per_name.second)
+      channel_per_id.second.Entries.clear();
+
+  if (H5Fclose(file_id_) >= 0)
+  {
+    file_id_ = -1;
+    return true ;
+  }
+  else
+  {
+    return false;
+  }
+}
+
+bool eCAL::eh5::HDF5MeasFileWriterV6::IsOk() const
+{
+  return (file_id_ >= 0);
+}
+
+std::string eCAL::eh5::HDF5MeasFileWriterV6::GetFileVersion() const
+{
+  // UNSUPPORTED FUNCTION
+  return "";
+}
+
+size_t eCAL::eh5::HDF5MeasFileWriterV6::GetMaxSizePerFile() const
+{
+  return max_size_per_file_ / 1024 / 1024;
+}
+
+void eCAL::eh5::HDF5MeasFileWriterV6::SetMaxSizePerFile(size_t max_file_size_mib)
+{
+  max_size_per_file_ = max_file_size_mib * 1024 * 1024;
+}
+
+bool eCAL::eh5::HDF5MeasFileWriterV6::IsOneFilePerChannelEnabled() const
+{
+  return false;
+}
+
+void eCAL::eh5::HDF5MeasFileWriterV6::SetOneFilePerChannelEnabled(bool /*enabled*/)
+{
+}
+
+std::set<std::string> eCAL::eh5::HDF5MeasFileWriterV6::GetChannelNames() const
+{
+  // UNSUPPORTED FUNCTION
+  return {};
+}
+
+std::set<eCAL::eh5::SChannel> eCAL::eh5::HDF5MeasFileWriterV6::GetChannels() const
+{
+  // UNSUPPORTED FUNCTION
+  return std::set<eCAL::eh5::SChannel>();
+}
+
+bool eCAL::eh5::HDF5MeasFileWriterV6::HasChannel(const std::string& /*channel_name*/) const
+{
+  // UNSUPPORTED FUNCTION
+  return false;
+}
+
+eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5MeasFileWriterV6::GetChannelDataTypeInformation(const SChannel& /*channel*/) const
+{
+  // UNSUPPORTED FUNCTION
+  return eCAL::eh5::DataTypeInformation{};
+}
+
+void eCAL::eh5::HDF5MeasFileWriterV6::SetChannelDataTypeInformation(const SChannel& channel , const eCAL::eh5::DataTypeInformation& info)
+{
+  channels_[channel.name][channel.id].Info = info;
+}
+
+
+long long eCAL::eh5::HDF5MeasFileWriterV6::GetMinTimestamp(const SChannel& /*channel_name*/) const
+{
+  // UNSUPPORTED FUNCTION
+  return -1;
+}
+
+long long eCAL::eh5::HDF5MeasFileWriterV6::GetMaxTimestamp(const SChannel&  /*channel_name*/) const
+{
+  // UNSUPPORTED FUNCTION
+  return -1;
+}
+
+bool eCAL::eh5::HDF5MeasFileWriterV6::GetEntriesInfo(const SChannel&  /*channel_name*/, EntryInfoSet& /*entries*/) const
+{
+  // UNSUPPORTED FUNCTION
+  return false;
+}
+
+bool eCAL::eh5::HDF5MeasFileWriterV6::GetEntriesInfoRange(const SChannel&  /*channel_name*/, long long /*begin*/, long long /*end*/, EntryInfoSet& /*entries*/) const
+{
+  // UNSUPPORTED FUNCTION
+  return false;
+}
+
+bool eCAL::eh5::HDF5MeasFileWriterV6::GetEntryDataSize(long long /*entry_id*/, size_t& /*size*/) const
+{
+  // UNSUPPORTED FUNCTION
+  return false;
+}
+
+bool eCAL::eh5::HDF5MeasFileWriterV6::GetEntryData(long long /*entry_id*/, void* /*data*/) const
+{
+  // UNSUPPORTED FUNCTION
+  return false;
+}
+
+void eCAL::eh5::HDF5MeasFileWriterV6::SetFileBaseName(const std::string& base_name)
+{
+  base_name_ = base_name;
+}
+
+bool eCAL::eh5::HDF5MeasFileWriterV6::AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const std::string& channel_name, long long id, long long clock)
+{
+  if (!IsOk()) file_id_ = Create();
+  if (!IsOk())
+    return false;
+
+  hsize_t hsSize = static_cast<hsize_t>(size);
+
+  if (!EntryFitsTheFile(hsSize))
+  {
+    if (cb_pre_split_ != nullptr)
+    {
+      cb_pre_split_();
+    }
+
+    if (Create() < 0)
+      return false;
+  }
+
+  //  Create DataSpace with rank 1 and size dimension
+  auto dataSpace = H5Screate_simple(1, &hsSize, nullptr);
+
+  //  Create creation property for dataSpace
+  auto dsProperty = H5Pcreate(H5P_DATASET_CREATE);
+  H5Pset_obj_track_times(dsProperty, false);
+
+  //  Create dataset in dataSpace
+  auto dataSet = H5Dcreate(file_id_, std::to_string(entries_counter_).c_str(), H5T_NATIVE_UCHAR, dataSpace, H5P_DEFAULT, dsProperty, H5P_DEFAULT);
+
+  //  Write buffer to dataset
+  herr_t writeStatus = H5Dwrite(dataSet, H5T_NATIVE_UCHAR, H5S_ALL, H5S_ALL, H5P_DEFAULT, data);
+
+  //  Close dataset, data space, and data set property
+  H5Dclose(dataSet);
+  H5Pclose(dsProperty);
+  H5Sclose(dataSpace);
+
+  channels_[channel_name][id].Entries.emplace_back(SEntryInfo(rcv_timestamp, static_cast<long long>(entries_counter_), clock, snd_timestamp, id));
+
+  entries_counter_++;
+
+  return (writeStatus >= 0);
+}
+
+void eCAL::eh5::HDF5MeasFileWriterV6::ConnectPreSplitCallback(CallbackFunction cb)
+{
+  cb_pre_split_ = cb;
+}
+
+void eCAL::eh5::HDF5MeasFileWriterV6::DisconnectPreSplitCallback()
+{
+  cb_pre_split_ = nullptr;
+}
+
+hid_t eCAL::eh5::HDF5MeasFileWriterV6::Create()
+{
+  if (output_dir_.empty()) return -1;
+
+  if (!EcalUtils::Filesystem::IsDir(output_dir_, EcalUtils::Filesystem::OsStyle::Current)
+      && !EcalUtils::Filesystem::MkPath(output_dir_, EcalUtils::Filesystem::OsStyle::Current))
+    return -1;
+
+  if (base_name_.empty()) return -1;
+
+  if (IsOk() && !Close()) return -1;
+
+  file_split_counter_++;
+
+  std::string filePath = output_dir_ + "/" + base_name_;
+
+  if (file_split_counter_ > 0)
+    filePath += "_" + std::to_string(file_split_counter_);
+
+  filePath += ".hdf5";
+
+  //  create file access property
+  hid_t fileAccessPropery = H5Pcreate(H5P_FILE_ACCESS);
+  //  create file create property
+  hid_t fileCreateProperty = H5Pcreate(H5P_FILE_CREATE);
+
+  //  Create hdf file and get file id
+  file_id_ = H5Fcreate(filePath.c_str(), H5F_ACC_TRUNC, fileCreateProperty, fileAccessPropery);
+
+  if (file_id_ >= 0)
+    SetAttribute(file_id_, kFileVerAttrTitle, "6.0");
+  else
+    file_split_counter_--;
+
+  return file_id_;
+}
+
+bool eCAL::eh5::HDF5MeasFileWriterV6::EntryFitsTheFile(const hsize_t& size) const
+{
+  hsize_t fileSize = 0;
+  bool status = GetFileSize(fileSize);
+
+  //  check if buffer fits the current file
+  return (status && ((fileSize + size) <= max_size_per_file_));
+}
+
+bool eCAL::eh5::HDF5MeasFileWriterV6::GetFileSize(hsize_t& size) const
+{
+  if (!IsOk())
+  {
+    size = 0;
+    return false;
+  }
+  else
+  {
+    return H5Fget_filesize(file_id_, &size) >= 0;
+  }
+}
+
+bool eCAL::eh5::HDF5MeasFileWriterV6::CreateEntriesTableOfContentsFor(const std::string& channelName, std::uint64_t channelId, const DataTypeInformation& channelInfo, const EntryInfoVect& entries) const
+{
+  if (!IsOk()) return false;
+
+//  const size_t dataSetsSize = entries.size();
+//  if (dataSetsSize == 0)  return false;
+
+  std::string hex_id = printHex(channelId);
+
+  // Create a group with the cannel name
+  auto group_name_id = OpenOrCreateGroup(file_id_, channelName);
+  auto group_id_id = OpenOrCreateGroup(group_name_id, hex_id);
+
+  CreateStringEntryInRoot(file_id_, v6::GetUrl(channelName, hex_id, kChnIdTypename), channelInfo.name);
+  CreateStringEntryInRoot(file_id_, v6::GetUrl(channelName, hex_id, kChnIdEncoding),   channelInfo.encoding);
+  CreateStringEntryInRoot(file_id_, v6::GetUrl(channelName, hex_id, kChnIdDescriptor), channelInfo.descriptor);
+  CreateInformationEntryInRoot(file_id_, v6::GetUrl(channelName, hex_id, kChnIdData), entries);
+
+  H5Gclose(group_name_id);
+  H5Gclose(group_id_id);
+
+  return true;
+}
+

--- a/contrib/ecalhdf5/src/eh5_meas_file_writer_v6.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_writer_v6.cpp
@@ -199,13 +199,13 @@ void eCAL::eh5::HDF5MeasFileWriterV6::SetFileBaseName(const std::string& base_na
   base_name_ = base_name;
 }
 
-bool eCAL::eh5::HDF5MeasFileWriterV6::AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long id, long long clock)
+bool eCAL::eh5::HDF5MeasFileWriterV6::AddEntryToFile(const SWriteEntry& entry)
 {
   if (!IsOk()) file_id_ = Create();
   if (!IsOk())
     return false;
 
-  hsize_t hsSize = static_cast<hsize_t>(size);
+  hsize_t hsSize = static_cast<hsize_t>(entry.size);
 
   if (!EntryFitsTheFile(hsSize))
   {
@@ -229,7 +229,7 @@ bool eCAL::eh5::HDF5MeasFileWriterV6::AddEntryToFile(const void* data, const uns
   auto dataSet = H5Dcreate(file_id_, std::to_string(entries_counter_).c_str(), H5T_NATIVE_UCHAR, dataSpace, H5P_DEFAULT, dsProperty, H5P_DEFAULT);
 
   //  Write buffer to dataset
-  herr_t writeStatus = H5Dwrite(dataSet, H5T_NATIVE_UCHAR, H5S_ALL, H5S_ALL, H5P_DEFAULT, data);
+  herr_t writeStatus = H5Dwrite(dataSet, H5T_NATIVE_UCHAR, H5S_ALL, H5S_ALL, H5P_DEFAULT, entry.data);
 
   //  Close dataset, data space, and data set property
   H5Dclose(dataSet);
@@ -237,7 +237,7 @@ bool eCAL::eh5::HDF5MeasFileWriterV6::AddEntryToFile(const void* data, const uns
   H5Sclose(dataSpace);
 
   // TODO: check here about id vs channel.id
-  channels_[channel.name][channel.id].Entries.emplace_back(SEntryInfo(rcv_timestamp, static_cast<long long>(entries_counter_), clock, snd_timestamp, id));
+  channels_[entry.channel.name][entry.channel.id].Entries.emplace_back(SEntryInfo(entry.rcv_timestamp, static_cast<long long>(entries_counter_), entry.clock, entry.snd_timestamp, entry.sender_id));
 
   entries_counter_++;
 

--- a/contrib/ecalhdf5/src/eh5_meas_file_writer_v6.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_writer_v6.cpp
@@ -56,7 +56,7 @@ eCAL::eh5::HDF5MeasFileWriterV6::~HDF5MeasFileWriterV6()
   HDF5MeasFileWriterV6::Close();
 }
 
-bool eCAL::eh5::HDF5MeasFileWriterV6::Open(const std::string& output_dir, eAccessType /*access = eAccessType::RDONLY*/)
+bool eCAL::eh5::HDF5MeasFileWriterV6::Open(const std::string& output_dir, v3::eAccessType /*access = eAccessType::RDONLY*/)
 {
   Close();
 
@@ -134,22 +134,10 @@ void eCAL::eh5::HDF5MeasFileWriterV6::SetOneFilePerChannelEnabled(bool /*enabled
 {
 }
 
-std::set<std::string> eCAL::eh5::HDF5MeasFileWriterV6::GetChannelNames() const
-{
-  // UNSUPPORTED FUNCTION
-  return {};
-}
-
 std::set<eCAL::eh5::SChannel> eCAL::eh5::HDF5MeasFileWriterV6::GetChannels() const
 {
   // UNSUPPORTED FUNCTION
   return std::set<eCAL::eh5::SChannel>();
-}
-
-bool eCAL::eh5::HDF5MeasFileWriterV6::HasChannel(const std::string& /*channel_name*/) const
-{
-  // UNSUPPORTED FUNCTION
-  return false;
 }
 
 bool eCAL::eh5::HDF5MeasFileWriterV6::HasChannel(const eCAL::eh5::SChannel& /*channel*/) const
@@ -211,13 +199,7 @@ void eCAL::eh5::HDF5MeasFileWriterV6::SetFileBaseName(const std::string& base_na
   base_name_ = base_name;
 }
 
-// V6 Measurements cannot handle ids properly and they should not be used. This function signature should not be used.
-bool eCAL::eh5::HDF5MeasFileWriterV6::AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const std::string& channel_name, long long /*id*/, long long clock)
-{
-  return AddEntryToFile(data, size, snd_timestamp, rcv_timestamp, SChannel(channel_name, 0), clock);
-}
-
-bool eCAL::eh5::HDF5MeasFileWriterV6::AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long clock)
+bool eCAL::eh5::HDF5MeasFileWriterV6::AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long id, long long clock)
 {
   if (!IsOk()) file_id_ = Create();
   if (!IsOk())
@@ -254,7 +236,8 @@ bool eCAL::eh5::HDF5MeasFileWriterV6::AddEntryToFile(const void* data, const uns
   H5Pclose(dsProperty);
   H5Sclose(dataSpace);
 
-  channels_[channel.name][channel.id].Entries.emplace_back(SEntryInfo(rcv_timestamp, static_cast<long long>(entries_counter_), clock, snd_timestamp, channel.id));
+  // TODO: check here about id vs channel.id
+  channels_[channel.name][channel.id].Entries.emplace_back(SEntryInfo(rcv_timestamp, static_cast<long long>(entries_counter_), clock, snd_timestamp, id));
 
   entries_counter_++;
 

--- a/contrib/ecalhdf5/src/eh5_meas_file_writer_v6.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_writer_v6.cpp
@@ -152,6 +152,12 @@ bool eCAL::eh5::HDF5MeasFileWriterV6::HasChannel(const std::string& /*channel_na
   return false;
 }
 
+bool eCAL::eh5::HDF5MeasFileWriterV6::HasChannel(const eCAL::eh5::SChannel& channel) const
+{
+  // UNSUPPORTED FUNCTION
+  return false;
+}
+
 eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5MeasFileWriterV6::GetChannelDataTypeInformation(const SChannel& /*channel*/) const
 {
   // UNSUPPORTED FUNCTION

--- a/contrib/ecalhdf5/src/eh5_meas_file_writer_v6.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_writer_v6.cpp
@@ -152,7 +152,7 @@ bool eCAL::eh5::HDF5MeasFileWriterV6::HasChannel(const std::string& /*channel_na
   return false;
 }
 
-bool eCAL::eh5::HDF5MeasFileWriterV6::HasChannel(const eCAL::eh5::SChannel& channel) const
+bool eCAL::eh5::HDF5MeasFileWriterV6::HasChannel(const eCAL::eh5::SChannel& /*channel*/) const
 {
   // UNSUPPORTED FUNCTION
   return false;
@@ -211,9 +211,10 @@ void eCAL::eh5::HDF5MeasFileWriterV6::SetFileBaseName(const std::string& base_na
   base_name_ = base_name;
 }
 
-bool eCAL::eh5::HDF5MeasFileWriterV6::AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const std::string& channel_name, long long id, long long clock)
+// V6 Measurements cannot handle ids properly and they should not be used. This function signature should not be used.
+bool eCAL::eh5::HDF5MeasFileWriterV6::AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const std::string& channel_name, long long /*id*/, long long clock)
 {
-  return AddEntryToFile(data, size, snd_timestamp, rcv_timestamp, SChannel(channel_name), clock);
+  return AddEntryToFile(data, size, snd_timestamp, rcv_timestamp, SChannel(channel_name, 0), clock);
 }
 
 bool eCAL::eh5::HDF5MeasFileWriterV6::AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long clock)

--- a/contrib/ecalhdf5/src/eh5_meas_file_writer_v6.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_writer_v6.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -213,6 +213,11 @@ void eCAL::eh5::HDF5MeasFileWriterV6::SetFileBaseName(const std::string& base_na
 
 bool eCAL::eh5::HDF5MeasFileWriterV6::AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const std::string& channel_name, long long id, long long clock)
 {
+  return AddEntryToFile(data, size, snd_timestamp, rcv_timestamp, SChannel(channel_name), clock);
+}
+
+bool eCAL::eh5::HDF5MeasFileWriterV6::AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long clock)
+{
   if (!IsOk()) file_id_ = Create();
   if (!IsOk())
     return false;
@@ -248,7 +253,7 @@ bool eCAL::eh5::HDF5MeasFileWriterV6::AddEntryToFile(const void* data, const uns
   H5Pclose(dsProperty);
   H5Sclose(dataSpace);
 
-  channels_[channel_name][id].Entries.emplace_back(SEntryInfo(rcv_timestamp, static_cast<long long>(entries_counter_), clock, snd_timestamp, id));
+  channels_[channel.name][channel.id].Entries.emplace_back(SEntryInfo(rcv_timestamp, static_cast<long long>(entries_counter_), clock, snd_timestamp, channel.id));
 
   entries_counter_++;
 

--- a/contrib/ecalhdf5/src/eh5_meas_file_writer_v6.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_writer_v6.h
@@ -148,6 +148,15 @@ namespace eCAL
       bool HasChannel(const std::string& channel_name) const override;
 
       /**
+       * @brief Check if channel exists in measurement
+       *
+       * @param channel   channel name & id
+       *
+       * @return       true if exists, false otherwise
+      **/
+      bool HasChannel(const eCAL::eh5::SChannel & channel) const override;
+
+      /**
        * @brief Get data type information of the given channel
        *
        * @param channel_name  channel name

--- a/contrib/ecalhdf5/src/eh5_meas_file_writer_v6.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_writer_v6.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -258,6 +258,8 @@ namespace eCAL
       * @return               true if succeeds, false if it fails
       **/
       bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const std::string& channel_name, long long id, long long clock) override;
+
+      bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long clock) override;
 
       using CallbackFunction = std::function<void ()>;
       /**

--- a/contrib/ecalhdf5/src/eh5_meas_file_writer_v6.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_writer_v6.h
@@ -65,7 +65,7 @@ namespace eCAL
       *
       * @return            true if succeeds, false if it fails
       **/
-      bool Open(const std::string& output_dir, eAccessType access) override;
+      bool Open(const std::string& output_dir, v3::eAccessType access) override;
 
       /**
       * @brief Close file
@@ -125,27 +125,11 @@ namespace eCAL
       void SetOneFilePerChannelEnabled(bool enabled) override;
 
       /**
-      * @brief Get the available channel names of the current opened file / measurement
-      *
-      * @return       channel names
-      **/
-      std::set<std::string> GetChannelNames() const override;
-
-      /**
        * @brief Get the available channel names of the current opened file / measurement
        *
        * @return       channel names & ids
       **/
       std::set<eCAL::eh5::SChannel> GetChannels() const override;
-
-      /**
-      * @brief Check if channel exists in measurement
-      *
-      * @param channel_name   name of the channel
-      *
-      * @return       true if exists, false otherwise
-      **/
-      bool HasChannel(const std::string& channel_name) const override;
 
       /**
        * @brief Check if channel exists in measurement
@@ -251,15 +235,13 @@ namespace eCAL
       * @param size           size of the data
       * @param snd_timestamp  send timestamp
       * @param rcv_timestamp  receive timestamp
-      * @param channel_name   channel name
+      * @param channel        channel name
       * @param id             message id
       * @param clock          message clock
       *
       * @return               true if succeeds, false if it fails
       **/
-      bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const std::string& channel_name, long long id, long long clock) override;
-
-      bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long clock) override;
+      bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long id, long long clock) override;
 
       using CallbackFunction = std::function<void ()>;
       /**

--- a/contrib/ecalhdf5/src/eh5_meas_file_writer_v6.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_writer_v6.h
@@ -241,7 +241,7 @@ namespace eCAL
       *
       * @return               true if succeeds, false if it fails
       **/
-      bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long id, long long clock) override;
+      bool AddEntryToFile(const SWriteEntry& entry) override;
 
       using CallbackFunction = std::function<void ()>;
       /**

--- a/contrib/ecalhdf5/src/eh5_meas_impl.h
+++ b/contrib/ecalhdf5/src/eh5_meas_impl.h
@@ -150,6 +150,13 @@ namespace eCAL
       virtual std::set<std::string> GetChannelNames() const = 0;
 
       /**
+       * @brief Get the available channel names of the current opened file / measurement
+       *
+       * @return       channel names & ids
+      **/
+      virtual std::set<eCAL::eh5::SChannel> GetChannels() const = 0;
+
+      /**
       * @brief Check if channel exists in measurement
       *
       * @param channel_name   name of the channel
@@ -165,7 +172,7 @@ namespace eCAL
        *
        * @return              channel type
       **/
-      virtual DataTypeInformation GetChannelDataTypeInformation(const std::string& channel_name) const = 0;
+      virtual DataTypeInformation GetChannelDataTypeInformation(const SChannel& channel) const = 0;
 
       /**
        * @brief Set data type information of the given channel
@@ -175,7 +182,7 @@ namespace eCAL
        *
        * @return              channel type
       **/
-      virtual void SetChannelDataTypeInformation(const std::string& channel_name, const DataTypeInformation& info) = 0;
+      virtual void SetChannelDataTypeInformation(const SChannel& channel, const eCAL::eh5::DataTypeInformation& info) = 0;
 
       /**
       * @brief Gets minimum timestamp for specified channel
@@ -184,7 +191,7 @@ namespace eCAL
       *
       * @return                minimum timestamp value
       **/
-      virtual long long GetMinTimestamp(const std::string& channel_name) const = 0;
+      virtual long long GetMinTimestamp(const SChannel& channel) const = 0;
 
       /**
       * @brief Gets maximum timestamp for specified channel
@@ -193,7 +200,7 @@ namespace eCAL
       *
       * @return                maximum timestamp value
       **/
-      virtual long long GetMaxTimestamp(const std::string& channel_name) const = 0;
+      virtual long long GetMaxTimestamp(const SChannel& channel) const = 0;
 
       /**
       * @brief Gets the header info for all data entries for the given channel
@@ -204,7 +211,7 @@ namespace eCAL
       *
       * @return                    true if succeeds, false if it fails
       **/
-      virtual bool GetEntriesInfo(const std::string& channel_name, EntryInfoSet& entries) const = 0;
+      virtual bool GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const = 0;
 
       /**
       * @brief Gets the header info for data entries for the given channel included in given time range (begin->end)
@@ -217,7 +224,7 @@ namespace eCAL
       *
       * @return                   true if succeeds, false if it fails
       **/
-      virtual bool GetEntriesInfoRange(const std::string& channel_name, long long begin, long long end, EntryInfoSet& entries) const = 0;
+      virtual bool GetEntriesInfoRange(const SChannel& channel, long long begin, long long end, EntryInfoSet& entries) const = 0;
 
       /**
       * @brief Gets data size of a specific entry

--- a/contrib/ecalhdf5/src/eh5_meas_impl.h
+++ b/contrib/ecalhdf5/src/eh5_meas_impl.h
@@ -166,6 +166,15 @@ namespace eCAL
       virtual bool HasChannel(const std::string& channel_name) const = 0;
 
       /**
+      * @brief Check if channel exists in measurement
+      *
+      * @param channel   channel name & id
+      *
+      * @return       true if exists, false otherwise
+      **/
+      virtual bool HasChannel(const eCAL::eh5::SChannel& channel) const = 0;
+
+      /**
        * @brief Get data type information of the given channel
        *
        * @param channel_name  channel name

--- a/contrib/ecalhdf5/src/eh5_meas_impl.h
+++ b/contrib/ecalhdf5/src/eh5_meas_impl.h
@@ -225,7 +225,7 @@ namespace eCAL
       *
       * @return               true if succeeds, false if it fails
       **/
-      virtual bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long id, long long clock) = 0;
+      virtual bool AddEntryToFile(const SWriteEntry& entry) = 0;
 
       typedef std::function<void(void)> CallbackFunction;
       /**

--- a/contrib/ecalhdf5/src/eh5_meas_impl.h
+++ b/contrib/ecalhdf5/src/eh5_meas_impl.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -276,6 +276,9 @@ namespace eCAL
       * @return               true if succeeds, false if it fails
       **/
       virtual bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const std::string& channel_name, long long id, long long clock) = 0;
+
+      virtual bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long clock) = 0;
+
 
       typedef std::function<void(void)> CallbackFunction;
       /**

--- a/contrib/ecalhdf5/src/eh5_meas_impl.h
+++ b/contrib/ecalhdf5/src/eh5_meas_impl.h
@@ -29,39 +29,6 @@
 
 #include "ecalhdf5/eh5_types.h"
 
-inline eCAL::eh5::DataTypeInformation CreateInfo(const std::string& combined_topic_type_, const std::string& descriptor_)
-{
-  eCAL::eh5::DataTypeInformation info;
-  auto pos = combined_topic_type_.find(':');
-  if (pos == std::string::npos)
-  {
-    info.name     = combined_topic_type_;
-    info.encoding = "";
-  }
-  else
-  {
-    info.name     = combined_topic_type_.substr(pos + 1);
-    info.encoding = combined_topic_type_.substr(0, pos);
-  }
-  info.descriptor = descriptor_;
-  return info;
-}
-
-inline std::pair<std::string, std::string> FromInfo(const eCAL::eh5::DataTypeInformation& datatype_info_)
-{
-  std::string combined_topic_type;
-  if (datatype_info_.encoding.empty())
-  {
-    combined_topic_type = datatype_info_.name;
-  }
-  else
-  {
-    combined_topic_type = datatype_info_.encoding + ":" + datatype_info_.name;
-  }
-
-  return std::make_pair(combined_topic_type, datatype_info_.descriptor);
-}
-
 namespace eCAL
 {
   namespace eh5
@@ -82,7 +49,7 @@ namespace eCAL
       *
       * @return         true if succeeds, false if it fails
       **/
-      virtual bool Open(const std::string& path, eAccessType access = eAccessType::RDONLY) = 0;
+      virtual bool Open(const std::string& path, v3::eAccessType access = v3::eAccessType::RDONLY) = 0;
 
       /**
       * @brief Close file
@@ -141,29 +108,12 @@ namespace eCAL
       */
       virtual void SetOneFilePerChannelEnabled(bool enabled) = 0;
 
-
-      /**
-      * @brief Get the available channel names of the current opened file / measurement
-      *
-      * @return       channel names
-      **/
-      virtual std::set<std::string> GetChannelNames() const = 0;
-
       /**
        * @brief Get the available channel names of the current opened file / measurement
        *
        * @return       channel names & ids
       **/
       virtual std::set<eCAL::eh5::SChannel> GetChannels() const = 0;
-
-      /**
-      * @brief Check if channel exists in measurement
-      *
-      * @param channel_name   name of the channel
-      *
-      * @return       true if exists, false otherwise
-      **/
-      virtual bool HasChannel(const std::string& channel_name) const = 0;
 
       /**
       * @brief Check if channel exists in measurement
@@ -275,10 +225,7 @@ namespace eCAL
       *
       * @return               true if succeeds, false if it fails
       **/
-      virtual bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const std::string& channel_name, long long id, long long clock) = 0;
-
-      virtual bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long clock) = 0;
-
+      virtual bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const SChannel& channel, long long id, long long clock) = 0;
 
       typedef std::function<void(void)> CallbackFunction;
       /**

--- a/contrib/ecalhdf5/src/escape.cpp
+++ b/contrib/ecalhdf5/src/escape.cpp
@@ -581,6 +581,13 @@ namespace eCAL
         return SChannel(GetEscapedTopicname(input.name), input.id);
     }
 
+    SWriteEntry GetEscapedEntry(const SWriteEntry& input)
+    {
+      SWriteEntry escaped_entry{ input };
+      escaped_entry.channel = GetEscapedTopicname(input.channel);
+      return escaped_entry;
+    }
+
     std::string GetEscapedFilename(const std::string& non_escaped_filename)
     {
       return GetEscapedString(non_escaped_filename, is_reserved_filename_);

--- a/contrib/ecalhdf5/src/escape.cpp
+++ b/contrib/ecalhdf5/src/escape.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -574,6 +574,11 @@ namespace eCAL
     std::string GetEscapedTopicname(const std::string& non_escaped_topicname)
     {
       return GetEscapedString(non_escaped_topicname, is_reserved_topicname_);
+    }
+
+    SChannel GetEscapedTopicname(const SChannel& input)
+    {
+        return SChannel(GetEscapedTopicname(input.name), input.id);
     }
 
     std::string GetEscapedFilename(const std::string& non_escaped_filename)

--- a/contrib/ecalhdf5/src/escape.h
+++ b/contrib/ecalhdf5/src/escape.h
@@ -28,6 +28,7 @@ namespace eCAL
   {
     std::string GetEscapedTopicname(const std::string& input);
     SChannel    GetEscapedTopicname(const SChannel& input);
+    SWriteEntry GetEscapedEntry(const SWriteEntry& input);
     std::string GetEscapedFilename(const std::string& input);
     std::string GetUnescapedString(const std::string& input);
   }

--- a/contrib/ecalhdf5/src/escape.h
+++ b/contrib/ecalhdf5/src/escape.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,12 +20,14 @@
 #pragma once
 
 #include <string>
+#include <ecalhdf5/eh5_types.h>
 
 namespace eCAL
 {
   namespace eh5
   {
     std::string GetEscapedTopicname(const std::string& input);
+    SChannel    GetEscapedTopicname(const SChannel& input);
     std::string GetEscapedFilename(const std::string& input);
     std::string GetUnescapedString(const std::string& input);
   }

--- a/contrib/ecalhdf5/src/hdf5_helper.cpp
+++ b/contrib/ecalhdf5/src/hdf5_helper.cpp
@@ -1,0 +1,272 @@
+#include "hdf5_helper.h"
+
+bool CreateStringEntryInRoot(hid_t root, const std::string& url, const std::string& dataset_content)
+{
+  //  create scalar dataset
+  hid_t scalar_dataspace = H5Screate(H5S_SCALAR);
+  //  create new string data type
+  hid_t string_data_type = H5Tcopy(H5T_C_S1);
+  
+  //  if attribute's value length exists, allocate space for it
+  if (dataset_content.length() > 0)
+    H5Tset_size(string_data_type, dataset_content.length());
+  //  Create creation property for data_space
+  auto ds_property = H5Pcreate(H5P_DATASET_CREATE);
+  H5Pset_obj_track_times(ds_property, false);
+  //H5Pset_create_intermediate_group(ds_property, 1);
+
+  //  create attribute
+  hid_t data_set = H5Dcreate(root, url.c_str(), string_data_type, scalar_dataspace, H5P_DEFAULT, ds_property, H5P_DEFAULT);
+  if (data_set < 0) return false;
+
+  auto write_status = H5Dwrite(data_set, string_data_type, H5S_ALL, H5S_ALL, H5P_DEFAULT, dataset_content.c_str());
+  if (write_status < 0) return false;
+
+  //  close all created stuff
+  H5Dclose(data_set);
+  H5Pclose(ds_property);
+  H5Tclose(string_data_type);
+  H5Sclose(scalar_dataspace);
+
+  return true;
+}
+
+
+bool ReadStringEntryAsString(hid_t root, const std::string& url, std::string& data)
+{
+  //  empty attribute value
+  data.clear();
+  if (root < 0) return false;
+
+  auto dataset_id = H5Dopen(root, url.c_str(), H5P_DEFAULT);
+  if (dataset_id < 0) return false;
+
+  auto size = H5Dget_storage_size(dataset_id);
+  data.resize(size);
+
+  herr_t read_status = -1;
+  if (size >= 0)
+  {
+    hid_t string_data_type = H5Tcopy(H5T_C_S1);
+    H5Tset_size(string_data_type, size);
+    read_status = H5Dread(dataset_id, string_data_type, H5S_ALL, H5S_ALL, H5P_DEFAULT, static_cast<void*>(const_cast<char*>(data.data())));
+  }
+
+  H5Dclose(dataset_id);
+  return (read_status >= 0);
+}
+
+//    status = H5Dread(dset, memtype, H5S_ALL, H5S_ALL, H5P_DEFAULT, rdata);
+bool CreateBinaryEntryInRoot(hid_t root, const std::string& url, const std::string& dataset_content)
+{
+
+  hsize_t hs_size = static_cast<hsize_t>(dataset_content.size());
+  //  Create DataSpace with rank 1 and size dimension
+  auto data_space = H5Screate_simple(1, &hs_size, nullptr);
+  //  Create creation property for data_space
+  auto ds_property = H5Pcreate(H5P_DATASET_CREATE);
+  H5Pset_obj_track_times(ds_property, false);
+  //H5Pset_create_intermediate_group(ds_property, 1);
+  //  Create dataset in data_space
+  auto data_set = H5Dcreate(root, url.c_str(), H5T_NATIVE_UCHAR, data_space, H5P_DEFAULT, ds_property, H5P_DEFAULT);
+
+  //  Write buffer to dataset
+  herr_t write_status = H5Dwrite(data_set, H5T_NATIVE_UCHAR, H5S_ALL, H5S_ALL, H5P_DEFAULT, dataset_content.c_str());
+
+  //  Close dataset, data space, and data set property
+  H5Dclose(data_set);
+  H5Pclose(ds_property);
+  H5Sclose(data_space);
+
+  return (write_status >= 0);
+}
+
+bool ReadBinaryEntryAsString(hid_t root, const std::string& url, std::string& data)
+{
+  data.clear();
+
+  auto dataset_id = H5Dopen(root, url.c_str(), H5P_DEFAULT);
+  if (dataset_id < 0) return false;
+
+  auto size = H5Dget_storage_size(dataset_id);
+  data.resize(size);
+
+  herr_t read_status = -1;
+  if (size >= 0)
+  {
+    read_status = H5Dread(dataset_id, H5T_NATIVE_UCHAR, H5S_ALL, H5S_ALL, H5P_DEFAULT, static_cast<void*>(const_cast<char*>(data.data())));
+  }
+
+  H5Dclose(dataset_id);
+  return (read_status >= 0);
+}
+
+
+bool CreateInformationEntryInRoot(hid_t root, const std::string& url, const eCAL::eh5::EntryInfoVect& entries)
+{
+  const size_t dataSetsSize = entries.size();
+  hsize_t dims[2] = { dataSetsSize, 5 };
+  //  Create DataSpace with rank 2 and size dimension
+  auto dataSpace = H5Screate_simple(2, dims, nullptr);
+  //  Create creation property for data_space
+  auto dsProperty = H5Pcreate(H5P_DATASET_CREATE);
+  H5Pset_obj_track_times(dsProperty, false);
+  auto dataSet = H5Dcreate(root, url.c_str(), H5T_NATIVE_LLONG, dataSpace, H5P_DEFAULT, dsProperty, H5P_DEFAULT);
+  if (dataSet < 0) return false;
+
+  //  Write buffer to dataset
+  herr_t writeStatus = H5Dwrite(dataSet, H5T_NATIVE_LLONG, H5S_ALL, H5S_ALL, H5P_DEFAULT, entries.data());
+  if (writeStatus < 0) return false;
+
+  //  Close dataset, data space, and data set property
+  H5Dclose(dataSet);
+  H5Pclose(dsProperty);
+  H5Sclose(dataSpace);
+
+  return true;
+}
+
+bool GetEntryInfoVector(hid_t root, const std::string& url, eCAL::eh5::EntryInfoSet& entries)
+{
+  entries.clear();
+  
+  auto dataset_id = H5Dopen(root, url.c_str(), H5P_DEFAULT);
+
+  if (dataset_id < 0) return false;
+
+  const size_t sizeof_ll = sizeof(long long);
+  hsize_t data_size = H5Dget_storage_size(dataset_id) / sizeof_ll;
+
+  if (data_size <= 0) return false;
+
+  std::vector<long long> data(data_size);
+  herr_t status = H5Dread(dataset_id, H5T_NATIVE_LLONG, H5S_ALL, H5S_ALL, H5P_DEFAULT, &data[0]);
+  H5Dclose(dataset_id);
+
+  for (unsigned int index = 0; index < data_size; index += 5)
+  {
+    //                        rec timestamp,  channel id,       send clock,       send time stamp,  send ID
+    entries.emplace(eCAL::eh5::SEntryInfo(data[index], data[index + 1], data[index + 2], data[index + 3], data[index + 4]));
+  }
+
+  return (status >= 0);
+}
+
+bool SetAttribute(hid_t id, const std::string& name, const std::string& value)
+{
+  if (id < 0) return false;
+
+  if (H5Aexists(id, name.c_str()) > 0)
+    H5Adelete(id, name.c_str());
+  //  create scalar dataset
+  hid_t scalarDataset = H5Screate(H5S_SCALAR);
+
+  //  create new string data type
+  hid_t stringDataType = H5Tcopy(H5T_C_S1);
+
+  //  if attribute's value length exists, allocate space for it
+  if (value.length() > 0)
+    H5Tset_size(stringDataType, value.length());
+
+  //  create attribute
+  hid_t attribute = H5Acreate(id, name.c_str(), stringDataType, scalarDataset, H5P_DEFAULT, H5P_DEFAULT);
+
+  if (attribute < 0) return false;
+
+  //  write attribute value to attribute
+  herr_t writeStatus = H5Awrite(attribute, stringDataType, value.c_str());
+  if (writeStatus < 0) return false;
+
+  //  close attribute
+  H5Aclose(attribute);
+  //  close scalar dataset
+  H5Sclose(scalarDataset);
+  //  close string data type
+  H5Tclose(stringDataType);
+
+  return true;
+}
+
+bool GetAttribute(hid_t id, const std::string& name, std::string& value)
+{
+  bool ret_val = false;
+  //  empty attribute value
+  value.clear();
+  if (id < 0) return false;
+
+  //  check if attribute exists
+  if (H5Aexists(id, name.c_str()) != 0)
+  {
+    //  open attribute by name, getting the attribute index
+    hid_t attr_id = H5Aopen_name(id, name.c_str());
+    //  fail - attribute can not be opened
+    if (attr_id <= 0) return false;
+
+    //  get attribute type
+    hid_t attr_type = H5Aget_type(attr_id);
+    //  get type class based on attribute type
+    H5T_class_t type_class = H5Tget_class(attr_type);
+    //  get attribute content dataSize
+    const size_t attr_size = H5Tget_size(attr_type);
+
+    //  if attribute class is string
+    if (type_class == H5T_STRING)
+    {
+      hid_t attr_type_mem = H5Tget_native_type(attr_type, H5T_DIR_ASCEND);
+      //  create buffer to store the value of the attribute
+      std::vector<char> content_buffer(attr_size);
+      //  get attribute value
+      ret_val = (H5Aread(attr_id, attr_type_mem, &content_buffer[0]) >= 0);
+
+      //  convert value to std string
+      value = std::string(&content_buffer[0], attr_size);
+    }
+    else
+    {
+      //  fail - attribute is not string type
+      ret_val = false;
+    }
+    //  close attribute
+    H5Aclose(attr_id);
+  }
+  else
+  {
+    //  fail - attribute name does not exist
+    ret_val = false;
+  }
+  //  return read status
+  return ret_val;
+}
+
+hid_t OpenOrCreateGroup(hid_t root, const std::string& name)
+{
+  auto exists = H5Lexists(root, name.c_str(), H5P_DEFAULT);
+  hid_t group;
+  if (exists > 0)
+  {
+    group = H5Gopen(root, name.c_str(), H5P_DEFAULT);
+  }
+  else 
+  {
+    group = H5Gcreate(root, name.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+  }
+
+  return group;
+}
+
+std::vector<std::string> ListSubgroups(hid_t id)
+{
+  std::vector<std::string> group_vector;
+  auto iterate_lambda = [](hid_t /*group*/, const char* name, const H5L_info_t* /*info*/, void* op_data)->herr_t
+  {
+    auto vec = static_cast<std::vector<std::string>*>(op_data);
+    vec->push_back(name);
+    return 0;
+  };
+
+  H5Literate(id, H5_INDEX_NAME, H5_ITER_INC, nullptr, iterate_lambda, (void*)&group_vector);
+  return group_vector;
+}
+
+
+

--- a/contrib/ecalhdf5/src/hdf5_helper.cpp
+++ b/contrib/ecalhdf5/src/hdf5_helper.cpp
@@ -238,11 +238,16 @@ bool GetAttribute(hid_t id, const std::string& name, std::string& value)
   return ret_val;
 }
 
+bool HasGroup(hid_t root, const std::string& path)
+{
+  hid_t exists = H5Lexists(root, path.c_str(), H5P_DEFAULT);
+  return (exists > 0);
+}
+
 hid_t OpenOrCreateGroup(hid_t root, const std::string& name)
 {
-  auto exists = H5Lexists(root, name.c_str(), H5P_DEFAULT);
   hid_t group;
-  if (exists > 0)
+  if (HasGroup(root, name))
   {
     group = H5Gopen(root, name.c_str(), H5P_DEFAULT);
   }
@@ -267,6 +272,3 @@ std::vector<std::string> ListSubgroups(hid_t id)
   H5Literate(id, H5_INDEX_NAME, H5_ITER_INC, nullptr, iterate_lambda, (void*)&group_vector);
   return group_vector;
 }
-
-
-

--- a/contrib/ecalhdf5/src/hdf5_helper.h
+++ b/contrib/ecalhdf5/src/hdf5_helper.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <string>
+#include <iomanip>
+#include <sstream>
+
+#include <hdf5.h>
+
+#include <ecalhdf5/eh5_types.h>
+
+bool CreateStringEntryInRoot(hid_t root, const std::string& url, const std::string& dataset_content);
+bool ReadStringEntryAsString(hid_t root, const std::string& url, std::string& data);
+
+bool CreateBinaryEntryInRoot(hid_t root, const std::string& url, const std::string& dataset_content);
+bool ReadBinaryEntryAsString(hid_t root, const std::string& url, std::string& data);
+
+bool CreateInformationEntryInRoot(hid_t root, const std::string& url, const eCAL::eh5::EntryInfoVect& entries);
+bool GetEntryInfoVector(hid_t root, const std::string& url, eCAL::eh5::EntryInfoSet& entries);
+
+/**
+* @brief Set attribute to object(file, entry...)
+*
+* @param id       ID of the attributes parent
+* @param name     Name of the attribute
+* @param value    Value of the attribute
+*
+* @return         true if succeeds, false if it fails
+**/
+bool SetAttribute(hid_t id, const std::string& name, const std::string& value);
+/**
+* @brief Gets the value of a string attribute
+*
+* @param [in]  obj_id ID of the attribute's parent
+* @param [in]  name   Name of the attribute
+* @param [out] value  Value of the attribute
+*
+* @return  true if succeeds, false if it fails
+**/
+bool GetAttribute(hid_t id, const std::string& name, std::string& value);
+
+
+hid_t OpenOrCreateGroup(hid_t root, const std::string& name);
+
+
+std::vector<std::string> ListSubgroups(hid_t id);
+
+
+
+
+inline std::string printHex(eCAL::experimental::measurement::base::Channel::id_t id)
+{
+  std::stringstream ss;
+  ss << std::hex << std::setw(16) << std::setfill('0') << std::uppercase << id;
+  return ss.str();
+}
+
+inline eCAL::experimental::measurement::base::Channel::id_t parseHexID(std::string string_id)
+{
+  auto unsigned_value = std::stoull(string_id, 0, 16);
+  return static_cast<eCAL::experimental::measurement::base::Channel::id_t>(unsigned_value);
+}
+
+namespace v6
+{
+  inline std::string GetUrl(const std::string& channel_name_, const std::string& channel_id, const std::string& attribute)
+  {
+    return "/" + channel_name_ + "/" + channel_id + "/" + attribute;
+    //return "/" + channel_name_ + "/" + attribute;
+  }
+}

--- a/contrib/ecalhdf5/src/hdf5_helper.h
+++ b/contrib/ecalhdf5/src/hdf5_helper.h
@@ -38,13 +38,11 @@ bool SetAttribute(hid_t id, const std::string& name, const std::string& value);
 **/
 bool GetAttribute(hid_t id, const std::string& name, std::string& value);
 
+bool HasGroup(hid_t root, const std::string& path);
 
 hid_t OpenOrCreateGroup(hid_t root, const std::string& name);
 
-
 std::vector<std::string> ListSubgroups(hid_t id);
-
-
 
 
 inline std::string printHex(eCAL::experimental::measurement::base::Channel::id_t id)

--- a/contrib/measurement/base/include/ecal/measurement/base/reader.h
+++ b/contrib/measurement/base/include/ecal/measurement/base/reader.h
@@ -117,65 +117,78 @@ namespace eCAL
           virtual std::set<std::string> GetChannelNames() const = 0;
 
           /**
+           * @brief Get the available channel names of the current opened file / measurement
+           *
+           * @return Channels (channel name & id)
+          **/
+          virtual std::set<eCAL::experimental::measurement::base::Channel> GetChannels() const = 0;
+
+          /**
+           * @brief Get the available channel names of the current opened file / measurement
+           *
+           * @return Channels (channel name & id)
+          **/
+          virtual std::set<eCAL::experimental::measurement::base::Channel> GetChannels(const std::string& channel_name) const = 0;
+
+          /**
            * @brief Check if channel exists in measurement
            *
-           * @param channel_name   name of the channel
+           * @param channel  The channel (channel name & id)
            *
            * @return       true if exists, false otherwise
           **/
-          virtual bool HasChannel(const std::string& channel_name) const = 0;
+          virtual bool HasChannel(const eCAL::experimental::measurement::base::Channel& channel) const = 0;
 
           /**
            * @brief Get data type information of the given channel
            *
-           * @param channel_name  channel name
+           * @param channel       (channel name & id)
            *
            * @return              channel type
           **/
-          virtual DataTypeInformation GetChannelDataTypeInformation(const std::string & channel_name) const = 0;
-
+          virtual DataTypeInformation GetChannelDataTypeInformation(const eCAL::experimental::measurement::base::Channel& channel) const = 0;
 
           /**
            * @brief Gets minimum timestamp for specified channel
            *
-           * @param channel_name    channel name
+           * @param channel         (channel name & id)
            *
            * @return                minimum timestamp value
           **/
-          virtual long long GetMinTimestamp(const std::string& channel_name) const = 0;
+          virtual long long GetMinTimestamp(const eCAL::experimental::measurement::base::Channel& channel) const = 0;
 
           /**
            * @brief Gets maximum timestamp for specified channel
            *
-           * @param channel_name    channel name
+           * @param channel         (channel name & id)
            *
            * @return                maximum timestamp value
           **/
-          virtual long long GetMaxTimestamp(const std::string& channel_name) const = 0;
+          virtual long long GetMaxTimestamp(const eCAL::experimental::measurement::base::Channel & channel) const = 0;
 
           /**
            * @brief Gets the header info for all data entries for the given channel
            *        Header = timestamp + entry id
            *
-           * @param [in]  channel_name  channel name
+           * @param [in]  channel       (channel name & id)
            * @param [out] entries       header info for all data entries
            *
            * @return                    true if succeeds, false if it fails
           **/
-          virtual bool GetEntriesInfo(const std::string& channel_name, EntryInfoSet& entries) const = 0;
+          virtual bool GetEntriesInfo(const eCAL::experimental::measurement::base::Channel & channel, EntryInfoSet& entries) const = 0;
 
           /**
            * @brief Gets the header info for data entries for the given channel included in given time range (begin->end)
            *        Header = timestamp + entry id
            *
-           * @param [in]  channel_name channel name
+           * @param [in]  channel      (channel name & id)
            * @param [in]  begin        time range begin timestamp
            * @param [in]  end          time range end timestamp
            * @param [out] entries      header info for data entries in given range
            *
            * @return                   true if succeeds, false if it fails
           **/
-          virtual bool GetEntriesInfoRange(const std::string& channel_name, long long begin, long long end, EntryInfoSet& entries) const = 0;
+          virtual bool GetEntriesInfoRange(const eCAL::experimental::measurement::base::Channel& channel, long long begin, long long end, EntryInfoSet& entries) const = 0;
 
           /**
            * @brief Gets data size of a specific entry

--- a/contrib/measurement/base/include/ecal/measurement/base/reader.h
+++ b/contrib/measurement/base/include/ecal/measurement/base/reader.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,7 +114,7 @@ namespace eCAL
            *
            * @return       channel names
           **/
-          virtual std::set<std::string> GetChannelNames() const = 0;
+          /*virtual std::set<std::string> GetChannelNames() const = 0;*/
 
           /**
            * @brief Get the available channel names of the current opened file / measurement
@@ -128,7 +128,7 @@ namespace eCAL
            *
            * @return Channels (channel name & id)
           **/
-          virtual std::set<eCAL::experimental::measurement::base::Channel> GetChannels(const std::string& channel_name) const = 0;
+          /*virtual std::set<eCAL::experimental::measurement::base::Channel> GetChannels(const std::string& channel_name) const = 0;*/
 
           /**
            * @brief Check if channel exists in measurement

--- a/contrib/measurement/base/include/ecal/measurement/base/types.h
+++ b/contrib/measurement/base/include/ecal/measurement/base/types.h
@@ -24,7 +24,9 @@
 
 #pragma once 
 
+#include <cstdint>
 #include <set>
+#include <tuple>
 #include <vector>
 
 namespace eCAL
@@ -42,22 +44,62 @@ namespace eCAL
         **/
         struct DataTypeInformation
         {
-          std::string name;          //!< name of the datatype
-          std::string encoding;      //!< encoding of the datatype (e.g. protobuf, flatbuffers, capnproto)
-          std::string descriptor;    //!< descriptor information of the datatype (necessary for reflection)
+          std::string name       = "";    //!< name of the datatype
+          std::string encoding   = "";    //!< encoding of the datatype (e.g. protobuf, flatbuffers, capnproto)
+          std::string descriptor = "";    //!< descriptor information of the datatype (necessary for reflection)
 
           //!< @cond
           bool operator==(const DataTypeInformation& other) const
           {
-            return name == other.name && encoding == other.encoding && descriptor == other.descriptor;
+            return std::tie(name, encoding, descriptor) == std::tie(other.name, other.encoding, other.descriptor);
           }
 
           bool operator!=(const DataTypeInformation& other) const
           {
             return !(*this == other);
           }
+
+          bool operator<(const DataTypeInformation& other) const
+          {
+            return std::tie(name, encoding, descriptor) < std::tie(other.name, other.encoding, other.descriptor);
+          }
           //!< @endcond
         };
+
+        struct Channel
+        {
+          using id_t = std::int64_t;
+
+          std::string name = "";
+          id_t        id = 0;
+
+          [[deprecated("Please construct a Channel object explicitly.")]]
+          Channel(const std::string name_) : name(name_) {};
+          
+          Channel(const std::string name_, id_t id_) : name(name_), id(id_) {};
+
+          //!< @cond
+          bool operator==(const Channel& other) const
+          {
+            return std::tie(name, id) == std::tie(other.name, other.id);
+          }
+
+          bool operator!=(const Channel& other) const
+          {
+            return !(*this == other);
+          }
+
+          bool operator<(const Channel& other) const
+          {
+            return std::tie(name, id) < std::tie(other.name, other.id);
+          }
+          //!< @endcond
+        };
+
+        inline Channel CreateChannel(const std::string& name)
+        {
+          return Channel{ name, 0 };
+        }
 
         /**
          * @brief Info struct for a single measurement entry

--- a/contrib/measurement/base/include/ecal/measurement/base/types.h
+++ b/contrib/measurement/base/include/ecal/measurement/base/types.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ namespace eCAL
           //!< @cond
           bool operator==(const Channel& other) const
           {
-            return std::tie(name, id) == std::tie(other.name, other.id);
+            return std::tie(id, name) == std::tie(other.id, other.name);
           }
 
           bool operator!=(const Channel& other) const
@@ -91,7 +91,7 @@ namespace eCAL
 
           bool operator<(const Channel& other) const
           {
-            return std::tie(name, id) < std::tie(other.name, other.id);
+            return std::tie(id, name) < std::tie(other.id, other.name);
           }
           //!< @endcond
         };
@@ -107,10 +107,10 @@ namespace eCAL
         struct EntryInfo
         {
           long long RcvTimestamp;   //!< Receive time stamp
-          long long ID;             //!< Channel ID
+          long long ID;             //!< Data ID - to extract corresponding data
           long long SndClock;       //!< Send clock
           long long SndTimestamp;   //!< Send time stamp
-          long long SndID;          //!< Send ID
+          long long SndID;          //!< Send ID topic ID (v6) / can be set by user (v5)
 
           //!< @cond
           EntryInfo() : RcvTimestamp(0), ID(0), SndClock(0), SndTimestamp(0), SndID(0) {}

--- a/contrib/measurement/base/include/ecal/measurement/base/types.h
+++ b/contrib/measurement/base/include/ecal/measurement/base/types.h
@@ -146,3 +146,17 @@ namespace eCAL
     }
   }
 }
+
+namespace std {
+  template <>
+  struct hash<eCAL::experimental::measurement::base::Channel> {
+    std::size_t operator()(const eCAL::experimental::measurement::base::Channel& data) const {
+      // Combine the hash of the string and the integer
+      std::size_t h1 = std::hash<std::string>{}(data.name);
+      std::size_t h2 = std::hash<eCAL::experimental::measurement::base::Channel::id_t>{}(data.id);
+
+      // Combine the two hashes (this is a common technique)
+      return h1 ^ (h2 << 1); // XOR and shift
+    }
+  };
+}

--- a/contrib/measurement/base/include/ecal/measurement/base/types.h
+++ b/contrib/measurement/base/include/ecal/measurement/base/types.h
@@ -73,9 +73,6 @@ namespace eCAL
           std::string name = "";
           id_t        id = 0;
 
-          [[deprecated("Please construct a Channel object explicitly.")]]
-          Channel(const std::string name_) : name(name_) {};
-          
           Channel(const std::string name_, id_t id_) : name(name_), id(id_) {};
 
           //!< @cond

--- a/contrib/measurement/base/include/ecal/measurement/base/types.h
+++ b/contrib/measurement/base/include/ecal/measurement/base/types.h
@@ -73,6 +73,7 @@ namespace eCAL
           std::string name = "";
           id_t        id = 0;
 
+          Channel() = default;
           Channel(const std::string name_, id_t id_) : name(name_), id(id_) {};
 
           //!< @cond
@@ -97,6 +98,23 @@ namespace eCAL
         {
           return Channel{ name, 0 };
         }
+        
+        struct WriteEntry
+        {
+          // channel
+          Channel channel;
+
+          // data
+          const void* data = nullptr;
+          unsigned long long size = 0;
+
+          // metadata
+          long long snd_timestamp = 0;
+          long long rcv_timestamp = 0;
+          long long sender_id = 0; // Unique ID which may be set by sender
+          long long clock = 0;
+        };
+
 
         /**
          * @brief Info struct for a single measurement entry

--- a/contrib/measurement/base/include/ecal/measurement/base/types.h
+++ b/contrib/measurement/base/include/ecal/measurement/base/types.h
@@ -107,7 +107,7 @@ namespace eCAL
           long long ID;             //!< Data ID - to extract corresponding data
           long long SndClock;       //!< Send clock
           long long SndTimestamp;   //!< Send time stamp
-          long long SndID;          //!< Send ID topic ID (v6) / can be set by user (v5)
+          long long SndID;          //!< Send ID (!= channel ID!!!!)
 
           //!< @cond
           EntryInfo() : RcvTimestamp(0), ID(0), SndClock(0), SndTimestamp(0), SndID(0) {}

--- a/contrib/measurement/base/include/ecal/measurement/base/types.h
+++ b/contrib/measurement/base/include/ecal/measurement/base/types.h
@@ -145,15 +145,6 @@ namespace eCAL
         **/
         using EntryInfoVect = std::vector<EntryInfo>;
 
-        /**
-         * @brief eCAL Measurement Access types
-        **/
-        enum AccessType
-        {
-          RDONLY,  //!< ReadOnly - the measurement can only be read
-          CREATE   //!< Create   - a new measurement will be created
-        };
-
       }
     }
   }

--- a/contrib/measurement/base/include/ecal/measurement/base/writer.h
+++ b/contrib/measurement/base/include/ecal/measurement/base/writer.h
@@ -146,7 +146,10 @@ namespace eCAL
            *
            * @return              channel type
           **/
-          virtual void SetChannelDataTypeInformation(const std::string & channel_name, const DataTypeInformation& info) = 0;
+          virtual void SetChannelDataTypeInformation(const eCAL::experimental::measurement::base::Channel& channel_name, const DataTypeInformation& info) = 0;
+
+//          [[deprecated]]
+//          virtual void SetChannelDataTypeInformation(const std::string & channel_name, const base::DataTypeInformation & info) = 0;
 
           /**
            * @brief Set measurement file base name (desired name for the actual hdf5 files that will be created)
@@ -168,7 +171,7 @@ namespace eCAL
            *
            * @return              true if succeeds, false if it fails
           **/
-          virtual bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const std::string& channel_name, long long id, long long clock) = 0;
+          virtual bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const eCAL::experimental::measurement::base::Channel& channel, long long clock) = 0;
 
         };
       }

--- a/contrib/measurement/base/include/ecal/measurement/base/writer.h
+++ b/contrib/measurement/base/include/ecal/measurement/base/writer.h
@@ -168,8 +168,7 @@ namespace eCAL
            *
            * @return              true if succeeds, false if it fails
           **/
-          virtual bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const eCAL::experimental::measurement::base::Channel& channel, long long id, long long clock) = 0;
-
+          virtual bool AddEntryToFile(const base::WriteEntry& entry) = 0;
         };
       }
     }

--- a/contrib/measurement/base/include/ecal/measurement/base/writer.h
+++ b/contrib/measurement/base/include/ecal/measurement/base/writer.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -148,9 +148,6 @@ namespace eCAL
           **/
           virtual void SetChannelDataTypeInformation(const eCAL::experimental::measurement::base::Channel& channel_name, const DataTypeInformation& info) = 0;
 
-//          [[deprecated]]
-//          virtual void SetChannelDataTypeInformation(const std::string & channel_name, const base::DataTypeInformation & info) = 0;
-
           /**
            * @brief Set measurement file base name (desired name for the actual hdf5 files that will be created)
            *
@@ -171,7 +168,7 @@ namespace eCAL
            *
            * @return              true if succeeds, false if it fails
           **/
-          virtual bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const eCAL::experimental::measurement::base::Channel& channel, long long clock) = 0;
+          virtual bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const eCAL::experimental::measurement::base::Channel& channel, long long id, long long clock) = 0;
 
         };
       }

--- a/contrib/measurement/base/include/ecal/measurement/measurement.h
+++ b/contrib/measurement/base/include/ecal/measurement/measurement.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ namespace eCAL
 {
   namespace measurement
   {
-    using ChannelSet = std::set<std::string>;
+    using ChannelSet = std::set<eCAL::experimental::measurement::base::Channel>;
   
     struct SenderID
     {

--- a/contrib/measurement/base/include/ecal/measurement/omeasurement.h
+++ b/contrib/measurement/base/include/ecal/measurement/omeasurement.h
@@ -44,7 +44,7 @@ namespace eCAL
 
       OBinaryChannel& operator<<(const BinaryFrame& entry_)
       {
-        meas->AddEntryToFile((void*)entry_.message.data(), entry_.message.size(), entry_.send_timestamp, entry_.receive_timestamp, channel_name, SenderID, clock);
+        meas->AddEntryToFile((void*)entry_.message.data(), entry_.message.size(), entry_.send_timestamp, entry_.receive_timestamp, eCAL::experimental::measurement::base::Channel{ channel_name, SenderID }, clock);
         ++clock;
         return *this;
       }

--- a/contrib/measurement/base/include/ecal/measurement/omeasurement.h
+++ b/contrib/measurement/base/include/ecal/measurement/omeasurement.h
@@ -45,7 +45,16 @@ namespace eCAL
 
       OBinaryChannel& operator<<(const BinaryFrame& entry_)
       {
-        meas->AddEntryToFile((void*)entry_.message.data(), entry_.message.size(), entry_.send_timestamp, entry_.receive_timestamp, channel, id, clock);
+        eCAL::experimental::measurement::base::WriteEntry entry;
+        entry.channel = channel;
+        entry.data = entry_.message.data();
+        entry.size = entry_.message.size();
+        entry.snd_timestamp = entry_.send_timestamp;
+        entry.rcv_timestamp = entry_.receive_timestamp;
+        entry.sender_id = id;
+        entry.clock = clock;
+
+        meas->AddEntryToFile(entry);
         ++clock;
         return *this;
       }

--- a/contrib/measurement/hdf5/include/ecal/measurement/hdf5/reader.h
+++ b/contrib/measurement/hdf5/include/ecal/measurement/hdf5/reader.h
@@ -127,13 +127,27 @@ namespace eCAL
           std::set<std::string> GetChannelNames() const override;
 
           /**
+           * @brief Get the available channel names of the current opened file / measurement
+           *
+           * @return Channels (channel name & id)
+          **/
+          std::set<eCAL::experimental::measurement::base::Channel> GetChannels() const override;
+
+          /**
+           * @brief Get the available channel names of the current opened file / measurement
+           *
+           * @return Channels (channel name & id)
+          **/
+          std::set<eCAL::experimental::measurement::base::Channel> GetChannels(const std::string& channel_name) const override;
+
+          /**
            * @brief Check if channel exists in measurement
            *
            * @param channel_name   name of the channel
            *
            * @return       true if exists, false otherwise
           **/
-          bool HasChannel(const std::string& channel_name) const override;
+          bool HasChannel(const eCAL::experimental::measurement::base::Channel& channel) const override;
 
           /**
            * @brief Get data type information of the given channel
@@ -142,7 +156,7 @@ namespace eCAL
            *
            * @return              channel type
           **/
-          base::DataTypeInformation GetChannelDataTypeInformation(const std::string& channel_name) const override;
+          base::DataTypeInformation GetChannelDataTypeInformation(const eCAL::experimental::measurement::base::Channel& channel) const override;
 
           /**
            * @brief Gets minimum timestamp for specified channel
@@ -151,7 +165,7 @@ namespace eCAL
            *
            * @return                minimum timestamp value
           **/
-          long long GetMinTimestamp(const std::string& channel_name) const override;
+          long long GetMinTimestamp(const eCAL::experimental::measurement::base::Channel& channel) const override;
 
           /**
            * @brief Gets maximum timestamp for specified channel
@@ -160,7 +174,7 @@ namespace eCAL
            *
            * @return                maximum timestamp value
           **/
-          long long GetMaxTimestamp(const std::string& channel_name) const override;
+          long long GetMaxTimestamp(const eCAL::experimental::measurement::base::Channel& channel) const override;
 
           /**
            * @brief Gets the header info for all data entries for the given channel
@@ -171,7 +185,7 @@ namespace eCAL
            *
            * @return                    true if succeeds, false if it fails
           **/
-          bool GetEntriesInfo(const std::string& channel_name, measurement::base::EntryInfoSet& entries) const override;
+          bool GetEntriesInfo(const eCAL::experimental::measurement::base::Channel& channel, measurement::base::EntryInfoSet& entries) const override;
 
           /**
            * @brief Gets the header info for data entries for the given channel included in given time range (begin->end)
@@ -184,7 +198,7 @@ namespace eCAL
            *
            * @return                   true if succeeds, false if it fails
           **/
-          bool GetEntriesInfoRange(const std::string& channel_name, long long begin, long long end, measurement::base::EntryInfoSet& entries) const override;
+          bool GetEntriesInfoRange(const eCAL::experimental::measurement::base::Channel& channel, long long begin, long long end, measurement::base::EntryInfoSet& entries) const override;
 
           /**
            * @brief Gets data size of a specific entry

--- a/contrib/measurement/hdf5/include/ecal/measurement/hdf5/reader.h
+++ b/contrib/measurement/hdf5/include/ecal/measurement/hdf5/reader.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,20 +27,16 @@
 #include <memory>
 #include <ecal/measurement/base/reader.h>
 
-
 namespace eCAL
 {
-  namespace eh5
-  {
-    class HDF5Meas;
-  }
-
   namespace experimental
   {
     namespace measurement
     {
       namespace hdf5
       {
+        struct ReaderImpl;
+
         /**
          * @brief Hdf5 based Reader Implementation
         **/
@@ -124,7 +120,7 @@ namespace eCAL
            *
            * @return       channel names
           **/
-          std::set<std::string> GetChannelNames() const override;
+          //std::set<std::string> GetChannelNames() const override;
 
           /**
            * @brief Get the available channel names of the current opened file / measurement
@@ -138,7 +134,7 @@ namespace eCAL
            *
            * @return Channels (channel name & id)
           **/
-          std::set<eCAL::experimental::measurement::base::Channel> GetChannels(const std::string& channel_name) const override;
+          //std::set<eCAL::experimental::measurement::base::Channel> GetChannels(const std::string& channel_name) const override;
 
           /**
            * @brief Check if channel exists in measurement
@@ -221,7 +217,7 @@ namespace eCAL
           bool GetEntryData(long long entry_id, void* data) const override;
 
         private:
-          std::unique_ptr<eh5::HDF5Meas> measurement;
+          std::unique_ptr<ReaderImpl> impl;
 
         };
 

--- a/contrib/measurement/hdf5/include/ecal/measurement/hdf5/writer.h
+++ b/contrib/measurement/hdf5/include/ecal/measurement/hdf5/writer.h
@@ -156,7 +156,7 @@ namespace eCAL
            *
            * @return              channel type
           **/
-          void SetChannelDataTypeInformation(const std::string& channel_name, const base::DataTypeInformation& info) override;
+          void SetChannelDataTypeInformation(const eCAL::experimental::measurement::base::Channel& channel, const base::DataTypeInformation& info) override;
 
           /**
            * @brief Set measurement file base name (desired name for the actual hdf5 files that will be created)
@@ -178,7 +178,7 @@ namespace eCAL
            *
            * @return              true if succeeds, false if it fails
           **/
-          bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const std::string& channel_name, long long id, long long clock) override;
+          bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const eCAL::experimental::measurement::base::Channel& channel, long long clock) override;
 
         private:
           std::unique_ptr<eh5::HDF5Meas> measurement;

--- a/contrib/measurement/hdf5/include/ecal/measurement/hdf5/writer.h
+++ b/contrib/measurement/hdf5/include/ecal/measurement/hdf5/writer.h
@@ -175,7 +175,7 @@ namespace eCAL
            *
            * @return              true if succeeds, false if it fails
           **/
-          bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const eCAL::experimental::measurement::base::Channel& channel, long long id, long long clock) override;
+          bool AddEntryToFile(const base::WriteEntry& entry) override;
 
         private:
           std::unique_ptr<WriterImpl> impl;

--- a/contrib/measurement/hdf5/include/ecal/measurement/hdf5/writer.h
+++ b/contrib/measurement/hdf5/include/ecal/measurement/hdf5/writer.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,17 +33,14 @@
 
 namespace eCAL
 {
-  namespace eh5
-  {
-    class HDF5Meas;
-  }
-
   namespace experimental
   {
     namespace measurement
     {
       namespace hdf5
       {
+        class WriterImpl;
+
         /**
          * @brief Hdf5 based Writer implementation
         **/
@@ -178,10 +175,10 @@ namespace eCAL
            *
            * @return              true if succeeds, false if it fails
           **/
-          bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const eCAL::experimental::measurement::base::Channel& channel, long long clock) override;
+          bool AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const eCAL::experimental::measurement::base::Channel& channel, long long id, long long clock) override;
 
         private:
-          std::unique_ptr<eh5::HDF5Meas> measurement;
+          std::unique_ptr<WriterImpl> impl;
         };
       }  // namespace hdf5
     }  // namespace measurement

--- a/contrib/measurement/hdf5/src/reader.cpp
+++ b/contrib/measurement/hdf5/src/reader.cpp
@@ -44,34 +44,44 @@ std::set<std::string> Reader::GetChannelNames() const
   return measurement->GetChannelNames();
 }
 
-bool Reader::HasChannel(const std::string& channel_name) const
+std::set<eCAL::experimental::measurement::base::Channel> eCAL::experimental::measurement::hdf5::Reader::GetChannels() const
 {
-  return measurement->HasChannel(channel_name);
+  return measurement->GetChannels();
 }
 
-base::DataTypeInformation Reader::GetChannelDataTypeInformation(const std::string& channel_name) const
+std::set<eCAL::experimental::measurement::base::Channel> eCAL::experimental::measurement::hdf5::Reader::GetChannels(const std::string& channel_name) const
 {
-  return measurement->GetChannelDataTypeInformation(channel_name);
+  return measurement->GetChannels(channel_name);
 }
 
-long long Reader::GetMinTimestamp(const std::string& channel_name) const
+bool Reader::HasChannel(const eCAL::experimental::measurement::base::Channel& channel) const
 {
-  return measurement->GetMinTimestamp(channel_name);
+  return measurement->HasChannel(channel.name);
 }
 
-long long Reader::GetMaxTimestamp(const std::string& channel_name) const
+base::DataTypeInformation Reader::GetChannelDataTypeInformation(const base::Channel& channel) const
 {
-  return measurement->GetMaxTimestamp(channel_name);
+  return measurement->GetChannelDataTypeInformation(channel);
 }
 
-bool Reader::GetEntriesInfo(const std::string& channel_name, base::EntryInfoSet& entries) const
+long long Reader::GetMinTimestamp(const base::Channel& channel) const
 {
-  return measurement->GetEntriesInfo(channel_name, entries);
+  return measurement->GetMinTimestamp(channel);
 }
 
-bool Reader::GetEntriesInfoRange(const std::string& channel_name, long long begin, long long end, base::EntryInfoSet& entries) const
+long long Reader::GetMaxTimestamp(const base::Channel& channel) const
 {
-  return measurement->GetEntriesInfoRange(channel_name, begin, end, entries);
+  return measurement->GetMaxTimestamp(channel);
+}
+
+bool Reader::GetEntriesInfo(const base::Channel& channel, base::EntryInfoSet& entries) const
+{
+  return measurement->GetEntriesInfo(channel, entries);
+}
+
+bool Reader::GetEntriesInfoRange(const base::Channel& channel, long long begin, long long end, base::EntryInfoSet& entries) const
+{
+  return measurement->GetEntriesInfoRange(channel, begin, end, entries);
 }
 
 bool Reader::GetEntryDataSize(long long entry_id, size_t& size) const

--- a/contrib/measurement/hdf5/src/reader.cpp
+++ b/contrib/measurement/hdf5/src/reader.cpp
@@ -10,7 +10,7 @@ Reader::Reader()
 {}
 
 Reader::Reader(const std::string& path) 
-  : measurement(std::make_unique<eh5::HDF5Meas>(path, eh5::eAccessType::RDONLY))
+  : measurement(std::make_unique<eh5::HDF5Meas>(path, eCAL::eh5::RDONLY))
 {}
 
 Reader::~Reader() = default;
@@ -21,7 +21,7 @@ Reader& Reader::operator=(Reader&&) noexcept = default;
 
 bool Reader::Open(const std::string& path) 
 {
-  return measurement->Open(path, eh5::eAccessType::RDONLY);
+  return measurement->Open(path, eCAL::eh5::RDONLY);
 }
 
 bool Reader::Close() 

--- a/contrib/measurement/hdf5/src/reader.cpp
+++ b/contrib/measurement/hdf5/src/reader.cpp
@@ -5,12 +5,34 @@
 using namespace eCAL::experimental::measurement::hdf5;
 using namespace eCAL::experimental::measurement;
 
+namespace eCAL
+{
+  namespace experimental
+  {
+    namespace measurement
+    {
+      namespace hdf5
+      {
+        struct ReaderImpl
+        {
+          eCAL::eh5::HDF5Meas measurement;
+
+          ReaderImpl() = default;
+          ReaderImpl(const std::string& path)
+            : measurement(path, eCAL::eh5::eAccessType::RDONLY)
+          {}
+        };
+      }
+    }
+  }
+}
+
 Reader::Reader() 
-  : measurement(std::make_unique<eh5::HDF5Meas>()) 
+  : impl(std::make_unique<ReaderImpl>())
 {}
 
 Reader::Reader(const std::string& path) 
-  : measurement(std::make_unique<eh5::HDF5Meas>(path, eCAL::eh5::RDONLY))
+  : impl(std::make_unique<ReaderImpl>(path))
 {}
 
 Reader::~Reader() = default;
@@ -21,75 +43,77 @@ Reader& Reader::operator=(Reader&&) noexcept = default;
 
 bool Reader::Open(const std::string& path) 
 {
-  return measurement->Open(path, eCAL::eh5::RDONLY);
+  return impl->measurement.Open(path, eCAL::eh5::eAccessType::RDONLY);
 }
 
 bool Reader::Close() 
 {
-  return measurement->Close(); 
+  return impl->measurement.Close();
 }
 
 bool Reader::IsOk() const
 {
-  return measurement->IsOk();
+  return impl->measurement.IsOk();
 }
 
 std::string Reader::GetFileVersion() const
 {
-  return measurement->GetFileVersion();
+  return impl->measurement.GetFileVersion();
 }
 
+/*
 std::set<std::string> Reader::GetChannelNames() const
 {
-  return measurement->GetChannelNames();
-}
+  return impl->measurement.GetChannelNames();
+}*/
 
 std::set<eCAL::experimental::measurement::base::Channel> eCAL::experimental::measurement::hdf5::Reader::GetChannels() const
 {
-  return measurement->GetChannels();
+  return impl->measurement.GetChannels();
 }
 
+/*
 std::set<eCAL::experimental::measurement::base::Channel> eCAL::experimental::measurement::hdf5::Reader::GetChannels(const std::string& channel_name) const
 {
-  return measurement->GetChannels(channel_name);
-}
+  return impl->measurement.GetChannels(channel_name);
+}*/
 
 bool Reader::HasChannel(const eCAL::experimental::measurement::base::Channel& channel) const
 {
-  return measurement->HasChannel(channel.name);
+  return impl->measurement.HasChannel(channel);
 }
 
 base::DataTypeInformation Reader::GetChannelDataTypeInformation(const base::Channel& channel) const
 {
-  return measurement->GetChannelDataTypeInformation(channel);
+  return impl->measurement.GetChannelDataTypeInformation(channel);
 }
 
 long long Reader::GetMinTimestamp(const base::Channel& channel) const
 {
-  return measurement->GetMinTimestamp(channel);
+  return impl->measurement.GetMinTimestamp(channel);
 }
 
 long long Reader::GetMaxTimestamp(const base::Channel& channel) const
 {
-  return measurement->GetMaxTimestamp(channel);
+  return impl->measurement.GetMaxTimestamp(channel);
 }
 
 bool Reader::GetEntriesInfo(const base::Channel& channel, base::EntryInfoSet& entries) const
 {
-  return measurement->GetEntriesInfo(channel, entries);
+  return impl->measurement.GetEntriesInfo(channel, entries);
 }
 
 bool Reader::GetEntriesInfoRange(const base::Channel& channel, long long begin, long long end, base::EntryInfoSet& entries) const
 {
-  return measurement->GetEntriesInfoRange(channel, begin, end, entries);
+  return impl->measurement.GetEntriesInfoRange(channel, begin, end, entries);
 }
 
 bool Reader::GetEntryDataSize(long long entry_id, size_t& size) const
 {
-  return measurement->GetEntryDataSize(entry_id, size);
+  return impl->measurement.GetEntryDataSize(entry_id, size);
 }
 
 bool Reader::GetEntryData(long long entry_id, void* data) const
 {
-  return measurement->GetEntryData(entry_id, data);
+  return impl->measurement.GetEntryData(entry_id, data);
 }

--- a/contrib/measurement/hdf5/src/writer.cpp
+++ b/contrib/measurement/hdf5/src/writer.cpp
@@ -53,7 +53,7 @@ void Writer::SetOneFilePerChannelEnabled(bool enabled)
   return measurement->SetOneFilePerChannelEnabled(enabled);
 }
 
-void Writer::SetChannelDataTypeInformation(const std::string& channel_name, const base::DataTypeInformation& info)
+void Writer::SetChannelDataTypeInformation(const base::Channel& channel_name, const base::DataTypeInformation& info)
 {
   measurement->SetChannelDataTypeInformation(channel_name, info);
 }
@@ -63,7 +63,7 @@ void Writer::SetFileBaseName(const std::string& base_name)
   return measurement->SetFileBaseName(base_name);
 }
 
-bool Writer::AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const std::string& channel_name, long long id, long long clock)
+bool Writer::AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const eCAL::experimental::measurement::base::Channel& channel, long long clock)
 {
-  return measurement->AddEntryToFile(data, size, snd_timestamp, rcv_timestamp, channel_name, id, clock);
+  return measurement->AddEntryToFile(data, size, snd_timestamp, rcv_timestamp, channel, clock);
 }

--- a/contrib/measurement/hdf5/src/writer.cpp
+++ b/contrib/measurement/hdf5/src/writer.cpp
@@ -4,12 +4,34 @@
 using namespace eCAL::experimental::measurement::hdf5;
 using namespace eCAL::experimental::measurement;
 
+namespace eCAL
+{
+  namespace experimental
+  {
+    namespace measurement
+    {
+      namespace hdf5
+      {
+        struct WriterImpl
+        {
+          eCAL::eh5::HDF5Meas measurement;
+
+          WriterImpl() = default;
+          WriterImpl(const std::string& path)
+            : measurement(path, eCAL::eh5::eAccessType::CREATE)
+          {}
+        };
+      }
+    }
+  }
+}
+
 Writer::Writer() 
-  : measurement(std::make_unique<eh5::HDF5Meas>()) 
+  : impl(std::make_unique<WriterImpl>())
 {}
 
 Writer::Writer(const std::string& path) 
-  : measurement(std::make_unique<eh5::HDF5Meas>(path, eCAL::eh5::CREATE))
+  : impl(std::make_unique<WriterImpl>(path))
 {}
 
 Writer::~Writer() = default;
@@ -20,50 +42,50 @@ Writer& Writer::operator=(Writer&&) noexcept = default;
 
 bool Writer::Open(const std::string& path)
 {
-  return measurement->Open(path, eCAL::eh5::CREATE);
+  return impl->measurement.Open(path, eCAL::eh5::eAccessType::CREATE);
 }
 
 bool Writer::Close()
 {
-  return measurement->Close();
+  return impl->measurement.Close();
 }
 
 bool Writer::IsOk() const
 {
-  return measurement->IsOk();
+  return impl->measurement.IsOk();
 }
 
 size_t Writer::GetMaxSizePerFile() const
 {
-  return measurement->GetMaxSizePerFile();
+  return impl->measurement.GetMaxSizePerFile();
 }
 
 void Writer::SetMaxSizePerFile(size_t size)
 {
-  return measurement->SetMaxSizePerFile(size);
+  return impl->measurement.SetMaxSizePerFile(size);
 }
 
 bool Writer::IsOneFilePerChannelEnabled() const
 {
-  return measurement->IsOneFilePerChannelEnabled();
+  return impl->measurement.IsOneFilePerChannelEnabled();
 }
 
 void Writer::SetOneFilePerChannelEnabled(bool enabled)
 {
-  return measurement->SetOneFilePerChannelEnabled(enabled);
+  return impl->measurement.SetOneFilePerChannelEnabled(enabled);
 }
 
 void Writer::SetChannelDataTypeInformation(const base::Channel& channel_name, const base::DataTypeInformation& info)
 {
-  measurement->SetChannelDataTypeInformation(channel_name, info);
+  impl->measurement.SetChannelDataTypeInformation(channel_name, info);
 }
 
 void Writer::SetFileBaseName(const std::string& base_name)
 {
-  return measurement->SetFileBaseName(base_name);
+  return impl->measurement.SetFileBaseName(base_name);
 }
 
-bool Writer::AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const eCAL::experimental::measurement::base::Channel& channel, long long clock)
+bool Writer::AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const eCAL::experimental::measurement::base::Channel& channel, long long id, long long clock)
 {
-  return measurement->AddEntryToFile(data, size, snd_timestamp, rcv_timestamp, channel, clock);
+  return impl->measurement.AddEntryToFile(data, size, snd_timestamp, rcv_timestamp, channel, id, clock);
 }

--- a/contrib/measurement/hdf5/src/writer.cpp
+++ b/contrib/measurement/hdf5/src/writer.cpp
@@ -9,7 +9,7 @@ Writer::Writer()
 {}
 
 Writer::Writer(const std::string& path) 
-  : measurement(std::make_unique<eh5::HDF5Meas>(path, eh5::eAccessType::CREATE))
+  : measurement(std::make_unique<eh5::HDF5Meas>(path, eCAL::eh5::CREATE))
 {}
 
 Writer::~Writer() = default;
@@ -20,7 +20,7 @@ Writer& Writer::operator=(Writer&&) noexcept = default;
 
 bool Writer::Open(const std::string& path)
 {
-  return measurement->Open(path, eh5::eAccessType::CREATE);
+  return measurement->Open(path, eCAL::eh5::CREATE);
 }
 
 bool Writer::Close()

--- a/contrib/measurement/hdf5/src/writer.cpp
+++ b/contrib/measurement/hdf5/src/writer.cpp
@@ -85,7 +85,7 @@ void Writer::SetFileBaseName(const std::string& base_name)
   return impl->measurement.SetFileBaseName(base_name);
 }
 
-bool Writer::AddEntryToFile(const void* data, const unsigned long long& size, const long long& snd_timestamp, const long long& rcv_timestamp, const eCAL::experimental::measurement::base::Channel& channel, long long id, long long clock)
+bool Writer::AddEntryToFile(const base::WriteEntry& entry)
 {
-  return impl->measurement.AddEntryToFile(data, size, snd_timestamp, rcv_timestamp, channel, id, clock);
+  return impl->measurement.AddEntryToFile(entry);
 }

--- a/lang/python/ecalhdf5/src/ecalhdf5_wrap.cxx
+++ b/lang/python/ecalhdf5/src/ecalhdf5_wrap.cxx
@@ -430,7 +430,7 @@ static PyObject* Meas_AddEntryToFile(Meas *self, PyObject *args)
   if (!PyArg_ParseTuple(args, "y#LLs|L", &data, &size, &snd_timestamp, &rcv_timestamp, &channel_name, &counter))
     return nullptr;
 
-  return(Py_BuildValue("i", self->hdf5_meas->AddEntryToFile(data, (int)size, snd_timestamp, rcv_timestamp, channel_name, 0, counter)));
+  return(Py_BuildValue("i", self->hdf5_meas->AddEntryToFile(data, (int)size, snd_timestamp, rcv_timestamp, eCAL::experimental::measurement::base::CreateChannel(channel_name), counter)));
 }
 
 /****************************************/

--- a/lang/python/ecalhdf5/src/ecalhdf5_wrap.cxx
+++ b/lang/python/ecalhdf5/src/ecalhdf5_wrap.cxx
@@ -107,11 +107,11 @@ static PyObject* Meas_Open(Meas *self, PyObject *args)
   switch (access)
   {
   case 0:
-    open_meas = self->hdf5_meas->Open(path, eCAL::experimental::measurement::base::AccessType::RDONLY);
+    open_meas = self->hdf5_meas->Open(path, eCAL::eh5::RDONLY);
     break;
 
   case 1:
-    open_meas = self->hdf5_meas->Open(path, eCAL::experimental::measurement::base::AccessType::CREATE);
+    open_meas = self->hdf5_meas->Open(path, eCAL::eh5::CREATE);
     break;
 
   default:

--- a/lang/python/ecalhdf5/src/ecalhdf5_wrap.cxx
+++ b/lang/python/ecalhdf5/src/ecalhdf5_wrap.cxx
@@ -39,7 +39,7 @@
 typedef struct
 {
   PyObject_HEAD
-  eCAL::eh5::HDF5Meas *hdf5_meas;
+  eCAL::eh5::v2::HDF5Meas *hdf5_meas;
 } Meas;
 
 /****************************************/
@@ -52,7 +52,7 @@ static PyObject* Meas_New(PyTypeObject *type, PyObject* /*args*/, PyObject* /*kw
   self = (Meas *)type->tp_alloc(type, 0);
   if (self != NULL)
   {
-    self->hdf5_meas = new eCAL::eh5::HDF5Meas();
+    self->hdf5_meas = new eCAL::eh5::v2::HDF5Meas();
   }
 
   return (PyObject *)self;
@@ -107,11 +107,11 @@ static PyObject* Meas_Open(Meas *self, PyObject *args)
   switch (access)
   {
   case 0:
-    open_meas = self->hdf5_meas->Open(path, eCAL::eh5::RDONLY);
+    open_meas = self->hdf5_meas->Open(path, eCAL::eh5::v2::RDONLY);
     break;
 
   case 1:
-    open_meas = self->hdf5_meas->Open(path, eCAL::eh5::CREATE);
+    open_meas = self->hdf5_meas->Open(path, eCAL::eh5::v2::CREATE);
     break;
 
   default:
@@ -430,7 +430,7 @@ static PyObject* Meas_AddEntryToFile(Meas *self, PyObject *args)
   if (!PyArg_ParseTuple(args, "y#LLs|L", &data, &size, &snd_timestamp, &rcv_timestamp, &channel_name, &counter))
     return nullptr;
 
-  return(Py_BuildValue("i", self->hdf5_meas->AddEntryToFile(data, (int)size, snd_timestamp, rcv_timestamp, eCAL::experimental::measurement::base::CreateChannel(channel_name), counter)));
+  return(Py_BuildValue("i", self->hdf5_meas->AddEntryToFile(data, (int)size, snd_timestamp, rcv_timestamp, channel_name, 0, counter)));
 }
 
 /****************************************/

--- a/samples/cpp/measurement/benchmark/src/main.cpp
+++ b/samples/cpp/measurement/benchmark/src/main.cpp
@@ -116,7 +116,7 @@ void MeasPerf(const std::string& file_name, const size_t pkg_size, const size_t 
     writer.SetMaxSizePerFile(max_size_per_file);
     for (size_t loop = 0; loop < write_loops; ++loop)
     {
-      writer.AddEntryToFile(static_cast<void*>(data.data()), data.size(), 0, 0, "myChannel", 0, loop);
+      writer.AddEntryToFile(static_cast<void*>(data.data()), data.size(), 0, 0, eCAL::experimental::measurement::base::CreateChannel("myChannel"), loop);
     }
     writer.Close();
 

--- a/samples/cpp/measurement/benchmark/src/main.cpp
+++ b/samples/cpp/measurement/benchmark/src/main.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -111,12 +111,12 @@ void MeasPerf(const std::string& file_name, const size_t pkg_size, const size_t 
     // start time
     auto start = std::chrono::high_resolution_clock::now();
 
-    eCAL::eh5::HDF5Meas writer(output_dir, eCAL::eh5::CREATE);
+    eCAL::eh5::v2::HDF5Meas writer(output_dir, eCAL::eh5::v2::CREATE);
     writer.SetFileBaseName(file_name + "_hdf5");
     writer.SetMaxSizePerFile(max_size_per_file);
     for (size_t loop = 0; loop < write_loops; ++loop)
     {
-      writer.AddEntryToFile(static_cast<void*>(data.data()), data.size(), 0, 0, eCAL::experimental::measurement::base::CreateChannel("myChannel"), loop);
+      writer.AddEntryToFile(static_cast<void*>(data.data()), data.size(), 0, 0, "myChannel", 0, loop);
     }
     writer.Close();
 

--- a/samples/cpp/measurement/measurement_read/src/measurement_read.cpp
+++ b/samples/cpp/measurement/measurement_read/src/measurement_read.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,14 +41,17 @@ int main(int /*argc*/, char** /*argv*/)
   eCAL::measurement::IMeasurement meas(MEASUREMENT_PATH);
 
   // create a channel (topic name "person")
-  eCAL::measurement::IChannel<pb::People::Person> person_channel = meas.Get<pb::People::Person>("person");
-
-  // iterate over the messages
-  for (const auto& person_entry : person_channel)
+  auto person_channels = meas.Channels("person");
+  if (person_channels.size() > 0)
   {
-    std::cout << "Person object at timestamp " << person_entry.send_timestamp << std::endl;
-    print_person(person_entry.message);
-  }
+    eCAL::measurement::IChannel<pb::People::Person> person_channel = meas.Get<pb::People::Person>(*person_channels.begin());
 
+    // iterate over the messages
+    for (const auto& person_entry : person_channel)
+    {
+      std::cout << "Person object at timestamp " << person_entry.send_timestamp << std::endl;
+      print_person(person_entry.message);
+    }
+  }
   return 0;
 }

--- a/tests/contrib/ecalhdf5/hdf5_test/CMakeLists.txt
+++ b/tests/contrib/ecalhdf5/hdf5_test/CMakeLists.txt
@@ -32,7 +32,9 @@ target_link_libraries(${PROJECT_NAME}
     eCAL::hdf5
     Threads::Threads)
 
+target_include_directories(${PROJECT_NAME} PRIVATE $<TARGET_PROPERTY:eCAL::hdf5,INCLUDE_DIRECTORIES>)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
+target_compile_definitions(${PROJECT_NAME} PRIVATE ECAL_EH5_NO_DEPRECATION_WARNINGS)
 
 ecal_install_gtest(${PROJECT_NAME})
 

--- a/tests/contrib/ecalhdf5/hdf5_test/src/hdf5_test.cpp
+++ b/tests/contrib/ecalhdf5/hdf5_test/src/hdf5_test.cpp
@@ -878,6 +878,11 @@ TEST(HDF5, MergedMeasurements)
 
   {
     LegacyAPI hdf5_reader;
+    EXPECT_TRUE(hdf5_reader.Open(base_dir));
+
+    std::set<std::string> expected_channels{ topic_name_1_2, topic_name_3 };
+    EXPECT_EQ(hdf5_reader.GetChannelNames(), expected_channels);
+
     // Deprecated API
     EXPECT_EQ(hdf5_reader.GetMinTimestamp(topic_name_1_2), 0002);
     EXPECT_EQ(hdf5_reader.GetMinTimestamp(topic_name_3), 1002);

--- a/tests/contrib/ecalhdf5/hdf5_test/src/hdf5_test.cpp
+++ b/tests/contrib/ecalhdf5/hdf5_test/src/hdf5_test.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -111,7 +111,7 @@ EntryInfo FindInSet(const eCAL::eh5::EntryInfoSet& info_set, const TestingMeasEn
   }
 }
 
-void ValidataDataInMesurementGeneric(eCAL::eh5::HDF5Meas& hdf5_reader, const TestingMeasEntry& entry, std::function<bool(eCAL::eh5::EntryInfoSet& entries)> entry_info_function)
+void ValidateDataInMeasurementGeneric(eCAL::eh5::HDF5Meas& hdf5_reader, const TestingMeasEntry& entry, std::function<bool(eCAL::eh5::EntryInfoSet& entries)> entry_info_function)
 {
   eCAL::eh5::EntryInfoSet entries_info_set;
 
@@ -146,7 +146,7 @@ void ValidateDataInMeasurement(eCAL::eh5::HDF5Meas& hdf5_reader, const TestingMe
     return hdf5_reader.GetEntriesInfo(eCAL::eh5::SChannel{ entry.channel_name, entry.id }, entries);
   };
 
-  ValidataDataInMesurementGeneric(hdf5_reader, entry, get_entries_info);
+  ValidateDataInMeasurementGeneric(hdf5_reader, entry, get_entries_info);
 }
 
 void ValidateDataInMeasurementDeprecated(eCAL::eh5::HDF5Meas& hdf5_reader, const TestingMeasEntry& entry)
@@ -156,7 +156,7 @@ void ValidateDataInMeasurementDeprecated(eCAL::eh5::HDF5Meas& hdf5_reader, const
     return hdf5_reader.GetEntriesInfo(entry.channel_name, entries);
   };
 
-  ValidataDataInMesurementGeneric(hdf5_reader, entry, get_entries_info);
+  ValidateDataInMeasurementGeneric(hdf5_reader, entry, get_entries_info);
 }
 
 
@@ -840,6 +840,7 @@ TEST(HDF5, WriteReadEmptyMeasurement)
     EXPECT_TRUE(hdf5_writer.Close());
   }
 
+  /* Currently, we can't extract channel information from empty measurements.
   // Read entries with HDF5 dir API
   {
     eCAL::eh5::HDF5Meas hdf5_reader;
@@ -853,6 +854,7 @@ TEST(HDF5, WriteReadEmptyMeasurement)
     EXPECT_EQ(hdf5_reader.GetMinTimestamp(channel), 0);
     EXPECT_EQ(hdf5_reader.GetMaxTimestamp(channel), 0);
   }
+  */
 }
 
 // This tests confirms if you write with the new API, you can read the information with the old API

--- a/tests/contrib/ecalhdf5/hdf5_test/src/hdf5_test.cpp
+++ b/tests/contrib/ecalhdf5/hdf5_test/src/hdf5_test.cpp
@@ -86,6 +86,17 @@ std::string print(const TestingMeasEntry& entry) {
   return s.str();
 }
 
+std::string print(const EntryInfo& info) {
+  std::stringstream s;
+  s << "( rcv: " << info.RcvTimestamp
+    << ", id: " << info.ID
+    << ", clock: " << info.SndClock
+    << ", snd: " << info.SndTimestamp
+    << ", snd_id: " << info.SndID
+    << ")";
+  return s.str();
+}
+
 bool MeasEntryEqualsEntryInfo(const TestingMeasEntry& meas_entry, const EntryInfo entry_info)
 {
   return meas_entry.snd_id == entry_info.SndID
@@ -144,7 +155,11 @@ void ValidateChannelsInMeasurementV5(MeasAPI& hdf5_reader, const std::vector<Tes
 // Return default EntryInfo if it cannot be Found
 EntryInfo FindInSet(const eCAL::eh5::EntryInfoSet& info_set, const TestingMeasEntry& to_find)
 {
-  auto it = std::find_if(info_set.begin(), info_set.end(), [&to_find](const EntryInfo& entry) { return entry.SndClock == to_find.clock && entry.SndID == to_find.snd_id; });
+  auto it = std::find_if(info_set.begin(), info_set.end(), [&to_find](const EntryInfo& entry) { 
+    return entry.SndClock == to_find.clock && 
+           entry.SndID == to_find.snd_id &&
+           entry.SndTimestamp == to_find.snd_timestamp &&
+           entry.RcvTimestamp == to_find.rcv_timestamp; });
 
   if (it != info_set.end()) {
     return *it;
@@ -170,7 +185,7 @@ void ValidateDataInMeasurementGeneric(Reader& hdf5_reader, const TestingMeasEntr
     return;
   }
 
-  EXPECT_TRUE(MeasEntryEqualsEntryInfo(entry, info));
+  EXPECT_TRUE(MeasEntryEqualsEntryInfo(entry, info)) << print(entry) << " != " << print(info);
 
   size_t data_size;
   EXPECT_TRUE(hdf5_reader.GetEntryDataSize(info.ID, data_size));
@@ -205,8 +220,8 @@ void ValidateDataInMeasurement(LegacyAPI& hdf5_reader, const TestingMeasEntry& e
 
 
 TestingMeasEntry m1{
- //{"topic / with / slash", 1},
- {"t1", 1},
+ {"topic / with / slash", 1},
+ //{"t1", 1},
  "Hello World",
  1001LL,
  2001LL,
@@ -215,8 +230,8 @@ TestingMeasEntry m1{
 };
 
 TestingMeasEntry m2{
-  //{"another,topic", 2},
-  {"t2", 2},
+  {"another,topic", 2},
+  //{"t2", 2},
   "",
   1002LL,
   2002LL,
@@ -225,8 +240,8 @@ TestingMeasEntry m2{
 };
 
 TestingMeasEntry m3{
-  //{" ASCII and beyond!\a\b\t\n\v\f\r\"#$%&\'()*+,-./0123456789:,<=>\?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~üöäÜÖÄâÂôÔûÛáàÁÀúÙ", 3},
-  {"t3", 3},
+  {" ASCII and beyond!\a\b\t\n\v\f\r\"#$%&\'()*+,-./0123456789:,<=>\?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~üöäÜÖÄâÂôÔûÛáàÁÀúÙ", 3},
+  //{"t3", 3},
   "o.O",
   1003LL,
   2003LL,


### PR DESCRIPTION
### Description
This PR introduces a modified HDF5Meas API, based on Channel objects (channel + id) instead of channel names only.
The old API is still available as `eCAL::eh5::v2::HDF5Meas`, whereas the new API is available as `eCAL::eh5::HDF5Meas` respective `eCAL::eh5::v3HDF5Meas`, using an `v3` inline namespace.

This does *not* change the recorder or any app to record the new format. Replay is possible, but with the limitation of not distinguishing channels with the same name.

Open for discussion:
Namespaces: Do the namespaces make sense? Should we adapt them to the includes (e.g. `ecalhdf5` namespace?

### Related issues
This is loosely related to #1076, and also to #1292 

### Cherry-pick to
No cherry picking. However, we can manually sync the contrib/ecalhdf5 folder with the v5.x support branch and use the new api with the `v2::` namespace.
This allows to read v6 measurements in eCAL 5.x.

### Docs???