### PR TITLE
GH Actions Windows: Removed downgrade nuget

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -26,13 +26,6 @@ jobs:
         target: 'desktop'
         arch: 'win64_msvc2019_64'
 
-    # Downgrading nuget is required as of 2021-04-23, as nuget 5.9.1.111 fails installing protobuf
-    # https://github.com/actions/virtual-environments/issues/3240
-    - name: Downgrade nuget
-      uses: nuget/setup-nuget@v1
-      with:
-        nuget-version: '5.8.x'
-
     - name: Install Dependencies
       # choco install of version 1.9.3 produced a checksum error
       run: choco install doxygen.install --version=1.9.2


### PR DESCRIPTION
### Description
Removed the downgrade-nuget step that was introduced in 2021

### Cherry-pick to
_Let's see if it works, first_
<!-- Leave empty, if you don't know. For master-only changes use "none"
- _none_
- master-v5 (master for eCAL 5 feature backporting)
- 5.12 (old stable)
- 5.13 (current stable)
-->
