### PR TITLE
[play] fix crash when playing empty measurements.

### DIFF
--- a/app/play/play_core/src/measurement_container.cpp
+++ b/app/play/play_core/src/measurement_container.cpp
@@ -185,7 +185,7 @@ bool MeasurementContainer::PublishersCreated() const
 bool MeasurementContainer::PublishFrame(long long index)
 {
   // Check that the user created the publishers before publishing a frame
-  if (!publishers_initialized_ || (index < 0) || index > GetFrameCount())
+  if (!publishers_initialized_ || (index < 0) || index >= GetFrameCount())
     return false;
 
   if (frame_table_[index].publisher_info_)


### PR DESCRIPTION
### Description
Currently if there are 0 items in a measurement, the player will crash.

### Related issues
Fixes #1378

### Cherry-pick to
- master-v5 (master for eCAL 5 feature backporting)
- 5.12 (old stable)
- 5.13 (current stable)
