### PR TITLE
[cmake] Fixed qt autodetection script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,19 @@ file(TO_CMAKE_PATH "${CMAKE_PREFIX_PATH}" CMAKE_PREFIX_PATH)
 message(STATUS "Module Path: ${CMAKE_MODULE_PATH}")
 message(STATUS "Prefix Path: ${CMAKE_PREFIX_PATH}")
 
+# --------------------------------------------------------
+# detect qt library
+# --------------------------------------------------------
+if(MSVC)
+  if (HAS_QT)
+    find_package(QT NAMES Qt6 Qt5 COMPONENTS Core QUIET)
+    if (NOT "${QT_FOUND}")
+	  include("cmake/qt_msvc_path.cmake")
+      autodetect_qt_msvc_dir()
+    endif()
+  endif()
+endif()
+
 if(MSVC)
   message(STATUS "supress thirdparty warnings for windows platform ..")
   set(CMAKE_CXX_FLAGS_OLD "${CMAKE_CXX_FLAGS}")
@@ -222,19 +235,6 @@ if(MSVC)
 endif()
 
 find_package(CMakeFunctions REQUIRED)
-
-# --------------------------------------------------------
-# detect qt library
-# --------------------------------------------------------
-if(MSVC)
-  if (HAS_QT)
-    find_package(QT NAMES Qt6 Qt5 COMPONENTS Core QUIET)
-    if (NOT "${QT_FOUND}")
-      autodetect_qt_msvc_dir()
-    endif()
-  endif()
-endif()
-
 
 git_revision_information(DEFAULT ${ECAL_BUILD_VERSION})
 set(eCAL_VERSION_MAJOR  ${GIT_REVISION_MAJOR})

--- a/build_win/Readme.md
+++ b/build_win/Readme.md
@@ -1,5 +1,3 @@
-Please first adjust the CMAKE_PREFIX_PATH in `win_set_vars.bat` so that cmake can detect your QT installation, then:
-
 If you want to build complete eCAL setup for windows then simply call. 
 
 ```bash

--- a/build_win/win_set_vars.bat
+++ b/build_win/win_set_vars.bat
@@ -6,6 +6,3 @@ set "WORKSPACE=%~dp0\..\"
 rem - cmake will generate the build solution here
 set BUILD_DIR_COMPLETE=_build\complete
 set BUILD_DIR_SDK=_build\sdk
-
-rem replace with your Qt installation path:
-set CMAKE_PREFIX_PATH=C:\Qt\6.6.2\msvc2019_64

--- a/cmake/qt_msvc_path.cmake
+++ b/cmake/qt_msvc_path.cmake
@@ -113,13 +113,16 @@ macro(autodetect_qt_msvc_dir)
 
 		message(STATUS "Using Qt ${BEST_QT_MAJOR}.${BEST_QT_MINOR}.${BEST_QT_PATCH} MSVC ${BEST_QT_MSVC_YEAR} from ${BEST_QT_DIRECTORY}")
 		
+		list(APPEND CMAKE_PREFIX_PATH "${BEST_QT_DIRECTORY}")
 		# Dirs for legacy targets with version:
-		SET(Qt${BEST_QT_MAJOR}_DIR "${BEST_QT_DIRECTORY}/lib/cmake/Qt${BEST_QT_MAJOR}/")
-		SET(Qt${BEST_QT_MAJOR}Test_DIR "${BEST_QT_DIRECTORY}/lib/cmake/Qt${BEST_QT_MAJOR}Test")
+		
+		#SET(Qt${BEST_QT_MAJOR}_DIR "${BEST_QT_DIRECTORY}/lib/cmake/Qt${BEST_QT_MAJOR}/")
+		#SET(Qt${BEST_QT_MAJOR}CoreTools_DIR "${BEST_QT_DIRECTORY}/lib/cmake/Qt${BEST_QT_MAJOR}CoreTools/")
+		#SET(Qt${BEST_QT_MAJOR}Test_DIR "${BEST_QT_DIRECTORY}/lib/cmake/Qt${BEST_QT_MAJOR}Test")
 		
 		# Dirs for modern version-less targets
-		SET(QT_DIR "${BEST_QT_DIRECTORY}/lib/cmake/Qt${BEST_QT_MAJOR}/")
-		SET(QTTest_DIR "${BEST_QT_DIRECTORY}/lib/cmake/Qt${BEST_QT_MAJOR}Test")
+		#SET(QT_DIR "${BEST_QT_DIRECTORY}/lib/cmake/Qt${BEST_QT_MAJOR}/")
+		#SET(QTTest_DIR "${BEST_QT_DIRECTORY}/lib/cmake/Qt${BEST_QT_MAJOR}Test")
 	
 	endif()
 endmacro()

--- a/thirdparty/cmakefunctions/cmake_functions/cmake_functions.cmake
+++ b/thirdparty/cmakefunctions/cmake_functions/cmake_functions.cmake
@@ -7,7 +7,6 @@ set (file_list_include
 
 if(WIN32)
   list(APPEND file_list_include
-    qt/qt_msvc_path.cmake
     qt/qt_windeployqt.cmake
   )
 endif()


### PR DESCRIPTION
### Description
Now, Qt is discovered before QWT is included. Also, the script works with Qt6 now by setting the CMAKE_PREFIX_PATH


### Related issues
- Fixes #1374

### Cherry-pick to
- 5.12 (old stable)
- 5.13 (current stable)
