### PR TITLE
[Core / Process Stub] Added missing C++14 requirement in CMakeLists.txt

### DIFF
--- a/ecal/core/CMakeLists.txt
+++ b/ecal/core/CMakeLists.txt
@@ -603,7 +603,9 @@ if(UNIX)
         src/ecal_process_stub.cpp
         src/ecal_process_stub.h
     )
-
+    
+    target_compile_features(${PROJECT_NAME_PROCESS_STUB} PUBLIC cxx_std_14)
+    
     ecal_install_app(${PROJECT_NAME_PROCESS_STUB})
 
     set_property(TARGET ${PROJECT_NAME_PROCESS_STUB} PROPERTY FOLDER ecal/core)


### PR DESCRIPTION
### Description
Added missing C++14 requirement in CMakeLists.txt

Important for very old gcc versions (tested with gcc5 on Ubuntu 16.04)

### Cherry-pick to
- 5.12 (old stable)
- 5.13 (current stable)