### PR TITLE
[CMake / Cpack] replaces deprecated exec_program with execute_process

### DIFF
--- a/cpack/innosetup.cmake
+++ b/cpack/innosetup.cmake
@@ -25,8 +25,8 @@ if (ISSC_PATH STREQUAL "ISSC_PATH-NOTFOUND")
   message(FATAL_ERROR "Unable to find Innosetup (ISCC.exe)")
 else()
   message(STATUS "Found Innosetup at ${ISSC_PATH}")
-  exec_program("${ISSC_PATH}"
-    ARGS
-      "${CPACK_TOPLEVEL_DIRECTORY}/innosetup/ecal_setup.iss"
+  execute_process(
+    COMMAND "${ISSC_PATH}" "${CPACK_TOPLEVEL_DIRECTORY}/innosetup/ecal_setup.iss"
+    WORKING_DIRECTORY "${CPACK_TOPLEVEL_DIRECTORY}/innosetup"
   )
 endif()


### PR DESCRIPTION
### Description
[CMake / Cpack] replaced deprecated exec_program with execute_process

### Cherry-pick to
- 5.12 (old stable)
- 5.13 (current stable)
