### PR TITLE
[python] Don't link C extensions to libpython

### DIFF
--- a/lang/python/core/CMakeLists.txt
+++ b/lang/python/core/CMakeLists.txt
@@ -40,7 +40,6 @@ ecal_add_python_module(${PROJECT_NAME} SOURCES ${ecal_lang_py_src} PYTHON_CODE $
 
 target_link_libraries(${PROJECT_NAME}
     PRIVATE
-        Python::Python
         eCAL::core
         eCAL::core_pb
 )

--- a/lang/python/ecalhdf5/CMakeLists.txt
+++ b/lang/python/ecalhdf5/CMakeLists.txt
@@ -41,7 +41,6 @@ ecal_add_python_module(${PROJECT_NAME} SOURCES ${ecal_lang_py_src} PYTHON_CODE $
 
 target_link_libraries(${PROJECT_NAME}
     PRIVATE
-        Python::Python
         eCAL::hdf5
 )
 


### PR DESCRIPTION
### Description
<!-- What does your PR change? -->

Fixes the Python C extensions having an explicit link dependency on libpython. In environments without libpython this causes problems. The easiest way to encounter this is through pyenv.
Eg: Building the wheel using a Python install that has libpython and trying to install and run it in a Python without it (static build).

The first hint of the problem is running `ldd` on the shared object when using a pyenv installation (for example):

``` 
ldd out/wheel/build/python/ecal/_ecal_core_py.so
        linux-vdso.so.1 (0x00007ffefb729000)
        libpython3.12.so.1.0 => not found
        ...
```

This will actually run fine if it is run in a Python interpreter that has a shared libpython as the wheels inherit the symbols from Python (see the PEP 513 link below). However; trying to run this eCAL wheel in a statically built Python will cause an error like:

```
python samples/python/benchmarks/latency_snd/latency_snd.py
Traceback (most recent call last):
  File "/home/downercase/dev/ecal/samples/python/benchmarks/latency_snd/latency_snd.py", line 24, in <module>
    import ecal.core.core as ecal_core
  File "/home/downercase/dev/ecal/.venv_312_static/lib/python3.12/site-packages/ecal/core/core.py", line 26, in <module>
    import ecal._ecal_core_py as _ecal
ImportError: libpython3.12.so.1.0: cannot open shared object file: No such file or directory
```

[PEP 513 supporting material](https://peps.python.org/pep-0513/#libpythonx-y-so-1)

Fixing this is one small step closer to redistributable wheels.

### Related issues
<!-- Type "Fixes #123" to automatically close that issue, when this PR is merged -->
- This would be problematic for #1161 

### Cherry-pick to
- 5.12 (old stable)
- 5.13 (current stable)
