### PR TITLE
[core] protobuf process state now serialized too

### DIFF
--- a/ecal/core/src/serialization/ecal_serialize_sample_registration.cpp
+++ b/ecal/core/src/serialization/ecal_serialize_sample_registration.cpp
@@ -72,6 +72,8 @@ namespace
     eCAL::nanopb::encode_string(pb_sample_.process.uname, registration_.process.uname);
     // pparam
     eCAL::nanopb::encode_string(pb_sample_.process.pparam, registration_.process.pparam);
+    // state
+    pb_sample_.process.has_state = true;
     // state.severity
     pb_sample_.process.state.severity = static_cast<eCAL_pb_eProcessSeverity>(registration_.process.state.severity);
     // state.severity_level

--- a/testing/ecal/serialization_test/src/registration_generate.cpp
+++ b/testing/ecal/serialization_test/src/registration_generate.cpp
@@ -138,6 +138,9 @@ namespace eCAL
       sample.process.pname                = GenerateString(10);
       sample.process.uname                = GenerateString(5);
       sample.process.pparam               = GenerateString(12);
+      sample.process.state.severity       = static_cast<eProcessSeverity>(rand() % (proc_sev_failed + 1));
+      sample.process.state.severity_level = static_cast<eProcessSeverityLevel>(rand() % (proc_sev_level5 + 1));
+      sample.process.state.info           = GenerateString(10);
       sample.process.tsync_state          = static_cast<eTSyncState>(rand() % (tsync_replay + 1));
       sample.process.tsync_mod_name       = GenerateString(6);
       sample.process.component_init_state = rand() % 5;


### PR DESCRIPTION
### Description
Process state information was not serialized with nanopb and unfortunately not tested as well.

### Cherry-pick to
- _none_
