### PR TITLE
set unit name empty string and nullptr handling fixed

### DIFF
--- a/ecal/core/src/ecal.cpp
+++ b/ecal/core/src/ecal.cpp
@@ -228,12 +228,17 @@ namespace eCAL
    *
    * @param unit_name_  Defines the name of the eCAL unit. 
    *
-   * @return  Zero if succeeded.
+   * @return  Zero if succeeded, -1 if failed.
   **/
   int SetUnitName(const char *unit_name_)
   {
-    g_unit_name = unit_name_;
-    return(0);
+    if (unit_name_ == nullptr) return -1;
+    
+    const std::string uname = unit_name_;
+    if (uname.empty()) return -1;
+ 
+    g_unit_name = uname;
+    return 0;
   }
 
   /**


### PR DESCRIPTION
### Description
SetUnitName should not be able to set the eCAL global unit name to an empty string and nullptr argument should be handled as well.

### Cherry-pick to
- 5.12 (old stable)
- 5.13 (current stable)
