### PR TITLE
[core] core c test added / core cpp test cleaned up

### DIFF
--- a/ecal/tests/CMakeLists.txt
+++ b/ecal/tests/CMakeLists.txt
@@ -21,10 +21,14 @@ cmake_minimum_required(VERSION 3.13)
 # --------------------------------------------------------
 # c tests
 # --------------------------------------------------------
+add_subdirectory(c/core_test)
 
 # --------------------------------------------------------
 # cpp tests
 # --------------------------------------------------------
+add_subdirectory(cpp/core_test)
+
+
 add_subdirectory(cpp/event_test)
 add_subdirectory(cpp/expmap_test)
 add_subdirectory(cpp/serialization_test)
@@ -36,7 +40,6 @@ if(ECAL_CORE_REGISTRATION_SHM OR ECAL_CORE_TRANSPORT_SHM)
 endif()
 
 if(ECAL_CORE_REGISTRATION AND ECAL_CORE_PUBLISHER AND ECAL_CORE_SUBSCRIBER)
-  add_subdirectory(cpp/core_test)
   if(ECAL_CORE_TRANSPORT_SHM OR ECAL_CORE_TRANSPORT_UDP) # this test is running for shm and udp layer only, needs to be fixed for tcp
     add_subdirectory(cpp/pubsub_test)
   endif()

--- a/ecal/tests/c/core_test/CMakeLists.txt
+++ b/ecal/tests/c/core_test/CMakeLists.txt
@@ -1,0 +1,45 @@
+# ========================= eCAL LICENSE =================================
+#
+# Copyright (C) 2016 - 2019 Continental Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ========================= eCAL LICENSE =================================
+
+project(test_core_c)
+
+find_package(Threads REQUIRED)
+find_package(GTest REQUIRED)
+
+set(core_test_c_src
+  src/core_test.cpp
+)
+
+ecal_add_gtest(${PROJECT_NAME} ${core_test_c_src})
+
+target_include_directories(${PROJECT_NAME} PRIVATE $<TARGET_PROPERTY:eCAL::core,INCLUDE_DIRECTORIES>)
+
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE 
+    eCAL::core_c
+    Threads::Threads)
+
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
+
+ecal_install_gtest(${PROJECT_NAME})
+
+set_property(TARGET ${PROJECT_NAME} PROPERTY FOLDER core/tests/c/core)
+
+source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}" FILES 
+    ${${PROJECT_NAME}_src}
+)

--- a/ecal/tests/c/core_test/src/core_test.cpp
+++ b/ecal/tests/c/core_test/src/core_test.cpp
@@ -1,0 +1,123 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+#include <ecal/cimpl/ecal_core_cimpl.h>
+#include <ecal/ecal_defs.h>
+
+#include <gtest/gtest.h>
+
+TEST(core_c, Core_GetVersion)
+{
+  // get eCAL version string
+  EXPECT_STREQ(ECAL_VERSION, eCAL_GetVersionString());
+
+  // get eCAL version date
+  EXPECT_STREQ(ECAL_DATE, eCAL_GetVersionDateString());
+
+  // get eCAL version as separated integer values
+  int major = -1;
+  int minor = -1;
+  int patch = -1;
+  eCAL_GetVersion(&major, &minor, &patch);
+  EXPECT_EQ(ECAL_VERSION_MAJOR, major);
+  EXPECT_EQ(ECAL_VERSION_MINOR, minor);
+  EXPECT_EQ(ECAL_VERSION_PATCH, patch);
+}
+
+TEST(core_c, Core_InitializeFinalize)
+{
+  // Is eCAL API initialized ?
+  EXPECT_EQ(0, eCAL_IsInitialized(0));
+
+  // initialize eCAL API
+  EXPECT_EQ(0, eCAL_Initialize(0, nullptr, "initialize_test", 0));
+
+  // Is eCAL API initialized ?
+  EXPECT_EQ(1, eCAL_IsInitialized(0));
+
+  // initialize eCAL API again we expect return value 1 for yet initialized
+  EXPECT_EQ(1, eCAL_Initialize(0, nullptr, "initialize_test", 0));
+
+  // finalize eCAL API we expect return value 0 even it will not be really finalized because it's 2 times initialzed and 1 time finalized
+  EXPECT_EQ(0, eCAL_Finalize(0));
+
+  // Is eCAL API initialized ? yes it' still initialized
+  EXPECT_EQ(1, eCAL_IsInitialized(0));
+
+  // finalize eCAL API we expect return value 0 because now it will be finalized
+  EXPECT_EQ(0, eCAL_Finalize(0));
+
+  // Is eCAL API initialized ? no
+  EXPECT_EQ(0, eCAL_IsInitialized(0));
+
+  // finalize eCAL API we expect return value 1 because it was finalized before
+  EXPECT_EQ(1, eCAL_Finalize(0));
+}
+
+TEST(core_c, Core_MultipleInitializeFinalize)
+{
+  // try to initialize / finalize multiple times
+  for (auto i = 0; i < 4; ++i)
+  {
+    // initialize eCAL API
+    EXPECT_EQ(0, eCAL_Initialize(0, nullptr, "multiple_initialize_finalize_test", 0));
+
+    // finalize eCAL API
+    EXPECT_EQ(0, eCAL_Finalize(0));
+  }
+}
+
+TEST(core_c, Core_UnitName)
+{
+  // initialize eCAL API with empty unit name (eCAL will use process name as unit name)
+  EXPECT_EQ(0, eCAL_Initialize(0, nullptr, "", 0));
+
+  // Is eCAL API initialized ?
+  EXPECT_EQ(1, eCAL_IsInitialized(0));
+
+  // set unit name
+  EXPECT_EQ(0, eCAL_SetUnitName("unit name"));
+
+  // set nullptr unit name
+  EXPECT_EQ(-1, eCAL_SetUnitName(nullptr));
+
+  // set empty unit name
+  EXPECT_EQ(-1, eCAL_SetUnitName(""));
+
+  // finalize eCAL API we expect return value 0 because it will be finalized
+  EXPECT_EQ(0, eCAL_Finalize(0));
+}
+
+TEST(core_c, Core_eCAL_Ok)
+{
+  // check uninitialized eCAL, should not be okay
+  EXPECT_EQ(0, eCAL_Ok());
+
+  // initialize eCAL API
+  EXPECT_EQ(0, eCAL_Initialize(0, nullptr, "okay_test", 0));
+
+  // check initialized eCAL, should be okay
+  EXPECT_EQ(1, eCAL_Ok());
+
+  // finalize eCAL API we expect return value 0 because it will be finalized
+  EXPECT_EQ(0, eCAL_Finalize(0));
+
+  // check finalized eCAL, should not be okay
+  EXPECT_EQ(0, eCAL_Ok());
+}

--- a/ecal/tests/cpp/core_test/src/core_test.cpp
+++ b/ecal/tests/cpp/core_test/src/core_test.cpp
@@ -17,6 +17,115 @@
  * ========================= eCAL LICENSE =================================
 */
 
+#include <ecal/ecal_core.h>
+#include <ecal/ecal_defs.h>
+
+#include <gtest/gtest.h>
+
+TEST(core, Core_GetVersion)
+{
+  // get eCAL version string
+  EXPECT_STREQ(ECAL_VERSION, eCAL::GetVersionString());
+
+  // get eCAL version date
+  EXPECT_STREQ(ECAL_DATE, eCAL::GetVersionDateString());
+
+  // get eCAL version as separated integer values
+  int major = -1;
+  int minor = -1;
+  int patch = -1;
+  eCAL::GetVersion(&major, &minor, &patch);
+  EXPECT_EQ(ECAL_VERSION_MAJOR, major);
+  EXPECT_EQ(ECAL_VERSION_MINOR, minor);
+  EXPECT_EQ(ECAL_VERSION_PATCH, patch);
+}
+
+TEST(core, Core_InitializeFinalize)
+{
+  // Is eCAL API initialized ?
+  EXPECT_EQ(0, eCAL::IsInitialized());
+
+  // initialize eCAL API
+  EXPECT_EQ(0, eCAL::Initialize(0, nullptr, "initialize_test"));
+
+  // Is eCAL API initialized ?
+  EXPECT_EQ(1, eCAL::IsInitialized());
+
+  // initialize eCAL API again we expect return value 1 for yet initialized
+  EXPECT_EQ(1, eCAL::Initialize(0, nullptr, "initialize_test"));
+
+  // finalize eCAL API we expect return value 0 even it will not be really finalized because it's 2 times initialzed and 1 time finalized
+  EXPECT_EQ(0, eCAL::Finalize());
+
+  // Is eCAL API initialized ? yes it' still initialized
+  EXPECT_EQ(1, eCAL::IsInitialized());
+
+  // finalize eCAL API we expect return value 0 because now it will be finalized
+  EXPECT_EQ(0, eCAL::Finalize());
+
+  // Is eCAL API initialized ? no
+  EXPECT_EQ(0, eCAL::IsInitialized());
+
+  // finalize eCAL API we expect return value 1 because it was finalized before
+  EXPECT_EQ(1, eCAL::Finalize());
+}
+
+TEST(core, Core_MultipleInitializeFinalize)
+{
+  // try to initialize / finalize multiple times
+  for (auto i = 0; i < 4; ++i)
+  {
+    // initialize eCAL API
+    EXPECT_EQ(0, eCAL::Initialize(0, nullptr, "multiple_initialize_finalize_test"));
+
+    // finalize eCAL API
+    EXPECT_EQ(0, eCAL::Finalize());
+  }
+}
+
+TEST(core, Core_UnitName)
+{
+  // initialize eCAL API with empty unit name (eCAL will use process name as unit name)
+  EXPECT_EQ(0, eCAL::Initialize(0, nullptr, ""));
+
+  // Is eCAL API initialized ?
+  EXPECT_EQ(1, eCAL::IsInitialized());
+
+  // set unit name
+  EXPECT_EQ(0, eCAL::SetUnitName("unit name"));
+
+  // set nullptr unit name
+  EXPECT_EQ(-1, eCAL::SetUnitName(nullptr));
+
+  // set empty unit name
+  EXPECT_EQ(-1, eCAL::SetUnitName(""));
+
+  // finalize eCAL API we expect return value 0 because it will be finalized
+  EXPECT_EQ(0, eCAL::Finalize());
+}
+
+TEST(core, Core_eCAL_Ok)
+{
+  // check uninitialized eCAL, should not be okay
+  EXPECT_EQ(0, eCAL::Ok());
+
+  // initialize eCAL API
+  EXPECT_EQ(0, eCAL::Initialize(0, nullptr, "okay_test"));
+
+  // check initialized eCAL, should be okay
+  EXPECT_EQ(1, eCAL::Ok());
+
+  // finalize eCAL API we expect return value 0 because it will be finalized
+  EXPECT_EQ(0, eCAL::Finalize());
+
+  // check finalized eCAL, should not be okay
+  EXPECT_EQ(0, eCAL::Ok());
+}
+
+
+// CHECK THIS AND MOVE THIS IN ANOTHER TEST UNIT
+#if 0
+
 #include <ecal/ecal.h>
 #include <ecal/msg/string/publisher.h>
 #include <ecal/msg/string/subscriber.h>
@@ -227,3 +336,5 @@ TEST(Core, TimerCallback)
   EXPECT_EQ(1, eCAL::Finalize());
 }
 #endif /* !defined ECAL_OS_WINDOWS */
+
+#endif

--- a/ecal/tests/cpp/core_test/src/core_test.cpp
+++ b/ecal/tests/cpp/core_test/src/core_test.cpp
@@ -22,7 +22,7 @@
 
 #include <gtest/gtest.h>
 
-TEST(core, Core_GetVersion)
+TEST(core_cpp, Core_GetVersion)
 {
   // get eCAL version string
   EXPECT_STREQ(ECAL_VERSION, eCAL::GetVersionString());
@@ -40,7 +40,7 @@ TEST(core, Core_GetVersion)
   EXPECT_EQ(ECAL_VERSION_PATCH, patch);
 }
 
-TEST(core, Core_InitializeFinalize)
+TEST(core_cpp, Core_InitializeFinalize)
 {
   // Is eCAL API initialized ?
   EXPECT_EQ(0, eCAL::IsInitialized());
@@ -70,7 +70,7 @@ TEST(core, Core_InitializeFinalize)
   EXPECT_EQ(1, eCAL::Finalize());
 }
 
-TEST(core, Core_MultipleInitializeFinalize)
+TEST(core_cpp, Core_MultipleInitializeFinalize)
 {
   // try to initialize / finalize multiple times
   for (auto i = 0; i < 4; ++i)
@@ -83,7 +83,7 @@ TEST(core, Core_MultipleInitializeFinalize)
   }
 }
 
-TEST(core, Core_UnitName)
+TEST(core_cpp, Core_UnitName)
 {
   // initialize eCAL API with empty unit name (eCAL will use process name as unit name)
   EXPECT_EQ(0, eCAL::Initialize(0, nullptr, ""));
@@ -104,7 +104,7 @@ TEST(core, Core_UnitName)
   EXPECT_EQ(0, eCAL::Finalize());
 }
 
-TEST(core, Core_eCAL_Ok)
+TEST(core_cpp, Core_eCAL_Ok)
 {
   // check uninitialized eCAL, should not be okay
   EXPECT_EQ(0, eCAL::Ok());

--- a/ecal/tests/cpp/pubsub_test/src/pubsub_test.cpp
+++ b/ecal/tests/cpp/pubsub_test/src/pubsub_test.cpp
@@ -50,49 +50,6 @@ static std::string CreatePayLoad(size_t payload_size_)
   return(s);
 }
 
-TEST(PubSub, InitializeFinalize)
-{
-  // Is eCAL API initialized ?
-  EXPECT_EQ(0, eCAL::IsInitialized());
-
-  // initialize eCAL API
-  EXPECT_EQ(0, eCAL::Initialize(0, nullptr, "initialize_test"));
-
-  // Is eCAL API initialized ?
-  EXPECT_EQ(1, eCAL::IsInitialized());
-
-  // initialize eCAL API again we expect return value 1 for yet initialized
-  EXPECT_EQ(1, eCAL::Initialize(0, nullptr, "initialize_test"));
-
-  // finalize eCAL API we expect return value 0 even it will not be really finalized because it's 2 times initialzed and 1 time finalized
-  EXPECT_EQ(0, eCAL::Finalize());
-
-  // Is eCAL API initialized ? yes it' still initialized
-  EXPECT_EQ(1, eCAL::IsInitialized());
-
-  // finalize eCAL API we expect return value 0 because now it will be finalized
-  EXPECT_EQ(0, eCAL::Finalize());
-
-  // Is eCAL API initialized ? no
-  EXPECT_EQ(0, eCAL::IsInitialized());
-
-  // finalize eCAL API we expect return value 1 because it was finalized before
-  EXPECT_EQ(1, eCAL::Finalize());
-}
-
-TEST(PubSub, MultipleInitializeFinalize)
-{
-  // try to initialize / finalize multiple times
-  for (auto i = 0; i < 4; ++i)
-  {
-    // initialize eCAL API
-    EXPECT_EQ(0, eCAL::Initialize(0, nullptr, "multiple initialize/finalize"));
-
-    // finalize eCAL API
-    EXPECT_EQ(0, eCAL::Finalize());
-  }
-}
-
 TEST(PubSub, LeakedPubSub)
 {
   // initialize eCAL API


### PR DESCRIPTION
### Description
eCAL C API is currently not tested. Therefore a core C API test is added and the existing C++ API test is aligned with that.

### Cherry-pick to
- _none_
