### PR TITLE
[core] create FrequencyCalculator class for sender / receiver frequency calculation.

### DIFF
--- a/ecal/core/CMakeLists.txt
+++ b/ecal/core/CMakeLists.txt
@@ -402,6 +402,7 @@ endif()
 set(ecal_util_src
     src/util/ecal_expmap.h
     src/util/ecal_thread.h
+    src/util/frequency_calculator.h
     src/util/getenvvar.h
 )
 if (ECAL_CORE_COMMAND_LINE)

--- a/ecal/core/src/readwrite/ecal_reader.cpp
+++ b/ecal/core/src/readwrite/ecal_reader.cpp
@@ -893,8 +893,9 @@ namespace eCAL
 
   int32_t CDataReader::GetFrequency()
   {
+    const auto frequency_time = std::chrono::steady_clock::now();
     const std::lock_guard<std::mutex> lock(m_frequency_calculator_mutex);
-    return static_cast<int32_t>(m_frequency_calculator.getFrequency(std::chrono::steady_clock::now()) * 1000);
+    return static_cast<int32_t>(m_frequency_calculator.getFrequency(frequency_time) * 1000);
   }
     
   void CDataReader::RefreshRegistration()

--- a/ecal/core/src/readwrite/ecal_reader.cpp
+++ b/ecal/core/src/readwrite/ecal_reader.cpp
@@ -160,6 +160,7 @@ namespace eCAL
 
     // reset defaults
     m_created                 = false;
+    m_clock                   = 0;
     m_message_drops           = 0;
 
     m_use_udp_mc_confirmed    = false;

--- a/ecal/core/src/readwrite/ecal_reader.cpp
+++ b/ecal/core/src/readwrite/ecal_reader.cpp
@@ -96,6 +96,7 @@ namespace eCAL
     m_topic_name    = topic_name_;
     m_topic_id.clear();
     m_topic_info    = topic_info_;
+    m_clock         = 0;
     m_message_drops = 0;
     m_created       = false;
 #ifndef NDEBUG

--- a/ecal/core/src/readwrite/ecal_reader.h
+++ b/ecal/core/src/readwrite/ecal_reader.h
@@ -110,6 +110,8 @@ namespace eCAL
     void Disconnect();
     bool CheckMessageClock(const std::string& tid_, long long current_clock_);
 
+    int32_t GetFrequency();
+
     std::string                               m_host_name;
     std::string                               m_host_group_name;
     int                                       m_pid;

--- a/ecal/core/src/readwrite/ecal_reader.h
+++ b/ecal/core/src/readwrite/ecal_reader.h
@@ -44,6 +44,8 @@
 #include <string>
 #include <unordered_map>
 
+#include <util/frequency_calculator.h>
+
 namespace eCAL
 {
   class CDataReader
@@ -141,9 +143,9 @@ namespace eCAL
     EventCallbackMapT                         m_event_callback_map;
 
     std::atomic<long long>                    m_clock;
-    long long                                 m_clock_old;
-    std::chrono::steady_clock::time_point     m_rec_time;
-    long                                      m_freq;
+
+    std::mutex                                               m_frequency_calculator_mutex;
+    ResettableFrequencyCalculator<std::chrono::steady_clock> m_frequency_calculator;
 
     std::set<long long>                       m_id_set;
 

--- a/ecal/core/src/readwrite/ecal_writer.cpp
+++ b/ecal/core/src/readwrite/ecal_writer.cpp
@@ -403,8 +403,9 @@ namespace eCAL
   {
     {
       // we should think about if we would like to potentially use the `time_` variable to tick with (but we would need the same base for checking incoming samples then....
-      std::lock_guard<std::mutex> lock(m_frequency_calculator_mutex);
-      m_frequency_calculator.addTick(std::chrono::steady_clock::now());
+      const auto send_time = std::chrono::steady_clock::now();
+      const std::lock_guard<std::mutex> lock(m_frequency_calculator_mutex);
+      m_frequency_calculator.addTick(send_time);
     }
 
     // check writer modes
@@ -743,12 +744,6 @@ namespace eCAL
 
   std::string CDataWriter::Dump(const std::string& indent_ /* = "" */)
   {
-    double frequency;
-    {
-      std::lock_guard<std::mutex> lock(m_frequency_calculator_mutex);
-      frequency = m_frequency_calculator.getFrequency(std::chrono::steady_clock::now()) * 1000000;
-    }
-
     std::stringstream out;
 
     out << '\n';
@@ -764,7 +759,7 @@ namespace eCAL
     out << indent_ << "m_topic_info.desc:        " << m_topic_info.descriptor << '\n';
     out << indent_ << "m_id:                     " << m_id << '\n';
     out << indent_ << "m_clock:                  " << m_clock << '\n';
-    out << indent_ << "frequency [mHz]:          " << frequency << '\n';
+    out << indent_ << "frequency [mHz]:          " << GetFrequency() << '\n';
     out << indent_ << "m_created:                " << m_created << '\n';
     out << indent_ << "m_loc_subscribed:         " << m_loc_subscribed << '\n';
     out << indent_ << "m_ext_subscribed:         " << m_ext_subscribed << '\n';
@@ -857,10 +852,7 @@ namespace eCAL
     ecal_reg_sample_topic.uname  = Process::GetUnitName();
     ecal_reg_sample_topic.did    = m_id;
     ecal_reg_sample_topic.dclock = m_clock;
-    {
-      std::lock_guard<std::mutex> lock(m_frequency_calculator_mutex);
-      ecal_reg_sample_topic.dfreq = static_cast<int32_t>(m_frequency_calculator.getFrequency(std::chrono::steady_clock::now()) * 1000);
-    }
+    ecal_reg_sample_topic.dfreq  = GetFrequency();
 
     size_t loc_connections(0);
     size_t ext_connections(0);
@@ -1231,5 +1223,10 @@ namespace eCAL
     (void)smode_;
     (void)base_msg_;
 #endif
+  }
+  int32_t CDataWriter::GetFrequency()
+  {
+    const std::lock_guard<std::mutex> lock(m_frequency_calculator_mutex);
+    return static_cast<int32_t>(m_frequency_calculator.getFrequency(std::chrono::steady_clock::now()) * 1000);
   }
 }

--- a/ecal/core/src/readwrite/ecal_writer.cpp
+++ b/ecal/core/src/readwrite/ecal_writer.cpp
@@ -1226,7 +1226,8 @@ namespace eCAL
   }
   int32_t CDataWriter::GetFrequency()
   {
+    const auto frequency_time = std::chrono::steady_clock::now();
     const std::lock_guard<std::mutex> lock(m_frequency_calculator_mutex);
-    return static_cast<int32_t>(m_frequency_calculator.getFrequency(std::chrono::steady_clock::now()) * 1000);
+    return static_cast<int32_t>(m_frequency_calculator.getFrequency(frequency_time) * 1000);
   }
 }

--- a/ecal/core/src/readwrite/ecal_writer.h
+++ b/ecal/core/src/readwrite/ecal_writer.h
@@ -33,6 +33,7 @@
 
 #include "ecal_def.h"
 #include "util/ecal_expmap.h"
+#include <util/frequency_calculator.h>
 
 #if ECAL_CORE_TRANSPORT_UDP
 #include "udp/ecal_writer_udp_mc.h"
@@ -178,9 +179,9 @@ namespace eCAL
 
     long long                              m_id;
     long long                              m_clock;
-    long long                              m_clock_old;
-    std::chrono::steady_clock::time_point  m_snd_time;
-    long                                   m_freq;
+
+    std::mutex                                               m_frequency_calculator_mutex;
+    ResettableFrequencyCalculator<std::chrono::steady_clock> m_frequency_calculator;
 
     std::atomic<bool>                      m_loc_subscribed;
     std::atomic<bool>                      m_ext_subscribed;

--- a/ecal/core/src/readwrite/ecal_writer.h
+++ b/ecal/core/src/readwrite/ecal_writer.h
@@ -149,6 +149,8 @@ namespace eCAL
     bool IsInternalSubscribedOnly();
     void LogSendMode(TLayer::eSendMode smode_, const std::string& base_msg_);
 
+    int32_t GetFrequency();
+
     std::string                            m_host_name;
     std::string                            m_host_group_name;
     int                                    m_pid;

--- a/ecal/core/src/util/frequency_calculator.h
+++ b/ecal/core/src/util/frequency_calculator.h
@@ -26,6 +26,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <memory>
 #include <numeric>
 
 namespace eCAL

--- a/ecal/core/src/util/frequency_calculator.h
+++ b/ecal/core/src/util/frequency_calculator.h
@@ -1,0 +1,141 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+/**
+ * @brief This file provides classes to calculate frequencies.
+ *        These classes are NOT threadsafe!
+**/
+
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <numeric>
+
+namespace eCAL
+{
+  template <typename T>
+  double calculateFrequency(const std::chrono::time_point<T>& start, const std::chrono::time_point<T>& end, long long ticks)
+  {
+    auto time_delta = (end - start).count();
+    if (time_delta == 0)
+    {
+      return std::numeric_limits<double>::max();
+    }
+    auto denominator = typename T::duration::period().den;
+    auto numerator = typename T::duration::period().num;
+    return ((double)denominator * ticks / ((double) numerator * time_delta));
+  }
+
+  template <class T>
+  class FrequencyCalculator
+  {
+  public:
+    using time_point = std::chrono::time_point<T>;
+
+    FrequencyCalculator(const time_point& now_)
+      : counted_elements(0)
+      , first_tick(now_)
+      , last_tick(now_)
+      , previous_frequency(0.0)
+    {
+    }
+
+    void addTick(const time_point& now)
+    {
+      counted_elements++;
+      last_tick = now;
+    }
+
+    double getFrequency()
+    {
+      if (counted_elements == 0)
+      {
+        return previous_frequency;
+      }
+
+      previous_frequency = calculateFrequency<T>(first_tick, last_tick, counted_elements);
+      first_tick = last_tick;
+      counted_elements = 0;
+      return previous_frequency;
+    }
+
+  private:
+    long long counted_elements;
+    time_point first_tick;
+    time_point last_tick;
+    double previous_frequency;
+  };
+
+
+  template <class T>
+  class ResettableFrequencyCalculator
+  {
+  public:
+    using time_point = std::chrono::time_point<T>;
+
+    ResettableFrequencyCalculator(float reset_factor_)
+      : reset_factor(reset_factor_)
+    {}
+
+    void addTick(const time_point& now)
+    {
+      if (!calculator)
+      {
+        calculator = std::make_unique<FrequencyCalculator<T>>(now);
+      }
+      else
+      {
+        calculator->addTick(now);
+      }
+      last_tick = now;
+    }
+
+    double getFrequency(const time_point& now)
+    {
+      double frequency = calculator ? calculator->getFrequency() : 0.0;
+
+      if (frequency == 0.0)
+      {
+        return 0.0;
+      }
+
+      // calculate theoretical frequency to detect timeouts;
+      double theoretical_frequency = calculateFrequency<T>(last_tick, now, 1);
+      // If the frequency is higher than reset_factor * theoretical_frequency, we reset. 
+      if (frequency >= theoretical_frequency * reset_factor)
+      {
+        calculator.reset();
+        return 0.0;
+      }
+
+      return frequency;
+    }
+
+  private:
+    float reset_factor;
+    time_point last_tick;
+    std::unique_ptr<FrequencyCalculator<T>> calculator;
+  };
+}
+
+
+
+
+

--- a/ecal/tests/cpp/util_test/src/util_test.cpp
+++ b/ecal/tests/cpp/util_test/src/util_test.cpp
@@ -61,7 +61,7 @@ struct MillisecondFrequencyPair
   double frequency;
 };
 
-std::vector<MillisecondFrequencyPair> pairs =
+const std::vector<MillisecondFrequencyPair> frequency_pairs =
 {
   {std::chrono::milliseconds(1000),   1.0},
   {std::chrono::milliseconds(1250),   0.8},
@@ -75,9 +75,9 @@ std::vector<MillisecondFrequencyPair> pairs =
 };
 
 
-TEST(FrequencyCalculator, FrequencyCalculator)
+TEST(Util, FrequencyCalculator)
 {
-  for (const auto& pair : pairs)
+  for (const auto& pair : frequency_pairs)
   {
     {
       auto now = std::chrono::steady_clock::now();
@@ -110,12 +110,12 @@ TEST(FrequencyCalculator, FrequencyCalculator)
   }
 }
 
-TEST(FrequencyCalculator, ResettableFrequencyCalculator)
+TEST(Util, ResettableFrequencyCalculator)
 {
   const auto check_delta_t = std::chrono::milliseconds(999);
 
 
-  for (const auto& pair : pairs)
+  for (const auto& pair : frequency_pairs)
   {
     {
       //auto start = std::chrono::steady_clock::now();
@@ -188,8 +188,6 @@ TEST(FrequencyCalculator, ResettableFrequencyCalculator)
           EXPECT_DOUBLE_EQ(calculator.getFrequency(next_frequency_update), pair.frequency);
         }
       }
-
-      // Then start again sending
     }
   }
 }

--- a/ecal/tests/cpp/util_test/src/util_test.cpp
+++ b/ecal/tests/cpp/util_test/src/util_test.cpp
@@ -17,8 +17,10 @@
  * ========================= eCAL LICENSE =================================
 */
 
+#include <vector>
 #include <ecal/ecal.h>
 #include <gtest/gtest.h>
+#include <util/frequency_calculator.h>
 
 
 namespace {
@@ -52,3 +54,143 @@ TEST(Util, SplitCombinedTopicType)
   TestSplitCombinedTopicType("base:std::string", "base", "std::string");
   TestSplitCombinedTopicType("MyType", "", "MyType");
 }
+
+struct MillisecondFrequencyPair
+{
+  std::chrono::milliseconds delta_t;
+  double frequency;
+};
+
+std::vector<MillisecondFrequencyPair> pairs =
+{
+  {std::chrono::milliseconds(1000),   1.0},
+  {std::chrono::milliseconds(1250),   0.8},
+  {std::chrono::milliseconds(5000),   0.2},
+  {std::chrono::milliseconds(20000),  0.05},
+  {std::chrono::milliseconds(500),    2.0},
+  {std::chrono::milliseconds(200),    5.0},
+  {std::chrono::milliseconds(100),   10.0},
+  {std::chrono::milliseconds(20),    50.0},
+  {std::chrono::milliseconds(2),    500.0},
+};
+
+
+TEST(FrequencyCalculator, FrequencyCalculator)
+{
+  for (const auto& pair : pairs)
+  {
+    {
+      auto now = std::chrono::steady_clock::now();
+      eCAL::FrequencyCalculator<std::chrono::steady_clock> calculator(now);
+      EXPECT_DOUBLE_EQ(calculator.getFrequency(), 0.0f);
+
+      for (int j = 0; j < 100; ++j)
+      {
+        for (int i = 0; i < 20; ++i)
+        {
+          now = now + pair.delta_t;
+          calculator.addTick(now);
+        }
+
+        EXPECT_DOUBLE_EQ(calculator.getFrequency(), pair.frequency);
+      }
+    }
+
+    {
+      auto now = std::chrono::steady_clock::now();
+      eCAL::FrequencyCalculator<std::chrono::steady_clock> calculator(now);
+
+      for (int i = 0; i < 5; ++i)
+      {
+        now = now + pair.delta_t;
+        calculator.addTick(now);
+        EXPECT_DOUBLE_EQ(calculator.getFrequency(), pair.frequency);
+      }
+    }
+  }
+}
+
+TEST(FrequencyCalculator, ResettableFrequencyCalculator)
+{
+  const auto check_delta_t = std::chrono::milliseconds(999);
+
+
+  for (const auto& pair : pairs)
+  {
+    {
+      //auto start = std::chrono::steady_clock::now();
+      auto start = std::chrono::steady_clock::time_point(std::chrono::milliseconds(0));
+      auto next_frequency_update = start;
+      auto next_tick = start;
+      eCAL::ResettableFrequencyCalculator<std::chrono::steady_clock> calculator(3.0f);
+      calculator.addTick(next_tick);
+      EXPECT_DOUBLE_EQ(calculator.getFrequency(next_frequency_update), 0.0f);
+
+      for (int i = 0; i < 100; ++i)
+      {
+        next_frequency_update = next_frequency_update + check_delta_t;
+
+        while (next_tick + pair.delta_t <= next_frequency_update)
+        {
+          next_tick = next_tick + pair.delta_t;
+          calculator.addTick(next_tick);
+        }
+
+        if (next_frequency_update - start < pair.delta_t)
+        {
+          // no updates happened yet - expect 0 frequency
+          EXPECT_DOUBLE_EQ(calculator.getFrequency(next_frequency_update), 0.0);
+        }
+        else
+        {
+          EXPECT_DOUBLE_EQ(calculator.getFrequency(next_frequency_update), pair.frequency);
+        }
+      }
+
+      // Now check timeout behavior
+      // Calculate when timeout should happen
+      auto timeout_time = next_tick + 3.0f * pair.delta_t;
+      for (int i = 0; i < 100; ++i)
+      {
+        next_frequency_update = next_frequency_update + check_delta_t;
+        if (next_frequency_update <= timeout_time)
+        {
+          EXPECT_DOUBLE_EQ(calculator.getFrequency(next_frequency_update), pair.frequency);
+        }
+        else
+        {
+          EXPECT_DOUBLE_EQ(calculator.getFrequency(next_frequency_update), 0.0);
+        }
+      }
+
+      // Finally we're getting new ticks again! let's check frequencies again!
+      auto new_start = next_frequency_update;
+      next_tick = next_frequency_update;
+      // Check that filter goes back
+      calculator.addTick(next_tick);
+      for (int i = 0; i < 100; ++i)
+      {
+        next_frequency_update = next_frequency_update + check_delta_t;
+
+        while (next_tick + pair.delta_t <= next_frequency_update)
+        {
+          next_tick = next_tick + pair.delta_t;
+          calculator.addTick(next_tick);
+        }
+
+        if (next_frequency_update - new_start < pair.delta_t)
+        {
+          // no updates happened yet - expect 0 frequency
+          EXPECT_DOUBLE_EQ(calculator.getFrequency(next_frequency_update), 0.0);
+        }
+        else
+        {
+          EXPECT_DOUBLE_EQ(calculator.getFrequency(next_frequency_update), pair.frequency);
+        }
+      }
+
+      // Then start again sending
+    }
+  }
+}
+


### PR DESCRIPTION
### Description
The frequency calculation for reader / writer frequencies was moved from reader.cpp / writer.cpp into it's own class.
The calculator properly handles frequencies below 1Hz and is able to reset if no data is coming in.

### Discussion
The calculator is not thread safe. Therefore mutexes are needed for synchronization.

The non-resettable calculator can probably be made threadsafe by moving the two members with are accessed concurrently into a struct with a size of < 8 bytes and proper memory alignment. Both functions could atomically load/store the values and a lock-free thread safety can be achieved.

The resettable calculator sees a bit harder. The unique_ptr needs to be handled and atomic unique_pointers are not available. That pointer may be created in `addTick` and destroyed in `getFrequency`, and I have low hopes of getting that part threadsafe easily without using locks.


### Related issues
Fixes #1404 

### Cherry-pick to
To be discussed, potentially 5.13, as it is not yet released.
- 5.13 (current stable)