### PR TITLE
Ecal Parser: Added QNX and default OS

### DIFF
--- a/lib/EcalParser/src/functions/os.cpp
+++ b/lib/EcalParser/src/functions/os.cpp
@@ -39,6 +39,10 @@ namespace EcalParser
     return "NetBSD";
 #elif __OpenBSD__
     return "OpenBSD";
+#elif defined(__QNX__)
+    return "QNX";
+#else
+    return "UNKNOWN_OS";
 #endif
   }
 


### PR DESCRIPTION
### Cherry-pick to
- 5.12 (old stable)
- 5.13 (current stable)
