### PR TITLE
[core] new public api getlogging as struct

### DIFF
--- a/ecal/core/CMakeLists.txt
+++ b/ecal/core/CMakeLists.txt
@@ -355,7 +355,6 @@ set(ecal_serialization_src
     src/serialization/ecal_serialize_sample_registration.h
     src/serialization/ecal_serialize_service.cpp
     src/serialization/ecal_serialize_service.h
-    src/serialization/ecal_struct_logging.h
     src/serialization/ecal_struct_sample_common.h
     src/serialization/ecal_struct_sample_payload.h
     src/serialization/ecal_struct_sample_registration.h
@@ -471,6 +470,7 @@ endif()
 # public header
 ######################################
 set(ecal_header_cmn
+    include/ecal/types/logging.h
     include/ecal/types/monitoring.h
     include/ecal/ecal.h
     include/ecal/ecal_callback.h

--- a/ecal/core/include/ecal/cimpl/ecal_core_cimpl.h
+++ b/ecal/core/include/ecal/cimpl/ecal_core_cimpl.h
@@ -107,7 +107,7 @@ extern "C"
 
   /**
    * @brief  Free an eCAL memory block allocated by functions like
-   *         eCAL_Monitoring_GetMonitoring, eCAL_Monitoring_GetLogging, 
+   *         eCAL_Monitoring_GetMonitoring, eCAL_Logging_GetLogging, 
    *         eCAL_Sub_Receive ... that use 'ECAL_ALLOCATE_4ME' as 
    *         buffer length parameter and let eCAL allocate 
    *         the memory internally.

--- a/ecal/core/include/ecal/cimpl/ecal_log_cimpl.h
+++ b/ecal/core/include/ecal/cimpl/ecal_log_cimpl.h
@@ -53,6 +53,17 @@ extern "C"
    * @param msg_  The log message string.
   **/
   ECALC_API void eCAL_Logging_Log(const char* const msg_);
+
+  /**
+   * @brief Get logging string.
+   *
+   * @param [out] buf_      Pointer to store the logging information.
+   * @param       buf_len_  Length of allocated buffer or ECAL_ALLOCATE_4ME if
+   *                        eCAL should allocate the buffer for you (see eCAL_FreeMem).
+   *
+   * @return  Logging buffer length or zero if failed.
+  **/
+  ECALC_API int eCAL_Logging_GetLogging(void* buf_, int buf_len_);
 #ifdef __cplusplus
 }
 #endif /*__cplusplus*/

--- a/ecal/core/include/ecal/cimpl/ecal_monitoring_cimpl.h
+++ b/ecal/core/include/ecal/cimpl/ecal_monitoring_cimpl.h
@@ -71,7 +71,7 @@ extern "C"
    * @code
    *            // let eCAL allocate memory for the monitoring buffer and return the pointer to 'buf'
    *            void*     buf      = NULL;
-   *            int       buf_len  = eCAL_Monitoring_GetLogging(subscriber_handle, &buf, ECAL_ALLOCATE_4ME);
+   *            int       buf_len  = eCAL_Monitoring_GetMonitoring(&buf, ECAL_ALLOCATE_4ME);
    *            if(buf_len > 0)
    *            {
    *              ...
@@ -83,37 +83,6 @@ extern "C"
    * @endcode
   **/
   ECALC_API int eCAL_Monitoring_GetMonitoring(void* buf_, int buf_len_);
-
-  /**
-   * @brief Get logging string.
-   *
-   * @param [out] buf_      Pointer to store the logging information. 
-   * @param       buf_len_  Length of allocated buffer or ECAL_ALLOCATE_4ME if
-   *                        eCAL should allocate the buffer for you (see eCAL_FreeMem). 
-   *
-   * @return  Logging buffer length or zero if failed. 
-  **/
-  ECALC_API int eCAL_Monitoring_GetLogging(void* buf_, int buf_len_);
-
-  /**
-  * @brief Publish monitoring protobuf message.
-   *
-   * @param state_  Switch publishing on/off.
-   * @param name_   Monitoring topic name.
-   *
-   * @return Zero if succeeded.
-  **/
-  ECALC_API int eCAL_Monitoring_PubMonitoring(int state_, const char* name_);
-
-  /**
-   * @brief Publish logging protobuf message.
-   *
-   * @param state_  Switch publishing on/off.
-   * @param name_   Logging topic name.
-   *
-   * @return Zero if succeeded.
-  **/
-  ECALC_API int eCAL_Monitoring_PubLogging(int state_, const char* name_);
 #ifdef __cplusplus
 }
 #endif /*__cplusplus*/

--- a/ecal/core/include/ecal/ecal_log.h
+++ b/ecal/core/include/ecal/ecal_log.h
@@ -26,6 +26,7 @@
 
 #include <ecal/ecal_os.h>
 #include <ecal/ecal_log_level.h>
+#include <ecal/types/logging.h>
 
 #include <list>
 #include <string>
@@ -72,8 +73,17 @@ namespace eCAL
      *
      * @param [out] log_  String to store the logging information.
      *
-     * @return  Monitoring buffer length or zero if failed.
+     * @return  Logging buffer length or zero if failed.
     **/
     ECAL_API int GetLogging(std::string& log_);
+
+    /**
+     * @brief Get logging as struct.
+     *
+     * @param [out] log_  Target struct to store the logging information.
+     *
+     * @return Number of log messages.
+    **/
+    ECAL_API int GetLogging(Logging::SLogging& log_);
   }
 }

--- a/ecal/core/include/ecal/ecal_monitoring.h
+++ b/ecal/core/include/ecal/ecal_monitoring.h
@@ -65,7 +65,7 @@ namespace eCAL
      * @param [out] mon_       Target string to store the monitoring information. 
      * @param       entities_  Entities to get.
      *
-     * @return Zero if succeeded.
+     * @return  Monitoring buffer length or zero if failed.
     **/
     ECAL_API int GetMonitoring(std::string& mon_, unsigned int entities_ = Entity::All);
     
@@ -75,7 +75,7 @@ namespace eCAL
      * @param [out] mon_       Target struct to store the monitoring information.
      * @param       entities_  Entities definition.
      *
-     * @return Number of struct elements if succeeded.
+     * @return Number of struct elements.
     **/
     ECAL_API int GetMonitoring(SMonitoring& mon_, unsigned int entities_ = Entity::All);
   }

--- a/ecal/core/include/ecal/types/logging.h
+++ b/ecal/core/include/ecal/types/logging.h
@@ -5,9 +5,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,8 +18,8 @@
 */
 
 /**
- * @file   ecal_struct_logging.h
- * @brief  eCAL logging as struct
+ * @file   logging.h
+ * @brief  eCAL logging struct interface
 **/
 
 #pragma once
@@ -34,7 +34,7 @@ namespace eCAL
 {
   namespace Logging
   {
-    struct LogMessage
+    struct SLogMessage
     {
       int64_t                time  = 0;               // time
       std::string            hname;                   // host name
@@ -45,10 +45,9 @@ namespace eCAL
       std::string            content;                 // message content
     };
 
-    // LogMessage list
-    struct LogMessageList
+    struct SLogging
     {
-      std::list<LogMessage>  log_messages;            // log messages
+      std::list<SLogMessage>  log_messages;            // log messages
     };
   }
 }

--- a/ecal/core/include/ecal/types/monitoring.h
+++ b/ecal/core/include/ecal/types/monitoring.h
@@ -18,8 +18,8 @@
 */
 
 /**
- * @file   ecal_monitoring_pb.h
- * @brief  eCAL monitoring interface using structs
+ * @file   monitoring.h
+ * @brief  eCAL monitoring struct interface
 **/
 
 #pragma once

--- a/ecal/core/src/cimpl/ecal_log_cimpl.cpp
+++ b/ecal/core/src/cimpl/ecal_log_cimpl.cpp
@@ -25,6 +25,8 @@
 #include <ecal/ecal.h>
 #include <ecal/cimpl/ecal_log_cimpl.h>
 
+#include "ecal_common_cimpl.h"
+
 extern "C"
 {
   ECALC_API void eCAL_Logging_SetLogLevel(enum eCAL_Logging_eLogLevel level_)
@@ -40,5 +42,15 @@ extern "C"
   ECALC_API void eCAL_Logging_Log(const char* const msg_)
   {
     eCAL::Logging::Log(msg_);
+  }
+
+  ECALC_API int eCAL_Logging_GetLogging(void* buf_, int buf_len_)
+  {
+    std::string buf;
+    if (eCAL::Logging::GetLogging(buf) != 0)
+    {
+      return(CopyBuffer(buf_, buf_len_, buf));
+    }
+    return(0);
   }
 }

--- a/ecal/core/src/cimpl/ecal_monitoring_cimpl.cpp
+++ b/ecal/core/src/cimpl/ecal_monitoring_cimpl.cpp
@@ -54,15 +54,5 @@ extern "C"
     }
     return(0);
   }
-
-  ECALC_API int eCAL_Monitoring_GetLogging(void* buf_, int buf_len_)
-  {
-    std::string buf;
-    if (eCAL::Logging::GetLogging(buf) != 0)
-    {
-      return(CopyBuffer(buf_, buf_len_, buf));
-    }
-    return(0);
-  }
 }
 #endif // ECAL_CORE_MONITORING

--- a/ecal/core/src/logging/ecal_log.cpp
+++ b/ecal/core/src/logging/ecal_log.cpp
@@ -66,12 +66,25 @@ namespace eCAL
      *
      * @param [out] log_  String to store the logging information.
      *
-     * @return  Monitoring buffer length or zero if failed.
+     * @return  Logging buffer length or zero if failed.
     **/
     int GetLogging(std::string& log_)
     {
       if (g_log() != nullptr) g_log()->GetLogging(log_);
       return static_cast<int>(log_.size());
+    }
+
+    /**
+     * @brief Get logging as struct.
+     *
+     * @param [out] log_  Target struct to store the logging information.
+     *
+     * @return Number of struct elements if succeeded.
+    **/
+    int GetLogging(Logging::SLogging& log_)
+    {
+      if (g_log() != nullptr) g_log()->GetLogging(log_);
+      return static_cast<int>(log_.log_messages.size());
     }
   }
 }

--- a/ecal/core/src/logging/ecal_log_impl.h
+++ b/ecal/core/src/logging/ecal_log_impl.h
@@ -25,13 +25,13 @@
 
 #include "io/udp/ecal_udp_sample_receiver.h"
 #include "io/udp/ecal_udp_sample_sender.h"
-#include "serialization/ecal_struct_logging.h"
 
 #include <cstddef>
 #include <ecal/ecal.h>
 #include <ecal/ecal_os.h>
 
 #include <ecal/ecal_log_level.h>
+#include <ecal/types/logging.h>
 
 #include "ecal_global_accessors.h"
 
@@ -97,6 +97,7 @@ namespace eCAL
     void Log(const std::string& msg_);
 
     void GetLogging(std::string& log_msg_list_string_);
+    void GetLogging(Logging::SLogging& log_);
 
   private:
     bool HasSample(const std::string& sample_name_);
@@ -105,15 +106,14 @@ namespace eCAL
     CLog(const CLog&);                 // prevent copy-construction
     CLog& operator=(const CLog&);      // prevent assignment
 
-    std::mutex                             m_log_sync;
-    std::vector<char>                      m_log_message_vec;
+    std::mutex                             m_log_mtx;
 
     std::atomic<bool>                      m_created;
     std::unique_ptr<UDP::CSampleSender>    m_udp_logging_sender;
 
-    // log messages
-    std::mutex                             m_log_msglist_sync;
-    Logging::LogMessageList                m_log_msglist;
+    // log message list and log message serialization buffer
+    Logging::SLogging                      m_log_msglist;
+    std::vector<char>                      m_log_message_vec;
 
     // udp logging receiver
     std::shared_ptr<UDP::CSampleReceiver>  m_log_receiver;

--- a/ecal/core/src/monitoring/ecal_monitoring_impl.cpp
+++ b/ecal/core/src/monitoring/ecal_monitoring_impl.cpp
@@ -591,11 +591,10 @@ namespace eCAL
 
   void CMonitoringImpl::GetMonitoring(Monitoring::SMonitoring& monitoring_, unsigned int entities_)
   {
+    // processes
+    monitoring_.processes.clear();
     if ((entities_ & Monitoring::Entity::Process) != 0u)
     {
-      // clear target
-      monitoring_.processes.clear();
-
       // lock map
       const std::lock_guard<std::mutex> lock(m_process_map.sync);
 
@@ -610,11 +609,10 @@ namespace eCAL
       }
     }
 
+    // publisher
+    monitoring_.publisher.clear();
     if ((entities_ & Monitoring::Entity::Publisher) != 0u)
     {
-      // clear target
-      monitoring_.publisher.clear();
-
       // lock map
       const std::lock_guard<std::mutex> lock(m_publisher_map.sync);
 
@@ -629,11 +627,10 @@ namespace eCAL
       }
     }
 
+    // subscriber
+    monitoring_.subscriber.clear();
     if ((entities_ & Monitoring::Entity::Subscriber) != 0u)
     {
-      // clear target
-      monitoring_.subscriber.clear();
-
       // lock map
       const std::lock_guard<std::mutex> lock(m_subscriber_map.sync);
 
@@ -648,11 +645,10 @@ namespace eCAL
       }
     }
 
+    // server
+    monitoring_.server.clear();
     if ((entities_ & Monitoring::Entity::Server) != 0u)
     {
-      // clear target
-      monitoring_.server.clear();
-
       // lock map
       const std::lock_guard<std::mutex> lock(m_server_map.sync);
 
@@ -667,11 +663,10 @@ namespace eCAL
       }
     }
 
+    // clients
+    monitoring_.clients.clear();
     if ((entities_ & Monitoring::Entity::Client) != 0u)
     {
-      // clear target
-      monitoring_.clients.clear();
-
       // lock map
       const std::lock_guard<std::mutex> lock(m_clients_map.sync);
 

--- a/ecal/core/src/serialization/ecal_serialize_logging.cpp
+++ b/ecal/core/src/serialization/ecal_serialize_logging.cpp
@@ -40,7 +40,7 @@ namespace
   /////////////////////////////////////////////////////////////////////////////////
   // eCAL::Logging::LogMessage
   /////////////////////////////////////////////////////////////////////////////////
-  void PrepareEncoding(const eCAL::Logging::LogMessage& log_message_, eCAL_pb_LogMessage& pb_log_message_)
+  void PrepareEncoding(const eCAL::Logging::SLogMessage& log_message_, eCAL_pb_LogMessage& pb_log_message_)
   {
     // time
     pb_log_message_.time = log_message_.time;
@@ -58,7 +58,7 @@ namespace
     eCAL::nanopb::encode_string(pb_log_message_.content, log_message_.content);
   }
 
-  size_t LogMessageStruct2PbLogMessage(const eCAL::Logging::LogMessage& log_message_, eCAL_pb_LogMessage& pb_log_message_)
+  size_t LogMessageStruct2PbLogMessage(const eCAL::Logging::SLogMessage& log_message_, eCAL_pb_LogMessage& pb_log_message_)
   {
     ///////////////////////////////////////////////
     // prepare sample for encoding
@@ -76,7 +76,7 @@ namespace
   }
 
   template <typename T>
-  bool LogMessageStruct2Buffer(const eCAL::Logging::LogMessage& log_message_, T& target_buffer_)
+  bool LogMessageStruct2Buffer(const eCAL::Logging::SLogMessage& log_message_, T& target_buffer_)
   {
     target_buffer_.clear();
 
@@ -104,7 +104,7 @@ namespace
     return false;
   }
 
-  void PrepareDecoding(eCAL_pb_LogMessage& pb_log_message_, eCAL::Logging::LogMessage& log_message_)
+  void PrepareDecoding(eCAL_pb_LogMessage& pb_log_message_, eCAL::Logging::SLogMessage& log_message_)
   {
     // initialize
     pb_log_message_ = eCAL_pb_LogMessage_init_default;
@@ -123,7 +123,7 @@ namespace
     eCAL::nanopb::decode_string(pb_log_message_.content, log_message_.content);
   }
 
-  void AssignValues(const eCAL_pb_LogMessage& pb_log_message_, eCAL::Logging::LogMessage& log_message_)
+  void AssignValues(const eCAL_pb_LogMessage& pb_log_message_, eCAL::Logging::SLogMessage& log_message_)
   {
     ///////////////////////////////////////////////
     // assign values
@@ -136,7 +136,7 @@ namespace
     log_message_.level = static_cast<eCAL_Logging_eLogLevel>(pb_log_message_.level);
   }
 
-  bool Buffer2LogMessageStruct(const char* data_, size_t size_, eCAL::Logging::LogMessage& log_message_)
+  bool Buffer2LogMessageStruct(const char* data_, size_t size_, eCAL::Logging::SLogMessage& log_message_)
   {
     if (data_ == nullptr) return false;
     if (size_ == 0)       return false;
@@ -175,7 +175,7 @@ namespace
     if (arg == nullptr)  return false;
     if (*arg == nullptr) return false;
 
-    auto* sample_list = static_cast<std::list<eCAL::Logging::LogMessage>*>(*arg);
+    auto* sample_list = static_cast<std::list<eCAL::Logging::SLogMessage>*>(*arg);
 
     for (const auto& sample : *sample_list)
     {
@@ -199,7 +199,7 @@ namespace
     return true;
   }
 
-  size_t LogMessageListStruct2PbLogMessageList(const eCAL::Logging::LogMessageList& log_message_list_, eCAL_pb_LogMessageList& pb_log_message_list_)
+  size_t LogMessageListStruct2PbLogMessageList(const eCAL::Logging::SLogging& log_message_list_, eCAL_pb_LogMessageList& pb_log_message_list_)
   {
     ///////////////////////////////////////////////
     // prepare sample for encoding
@@ -218,7 +218,7 @@ namespace
   }
 
   template <typename T>
-  bool LogMessageListStruct2Buffer(const eCAL::Logging::LogMessageList& log_message_list_, T& target_buffer_)
+  bool LogMessageListStruct2Buffer(const eCAL::Logging::SLogging& log_message_list_, T& target_buffer_)
   {
     ///////////////////////////////////////////////
     // prepare sample for encoding
@@ -250,7 +250,7 @@ namespace
     if (*arg == nullptr) return false;
 
     eCAL_pb_LogMessage pb_log_message = eCAL_pb_LogMessage_init_default;
-    eCAL::Logging::LogMessage sample{};
+    eCAL::Logging::SLogMessage sample{};
 
     // prepare sample for decoding
     PrepareDecoding(pb_log_message, sample);
@@ -265,13 +265,13 @@ namespace
     AssignValues(pb_log_message, sample);
 
     // add sample to list
-    auto* sample_list = static_cast<std::list<eCAL::Logging::LogMessage>*>(*arg);
+    auto* sample_list = static_cast<std::list<eCAL::Logging::SLogMessage>*>(*arg);
     sample_list->push_back(sample);
 
     return true;
   }
 
-  bool Buffer2LogMessageListStruct(const char* data_, size_t size_, eCAL::Logging::LogMessageList& log_message_list_)
+  bool Buffer2LogMessageListStruct(const char* data_, size_t size_, eCAL::Logging::SLogging& log_message_list_)
   {
     if (data_ == nullptr) return false;
     if (size_ == 0)       return false;
@@ -302,34 +302,34 @@ namespace
 namespace eCAL
 {
   // log message - serialize/deserialize
-  bool SerializeToBuffer(const Logging::LogMessage& source_sample_, std::vector<char>& target_buffer_)
+  bool SerializeToBuffer(const Logging::SLogMessage& source_sample_, std::vector<char>& target_buffer_)
   {
     return LogMessageStruct2Buffer(source_sample_, target_buffer_);
   }
 
-  bool SerializeToBuffer(const Logging::LogMessage& source_sample_, std::string& target_buffer_)
+  bool SerializeToBuffer(const Logging::SLogMessage& source_sample_, std::string& target_buffer_)
   {
     return LogMessageStruct2Buffer(source_sample_, target_buffer_);
   }
 
-  bool DeserializeFromBuffer(const char* data_, size_t size_, Logging::LogMessage& target_sample_)
+  bool DeserializeFromBuffer(const char* data_, size_t size_, Logging::SLogMessage& target_sample_)
   {
     return Buffer2LogMessageStruct(data_, size_, target_sample_);
   }
 
-  bool SerializeToBuffer(const Logging::LogMessageList& source_sample_, std::vector<char>& target_buffer_)
+  bool SerializeToBuffer(const Logging::SLogging& source_sample_, std::vector<char>& target_buffer_)
   {
     target_buffer_.clear();
     return LogMessageListStruct2Buffer(source_sample_, target_buffer_);
   }
 
-  bool SerializeToBuffer(const Logging::LogMessageList& source_sample_, std::string& target_buffer_)
+  bool SerializeToBuffer(const Logging::SLogging& source_sample_, std::string& target_buffer_)
   {
     target_buffer_.clear();
     return LogMessageListStruct2Buffer(source_sample_, target_buffer_);
   }
 
-  bool DeserializeFromBuffer(const char* data_, size_t size_, Logging::LogMessageList& target_sample_)
+  bool DeserializeFromBuffer(const char* data_, size_t size_, Logging::SLogging& target_sample_)
   {
     return Buffer2LogMessageListStruct(data_, size_, target_sample_);
   }

--- a/ecal/core/src/serialization/ecal_serialize_logging.h
+++ b/ecal/core/src/serialization/ecal_serialize_logging.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#include "ecal_struct_logging.h"
+#include <ecal/types/logging.h>
 
 #include <string>
 #include <vector>
@@ -32,12 +32,12 @@
 namespace eCAL
 {
   // logmessage - serialize/deserialize
-  bool SerializeToBuffer     (const Logging::LogMessage& source_sample_, std::vector<char>& target_buffer_);
-  bool SerializeToBuffer     (const Logging::LogMessage& source_sample_, std::string& target_buffer_);
-  bool DeserializeFromBuffer (const char* data_, size_t size_, Logging::LogMessage& target_sample_);
+  bool SerializeToBuffer     (const Logging::SLogMessage& source_sample_, std::vector<char>& target_buffer_);
+  bool SerializeToBuffer     (const Logging::SLogMessage& source_sample_, std::string& target_buffer_);
+  bool DeserializeFromBuffer (const char* data_, size_t size_, Logging::SLogMessage& target_sample_);
 
   // logmessage list - serialize/deserialize
-  bool SerializeToBuffer     (const Logging::LogMessageList& source_sample_, std::vector<char>& target_buffer_);
-  bool SerializeToBuffer     (const Logging::LogMessageList& source_sample_, std::string& target_buffer_);
-  bool DeserializeFromBuffer (const char* data_, size_t size_, Logging::LogMessageList& target_sample_);
+  bool SerializeToBuffer     (const Logging::SLogging& source_sample_, std::vector<char>& target_buffer_);
+  bool SerializeToBuffer     (const Logging::SLogging& source_sample_, std::string& target_buffer_);
+  bool DeserializeFromBuffer (const char* data_, size_t size_, Logging::SLogging& target_sample_);
 }

--- a/ecal/tests/cpp/serialization_test/CMakeLists.txt
+++ b/ecal/tests/cpp/serialization_test/CMakeLists.txt
@@ -63,7 +63,6 @@ set(ecal_serialize_src
   ../../../core/src/serialization/ecal_serialize_sample_registration.h
   ../../../core/src/serialization/ecal_serialize_service.cpp
   ../../../core/src/serialization/ecal_serialize_service.h
-  ../../../core/src/serialization/ecal_struct_logging.h
   ../../../core/src/serialization/ecal_struct_sample_common.h
   ../../../core/src/serialization/ecal_struct_sample_payload.h
   ../../../core/src/serialization/ecal_struct_sample_registration.h

--- a/ecal/tests/cpp/serialization_test/src/logging_compare.cpp
+++ b/ecal/tests/cpp/serialization_test/src/logging_compare.cpp
@@ -17,14 +17,14 @@
  * ========================= eCAL LICENSE =================================
 */
 
-#include "../../serialization/ecal_struct_logging.h"
+#include <ecal/types/logging.h>
 
 namespace eCAL
 {
   namespace Logging
   {
     // compare two LogMessages for equality
-    bool CompareLogMessages(const LogMessage& message1, const LogMessage& message2)
+    bool CompareLogMessages(const SLogMessage& message1, const SLogMessage& message2)
     {
       return (message1.time    == message2.time &&
               message1.hname   == message2.hname &&

--- a/ecal/tests/cpp/serialization_test/src/logging_generate.cpp
+++ b/ecal/tests/cpp/serialization_test/src/logging_generate.cpp
@@ -17,7 +17,7 @@
  * ========================= eCAL LICENSE =================================
 */
 
-#include "../../serialization/ecal_struct_logging.h"
+#include <ecal/types/logging.h>
 
 #include <cstdlib>
 
@@ -27,9 +27,9 @@ namespace eCAL
 
   namespace Logging
   {
-    LogMessage GenerateLogMessage()
+    SLogMessage GenerateLogMessage()
     {
-      LogMessage logMessage;
+      SLogMessage logMessage;
       logMessage.time    = rand() % 1000;
       logMessage.hname   = GenerateString(10);
       logMessage.pid     = rand() % 1000;

--- a/ecal/tests/cpp/serialization_test/src/logging_serialization_test.cpp
+++ b/ecal/tests/cpp/serialization_test/src/logging_serialization_test.cpp
@@ -25,17 +25,17 @@ namespace eCAL
 {
   namespace Logging
   {
-    LogMessage GenerateLogMessage();
-    bool CompareLogMessages(const LogMessage& message1, const LogMessage& message2);
+    SLogMessage GenerateLogMessage();
+    bool CompareLogMessages(const SLogMessage& message1, const SLogMessage& message2);
 
     TEST(Serialization, LogMessage2String)
     {
-      LogMessage message_in = GenerateLogMessage();
+      SLogMessage message_in = GenerateLogMessage();
 
       std::string message_buffer;
       ASSERT_TRUE(SerializeToBuffer(message_in, message_buffer));
 
-      LogMessage message_out;
+      SLogMessage message_out;
       ASSERT_TRUE(DeserializeFromBuffer(message_buffer.data(), message_buffer.size(), message_out));
 
       ASSERT_TRUE(CompareLogMessages(message_in, message_out));
@@ -43,12 +43,12 @@ namespace eCAL
 
     TEST(Serialization, LogMessage2Vector)
     {
-      LogMessage message_in = GenerateLogMessage();
+      SLogMessage message_in = GenerateLogMessage();
 
       std::vector<char> message_buffer;
       ASSERT_TRUE(SerializeToBuffer(message_in, message_buffer));
 
-      LogMessage message_out;
+      SLogMessage message_out;
       ASSERT_TRUE(DeserializeFromBuffer(message_buffer.data(), message_buffer.size(), message_out));
 
       ASSERT_TRUE(CompareLogMessages(message_in, message_out));
@@ -57,7 +57,7 @@ namespace eCAL
 
     TEST(Serialization, LogMessageList2String)
     {
-      LogMessageList message_list_in;
+      SLogging message_list_in;
       message_list_in.log_messages.push_back(GenerateLogMessage());
       message_list_in.log_messages.push_back(GenerateLogMessage());
       message_list_in.log_messages.push_back(GenerateLogMessage());
@@ -65,7 +65,7 @@ namespace eCAL
       std::string sample_buffer;
       ASSERT_TRUE(SerializeToBuffer(message_list_in, sample_buffer));
 
-      LogMessageList message_list_out;
+      SLogging message_list_out;
       ASSERT_TRUE(DeserializeFromBuffer(sample_buffer.data(), sample_buffer.size(), message_list_out));
 
       ASSERT_TRUE(message_list_in.log_messages.size() == message_list_out.log_messages.size());
@@ -74,7 +74,7 @@ namespace eCAL
 
     TEST(Serialization, LogMessageList2Vector)
     {
-      LogMessageList message_list_in;
+      SLogging message_list_in;
       message_list_in.log_messages.push_back(GenerateLogMessage());
       message_list_in.log_messages.push_back(GenerateLogMessage());
       message_list_in.log_messages.push_back(GenerateLogMessage());
@@ -82,7 +82,7 @@ namespace eCAL
       std::vector<char> sample_buffer;
       ASSERT_TRUE(SerializeToBuffer(message_list_in, sample_buffer));
 
-      LogMessageList message_list_out;
+      SLogging message_list_out;
       ASSERT_TRUE(DeserializeFromBuffer(sample_buffer.data(), sample_buffer.size(), message_list_out));
 
       ASSERT_TRUE(message_list_in.log_messages.size() == message_list_out.log_messages.size());


### PR DESCRIPTION
### Description
New public API function int GetLogging(Logging::SLogging& log_) to get log messages as struct without the need to serialize and deserialize it via protobuf.

### Cherry-pick to
- _none_
