### PR TITLE
Cleanup: Remove a ton of unnecessary ";" (that cause pedantic warnings).

### DIFF
--- a/app/meas_cutter/src/ecal_meas_cutter_globals.h
+++ b/app/meas_cutter/src/ecal_meas_cutter_globals.h
@@ -34,4 +34,4 @@ namespace EcalMeasCutterGlobals
       + (VERSION_MINOR * 1000)
       + (VERSION_MAJOR * 1000 * 1000));
   }
-};
+}

--- a/app/mon/mon_cli/src/ecal_mon_cli_defs.h
+++ b/app/mon/mon_cli/src/ecal_mon_cli_defs.h
@@ -1,36 +1,36 @@
-;/* ========================= eCAL LICENSE =================================
-; *
-; * Copyright (C) 2016 - 2019 Continental Corporation
-; *
-; * Licensed under the Apache License, Version 2.0 (the "License");
-; * you may not use this file except in compliance with the License.
-; * You may obtain a copy of the License at
-; * 
-; *      http://www.apache.org/licenses/LICENSE-2.0
-; * 
-; * Unless required by applicable law or agreed to in writing, software
-; * distributed under the License is distributed on an "AS IS" BASIS,
-; * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-; * See the License for the specific language governing permissions and
-; * limitations under the License.
-; *
-; * ========================= eCAL LICENSE =================================
-;*/
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
 
-;/**
-; * eCALMon CLI version definition
-;**/
+/**
+ * eCALMon CLI version definition
+**/
 
 #pragma once
 
-;/* version parsed out into numeric values */
+/* version parsed out into numeric values */
 #define ECAL_MON_CLI_VERSION_MAJOR              1
 #define ECAL_MON_CLI_VERSION_MINOR              0
 #define ECAL_MON_CLI_VERSION_PATCH              2
 
-;/* version as string */
+/* version as string */
 #define ECAL_MON_CLI_VERSION                    "1.0.2"
 #define ECAL_MON_CLI_DATE                       "13.03.2020"
 
-;/* name as string */
+/* name as string */
 #define ECAL_MON_CLI_NAME                       "eCALMon CLI"

--- a/app/mon/mon_gui/src/ecalmon_globals.h
+++ b/app/mon/mon_gui/src/ecalmon_globals.h
@@ -33,4 +33,4 @@ namespace EcalmonGlobals
       + (VERSION_MINOR * 1000)
       + (VERSION_MAJOR * 1000 * 1000));
   }
-};
+}

--- a/app/mon/mon_tui/src/ecal_mon_tui_defs.h
+++ b/app/mon/mon_tui/src/ecal_mon_tui_defs.h
@@ -1,36 +1,36 @@
-;/* ========================= eCAL LICENSE =================================
-; *
-; * Copyright (C) 2016 - 2019 Continental Corporation
-; *
-; * Licensed under the Apache License, Version 2.0 (the "License");
-; * you may not use this file except in compliance with the License.
-; * You may obtain a copy of the License at
-; * 
-; *      http://www.apache.org/licenses/LICENSE-2.0
-; * 
-; * Unless required by applicable law or agreed to in writing, software
-; * distributed under the License is distributed on an "AS IS" BASIS,
-; * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-; * See the License for the specific language governing permissions and
-; * limitations under the License.
-; *
-; * ========================= eCAL LICENSE =================================
-;*/
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
 
-;/**
-; * eCALMon TUI version definition
-;**/
+/**
+ * eCALMon TUI version definition
+**/
 
 #pragma once
 
-;/* version parsed out into numeric values */
+/* version parsed out into numeric values */
 #define ECAL_MON_TUI_VERSION_MAJOR              1
 #define ECAL_MON_TUI_VERSION_MINOR              0
 #define ECAL_MON_TUI_VERSION_PATCH              0
 
-;/* version as string */
+/* version as string */
 #define ECAL_MON_TUI_VERSION                    "1.0.0"
 #define ECAL_MON_TUI_DATE                       "11.10.2022"
 
-;/* name as string */
+/* name as string */
 #define ECAL_MON_TUI_NAME                       "eCALMon TUI"

--- a/app/mon/mon_tui/src/tui/command_manager.hpp
+++ b/app/mon/mon_tui/src/tui/command_manager.hpp
@@ -180,4 +180,4 @@ std::shared_ptr<CommandDescriptionMap> CreateCommandDescriptionMap()
     {Command::HELP, "Show help view"},
     {Command::SYSTEM_INFORMATION, "Show system info view"},
   });
-};
+}

--- a/app/play/play_core/include/ecal_play_globals.h
+++ b/app/play/play_core/include/ecal_play_globals.h
@@ -35,4 +35,4 @@ namespace EcalPlayGlobals
       + (VERSION_MINOR * 1000)
       + (VERSION_MAJOR * 1000 * 1000));
   }
-};
+}

--- a/app/rec/rec_gui/src/qecalrec.cpp
+++ b/app/rec/rec_gui/src/qecalrec.cpp
@@ -168,7 +168,7 @@ bool QEcalRec::setHostFilter(const std::string& hostname, const std::set<std::st
   return success;
 }
 
-std::set<std::string> QEcalRec::hostFilter(const std::string& hostname) const { return rec_server_->GetHostFilter(hostname); };
+std::set<std::string> QEcalRec::hostFilter(const std::string& hostname) const { return rec_server_->GetHostFilter(hostname); }
 
 bool QEcalRec::setConnectionToClientsActive(bool active, bool omit_dialogs)
 {
@@ -200,7 +200,7 @@ bool QEcalRec::setConnectionToClientsActive(bool active, bool omit_dialogs)
   return success;
 }
 
-bool QEcalRec::connectionToClientsActive() const { return rec_server_->IsConnectionToClientsActive(); };
+bool QEcalRec::connectionToClientsActive() const { return rec_server_->IsConnectionToClientsActive(); }
 
 ////////////////////////////////////
 // Recorder control
@@ -366,9 +366,9 @@ bool QEcalRec::stopRecording(bool omit_dialogs)
   return success;
 }
 
-bool QEcalRec::connectedToEcal() const { return rec_server_->IsConnectedToEcal(); };
+bool QEcalRec::connectedToEcal() const { return rec_server_->IsConnectedToEcal(); }
 
-bool QEcalRec::recording() const { return rec_server_->IsRecording(); };
+bool QEcalRec::recording() const { return rec_server_->IsRecording(); }
 
 int64_t QEcalRec::currentlyRecordingMeasId() const { return rec_server_->GetCurrentlyRecordingMeasId(); }
 
@@ -382,9 +382,9 @@ void QEcalRec::waitForPendingRequests() const { rec_server_->WaitForPendingReque
 // Status
 ////////////////////////////////////
 
-eCAL::rec_server::RecorderStatusMap_T                   QEcalRec::recorderStatuses()              const { return rec_server_->GetRecorderStatuses(); };
+eCAL::rec_server::RecorderStatusMap_T                   QEcalRec::recorderStatuses()              const { return rec_server_->GetRecorderStatuses(); }
 
-eCAL::rec::RecorderStatus                               QEcalRec::builtInRecorderInstanceStatus() const { return rec_server_->GetBuiltInRecorderInstanceStatus(); };
+eCAL::rec::RecorderStatus                               QEcalRec::builtInRecorderInstanceStatus() const { return rec_server_->GetBuiltInRecorderInstanceStatus(); }
 
 eCAL::rec_server::TopicInfoMap_T                        QEcalRec::topicInfo()                     const { return rec_server_->GetTopicInfo(); }
 
@@ -529,11 +529,11 @@ bool QEcalRec::setTopicWhitelist(const std::set<std::string>& topic_whitelist, b
   }
 }
 
-std::chrono::steady_clock::duration QEcalRec::maxPreBufferLength () const { return rec_server_->GetMaxPreBufferLength();  };
-bool                                QEcalRec::preBufferingEnabled() const { return rec_server_->GetPreBufferingEnabled(); };
-eCAL::rec::RecordMode               QEcalRec::recordMode         () const { return rec_server_->GetRecordMode();          };
-std::set<std::string>               QEcalRec::topicBlacklist     () const { return topic_blacklist_;                      };
-std::set<std::string>               QEcalRec::topicWhitelist     () const { return topic_whitelist_;                      };
+std::chrono::steady_clock::duration QEcalRec::maxPreBufferLength () const { return rec_server_->GetMaxPreBufferLength();  }
+bool                                QEcalRec::preBufferingEnabled() const { return rec_server_->GetPreBufferingEnabled(); }
+eCAL::rec::RecordMode               QEcalRec::recordMode         () const { return rec_server_->GetRecordMode();          }
+std::set<std::string>               QEcalRec::topicBlacklist     () const { return topic_blacklist_;                      }
+std::set<std::string>               QEcalRec::topicWhitelist     () const { return topic_whitelist_;                      }
 
 ////////////////////////////////////
 // Job Settings
@@ -574,10 +574,10 @@ void QEcalRec::setDescription(const std::string& description)
   emit descriptionChangedSignal(description);
 }
 
-std::string  QEcalRec::measRootDir   () const { return rec_server_->GetMeasRootDir();    };
-std::string  QEcalRec::measName      () const { return rec_server_->GetMeasName();       };
-unsigned int QEcalRec::maxFileSizeMib() const { return rec_server_->GetMaxFileSizeMib(); };
-std::string  QEcalRec::description   () const { return rec_server_->GetDescription();    };
+std::string  QEcalRec::measRootDir   () const { return rec_server_->GetMeasRootDir();    }
+std::string  QEcalRec::measName      () const { return rec_server_->GetMeasName();       }
+unsigned int QEcalRec::maxFileSizeMib() const { return rec_server_->GetMaxFileSizeMib(); }
+std::string  QEcalRec::description   () const { return rec_server_->GetDescription();    }
 
 ////////////////////////////////////
 // Server Settings

--- a/app/rec/rec_gui/src/widgets/recording_history_widget/job_history_jobitem.cpp
+++ b/app/rec/rec_gui/src/widgets/recording_history_widget/job_history_jobitem.cpp
@@ -270,7 +270,7 @@ int JobHistoryJobItem::type() const
 
 int64_t                               JobHistoryJobItem::jobId()     const { return local_evaluated_job_config_.GetJobId(); }
 const eCAL::rec::JobConfig&           JobHistoryJobItem::localEvaluatedJobConfig() const { return local_evaluated_job_config_; }
-std::chrono::system_clock::time_point JobHistoryJobItem::timestamp() const { return local_start_timestamp_; };
+std::chrono::system_clock::time_point JobHistoryJobItem::timestamp() const { return local_start_timestamp_; }
 bool                                  JobHistoryJobItem::isDeleted() const { return is_deleted_; }
 
 void                                  JobHistoryJobItem::setIsDeleted(bool is_deleted) { is_deleted_ = is_deleted; }

--- a/app/rec/rec_server_cli/src/commands/table_printer.h
+++ b/app/rec/rec_server_cli/src/commands/table_printer.h
@@ -60,7 +60,7 @@ namespace eCAL
         constexpr int REVERSE   = (1 << 5);
         constexpr int CONCEALED = (1 << 6);
         constexpr int CROSSED   = (1 << 7);
-      };
+      }
 
       struct TableEntry
       {

--- a/app/rec/rec_server_core/src/rec_server.cpp
+++ b/app/rec/rec_server_core/src/rec_server.cpp
@@ -119,10 +119,10 @@ namespace eCAL
     uint16_t RecServer::GetInternalFtpServerPort() const                         { return rec_server_impl_->GetInternalFtpServerPort(); }
 
     eCAL::rec::Error RecServer::UploadMeasurement(int64_t meas_id)               { return rec_server_impl_->UploadMeasurement(meas_id); }
-    bool RecServer::CanUploadMeasurement(int64_t meas_id) const                  { return rec_server_impl_->CanUploadMeasurement(meas_id); };
-    eCAL::rec::Error RecServer::SimulateUploadMeasurement(int64_t meas_id) const { return rec_server_impl_->SimulateUploadMeasurement(meas_id); };
+    bool RecServer::CanUploadMeasurement(int64_t meas_id) const                  { return rec_server_impl_->CanUploadMeasurement(meas_id); }
+    eCAL::rec::Error RecServer::SimulateUploadMeasurement(int64_t meas_id) const { return rec_server_impl_->SimulateUploadMeasurement(meas_id); }
 
-    int RecServer::UploadNonUploadedMeasurements()                               { return rec_server_impl_->UploadNonUploadedMeasurements(); };
+    int RecServer::UploadNonUploadedMeasurements()                               { return rec_server_impl_->UploadNonUploadedMeasurements(); }
 
     bool RecServer::HasAnyUploadError(int64_t meas_id) const                     { return rec_server_impl_->HasAnyUploadError(meas_id); }
 

--- a/contrib/mma/include/mma_defs.h
+++ b/contrib/mma/include/mma_defs.h
@@ -1,36 +1,36 @@
-;/* ========================= eCAL LICENSE =================================
-; *
-; * Copyright (C) 2016 - 2019 Continental Corporation
-; *
-; * Licensed under the Apache License, Version 2.0 (the "License");
-; * you may not use this file except in compliance with the License.
-; * You may obtain a copy of the License at
-; * 
-; *      http://www.apache.org/licenses/LICENSE-2.0
-; * 
-; * Unless required by applicable law or agreed to in writing, software
-; * distributed under the License is distributed on an "AS IS" BASIS,
-; * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-; * See the License for the specific language governing permissions and
-; * limitations under the License.
-; *
-; * ========================= eCAL LICENSE =================================
-;*/
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
 
-;/**
-; * @brief  MMA version definition
-;**/
+/**
+ * @brief  MMA version definition
+**/
 
 #pragma once
 
-;/* application name */
+/* application name */
 #define MMA_APPLICATION_NAME    "Machine Monitoring Agent"
 
-;/* version parsed out into numeric values */
+/* version parsed out into numeric values */
 #define MMA_VERSION_MAJOR              1
 #define MMA_VERSION_MINOR              0
 #define MMA_VERSION_PATCH              8
 
-;/* version as string */
+/* version as string */
 #define MMA_VERSION                    "v.1.0.8.20170224"
 #define MMA_DATE                       "24.02.2017"

--- a/ecal/core/include/ecal/ecal_callback.h
+++ b/ecal/core/include/ecal/ecal_callback.h
@@ -207,4 +207,4 @@ namespace eCAL
    * @param data_  Event callback data structure with the event specific informations.
   **/
   typedef std::function<void(const char* name_, const struct SServerEventCallbackData* data_)> ServerEventCallbackT;
-};
+}

--- a/ecal/core/include/ecal/ecal_publisher.h
+++ b/ecal/core/include/ecal/ecal_publisher.h
@@ -549,4 +549,4 @@ namespace eCAL
     bool                             m_created;
     bool                             m_initialized;
   };
-};
+}

--- a/ecal/core/include/ecal/ecal_service_info.h
+++ b/ecal/core/include/ecal/ecal_service_info.h
@@ -70,4 +70,4 @@ namespace eCAL
    * @param service_response_  Service response struct containing the (responding) server informations and the response itself.
   **/
   typedef std::function<void(const struct SServiceResponse& service_response_)> ResponseCallbackT;
-};
+}

--- a/ecal/core/include/ecal/ecal_subscriber.h
+++ b/ecal/core/include/ecal/ecal_subscriber.h
@@ -356,4 +356,4 @@ namespace eCAL
     bool                             m_created;
     bool                             m_initialized;
   };
-};
+}

--- a/ecal/core/include/ecal/msg/protobuf/dynamic_subscriber.h
+++ b/ecal/core/include/ecal/msg/protobuf/dynamic_subscriber.h
@@ -186,7 +186,7 @@ namespace eCAL
     inline CDynamicSubscriber::~CDynamicSubscriber()
     {
       Destroy();
-    };
+    }
 
     inline void CDynamicSubscriber::Create(const std::string& topic_name_)
     {

--- a/ecal/core/src/ecal_descgate.cpp
+++ b/ecal/core/src/ecal_descgate.cpp
@@ -320,4 +320,4 @@ namespace eCAL
     resp_type_desc_ = (*service_info_map_it).second.info.response_type.descriptor;
     return true;
   }
-};
+}

--- a/ecal/core/src/ecal_descgate.h
+++ b/ecal/core/src/ecal_descgate.h
@@ -132,4 +132,4 @@ namespace eCAL
   inline           CDescGate::QualityFlags& operator|= (CDescGate::QualityFlags& a, CDescGate::QualityFlags b) { return reinterpret_cast<CDescGate::QualityFlags&>( reinterpret_cast<std::underlying_type<CDescGate::QualityFlags>::type&>(a) |= static_cast<std::underlying_type<CDescGate::QualityFlags>::type>(b) ); }
   inline           CDescGate::QualityFlags& operator&= (CDescGate::QualityFlags& a, CDescGate::QualityFlags b) { return reinterpret_cast<CDescGate::QualityFlags&>( reinterpret_cast<std::underlying_type<CDescGate::QualityFlags>::type&>(a) &= static_cast<std::underlying_type<CDescGate::QualityFlags>::type>(b) ); }
   inline           CDescGate::QualityFlags& operator^= (CDescGate::QualityFlags& a, CDescGate::QualityFlags b) { return reinterpret_cast<CDescGate::QualityFlags&>( reinterpret_cast<std::underlying_type<CDescGate::QualityFlags>::type&>(a) ^= static_cast<std::underlying_type<CDescGate::QualityFlags>::type>(b) ); }
-};
+}

--- a/ecal/core/src/ecal_globals.cpp
+++ b/ecal/core/src/ecal_globals.cpp
@@ -35,7 +35,7 @@ namespace eCAL
   CGlobals::~CGlobals()
   {
     Finalize(Init::All);
-  };
+  }
 
   int CGlobals::Initialize(unsigned int components_, std::vector<std::string>* config_keys_ /*= nullptr*/)
   {

--- a/ecal/core/src/ecal_process.cpp
+++ b/ecal/core/src/ecal_process.cpp
@@ -413,32 +413,32 @@ namespace eCAL
     long long GetSClock()
     {
       return(GetWClock());
-    };
+    }
 
     long long GetSBytes()
     {
       return(GetWBytes());
-    };
+    }
 
     long long GetWClock()
     {
       return(g_process_wclock);
-    };
+    }
 
     long long GetWBytes()
     {
       return(g_process_wbytes);
-    };
+    }
 
     long long GetRClock()
     {
       return(g_process_rclock);
-    };
+    }
 
     long long GetRBytes()
     {
       return(g_process_rbytes);
-    };
+    }
 
     void SetState(eCAL_Process_eSeverity severity_, eCAL_Process_eSeverity_Level level_, const char* info_)
     {

--- a/ecal/core/src/ecal_registration_provider.h
+++ b/ecal/core/src/ecal_registration_provider.h
@@ -121,4 +121,4 @@ namespace eCAL
     bool m_use_network_monitoring;
     bool m_use_shm_monitoring;
   };
-};
+}

--- a/ecal/core/src/ecal_registration_receiver.cpp
+++ b/ecal/core/src/ecal_registration_receiver.cpp
@@ -430,4 +430,4 @@ namespace eCAL
     const std::lock_guard<std::mutex> lock(m_callback_custom_apply_sample_mtx);
     m_callback_custom_apply_sample = [](const auto&){};
   }
-};
+}

--- a/ecal/core/src/ecal_registration_receiver.h
+++ b/ecal/core/src/ecal_registration_receiver.h
@@ -136,4 +136,4 @@ namespace eCAL
 
     std::string                      m_host_group_name;
   };
-};
+}

--- a/ecal/core/src/ecal_timegate.cpp
+++ b/ecal/core/src/ecal_timegate.cpp
@@ -65,7 +65,7 @@ namespace eCAL
     m_successfully_loaded_replay(false),
     m_sync_mode(eTimeSyncMode::none)
   {
-  };
+  }
 
   CTimeGate::~CTimeGate()
   {
@@ -469,4 +469,4 @@ namespace eCAL
 
     return true;
   }
-};
+}

--- a/ecal/core/src/ecal_timegate.h
+++ b/ecal/core/src/ecal_timegate.h
@@ -132,4 +132,4 @@ namespace eCAL
     STimeDllInterface        m_time_sync_rt;
     STimeDllInterface        m_time_sync_replay;
   };
-};
+}

--- a/ecal/core/src/getenvvar.h
+++ b/ecal/core/src/getenvvar.h
@@ -63,4 +63,4 @@ inline std::vector<std::string> splitPaths(const std::string& paths_value)
     tokens.push_back(token);
   }
   return tokens;
-};
+}

--- a/ecal/core/src/io/ecal_memfile.h
+++ b/ecal/core/src/io/ecal_memfile.h
@@ -226,4 +226,4 @@ namespace eCAL
     CMemoryFile(const CMemoryFile&);                 // prevent copy-construction
     CMemoryFile& operator=(const CMemoryFile&);      // prevent assignment
   };
-};
+}

--- a/ecal/core/src/mon/ecal_monitoring_threads.cpp
+++ b/ecal/core/src/mon/ecal_monitoring_threads.cpp
@@ -94,20 +94,20 @@ namespace eCAL
     }
 
     return(0);
-  };
+  }
 
   CMonLogPublishingThread::CMonLogPublishingThread(MonitoringCallbackT mon_cb_, LoggingCallbackT log_cb_) :
     m_mon_cb(mon_cb_), m_log_cb(log_cb_)
   {
     m_pub_thread.Start(CMN_REGISTRATION_REFRESH, std::bind(&CMonLogPublishingThread::ThreadFun, this));
-  };
+  }
 
   CMonLogPublishingThread::~CMonLogPublishingThread()
   {
     m_pub_thread.Stop();
     m_mon_pub.pub.Destroy();
     m_log_pub.pub.Destroy();
-  };
+  }
 
   void CMonLogPublishingThread::SetMonState(bool state_, const std::string& name_)
   {

--- a/ecal/core/src/pubsub/ecal_proto_dyn_json_sub.cpp
+++ b/ecal/core/src/pubsub/ecal_proto_dyn_json_sub.cpp
@@ -207,7 +207,7 @@ namespace eCAL
     CDynamicJSONSubscriber::~CDynamicJSONSubscriber()
     {
       Destroy();
-    };
+    }
 
     void CDynamicJSONSubscriber::Create(const std::string& topic_name_)
     {

--- a/ecal/core/src/pubsub/ecal_pubgate.cpp
+++ b/ecal/core/src/pubsub/ecal_pubgate.cpp
@@ -240,4 +240,4 @@ namespace eCAL
     }
     return false;
   }
-};
+}

--- a/ecal/core/src/pubsub/ecal_publisher.cpp
+++ b/ecal/core/src/pubsub/ecal_publisher.cpp
@@ -102,7 +102,7 @@ namespace eCAL
     rhs.m_initialized = false;
 
     return *this;
-  };
+  }
 
   bool CPublisher::Create(const std::string& topic_name_, const std::string& topic_type_ /* = "" */, const std::string& topic_desc_ /* = "" */)
   {

--- a/ecal/core/src/pubsub/ecal_subgate.h
+++ b/ecal/core/src/pubsub/ecal_subgate.h
@@ -71,4 +71,4 @@ namespace eCAL
 
     eCAL::CThread            m_subtimeout_thread;
   };
-};
+}

--- a/ecal/core/src/pubsub/ecal_subscriber.cpp
+++ b/ecal/core/src/pubsub/ecal_subscriber.cpp
@@ -85,7 +85,7 @@ namespace eCAL
     rhs.m_initialized = false;
 
     return *this;
-  };
+  }
 
   bool CSubscriber::Create(const std::string& topic_name_, const std::string& topic_type_, const std::string& topic_desc_ /* = "" */)
   {

--- a/ecal/core/src/readwrite/ecal_reader_layer.h
+++ b/ecal/core/src/readwrite/ecal_reader_layer.h
@@ -74,4 +74,4 @@ namespace eCAL
     }
 
   };
-};
+}

--- a/ecal/core/src/service/ecal_clientgate.cpp
+++ b/ecal/core/src/service/ecal_clientgate.cpp
@@ -194,4 +194,4 @@ namespace eCAL
     }
     return false;
   }
-};
+}

--- a/ecal/core/src/service/ecal_clientgate.h
+++ b/ecal/core/src/service/ecal_clientgate.h
@@ -78,4 +78,4 @@ namespace eCAL
     std::shared_timed_mutex     m_service_register_map_sync;
     ConnectedMapT               m_service_register_map;
   };
-};
+}

--- a/lang/python/core/src/ecal_wrap.cxx
+++ b/lang/python/core/src/ecal_wrap.cxx
@@ -658,7 +658,7 @@ PyObject* sub_set_callback(PyObject* /*self*/, PyObject* args)
     }
   }
   return Py_BuildValue("is", 0, "error: could not set callback");
-};
+}
 
 /****************************************/
 /*      sub_rem_callback                */
@@ -697,7 +697,7 @@ PyObject* sub_rem_callback(PyObject* /*self*/, PyObject* args)
   {
     return Py_BuildValue("is", 0, "error: could not remove callback");
   }
-};
+}
 
 /****************************************/
 /*      dyn_json_sub_create             */
@@ -783,7 +783,7 @@ PyObject* dyn_json_sub_set_callback(PyObject* /*self*/, PyObject* args)
     }
   }
   return Py_BuildValue("is", 0, "error: could not set callback");
-};
+}
 
 /****************************************/
 /*      dyn_json_sub_rem_callback       */
@@ -822,7 +822,7 @@ PyObject* dyn_json_sub_rem_callback(PyObject* /*self*/, PyObject* args)
   {
     return Py_BuildValue("is", 0, "error: could not remove callback");
   }
-};
+}
 
 
 /****************************************/

--- a/samples/cpp/measurement/measurement_write/src/measurement_write.cpp
+++ b/samples/cpp/measurement/measurement_write/src/measurement_write.cpp
@@ -25,7 +25,7 @@
 
 #include "person.pb.h"
 
-constexpr auto ONE_SECOND = 1000000;;
+constexpr auto ONE_SECOND = 1000000;
 
 int main(int /*argc*/, char** /*argv*/)
 {

--- a/testing/ecal/clientserver_test/src/clientserver_test.cpp
+++ b/testing/ecal/clientserver_test/src/clientserver_test.cpp
@@ -85,7 +85,7 @@ namespace
     std::cout << "Execution error msg   : " << service_response_.error_msg << std::endl;
     std::cout << "Response              : " << service_response_.response  << std::endl  << std::endl;
     std::cout << std::endl;
-  };
+  }
 }
 
 #if ClientConnectEventTest


### PR DESCRIPTION
### Description
Apply the patch to remove `;` that cause pedantic warnings with gcc.