### PR TITLE
Feature/cherry pick to support

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,10 +4,3 @@
 ### Related issues
 <!-- Type "Fixes #123" to automatically close that issue, when this PR is merged -->
 - 
-
-### Cherry-pick to
-<!-- Leave empty, if you don't know. For master-only changes use "none"
-- _none_
-- 5.12 (old stable)
-- 5.13 (current stable)
--->

--- a/.github/workflows/cherry-pick-to.yml
+++ b/.github/workflows/cherry-pick-to.yml
@@ -1,0 +1,194 @@
+name: Cherry-pick-to-branch
+
+on:
+  push:
+    branches: [ "master" ]
+
+env:
+  cherry_pick_label_prefix: "cherry-pick-to-"
+  cherry_pick_pr_success_label: "Auto cherry-pick success ✅"
+  cherry_pick_pr_failure_label: "Auto cherry-pick failure ⚠️"
+  use_draft_pr: "true"
+
+jobs:
+  cherry-pick-from-push:
+    strategy:
+      matrix:
+        target-branch: [ "support/v5.12", "support/v5.13" ]
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    
+    - name: Setup Variables
+      id: setup
+      run: |
+        echo continue_workflow=true >> $GITHUB_ENV
+        short_sha=$(echo ${{ github.event.after }} | cut -c1-7)
+        echo cherry_pick_branch=cherry-pick/$short_sha/${{matrix.target-branch}} >> $GITHUB_ENV
+
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Determine PR number (if any)
+      id: pr
+      run: |
+        pr_number=$(gh pr list --search ${{ github.event.after }} --state merged --json number --jq '.[0].number')
+        echo "PR number: $pr_number"
+        echo pr_number=$pr_number >> $GITHUB_OUTPUT
+
+        # Set the continue workflow to false, if the pr_number is empty
+        if [ -z "$pr_number" ]; then
+          echo continue_workflow=false >> $GITHUB_ENV
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Check for a cherry pick label and save whether that is the case
+      if: ${{ env.continue_workflow == 'true' }}
+      run: |
+        # List all labels for the PR number from the last step
+        labels=$(gh pr view ${{ steps.pr.outputs.pr_number }} --json labels --jq '.labels[].name')
+
+        echo "Labels: $labels"
+
+        # Check if the list contains the special cherry pick label
+        if [[ $labels == *"${{ env.cherry_pick_label_prefix }}${{matrix.target-branch}}"* ]]; then
+          echo "Cherry pick label found"
+          echo continue_workflow=true >> $GITHUB_ENV
+        else
+          echo "Cherry pick label not found"
+          echo continue_workflow=false >> $GITHUB_ENV
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Create new branch for cherry picking
+      if: ${{ steps.pr.outputs.pr_number != '' }}
+      run: |
+        # Set the git config to the pr_author and pr_author_email
+        git config user.name '${{ github.event.pusher.name }}'
+        git config user.email '${{ github.event.pusher.email }}'
+
+        git checkout ${{ matrix.target-branch }}
+        git checkout -b ${{ env.cherry_pick_branch }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Cherry pick the commit between the before (exclusive) and after (inclusive) commits
+      id: cherry-pick
+      if: ${{ env.continue_workflow == 'true' }}
+      run: |
+        git cherry-pick ${{ github.event.before }}..${{ github.event.after }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      continue-on-error: true
+
+    - name: Create PR description
+      if: ${{ env.continue_workflow == 'true' }}
+      id: pr-description
+      run: |
+        # Determine original PR title
+        original_pr_title=$(gh pr view ${{ steps.pr.outputs.pr_number }} --json title --jq '.title')
+
+        # Create a title for the new PR
+        echo pr_title="[CP #${{ steps.pr.outputs.pr_number }} > ${{ matrix.target-branch }}] $original_pr_title" >> $GITHUB_OUTPUT
+
+        if [ "${{ steps.cherry-pick.outcome }}" == "success" ]; then
+          echo pr_label="${{ env.cherry_pick_pr_success_label }}" >> $GITHUB_OUTPUT
+
+          echo pr_draft_command="" >> $GITHUB_OUTPUT
+
+          # Create multiline pr_description
+          echo "pr_description<<EOF" >> $GITHUB_OUTPUT
+          echo "# Cherry-pick" >> $GITHUB_OUTPUT
+          echo "Cherry-picked PR #${{ steps.pr.outputs.pr_number }} to branch \`${{ matrix.target-branch }}\`." >> $GITHUB_OUTPUT
+          echo "The cherry-pick was **successfull**." >> $GITHUB_OUTPUT
+          echo "" >> $GITHUB_OUTPUT
+          echo "Please review the changes and **rebase-merge** if desired." >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+        else
+
+          echo pr_label="${{ env.cherry_pick_pr_failure_label }}" >> $GITHUB_OUTPUT
+
+          # Only set the pr_draft_command if the use_draft_pr is true. Otherwise, set it to an empty string.
+          # Some repos (like personal ones) might not have the draft PR feature enabled.
+          if [ "${{ env.use_draft_pr }}" == "true" ]; then
+            echo pr_draft_command="--draft" >> $GITHUB_OUTPUT
+          else
+            echo pr_draft_command="" >> $GITHUB_OUTPUT
+          fi
+
+          # Create multiline pr_description
+          echo "pr_description<<EOF" >> $GITHUB_OUTPUT
+          echo "# Cherry-pick failed" >> $GITHUB_OUTPUT
+          echo "Cherry-picked PR #${{ steps.pr.outputs.pr_number }} to branch \`${{ matrix.target-branch }}\`." >> $GITHUB_OUTPUT
+          echo "The cherry-pick has **failed**" >> $GITHUB_OUTPUT
+          echo "" >> $GITHUB_OUTPUT
+          echo "The following files have caused conflicts:" >> $GITHUB_OUTPUT
+          echo "" >> $GITHUB_OUTPUT
+          echo "\`\`\`bash" >> $GITHUB_OUTPUT
+          git diff --name-only --diff-filter=U >> $GITHUB_OUTPUT
+          echo "\`\`\`" >> $GITHUB_OUTPUT
+          echo "" >> $GITHUB_OUTPUT
+          echo "## Resolving" >> $GITHUB_OUTPUT
+          echo "Please resolve conflicts manually. You can use this PR and branch to your convenience." >> $GITHUB_OUTPUT
+          echo "" >> $GITHUB_OUTPUT
+          echo "\`\`\`bash" >> $GITHUB_OUTPUT
+          echo "git fetch origin" >> $GITHUB_OUTPUT
+          echo "git checkout -b local/${{ env.cherry_pick_branch }} origin/${{ matrix.target-branch }}" >> $GITHUB_OUTPUT
+          echo "git branch -u origin/${{ env.cherry_pick_branch }}" >> $GITHUB_OUTPUT
+          echo "git cherry-pick ${{ github.event.before }}..${{ github.event.after }}" >> $GITHUB_OUTPUT
+          echo "" >> $GITHUB_OUTPUT
+          echo "# Resolve conflicts and use git cherry-pick --contiue until all conflicts are resolved" >> $GITHUB_OUTPUT
+          echo "" >> $GITHUB_OUTPUT
+          echo "git push -f origin HEAD:${{ env.cherry_pick_branch }}" >> $GITHUB_OUTPUT
+          echo "\`\`\`" >> $GITHUB_OUTPUT
+          echo "" >> $GITHUB_OUTPUT
+          echo "After resolving all conflicts, **rebase-merge** this PR." >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    # If the cherry-pick fails, abort the cherry-pick and create an empty commit on it.
+    - name: Abort cherry-pick if it failed and add empty commit for PR creation
+      if: ${{ env.continue_workflow == 'true' && steps.cherry-pick.outcome == 'failure' }}
+      run: |
+        git cherry-pick --abort
+
+        # Use the bot user for the commit
+        git config user.name 'github-actions[bot]'
+        git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+        # Create an empty commit
+        git commit --allow-empty -m "Cherry-pick failed"
+
+        git log --oneline -n 5
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Push the cherry-pick branch
+      if: ${{ env.continue_workflow == 'true' }}
+      run: git push origin ${{ env.cherry_pick_branch }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        
+    - name: create pull request
+      if: ${{ env.continue_workflow == 'true' }}
+      run: |
+        # Check if the label exists in the repository. If not, create it.
+        gh label list | grep -q "${{ steps.pr-description.outputs.pr_label }}" || gh label create "${{ steps.pr-description.outputs.pr_label }}"
+
+        # Create the pull request
+        gh pr create -B '${{ matrix.target-branch }}' \
+                     -H '${{ env.cherry_pick_branch }}' \
+                     --title '${{ steps.pr-description.outputs.pr_title }}' \
+                     --body '${{ steps.pr-description.outputs.pr_description }}' \
+                     --label '${{ steps.pr-description.outputs.pr_label }}' \
+                     ${{ steps.pr-description.outputs.pr_draft_command }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description
Added action that can auto cherry-pick commits to support branches.

Features:
- Cherry pick single commits
- cherry pick multiple commits from a rebase merge
- Controlable by PR labels
- Preserve commit author
- Handle cherry-pick conflicts with empty PR + instructions for user

![image](https://github.com/eclipse-ecal/ecal/assets/11774314/05cf71c5-9984-41fd-ad86-529cee698f2c)

![image](https://github.com/eclipse-ecal/ecal/assets/11774314/498163c1-8693-45e4-945f-3b542efb4e4d)

