### PR TITLE
[GH Actions] Create cherry-pick-label-check.yml

### DIFF
--- a/.github/workflows/cherry-pick-label-check.yml
+++ b/.github/workflows/cherry-pick-label-check.yml
@@ -1,0 +1,22 @@
+name: Cherry Pick Label Check
+
+on:
+  pull_request:
+    types: 
+      - labeled
+      - unlabeled
+    branches:
+      - main
+
+jobs:
+  cherry-pick-label-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check labels
+        run: |
+            labels=$(jq -r '.pull_request.labels[].name' $GITHUB_EVENT_PATH)
+            if [[ ! $labels =~ ^cherry-pick-to- ]]; then
+                echo "No label starting with 'cherry-pick-to-' found."
+                exit 1
+            fi

--- a/.github/workflows/cherry-pick-label-check.yml
+++ b/.github/workflows/cherry-pick-label-check.yml
@@ -6,7 +6,7 @@ on:
       - labeled
       - unlabeled
     branches:
-      - main
+      - master
 
 jobs:
   cherry-pick-label-check:


### PR DESCRIPTION
### Description
The action fails if there is no cherry-pick-to- label applied to a PR. The goal is to remind us of always applying a label explicitly.