### PR TITLE
[core, test] set-get-unit-name

### DIFF
--- a/app/rec/rec_tests/rec_rpc_tests/src/rec_cli_test.cpp
+++ b/app/rec/rec_tests/rec_rpc_tests/src/rec_cli_test.cpp
@@ -149,7 +149,7 @@ std::vector<TestCase> getRpcConfigTestcases()
   return testcases;
 }
 
-TEST(EcalRecCli, NoDefault)
+TEST(app, EcalRecCli_NoDefault)
 {
   eCAL::rec_server::RecServerConfig config;
 
@@ -159,7 +159,7 @@ TEST(EcalRecCli, NoDefault)
   EXPECT_EQ(config, eCAL::rec_server::RecServerConfig());
 }
 
-TEST(EcalRecCli, SetConfigViaRPC)
+TEST(app, EcalRecCli_SetConfigViaRPC)
 {
   auto test_cases = getRpcConfigTestcases();
   auto rec = ExternalEcalRecInstance();
@@ -177,7 +177,7 @@ TEST(EcalRecCli, SetConfigViaRPC)
   }
 }
 
-TEST(EcalRecGui, SetConfigViaRPC)
+TEST(app, EcalRecGui_SetConfigViaRPC)
 {
   auto test_cases = getRpcConfigTestcases();
   auto rec = ExternalEcalRecInstance(true);

--- a/ecal/tests/c/core_test/src/core_test.cpp
+++ b/ecal/tests/c/core_test/src/core_test.cpp
@@ -100,12 +100,14 @@ namespace
       processName = full_path_.substr(lastSeparatorPos + 1);
     }
 
+#ifdef ECAL_OS_WINDOWS
     // remove the file extension if found
     size_t lastDotPos = processName.find_last_of('.');
     if (lastDotPos != std::string::npos)
     {
       processName = processName.substr(0, lastDotPos);
     }
+#endif // ECAL_OS_WINDOWS
 
     return processName;
   }

--- a/ecal/tests/c/core_test/src/core_test.cpp
+++ b/ecal/tests/c/core_test/src/core_test.cpp
@@ -86,7 +86,32 @@ TEST(core_c_core, MultipleInitializeFinalize)
   }
 }
 
-TEST(core_c_core, UnitName)
+namespace
+{
+  std::string extractProcessName(const std::string& full_path_)
+  {
+    // initialize process name with full path
+    std::string processName = full_path_;
+
+    // extract the substring after the last separator
+    size_t lastSeparatorPos = full_path_.find_last_of("\\/");
+    if (lastSeparatorPos != std::string::npos)
+    {
+      processName = full_path_.substr(lastSeparatorPos + 1);
+    }
+
+    // remove the file extension if found
+    size_t lastDotPos = processName.find_last_of('.');
+    if (lastDotPos != std::string::npos)
+    {
+      processName = processName.substr(0, lastDotPos);
+    }
+
+    return processName;
+  }
+}
+
+TEST(core_c_core, SetGetUnitName)
 {
   // initialize eCAL API with empty unit name (eCAL will use process name as unit name)
   EXPECT_EQ(0, eCAL_Initialize(0, nullptr, "", 0));
@@ -95,9 +120,12 @@ TEST(core_c_core, UnitName)
   EXPECT_EQ(1, eCAL_IsInitialized(0));
 
   // if we call eCAL_Initialize with empty unit name, eCAL will use the process name as unit name
-  char unit_name[1024] = {0};
+  char process_name[1024] = { 0 };
+  eCAL_Process_GetProcessName(process_name, sizeof(process_name));
+  std::string process_name_s = extractProcessName(process_name);
+  char unit_name[1024] = { 0 };
   eCAL_Process_GetUnitName(unit_name, sizeof(unit_name));
-  EXPECT_STREQ("ecal_test_core_c", unit_name);
+  EXPECT_STREQ(process_name_s.c_str(), unit_name);
 
   // set unit name (should change the name to 'unit name')
   EXPECT_EQ(0, eCAL_SetUnitName("unit name"));

--- a/ecal/tests/c/core_test/src/core_test.cpp
+++ b/ecal/tests/c/core_test/src/core_test.cpp
@@ -18,7 +18,10 @@
 */
 
 #include <ecal/cimpl/ecal_core_cimpl.h>
+#include <ecal/cimpl/ecal_process_cimpl.h>
 #include <ecal/ecal_defs.h>
+
+#include <cstring>
 
 #include <gtest/gtest.h>
 
@@ -91,14 +94,28 @@ TEST(core_c_core, UnitName)
   // Is eCAL API initialized ?
   EXPECT_EQ(1, eCAL_IsInitialized(0));
 
-  // set unit name
+  // if we call eCAL_Initialize with empty unit name, eCAL will use the process name as unit name
+  char unit_name[1024] = {0};
+  eCAL_Process_GetUnitName(unit_name, sizeof(unit_name));
+  EXPECT_STREQ("ecal_test_core_c", unit_name);
+
+  // set unit name (should change the name to 'unit name')
   EXPECT_EQ(0, eCAL_SetUnitName("unit name"));
+  memset(unit_name, 0, sizeof(unit_name));
+  eCAL_Process_GetUnitName(unit_name, sizeof(unit_name));
+  EXPECT_STREQ("unit name", unit_name);
 
-  // set nullptr unit name
+  // set nullptr unit name (should not change the unit name)
   EXPECT_EQ(-1, eCAL_SetUnitName(nullptr));
+  memset(unit_name, 0, sizeof(unit_name));
+  eCAL_Process_GetUnitName(unit_name, sizeof(unit_name));
+  EXPECT_STREQ("unit name", unit_name);
 
-  // set empty unit name
+  // set empty unit name (should not change the unit name)
   EXPECT_EQ(-1, eCAL_SetUnitName(""));
+  memset(unit_name, 0, sizeof(unit_name));
+  eCAL_Process_GetUnitName(unit_name, sizeof(unit_name));
+  EXPECT_STREQ("unit name", unit_name);
 
   // finalize eCAL API we expect return value 0 because it will be finalized
   EXPECT_EQ(0, eCAL_Finalize(0));

--- a/ecal/tests/cpp/core_test/src/core_test.cpp
+++ b/ecal/tests/cpp/core_test/src/core_test.cpp
@@ -18,6 +18,7 @@
 */
 
 #include <ecal/ecal_core.h>
+#include <ecal/ecal_os.h>
 #include <ecal/ecal_process.h>
 #include <ecal/ecal_defs.h>
 
@@ -98,12 +99,14 @@ namespace
       processName = full_path_.substr(lastSeparatorPos + 1);
     }
 
+#ifdef ECAL_OS_WINDOWS
     // remove the file extension if found
     size_t lastDotPos = processName.find_last_of('.');
     if (lastDotPos != std::string::npos)
     {
       processName = processName.substr(0, lastDotPos);
     }
+#endif // ECAL_OS_WINDOWS
 
     return processName;
   }

--- a/ecal/tests/cpp/core_test/src/core_test.cpp
+++ b/ecal/tests/cpp/core_test/src/core_test.cpp
@@ -84,6 +84,31 @@ TEST(core_cpp_core, MultipleInitializeFinalize)
   }
 }
 
+namespace
+{
+  std::string extractProcessName(const std::string& full_path_)
+  {
+    // initialize process name with full path
+    std::string processName = full_path_;
+
+    // extract the substring after the last separator
+    size_t lastSeparatorPos = full_path_.find_last_of("\\/");
+    if (lastSeparatorPos != std::string::npos)
+    {
+      processName = full_path_.substr(lastSeparatorPos + 1);
+    }
+
+    // remove the file extension if found
+    size_t lastDotPos = processName.find_last_of('.');
+    if (lastDotPos != std::string::npos)
+    {
+      processName = processName.substr(0, lastDotPos);
+    }
+
+    return processName;
+  }
+}
+
 TEST(core_cpp_core, SetGetUnitName)
 {
   // initialize eCAL API with empty unit name (eCAL will use process name as unit name)
@@ -93,7 +118,8 @@ TEST(core_cpp_core, SetGetUnitName)
   EXPECT_EQ(1, eCAL::IsInitialized());
 
   // if we call eCAL_Initialize with empty unit name, eCAL will use the process name as unit name
-  EXPECT_STREQ("ecal_test_core", eCAL::Process::GetUnitName().c_str());
+  std::string process_name = extractProcessName(eCAL::Process::GetProcessName());
+  EXPECT_STREQ(process_name.c_str(), eCAL::Process::GetUnitName().c_str());
 
   // set unit name (should change the name to 'unit name')
   EXPECT_EQ(0, eCAL::SetUnitName("unit name"));

--- a/ecal/tests/cpp/core_test/src/core_test.cpp
+++ b/ecal/tests/cpp/core_test/src/core_test.cpp
@@ -18,6 +18,7 @@
 */
 
 #include <ecal/ecal_core.h>
+#include <ecal/ecal_process.h>
 #include <ecal/ecal_defs.h>
 
 #include <gtest/gtest.h>
@@ -91,14 +92,20 @@ TEST(core_cpp_core, SetGetUnitName)
   // Is eCAL API initialized ?
   EXPECT_EQ(1, eCAL::IsInitialized());
 
-  // set unit name
+  // if we call eCAL_Initialize with empty unit name, eCAL will use the process name as unit name
+  EXPECT_STREQ("ecal_test_core", eCAL::Process::GetUnitName().c_str());
+
+  // set unit name (should change the name to 'unit name')
   EXPECT_EQ(0, eCAL::SetUnitName("unit name"));
+  EXPECT_STREQ("unit name", eCAL::Process::GetUnitName().c_str());
 
-  // set nullptr unit name
+  // set nullptr unit name (should not change the unit name)
   EXPECT_EQ(-1, eCAL::SetUnitName(nullptr));
+  EXPECT_STREQ("unit name", eCAL::Process::GetUnitName().c_str());
 
-  // set empty unit name
+  // set empty unit name (should not change the unit name)
   EXPECT_EQ(-1, eCAL::SetUnitName(""));
+  EXPECT_STREQ("unit name", eCAL::Process::GetUnitName().c_str());
 
   // finalize eCAL API we expect return value 0 because it will be finalized
   EXPECT_EQ(0, eCAL::Finalize());
@@ -122,28 +129,10 @@ TEST(core_cpp_core, eCAL_Ok)
   EXPECT_EQ(0, eCAL::Ok());
 }
 
-
-// CHECK THIS AND MOVE THIS IN ANOTHER TEST UNIT
+/* excluded for now, system timer jitter too high */
 #if 0
-
-#include <ecal/ecal.h>
-#include <ecal/msg/string/publisher.h>
-#include <ecal/msg/string/subscriber.h>
-#include <atomic>
-#include <thread>
-#include <gtest/gtest.h>
-
-#define CMN_REGISTRATION_REFRESH   1000
-
-namespace {
-  // subscriber callback function
-  void OnReceive(long long clock_)
-  {
-    static long long accumulated_clock = 0;
-    accumulated_clock += clock_;
-  }
-
-#if 0
+namespace
+{
   // timer callback function
   std::atomic_size_t     g_callback_received{ 0 };
   std::vector<long long> g_timer_vec(100);
@@ -152,131 +141,8 @@ namespace {
     if (g_callback_received < g_timer_vec.size()) g_timer_vec[g_callback_received] = eCAL::Time::GetMicroSeconds();
     g_callback_received += 1;
   }
-#endif
 }
 
-TEST(Core, MultipleInitializeFinalize)
-{
-  // try to initialize / finalize multiple times
-  for (auto i = 0; i < 4; ++i)
-  {
-    // initialize eCAL API
-    EXPECT_EQ(0, eCAL::Initialize(0, nullptr, "multiple initialize/finalize"));
-
-    // finalize eCAL API
-    EXPECT_EQ(0, eCAL::Finalize());
-  }
-}
-
-TEST(Core, LeakedPubSub)
-{
-  // initialize eCAL API
-  EXPECT_EQ(0, eCAL::Initialize(0, nullptr, "leaked pub/sub"));
-
-  // enable loop back communication in the same thread
-  eCAL::Util::EnableLoopback(true);
-
-  // create subscriber and register a callback
-  eCAL::string::CSubscriber<std::string> sub("foo");
-  sub.AddReceiveCallback(std::bind(OnReceive, std::placeholders::_4));
-
-  // create publisher
-  eCAL::string::CPublisher<std::string> pub("foo");
-
-  // let's match them
-  eCAL::Process::SleepMS(2 * CMN_REGISTRATION_REFRESH);
-
-  // start publishing thread
-  std::atomic<bool> pub_stop(false);
-  std::thread pub_t([&]() {
-    while (!pub_stop)
-    {
-      pub.Send("Hello World");
-#if 0
-      // some kind of busy waiting....
-      int y = 0;
-      for (int i = 0; i < 100000; i++)
-      {
-        y += i;
-      }
-#else
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
-#endif
-    }
-  });
-
-  // let them work together
-  std::this_thread::sleep_for(std::chrono::seconds(2));
-
-  // finalize eCAL API
-  // without destroying any pub / sub
-  EXPECT_EQ(0, eCAL::Finalize());
-
-  // stop publishing thread
-  pub_stop = true; pub_t.join();
-}
-
-TEST(Core, CallbackDestruction)
-{
-  for (int i = 0; i < 10; ++i)
-  {
-    // initialize eCAL API
-    EXPECT_EQ(0, eCAL::Initialize(0, nullptr, "callback destruction"));
-
-    // enable loop back communication in the same thread
-    eCAL::Util::EnableLoopback(true);
-
-    // create subscriber and register a callback
-    std::shared_ptr<eCAL::string::CSubscriber<std::string>> sub;
-
-    // create publisher
-    eCAL::string::CPublisher<std::string> pub("foo");
-
-    // start publishing thread
-    std::atomic<bool> pub_stop(false);
-    std::thread pub_t([&]() {
-      while (!pub_stop) {
-        pub.Send("Hello World");
-#if 0
-        // some kind of busy waiting....
-        int y = 0;
-        for (int i = 0; i < 100000; i++)
-        {
-          y += i;
-        }
-#else
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-#endif
-      }
-      });
-
-    std::atomic<bool> sub_stop(false);
-    std::thread sub_t([&]() {
-      while (!sub_stop) {
-        sub = std::make_shared<eCAL::string::CSubscriber<std::string>>("foo");
-        sub->AddReceiveCallback(std::bind(OnReceive, std::placeholders::_4));
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-      }
-      });
-
-    // let them work together
-    std::this_thread::sleep_for(std::chrono::seconds(10));
-
-    // stop publishing thread
-    pub_stop = true;
-    pub_t.join();
-
-    sub_stop = true;
-    sub_t.join();
-
-    // finalize eCAL API
-    // without destroying any pub / sub
-    EXPECT_EQ(0, eCAL::Finalize());
-  }
-}
-
-/* excluded for now, system timer jitter too high */
-#if 0
 TEST(Core, TimerCallback)
 { 
   // initialize eCAL API
@@ -335,6 +201,4 @@ TEST(Core, TimerCallback)
   // finalize eCAL API again we expect 1 because yet finalized
   EXPECT_EQ(1, eCAL::Finalize());
 }
-#endif /* !defined ECAL_OS_WINDOWS */
-
 #endif

--- a/ecal/tests/cpp/util_test/src/util_test.cpp
+++ b/ecal/tests/cpp/util_test/src/util_test.cpp
@@ -38,7 +38,7 @@ namespace {
   }
 }
 
-TEST(core_cpp_util, Util_CombineTopicEncodingAndType)
+TEST(core_cpp_util, Topic_CombinedTopicEncodingAndType)
 {
   TestCombinedTopicEncodingAndType("", "", "");
   TestCombinedTopicEncodingAndType("proto", "pb.Person.People", "proto:pb.Person.People");
@@ -46,7 +46,7 @@ TEST(core_cpp_util, Util_CombineTopicEncodingAndType)
   TestCombinedTopicEncodingAndType("", "MyType", "MyType");
 }
 
-TEST(core_cpp_util, Util_SplitCombinedTopicType)
+TEST(core_cpp_util, Topic_SplitCombinedTopicType)
 {
   TestSplitCombinedTopicType("", "", "");
   TestSplitCombinedTopicType("proto:pb.Person.People", "proto", "pb.Person.People");
@@ -55,27 +55,29 @@ TEST(core_cpp_util, Util_SplitCombinedTopicType)
   TestSplitCombinedTopicType("MyType", "", "MyType");
 }
 
-struct MillisecondFrequencyPair
+namespace
 {
-  std::chrono::milliseconds delta_t;
-  double frequency;
-};
+  struct MillisecondFrequencyPair
+  {
+    std::chrono::milliseconds delta_t;
+    double frequency;
+  };
 
-const std::vector<MillisecondFrequencyPair> frequency_pairs =
-{
-  {std::chrono::milliseconds(1000),   1.0},
-  {std::chrono::milliseconds(1250),   0.8},
-  {std::chrono::milliseconds(5000),   0.2},
-  {std::chrono::milliseconds(20000),  0.05},
-  {std::chrono::milliseconds(500),    2.0},
-  {std::chrono::milliseconds(200),    5.0},
-  {std::chrono::milliseconds(100),   10.0},
-  {std::chrono::milliseconds(20),    50.0},
-  {std::chrono::milliseconds(2),    500.0},
-};
+  const std::vector<MillisecondFrequencyPair> frequency_pairs =
+  {
+    {std::chrono::milliseconds(1000),   1.0},
+    {std::chrono::milliseconds(1250),   0.8},
+    {std::chrono::milliseconds(5000),   0.2},
+    {std::chrono::milliseconds(20000),  0.05},
+    {std::chrono::milliseconds(500),    2.0},
+    {std::chrono::milliseconds(200),    5.0},
+    {std::chrono::milliseconds(100),   10.0},
+    {std::chrono::milliseconds(20),    50.0},
+    {std::chrono::milliseconds(2),    500.0},
+  };
+}
 
-
-TEST(Util, FrequencyCalculator)
+TEST(core_cpp_util, Freq_FrequencyCalculator)
 {
   for (const auto& pair : frequency_pairs)
   {
@@ -110,7 +112,7 @@ TEST(Util, FrequencyCalculator)
   }
 }
 
-TEST(Util, ResettableFrequencyCalculator)
+TEST(core_cpp_util, Freq_ResettableFrequencyCalculator)
 {
   const auto check_delta_t = std::chrono::milliseconds(999);
 
@@ -191,4 +193,3 @@ TEST(Util, ResettableFrequencyCalculator)
     }
   }
 }
-

--- a/tests/contrib/ecalhdf5/hdf5_test/src/hdf5_test.cpp
+++ b/tests/contrib/ecalhdf5/hdf5_test/src/hdf5_test.cpp
@@ -185,7 +185,7 @@ TestingMeasEntry topic_2
   std::vector<char> data;
 }
 
-TEST(HDF5, EscapeUnescape)
+TEST(contrib, HDF5_EscapeUnescape)
 {
   std::string test_string             = "This string contains commata,slashes/ spaces, a percent sign (%), a bell\a, nasty line endings\r\n and a german letter oe from the Latin-1 codepage: \xF8";
   std::string expected_escaped_string = "This string contains commata%2Cslashes%2F spaces%2C a percent sign (%25)%2C a bell%07%2C nasty line endings%0D%0A and a german letter oe from the Latin-1 codepage: %F8";
@@ -202,7 +202,7 @@ TEST(HDF5, EscapeUnescape)
 
 
 
-TEST(HDF5, WriteReadIntegrity)
+TEST(contrib, HDF5_WriteReadIntegrity)
 {
   // Define data that will be written to the file
 
@@ -258,7 +258,7 @@ TEST(HDF5, WriteReadIntegrity)
   }
 }
 
-TEST(HDF5, ReadWrite)
+TEST(contrib, HDF5_ReadWrite)
 {
   std::string file_name = "meas_readwrite";
 
@@ -274,7 +274,7 @@ TEST(HDF5, ReadWrite)
 }
 
 
-TEST(HDF5, IsOneFilePerChannelEnabled)
+TEST(contrib, HDF5_IsOneFilePerChannelEnabled)
 {
   eCAL::eh5::HDF5Meas hdf5_writer;
   std::string base_name = "output";
@@ -296,7 +296,7 @@ TEST(HDF5, IsOneFilePerChannelEnabled)
   EXPECT_TRUE(!hdf5_writer.IsOneFilePerChannelEnabled());
 }
 
-TEST(HDF5, SetOneFilePerChannelEnabled)
+TEST(contrib, HDF5_SetOneFilePerChannelEnabled)
 {
   std::string base_name = "output";
   
@@ -344,7 +344,7 @@ TEST(HDF5, SetOneFilePerChannelEnabled)
 
 }
 
-TEST(HDF5, EscapeFilenamesForOneFilePerChannel)
+TEST(contrib, HDF5_EscapeFilenamesForOneFilePerChannel)
 {
   // Define data that will be written to the file
   TestingMeasEntry normal_ascii = topic_1;
@@ -420,7 +420,7 @@ TEST(HDF5, EscapeFilenamesForOneFilePerChannel)
 }
 
 // This test validates that Datatypinformation is stored to / can be retrieved from the measurement correctly.
-TEST(HDF5, WriteReadTopicTypeInformation)
+TEST(contrib, HDF5_WriteReadTopicTypeInformation)
 {
   // Define data that will be written to the file
   TestingMeasEntry entry;
@@ -457,7 +457,7 @@ TEST(HDF5, WriteReadTopicTypeInformation)
   }
 }
 
-TEST(HDF5, WriteReadTopicTypeInformationDeprecated)
+TEST(contrib, HDF5_WriteReadTopicTypeInformationDeprecated)
 {
   // Define data that will be written to the file
   TestingMeasEntry entry;

--- a/tests/contrib/ecalproto/dynproto_test/src/dynproto_test.cpp
+++ b/tests/contrib/ecalproto/dynproto_test/src/dynproto_test.cpp
@@ -29,7 +29,7 @@
 void ProcProtoMsg(const google::protobuf::Message& msg_, const std::string& prefix_ /* = "" */);
 
 // google test
-TEST(DynProto, dynproto)
+TEST(contrib, dynproto)
 { 
   // generate a class instance of Person
   pb::People::Person person;

--- a/tests/contrib/ecalproto/ecal_proto_test/src/test_filters.cpp
+++ b/tests/contrib/ecalproto/ecal_proto_test/src/test_filters.cpp
@@ -29,14 +29,14 @@
 
 using namespace eCAL::protobuf;
 
-TEST(Filter, nofilter)
+TEST(contrib, Filter_nofilter)
 {
   NoFilter filter;
   bool result = filter.Filter("abc");
   EXPECT_EQ(true, result);
 }
 
-TEST(Filter, include_filter_clear)
+TEST(contrib, Filter_include_filter_clear)
 {
   SimpleIncludeFilter filter;
   std::string a("a");
@@ -90,7 +90,7 @@ void test_regular_includes(BaseIncludeFilter& filter)
   EXPECT_EQ(false, filter.Filter(adf));
 }
 
-TEST(Filter, include_filter)
+TEST(contrib, Filter_include_filter)
 {
   SimpleIncludeFilter simple_filter;
   test_regular_includes(simple_filter);
@@ -98,7 +98,7 @@ TEST(Filter, include_filter)
   test_regular_includes(complex_filter);
 }
 
-TEST(Filter, include_filter_array_simple)
+TEST(contrib, Filter_include_filter_array_simple)
 {
   const std::string a("a");
   const std::string a1("a[1]");
@@ -130,7 +130,7 @@ TEST(Filter, include_filter_array_simple)
   EXPECT_EQ(false, filter.Filter(a2b)); // should not accept a[2].b
 }
 
-TEST(Filter, include_filter_array_complex)
+TEST(contrib, Filter_include_filter_array_complex)
 {
   const std::string a    ("a"          );
   const std::string a1   ("a[1]"       );


### PR DESCRIPTION
### Description
* SetUnitName test by comparison via eCAL::Process::GetUnitName, eCAL_Process_GetUnitName. 
* (Out commented) PubSub tests removed from cpp core_test. These tests were moved to pubsub_test before.
* Renamed some test suites (app, contrib, hdf5) to get more consistent test grouping