### PR TITLE
[core] register, unregister logic adapted to prevent data races

### DIFF
--- a/ecal/core/src/readwrite/ecal_reader.cpp
+++ b/ecal/core/src/readwrite/ecal_reader.cpp
@@ -118,11 +118,11 @@ namespace eCAL
     // start transport layers
     SubscribeToLayers();
 
-    // register
-    Register(false);
-
     // mark as created
     m_created = true;
+
+    // register
+    Register(false);
 
     return(true);
   }
@@ -151,11 +151,13 @@ namespace eCAL
       m_event_callback_map.clear();
     }
 
+    // mark as no more created (and prevent reregistering)
+    m_created = false;
+
     // unregister
     Unregister();
 
     // reset defaults
-    m_created                 = false;
     m_clock                   = 0;
     m_message_drops           = 0;
 
@@ -214,7 +216,8 @@ namespace eCAL
 
   bool CDataReader::Register(const bool force_)
   {
-    if(m_topic_name.empty()) return(false);
+    if (!m_created)           return(false);
+    if (m_topic_name.empty()) return(false);
 
     // create command parameter
     eCAL::pb::Sample ecal_reg_sample;
@@ -914,10 +917,8 @@ namespace eCAL
     
   void CDataReader::RefreshRegistration()
   {
+    // this function will be called finally from registration provider every second (by default settings)
     if(!m_created) return;
-
-    // ensure that registration is not called within zero nanoseconds
-    // normally it will be called from registration logic every second
 
     // register without send
     Register(false);

--- a/ecal/core/src/readwrite/ecal_reader.h
+++ b/ecal/core/src/readwrite/ecal_reader.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <chrono>
 #include <cstddef>
 #include <deque>

--- a/ecal/core/src/readwrite/ecal_writer.cpp
+++ b/ecal/core/src/readwrite/ecal_writer.cpp
@@ -137,11 +137,11 @@ namespace eCAL
     // allow to share topic description
     m_use_tdesc = Config::IsTopicDescriptionSharingEnabled();
 
-    // register
-    Register(false);
-
     // mark as created
     m_created = true;
+
+    // register
+    Register(false);
 
     // create udp multicast layer
     SetUseUdpMC(m_writer.udp_mc_mode.requested);
@@ -206,10 +206,11 @@ namespace eCAL
       m_event_callback_map.clear();
     }
 
+    // mark as no more created (and prevent reregistering)
+    m_created = false;
+
     // unregister
     Unregister();
-
-    m_created = false;
 
     return(true);
   }
@@ -739,6 +740,7 @@ namespace eCAL
 
   void CDataWriter::RefreshRegistration()
   {
+    // this function will be called finally from registration provider every second (by default settings)
     if (!m_created) return;
 
     // register without send
@@ -798,6 +800,7 @@ namespace eCAL
 
   bool CDataWriter::Register(bool force_)
   {
+    if (!m_created)           return(false);
     if (m_topic_name.empty()) return(false);
 
     //@Rex: why is the logic different in CDataReader???

--- a/ecal/core/src/readwrite/ecal_writer.h
+++ b/ecal/core/src/readwrite/ecal_writer.h
@@ -217,6 +217,6 @@ namespace eCAL
     bool               m_use_tdesc;
     int                m_share_ttype;
     int                m_share_tdesc;
-    bool               m_created;
+    std::atomic<bool>  m_created;
   };
 }

--- a/ecal/core/src/service/ecal_service_client_impl.cpp
+++ b/ecal/core/src/service/ecal_service_client_impl.cpp
@@ -80,11 +80,11 @@ namespace eCAL
     counter << std::chrono::steady_clock::now().time_since_epoch().count();
     m_service_id = counter.str();
 
-    // register this client
-    Register(false);
-
     // mark as created
     m_created = true;
+
+    // register this client
+    Register(false);
 
     return(true);
   }
@@ -111,6 +111,9 @@ namespace eCAL
       m_event_callback_map.clear();
     }
 
+    // mark as no more created (and prevent reregistering)
+    m_created = false;
+
     // unregister this client
     Unregister();
 
@@ -118,9 +121,6 @@ namespace eCAL
     m_service_name.clear();
     m_service_id.clear();
     m_host_name.clear();
-
-    // mark as not created
-    m_created = false;
 
     return(true);
   }
@@ -613,10 +613,12 @@ namespace eCAL
     }
   }
 
-  // called by eCAL:CClientGate every second to update registration layer
   void CServiceClientImpl::RefreshRegistration()
   {
+    // this function will be called finally from registration provider every second (by default settings)
     if (!m_created) return;
+
+    // register without send
     Register(false);
   }
 
@@ -661,6 +663,7 @@ namespace eCAL
 
   void CServiceClientImpl::Register(const bool force_)
   {
+    if (!m_created)             return;
     if (m_service_name.empty()) return;
 
     eCAL::pb::Sample sample;

--- a/ecal/core/src/service/ecal_service_client_impl.h
+++ b/ecal/core/src/service/ecal_service_client_impl.h
@@ -27,6 +27,7 @@
 
 #include <ecal/service/client_session.h>
 
+#include <atomic>
 #include <map>
 #include <mutex>
 #include <memory>
@@ -128,6 +129,6 @@ namespace eCAL
     std::string           m_service_id;
     std::string           m_host_name;
 
-    bool                  m_created;
+    std::atomic<bool>     m_created;
   };
 }

--- a/ecal/core/src/service/ecal_service_server_impl.cpp
+++ b/ecal/core/src/service/ecal_service_server_impl.cpp
@@ -53,8 +53,10 @@ namespace eCAL
     return instance;
   }
 
-  CServiceServerImpl::CServiceServerImpl()
-  {}
+  CServiceServerImpl::CServiceServerImpl() :
+    m_created(false)
+  {
+  }
 
   CServiceServerImpl::~CServiceServerImpl()
   {
@@ -126,11 +128,11 @@ namespace eCAL
       m_tcp_server_v1 = server_manager->create_server(1, 0, service_callback, true, event_callback);
     }
 
-    // register this service
-    Register(false);
-
     // mark as created
     m_created = true;
+
+    // register this service
+    Register(false);
 
     return(true);
   }
@@ -157,6 +159,9 @@ namespace eCAL
       m_event_callback_map.clear();
     }
 
+    // mark as no more created (and prevent reregistering)
+    m_created = false;
+
     // unregister this service
     Unregister();
 
@@ -169,8 +174,6 @@ namespace eCAL
       m_connected_v0 = false;
       m_connected_v1 = false;
     }
-
-    m_created      = false;
 
     return(true);
   }
@@ -312,15 +315,18 @@ namespace eCAL
   {
   }
 
-  // called by eCAL:CServiceGate every second to update registration layer
   void CServiceServerImpl::RefreshRegistration()
   {
+    // this function will be called finally from registration provider every second (by default settings)
     if (!m_created) return;
+
+    // register without send
     Register(false);
   }
 
   void CServiceServerImpl::Register(const bool force_)
   {
+    if (!m_created)             return;
     if (m_service_name.empty()) return;
 
     // might be zero in contruction phase

--- a/ecal/core/src/service/ecal_service_server_impl.h
+++ b/ecal/core/src/service/ecal_service_server_impl.h
@@ -25,6 +25,8 @@
 
 #include <ecal/ecal.h>
 #include <ecal/ecal_callback.h>
+
+#include <atomic>
 #include <memory>
 #include <string>
 
@@ -130,10 +132,10 @@ namespace eCAL
     using EventCallbackMapT = std::map<eCAL_Server_Event, ServerEventCallbackT>;
     EventCallbackMapT     m_event_callback_map;
     
-    bool                  m_created      = false;
-
     mutable std::mutex    m_connected_mutex;          //!< mutex protecting the m_connected_v0 and m_connected_v1 variable, as those are modified by the event callbacks in another thread.
     bool                  m_connected_v0 = false;
     bool                  m_connected_v1 = false;
+
+    std::atomic<bool>     m_created;
   };
 }


### PR DESCRIPTION
### Description
In the destruction phase of a publisher, subscriber, client, server it could happen that parallel to the unregistration of the entity a cyclic registration is triggered by the registration provider refresh thread. This should be avoided by adaption the creation flag logic and making this state atomic.
