### PR TITLE
[GUI Apps] Added eCAL and Qt runtime and compile-time versions to the about dialog

### DIFF
--- a/app/mon/mon_gui/src/widgets/about_dialog/about_dialog.cpp
+++ b/app/mon/mon_gui/src/widgets/about_dialog/about_dialog.cpp
@@ -20,9 +20,11 @@
 #include "about_dialog.h"
 #include "ecalmon_globals.h"
 
-#include <ecal/ecal_defs.h>
+#include <ecal/ecal.h>
 
 #include <QPushButton>
+#include <QtVersion>
+#include <QLibraryInfo>
 
 AboutDialog::AboutDialog(QWidget *parent)
   : QDialog(parent)
@@ -30,6 +32,12 @@ AboutDialog::AboutDialog(QWidget *parent)
   ui_.setupUi(this);
   ui_.version_label->setText("Version: " + QString(EcalmonGlobals::VERSION_STRING));
   ui_.ecalversion_label->setText("eCAL " + QString(ECAL_VERSION) + " (" + QString(ECAL_DATE) + ")");
+
+  ui_.ecal_runtime_version_string_label->setText(QString(eCAL::GetVersionString()) + " (" + QString(eCAL::GetVersionDateString()) + ")");
+  ui_.ecal_compiletime_versin_string_label->setText(QString(ECAL_VERSION) + " (" + QString(ECAL_DATE) + ")");
+  ui_.qt_runtime_version_string_label->setText(QString(qVersion()));
+  ui_.qt_compiletime_version_string_label->setText(QString(QT_VERSION_STR));
+
   connect(ui_.button_box->button(QDialogButtonBox::StandardButton::Ok), SIGNAL(clicked()), this, SLOT(close()));
 }
 

--- a/app/mon/mon_gui/src/widgets/about_dialog/about_dialog.ui
+++ b/app/mon/mon_gui/src/widgets/about_dialog/about_dialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>326</width>
-    <height>209</height>
+    <width>304</width>
+    <height>312</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -62,7 +62,6 @@ Advanced Engineering Department
 
 Developed by Florian Reimold
 Based on work by Rex Schilasky, Ileana Zepa
-
 </string>
      </property>
      <property name="textFormat">
@@ -71,6 +70,68 @@ Based on work by Rex Schilasky, Ileana Zepa
      <property name="alignment">
       <set>Qt::AlignCenter</set>
      </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="lib_versions_groupbox">
+     <layout class="QFormLayout" name="lib_vresions_groupbox_layout">
+      <item row="2" column="0">
+       <widget class="QLabel" name="qt_runtime_rowlabel">
+        <property name="text">
+         <string>Qt runtime version:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLabel" name="qt_runtime_version_string_label">
+        <property name="text">
+         <string>qt-runtime-version</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="ecal_runtime_rowlabel">
+        <property name="text">
+         <string>eCAL runtime version:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="ecal_runtime_version_string_label">
+        <property name="text">
+         <string>ecal-runtime-version</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="ecal_compiletime_rowlabel">
+        <property name="text">
+         <string>eCAL compile-time version:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="ecal_compiletime_versin_string_label">
+        <property name="text">
+         <string>ecal-compiletime-version</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="qt_compiletime_rowlabel">
+        <property name="text">
+         <string>Qt compile-time version:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QLabel" name="qt_compiletime_version_string_label">
+        <property name="text">
+         <string>qt-compiletime-version</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>

--- a/app/play/play_gui/src/widgets/about_dialog/about_dialog.cpp
+++ b/app/play/play_gui/src/widgets/about_dialog/about_dialog.cpp
@@ -20,9 +20,10 @@
 #include "about_dialog.h"
 #include "ecal_play_globals.h"
 
-#include <ecal/ecal_defs.h>
+#include <ecal/ecal.h>
 
 #include <QPushButton>
+#include <QtVersion>
 
 AboutDialog::AboutDialog(QWidget *parent)
   : QDialog(parent)
@@ -30,6 +31,12 @@ AboutDialog::AboutDialog(QWidget *parent)
   ui_.setupUi(this);
   ui_.version_label->setText("Version: " + QString(EcalPlayGlobals::VERSION_STRING));
   ui_.ecalversion_label->setText("eCAL " + QString(ECAL_VERSION) + " (" + QString(ECAL_DATE) + ")");
+
+  ui_.ecal_runtime_version_string_label->setText(QString(eCAL::GetVersionString()) + " (" + QString(eCAL::GetVersionDateString()) + ")");
+  ui_.ecal_compiletime_versin_string_label->setText(QString(ECAL_VERSION) + " (" + QString(ECAL_DATE) + ")");
+  ui_.qt_runtime_version_string_label->setText(QString(qVersion()));
+  ui_.qt_compiletime_version_string_label->setText(QString(QT_VERSION_STR));
+
   connect(ui_.button_box->button(QDialogButtonBox::StandardButton::Ok), SIGNAL(clicked()), this, SLOT(close()));
 }
 

--- a/app/play/play_gui/src/widgets/about_dialog/about_dialog.ui
+++ b/app/play/play_gui/src/widgets/about_dialog/about_dialog.ui
@@ -62,7 +62,6 @@ Advanced Engineering Department
 
 Developed by Florian Reimold
 Based on work by Claudiu Vasilescu, Andreea Popa
-
 </string>
      </property>
      <property name="textFormat">
@@ -71,6 +70,68 @@ Based on work by Claudiu Vasilescu, Andreea Popa
      <property name="alignment">
       <set>Qt::AlignCenter</set>
      </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="lib_versions_groupbox">
+     <layout class="QFormLayout" name="lib_vresions_groupbox_layout">
+      <item row="2" column="0">
+       <widget class="QLabel" name="qt_runtime_rowlabel">
+        <property name="text">
+         <string>Qt runtime version:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLabel" name="qt_runtime_version_string_label">
+        <property name="text">
+         <string>qt-runtime-version</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="ecal_runtime_rowlabel">
+        <property name="text">
+         <string>eCAL runtime version:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="ecal_runtime_version_string_label">
+        <property name="text">
+         <string>ecal-runtime-version</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="ecal_compiletime_rowlabel">
+        <property name="text">
+         <string>eCAL compile-time version:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="ecal_compiletime_versin_string_label">
+        <property name="text">
+         <string>ecal-compiletime-version</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="qt_compiletime_rowlabel">
+        <property name="text">
+         <string>Qt compile-time version:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QLabel" name="qt_compiletime_version_string_label">
+        <property name="text">
+         <string>qt-compiletime-version</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>

--- a/app/rec/rec_gui/src/widgets/about_dialog/about_dialog.cpp
+++ b/app/rec/rec_gui/src/widgets/about_dialog/about_dialog.cpp
@@ -20,9 +20,10 @@
 #include "about_dialog.h"
 #include "rec_client_core/ecal_rec_defs.h"
 
-#include <ecal/ecal_defs.h>
+#include <ecal/ecal.h>
 
 #include <QPushButton>
+#include <QtVersion>
 
 AboutDialog::AboutDialog(QWidget *parent)
   : QDialog(parent)
@@ -30,6 +31,12 @@ AboutDialog::AboutDialog(QWidget *parent)
   ui_.setupUi(this);
   ui_.version_label->setText("Version: " + QString(ECAL_REC_VERSION_STRING));
   ui_.ecalversion_label->setText("eCAL " + QString(ECAL_VERSION) + " (" + QString(ECAL_DATE) + ")");
+
+  ui_.ecal_runtime_version_string_label->setText(QString(eCAL::GetVersionString()) + " (" + QString(eCAL::GetVersionDateString()) + ")");
+  ui_.ecal_compiletime_versin_string_label->setText(QString(ECAL_VERSION) + " (" + QString(ECAL_DATE) + ")");
+  ui_.qt_runtime_version_string_label->setText(QString(qVersion()));
+  ui_.qt_compiletime_version_string_label->setText(QString(QT_VERSION_STR));
+
   connect(ui_.button_box->button(QDialogButtonBox::StandardButton::Ok), SIGNAL(clicked()), this, SLOT(close()));
 }
 

--- a/app/rec/rec_gui/src/widgets/about_dialog/about_dialog.ui
+++ b/app/rec/rec_gui/src/widgets/about_dialog/about_dialog.ui
@@ -60,7 +60,8 @@
 © 2019 Continental AG
 Advanced Engineering Department
 
-Developed by Florian Reimold</string>
+Developed by Florian Reimold
+</string>
      </property>
      <property name="textFormat">
       <enum>Qt::PlainText</enum>
@@ -68,6 +69,68 @@ Developed by Florian Reimold</string>
      <property name="alignment">
       <set>Qt::AlignCenter</set>
      </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="lib_versions_groupbox">
+     <layout class="QFormLayout" name="lib_vresions_groupbox_layout">
+      <item row="2" column="0">
+       <widget class="QLabel" name="qt_runtime_rowlabel">
+        <property name="text">
+         <string>Qt runtime version:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLabel" name="qt_runtime_version_string_label">
+        <property name="text">
+         <string>qt-runtime-version</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="ecal_runtime_rowlabel">
+        <property name="text">
+         <string>eCAL runtime version:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="ecal_runtime_version_string_label">
+        <property name="text">
+         <string>ecal-runtime-version</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="ecal_compiletime_rowlabel">
+        <property name="text">
+         <string>eCAL compile-time version:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="ecal_compiletime_versin_string_label">
+        <property name="text">
+         <string>ecal-compiletime-version</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="qt_compiletime_rowlabel">
+        <property name="text">
+         <string>Qt compile-time version:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QLabel" name="qt_compiletime_version_string_label">
+        <property name="text">
+         <string>qt-compiletime-version</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>

--- a/app/sys/sys_gui/src/widgets/about_dialog/about_dialog.cpp
+++ b/app/sys/sys_gui/src/widgets/about_dialog/about_dialog.cpp
@@ -19,9 +19,11 @@
 
 #include "about_dialog.h"
 #include "ecalsys/esys_defs.h"
-#include <ecal/ecal_defs.h>
+
+#include <ecal/ecal.h>
 
 #include <QPushButton>
+#include <QtVersion>
 
 AboutDialog::AboutDialog(QWidget *parent)
   : QDialog(parent)
@@ -29,8 +31,13 @@ AboutDialog::AboutDialog(QWidget *parent)
   ui_.setupUi(this);
   ui_.version_label->setText("Version: " + QString(ECAL_SYS_VERSION_STRING));
   ui_.ecalversion_label->setText("eCAL " + QString(ECAL_VERSION) + " (" + QString(ECAL_DATE) + ")");
-  connect(ui_.button_box->button(QDialogButtonBox::StandardButton::Ok), SIGNAL(clicked()), this, SLOT(close()));
-}
+
+  ui_.ecal_runtime_version_string_label->setText(QString(eCAL::GetVersionString()) + " (" + QString(eCAL::GetVersionDateString()) + ")");
+  ui_.ecal_compiletime_versin_string_label->setText(QString(ECAL_VERSION) + " (" + QString(ECAL_DATE) + ")");
+  ui_.qt_runtime_version_string_label->setText(QString(qVersion()));
+  ui_.qt_compiletime_version_string_label->setText(QString(QT_VERSION_STR));
+
+  connect(ui_.button_box->button(QDialogButtonBox::StandardButton::Ok), SIGNAL(clicked()), this, SLOT(close()));}
 
 AboutDialog::~AboutDialog()
 {

--- a/app/sys/sys_gui/src/widgets/about_dialog/about_dialog.ui
+++ b/app/sys/sys_gui/src/widgets/about_dialog/about_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>326</width>
-    <height>209</height>
+    <height>228</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -62,7 +62,6 @@ Advanced Engineering Department
 
 Developed by Florian Reimold
 Based on work by Ileana Zepa, Narcisa Mironese, Andrei Toader
-
 </string>
      </property>
      <property name="textFormat">
@@ -71,6 +70,68 @@ Based on work by Ileana Zepa, Narcisa Mironese, Andrei Toader
      <property name="alignment">
       <set>Qt::AlignCenter</set>
      </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="lib_versions_groupbox">
+     <layout class="QFormLayout" name="lib_vresions_groupbox_layout">
+      <item row="2" column="0">
+       <widget class="QLabel" name="qt_runtime_rowlabel">
+        <property name="text">
+         <string>Qt runtime version:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLabel" name="qt_runtime_version_string_label">
+        <property name="text">
+         <string>qt-runtime-version</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="ecal_runtime_rowlabel">
+        <property name="text">
+         <string>eCAL runtime version:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="ecal_runtime_version_string_label">
+        <property name="text">
+         <string>ecal-runtime-version</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="ecal_compiletime_rowlabel">
+        <property name="text">
+         <string>eCAL compile-time version:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="ecal_compiletime_versin_string_label">
+        <property name="text">
+         <string>ecal-compiletime-version</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="qt_compiletime_rowlabel">
+        <property name="text">
+         <string>Qt compile-time version:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QLabel" name="qt_compiletime_version_string_label">
+        <property name="text">
+         <string>qt-compiletime-version</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>

--- a/app/util/launcher/src/about_dialog.cpp
+++ b/app/util/launcher/src/about_dialog.cpp
@@ -19,9 +19,10 @@
 
 #include "about_dialog.h"
 
-#include <ecal/ecal_defs.h>
+#include <ecal/ecal.h>
 
 #include <QPushButton>
+#include <QtVersion>
 
 AboutDialog::AboutDialog(QWidget *parent)
   : QDialog(parent)
@@ -29,6 +30,12 @@ AboutDialog::AboutDialog(QWidget *parent)
   ui_.setupUi(this);
   ui_.version_label->setText("Version: " + QString("2.3.0"));
   ui_.ecalversion_label->setText("eCAL " + QString(ECAL_VERSION) + " (" + QString(ECAL_DATE) + ")");
+
+  ui_.ecal_runtime_version_string_label->setText(QString(eCAL::GetVersionString()) + " (" + QString(eCAL::GetVersionDateString()) + ")");
+  ui_.ecal_compiletime_versin_string_label->setText(QString(ECAL_VERSION) + " (" + QString(ECAL_DATE) + ")");
+  ui_.qt_runtime_version_string_label->setText(QString(qVersion()));
+  ui_.qt_compiletime_version_string_label->setText(QString(QT_VERSION_STR));
+
   connect(ui_.button_box->button(QDialogButtonBox::StandardButton::Ok), SIGNAL(clicked()), this, SLOT(close()));
 }
 

--- a/app/util/launcher/src/about_dialog.ui
+++ b/app/util/launcher/src/about_dialog.ui
@@ -70,7 +70,6 @@
 Advanced Engineering Department
 
 Developed by Mihai Muraru
-
 </string>
      </property>
      <property name="textFormat">
@@ -79,6 +78,68 @@ Developed by Mihai Muraru
      <property name="alignment">
       <set>Qt::AlignCenter</set>
      </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="lib_versions_groupbox">
+     <layout class="QFormLayout" name="lib_vresions_groupbox_layout">
+      <item row="2" column="0">
+       <widget class="QLabel" name="qt_runtime_rowlabel">
+        <property name="text">
+         <string>Qt runtime version:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLabel" name="qt_runtime_version_string_label">
+        <property name="text">
+         <string>qt-runtime-version</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="ecal_runtime_rowlabel">
+        <property name="text">
+         <string>eCAL runtime version:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="ecal_runtime_version_string_label">
+        <property name="text">
+         <string>ecal-runtime-version</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="ecal_compiletime_rowlabel">
+        <property name="text">
+         <string>eCAL compile-time version:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="ecal_compiletime_versin_string_label">
+        <property name="text">
+         <string>ecal-compiletime-version</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="qt_compiletime_rowlabel">
+        <property name="text">
+         <string>Qt compile-time version:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QLabel" name="qt_compiletime_version_string_label">
+        <property name="text">
+         <string>qt-compiletime-version</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>


### PR DESCRIPTION
### Description
![image](https://github.com/eclipse-ecal/ecal/assets/11774314/2612d483-6a43-4d7b-9ea0-2bb07e0ffe38)

I thinks this is a cool feature to quickly check if the compile-time and runtime versions match.