### PR TITLE
[BUILD] CMakePresets.json - enabled BUILD_SAMPLES for cli preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -89,6 +89,7 @@
         "HAS_CURL": "ON",
         "HAS_FTXUI": "ON",
         "BUILD_APPS": "ON",
+        "BUILD_SAMPLES": "ON",
         "ECAL_THIRDPARTY_BUILD_FINEFTP": "ON",
         "ECAL_THIRDPARTY_BUILD_FTXUI": "ON",
         "ECAL_THIRDPARTY_BUILD_SPDLOG": "ON",


### PR DESCRIPTION
### Description
Switched the option "BUILD_SAMPLES" in CMakePresets.json to ON for the CLI preset, as its neccessary for ecal_pb to build. Otherwise mon_tui, mon_cli, sys_core, sys, sys_client, sys_client_core and rec_client_core are missing this dependency.