### PR TITLE
Added ecaludp as submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -57,4 +57,4 @@
 	url = https://github.com/eclipse-ecal/udpcap.git
 [submodule "thirdparty/ecaludp/ecaludp"]
 	path = thirdparty/ecaludp/ecaludp
-	url = https://github.com/eclipse-ecal/ecaludp
+	url = https://github.com/eclipse-ecal/ecaludp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -55,3 +55,6 @@
 [submodule "thirdparty/udpcap"]
 	path = thirdparty/udpcap/udpcap
 	url = https://github.com/eclipse-ecal/udpcap.git
+[submodule "thirdparty/ecaludp/ecaludp"]
+	path = thirdparty/ecaludp/ecaludp
+	url = https://github.com/eclipse-ecal/ecaludp

--- a/cmake/submodule_dependencies.cmake
+++ b/cmake/submodule_dependencies.cmake
@@ -7,6 +7,7 @@ set(ecal_submodule_dependencies
   asio
   CMakeFunctions
   CURL
+  ecaludp
   fineftp
   ftxui
   GTest
@@ -23,7 +24,6 @@ set(ecal_submodule_dependencies
   tinyxml2
   udpcap
   yaml-cpp
-  ecaludp
 )
 
 set(ecal_inproject_dependencies

--- a/cmake/submodule_dependencies.cmake
+++ b/cmake/submodule_dependencies.cmake
@@ -23,6 +23,7 @@ set(ecal_submodule_dependencies
   tinyxml2
   udpcap
   yaml-cpp
+  ecaludp
 )
 
 set(ecal_inproject_dependencies

--- a/thirdparty/ecaludp/build-ecaludp.cmake
+++ b/thirdparty/ecaludp/build-ecaludp.cmake
@@ -12,4 +12,4 @@ set(ECALUDP_LIBRARY_TYPE        STATIC)
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/ecaludp thirdparty/ecaludp EXCLUDE_FROM_ALL SYSTEM)
 
 # move the ecaludp target to a subdirectory in the IDE
-set_property(TARGET ecaludp PROPERTY FOLDER lib/ecaludp)
+set_property(TARGET ecaludp PROPERTY FOLDER thirdparty/ecaludp)

--- a/thirdparty/ecaludp/build-ecaludp.cmake
+++ b/thirdparty/ecaludp/build-ecaludp.cmake
@@ -1,0 +1,15 @@
+include_guard(GLOBAL)
+
+set(ECALUDP_ENABLE_NPCAP        ${ECAL_CORE_NPCAP_SUPPORT})
+set(ECALUDP_BUILD_SAMPLES       OFF)
+set(ECALUDP_BUILD_TESTS         OFF)
+set(ECALUDP_USE_BUILTIN_ASIO    OFF)
+set(ECALUDP_USE_BUILTIN_RECYCLE OFF)
+set(ECALUDP_USE_BUILTIN_UDPCAP  OFF)
+set(ECALUDP_LIBRARY_TYPE        STATIC)
+
+# Add ecaludp library from subdirectory
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/ecaludp thirdparty/ecaludp EXCLUDE_FROM_ALL SYSTEM)
+
+# move the ecaludp target to a subdirectory in the IDE
+set_property(TARGET ecaludp PROPERTY FOLDER lib/ecaludp)


### PR DESCRIPTION
### Description
Added ecaludp as submodule.
Adapted submodule_dependencies.cmake.
Removed the line `add_library(ecaludp::ecaludp ALIAS ecaludp)` from build-ecaludp.cmake integration from ecal-core as per feedback from @rex-schilasky.