### PR TITLE
[core/test] util_test (ParallelGetTopics) was excluded due to incorrect CMake setting

### DIFF
--- a/ecal/tests/CMakeLists.txt
+++ b/ecal/tests/CMakeLists.txt
@@ -36,7 +36,7 @@ add_subdirectory(cpp/expmap_test)
 add_subdirectory(cpp/serialization_test)
 add_subdirectory(cpp/topic2mcast_test)
 
-if(ECAL_CORE_REGISTRATION)
+if(ECAL_CORE_REGISTRATION AND ECAL_CORE_PUBLISHER)
   add_subdirectory(cpp/util_test)
 endif()
 

--- a/ecal/tests/cpp/util_test/src/util_test.cpp
+++ b/ecal/tests/cpp/util_test/src/util_test.cpp
@@ -195,8 +195,6 @@ TEST(core_cpp_util, Freq_ResettableFrequencyCalculator)
   }
 }
 
-
-#if ECAL_CORE_PUBLISHER
 TEST(core_cpp_util, ParallelGetTopics)
 {
   constexpr const int max_publisher_count(2000);
@@ -262,4 +260,3 @@ TEST(core_cpp_util, ParallelGetTopics)
 
   eCAL::Finalize();
 }
-#endif // ECAL_CORE_PUBLISHER


### PR DESCRIPTION
### Description
Minimal fix: ParallelGetTopics (core/util_test) gtest was excluded due to ECAL_CORE_PUBLISHER condition (that should not used in test cpp modules, because all ECAL_CORE_XY variables are not forwarded as compiler defines.)