### PR TITLE
Convert defines to constexpr

### DIFF
--- a/ecal/core/src/config/ecal_config_reader.cpp
+++ b/ecal/core/src/config/ecal_config_reader.cpp
@@ -425,6 +425,16 @@ namespace eCAL
     return static_cast<int>(m_impl->GetLongValue(section_.c_str(), key_.c_str(), static_cast<long>(default_)));
   }
 
+  unsigned int CConfig::get(const std::string& section_, const std::string& key_, unsigned int default_)
+  {
+    return static_cast<unsigned int>(m_impl->GetLongValue(section_.c_str(), key_.c_str(), static_cast<long>(default_)));
+  }
+
+  size_t CConfig::get(const std::string& section_, const std::string& key_, size_t default_)
+  {
+    return static_cast<size_t>(m_impl->GetLongValue(section_.c_str(), key_.c_str(), static_cast<long>(default_)));
+  }
+
   double CConfig::get(const std::string& section_, const std::string& key_, double default_)
   {
     return m_impl->GetDoubleValue(section_.c_str(), key_.c_str(), default_);

--- a/ecal/core/src/config/ecal_config_reader.h
+++ b/ecal/core/src/config/ecal_config_reader.h
@@ -44,10 +44,12 @@ namespace eCAL
     bool Validate();
 
     // common getter
-    bool        get(const std::string& section_, const std::string& key_, bool        default_);
-    int         get(const std::string& section_, const std::string& key_, int         default_);
-    double      get(const std::string& section_, const std::string& key_, double      default_);
-    std::string get(const std::string& section_, const std::string& key_, const char* default_);
+    bool         get(const std::string& section_, const std::string& key_, bool         default_);
+    int          get(const std::string& section_, const std::string& key_, int          default_);
+    double       get(const std::string& section_, const std::string& key_, double       default_);
+    std::string  get(const std::string& section_, const std::string& key_, const char*  default_);
+    unsigned int get(const std::string& section_, const std::string& key_, unsigned int default_);
+    size_t       get(const std::string& section_, const std::string& key_, size_t       default_);
 
   private:
     std::unique_ptr<CConfigImpl> m_impl;

--- a/ecal/core/src/ecal_def.h
+++ b/ecal/core/src/ecal_def.h
@@ -23,103 +23,109 @@
 
 #pragma once
 
+#include <ecal/types/ecal_config_types.h>
 #include <ecal/ecal_os.h>
 
 /**********************************************************************************************/
 /*                                     config settings                                        */
 /**********************************************************************************************/
 /* base data path name */
-#define ECAL_HOME_PATH_WINDOWS                     ""
-#define ECAL_HOME_PATH_LINUX                       ".ecal"
-#define ECAL_LOG_PATH                              "logs"
-#define ECAL_SETTINGS_PATH                         "cfg"
+constexpr char ECAL_HOME_PATH_WINDOWS[] = "";
+constexpr char ECAL_HOME_PATH_WINDOWS[] = "";
+constexpr char ECAL_HOME_PATH_LINUX[]   = ".ecal";
+constexpr char ECAL_LOG_PATH[]          = "logs";
+constexpr char ECAL_SETTINGS_PATH[]     = "cfg";
 
 /* ini file name */
-#define ECAL_DEFAULT_CFG                           "ecal.ini"
+constexpr char ECAL_DEFAULT_CFG[]       = "ecal.ini";
 
 /**********************************************************************************************/
 /*                                     monitor settings                                       */
 /**********************************************************************************************/
 /* timeout for automatic removing monitoring topics in ms */
-#define MON_TIMEOUT                                5000
+constexpr unsigned int MON_TIMEOUT      = 5000U;
 /* topics blacklist as regular expression (will not be monitored) */
-#define MON_FILTER_EXCL                            "_.*"
+constexpr char MON_FILTER_EXCL[]        =    "^__.*$";
 /* topics whitelist as regular expression (will be monitored only) */
-#define MON_FILTER_INCL                            ""
+constexpr char MON_FILTER_INCL[]        =    "";
 
 /* logging filter settings */
-#define MON_LOG_FILTER_CON                         "info,warning,error,fatal"
-#define MON_LOG_FILTER_FILE                        ""
-#define MON_LOG_FILTER_UDP                         "info,warning,error,fatal"
+constexpr char MON_LOG_FILTER_CON[]     = "info,warning,error,fatal";
+constexpr char MON_LOG_FILTER_FILE[]    = "";
+constexpr char MON_LOG_FILTER_UDP[]     = "info,warning,error,fatal";
 
 
 /**********************************************************************************************/
 /*                                     sys settings                                       */
 /**********************************************************************************************/
 /* sys app witch will not be imported from cloud */
-#define SYS_FILTER_EXCL                            "^eCALSysClient$|^eCALSysGUI$|^eCALSys$*"
+constexpr char SYS_FILTER_EXCL[]        = "^eCALSysClient$|^eCALSysGUI$|^eCALSys$*";
 
 /**********************************************************************************************/
 /*                                     network settings                                       */
 /**********************************************************************************************/
 /* network switch */
-#define NET_ENABLED                                false
+constexpr bool NET_ENABLED              = false;
 
 /* eCAL udp multicast defines */
-#define NET_UDP_MULTICAST_CONFIG_VERSION           "v1"
-#define NET_UDP_MULTICAST_GROUP                    "239.0.0.1"
-#define NET_UDP_MULTICAST_MASK                     "0.0.0.15"
-#define NET_UDP_MULTICAST_PORT                     14000
-#define NET_UDP_MULTICAST_TTL                      3
-#define NET_UDP_MULTICAST_PORT_REG_OFF             0
-#define NET_UDP_MULTICAST_PORT_SAMPLE_OFF          2
-#define NET_UDP_MULTICAST_PORT_LOG_OFF             4
-#define NET_UDP_MULTICAST_SNDBUF                   (5*1024*1024)  /* 5 MByte */
-#define NET_UDP_MULTICAST_RCVBUF                   (5*1024*1024)  /* 5 MByte */
-#define NET_UDP_MULTICAST_JOIN_ALL_IF_ENABLED      false
+constexpr char NET_UDP_MULTICAST_CONFIG_VERSION[]         = "v1";
+constexpr char NET_UDP_MULTICAST_GROUP[]                  = "239.0.0.1";
+constexpr char NET_UDP_MULTICAST_MASK[]                   = "0.0.0.15";
+constexpr unsigned int NET_UDP_MULTICAST_PORT             = 14000;
+constexpr unsigned int NET_UDP_MULTICAST_TTL              = 3;
+constexpr unsigned int NET_UDP_MULTICAST_PORT_REG_OFF     = 0;
+constexpr unsigned int NET_UDP_MULTICAST_PORT_LOG_OFF     = 1;
+constexpr unsigned int NET_UDP_MULTICAST_PORT_SAMPLE_OFF  = 2;
+constexpr unsigned int NET_UDP_MULTICAST_SNDBUF           = (5*1024*1024);  /* 5 MByte */
+constexpr unsigned int NET_UDP_MULTICAST_RCVBUF           = (5*1024*1024);  /* 5 MByte */
+constexpr bool NET_UDP_MULTICAST_JOIN_ALL_IF_ENABLED      = false;
 
-#define NET_UDP_RECBUFFER_TIMEOUT                  1000  /* ms */
-#define NET_UDP_RECBUFFER_CLEANUP                  10    /* ms */
+constexpr unsigned int NET_UDP_RECBUFFER_TIMEOUT          = 1000;  /* ms */
+constexpr unsigned int NET_UDP_RECBUFFER_CLEANUP          = 10;    /* ms */
 
-#define NET_TCP_REC_ENABLED                        true
-#define NET_SHM_REC_ENABLED                        true
-#define NET_UDP_MC_REC_ENABLED                     true
+/* overall udp multicast bandwidth limitation in bytes/s, -1 == no limitation*/
+constexpr int NET_BANDWIDTH_MAX_UDP                       = (-1);
 
-#define NET_NPCAP_ENABLED                          false
+constexpr bool NET_TCP_REC_ENABLED                        = true;
+constexpr bool NET_SHM_REC_ENABLED                        = true;
 
-#define NET_TCP_PUBSUB_NUM_EXECUTOR_READER         4
-#define NET_TCP_PUBSUB_NUM_EXECUTOR_WRITER         4
-#define NET_TCP_PUBSUB_MAX_RECONNECTIONS           5
+constexpr bool NET_UDP_MC_REC_ENABLED                     = true;
+
+constexpr bool NET_NPCAP_ENABLED                          = false;
+
+constexpr unsigned int NET_TCP_PUBSUB_NUM_EXECUTOR_READER = 4;
+constexpr unsigned int NET_TCP_PUBSUB_NUM_EXECUTOR_WRITER = 4;
+constexpr unsigned int NET_TCP_PUBSUB_MAX_RECONNECTIONS   = 5;
 
 /* common host group name that enables interprocess mechanisms across (virtual) host borders (e.g, Docker); by default equivalent to local host name */
-#define NET_HOST_GROUP_NAME                         ""
+constexpr char NET_HOST_GROUP_NAME[]                      = "";
 
 /**********************************************************************************************/
 /*                                     publisher settings                                     */
 /**********************************************************************************************/
 /* use shared memory transport layer [auto = 2, on = 1, off = 0] */
-#define PUB_USE_SHM                                2
+constexpr unsigned int PUB_USE_SHM                        = 2;
 /* use tcp transport layer           [auto = 2, on = 1, off = 0] */
-#define PUB_USE_TCP                                0
+constexpr unsigned int PUB_USE_TCP                        = 0;
 /* use udp multicast transport layer [auto = 2, on = 1, off = 0] */
-#define PUB_USE_UDP_MC                             2
+constexpr unsigned int PUB_USE_UDP_MC                     = 2;
 
 /* share topic type                  [          on = 1, off = 0] */
-#define PUB_SHARE_TTYPE                            1
+constexpr unsigned int PUB_SHARE_TTYPE                    = 1;
 /* share topic description           [          on = 1, off = 0] */
-#define PUB_SHARE_TDESC                            1
+constexpr unsigned int PUB_SHARE_TDESC                    = 1;
 
 /* minimum size for created shared memory files */
-#define PUB_MEMFILE_MINSIZE                        (4*1024)
+constexpr unsigned int PUB_MEMFILE_MINSIZE                = (4*1024);
 /* reserve buffer size before reallocation in % */
-#define PUB_MEMFILE_RESERVE                        50
+constexpr unsigned int PUB_MEMFILE_RESERVE                = 50;
 
 /* timeout for create / open a memory file using mutex lock in ms */
-#define PUB_MEMFILE_CREATE_TO                      200
-#define PUB_MEMFILE_OPEN_TO                        200
+constexpr unsigned int PUB_MEMFILE_CREATE_TO              = 200;
+constexpr unsigned int PUB_MEMFILE_OPEN_TO                = 200;
 
 /* timeout for memory read acknowledge signal from data reader in ms */
-#define PUB_MEMFILE_ACK_TO                          0  /* ms */
+constexpr unsigned int PUB_MEMFILE_ACK_TO                 = 0;  /* ms */
 
 /* defines number of memory files handle by the publisher for a 1:n connection
    a higher number will increase data throughput, but will also increase the size of used memory, number of semaphores
@@ -127,68 +133,68 @@
    higher values than 3 are not recommended
    values > 1 will break local IPC compatibility to eCAL 5.9 and older
 */
-#define PUB_MEMFILE_BUF_COUNT                      1
+constexpr unsigned int PUB_MEMFILE_BUF_COUNT              = 1;
 
 /* allow subscriber to access memory file without copying content in advance (zero copy)
    this memory file is blocked for other readers wihle processed by the user callback function
    this option is fully IPC compatible to all eCAL 5.x versions
 */
-#define PUB_MEMFILE_ZERO_COPY                      0
+constexpr unsigned int PUB_MEMFILE_ZERO_COPY              = 0;
 
 /**********************************************************************************************/
 /*                                     service settings                                       */
 /**********************************************************************************************/
 /* support service protocol v0, eCAL 5.11 and older (0 = off, 1 = on) */
-#define SERVICE_PROTOCOL_V0                        1
+constexpr unsigned int SERVICE_PROTOCOL_V0                = 1;
 
 /* support service protocol v1, eCAL 5.12 and newer (0 = off, 1 = on) */
-#define SERVICE_PROTOCOL_V1                        1
+constexpr unsigned int SERVICE_PROTOCOL_V1                = 1;
 
 /**********************************************************************************************/
 /*                                     time settings                                          */
 /**********************************************************************************************/
-#define TIME_SYNC_MOD_RT                           ""
-#define TIME_SYNC_MOD_REPLAY                       ""
+constexpr char TIME_SYNC_MOD_RT[]                         = "";
+constexpr char TIME_SYNC_MOD_REPLAY[]                     = "";
 
 /**********************************************************************************************/
 /*                                     process settings                                       */
 /**********************************************************************************************/
-#define PROCESS_TERMINAL_EMULATOR                  ""
+constexpr char PROCESS_TERMINAL_EMULATOR[]                = "";
 
 /**********************************************************************************************/
 /*                                     ecal internal timings                                  */
 /**********************************************************************************************/
 /* timeout for automatic removing registered topics and memory files in global database in ms */
-#define CMN_REGISTRATION_TO                            (60*1000)
+constexpr unsigned int CMN_REGISTRATION_TO                  = (60*1000);
 
 /* time for resend registration info from publisher/subscriber in ms */
-#define CMN_REGISTRATION_REFRESH                       1000
+constexpr unsigned int CMN_REGISTRATION_REFRESH             = 1000;
 
 /* delta time to check timeout for data readers in ms */
-#define CMN_DATAREADER_TIMEOUT_RESOLUTION_MS           100
+constexpr unsigned int CMN_DATAREADER_TIMEOUT_RESOLUTION_MS = 100;
 
 /* cylce time udp receive threads in ms */
-#define CMN_UDP_RECEIVE_THREAD_CYCLE_TIME_MS           1000
+constexpr unsigned int CMN_UDP_RECEIVE_THREAD_CYCLE_TIME_MS = 1000;
 
 /**********************************************************************************************/
 /*                                     events                                                 */
 /**********************************************************************************************/
 /* common stop event prefix to shut down a local user process */
-#define EVENT_SHUTDOWN_PROC                        "ecal_shutdown_process"
+constexpr char EVENT_SHUTDOWN_PROC[]                        = "ecal_shutdown_process";
 
 /**********************************************************************************************/
 /*                                     experimental                                           */
 /**********************************************************************************************/
 /* enable distribution of monitoring/registration information via shared memory */
-#define EXP_SHM_MONITORING_ENABLED                  false
+constexpr bool EXP_SHM_MONITORING_ENABLED                   = false;
 /* disable distribution of monitoring/registration information via network (default) */
-#define EXP_NETWORK_MONITORING_DISABLED             false
+constexpr bool EXP_NETWORK_MONITORING_DISABLED              = false;
 /* queue size of monitoring/registration events  */
-#define EXP_SHM_MONITORING_QUEUE_SIZE              1024
+constexpr unsigned int EXP_SHM_MONITORING_QUEUE_SIZE        = 1024;
 /* domain name for shared memory based monitoring/registration */
-#define EXP_SHM_MONITORING_DOMAIN                  "ecal_monitoring"
+constexpr char EXP_SHM_MONITORING_DOMAIN[]                  = "ecal_monitoring";
 /* memory file access timeout */
-#define EXP_MEMFILE_ACCESS_TIMEOUT                 100
+constexpr unsigned int EXP_MEMFILE_ACCESS_TIMEOUT           = 100;
 
 /* enable dropping of payload messages that arrive out of order */
-#define EXP_DROP_OUT_OF_ORDER_MESSAGES             false
+constexpr bool EXP_DROP_OUT_OF_ORDER_MESSAGES               = false;

--- a/ecal/core/src/ecal_def.h
+++ b/ecal/core/src/ecal_def.h
@@ -23,43 +23,41 @@
 
 #pragma once
 
-#include <ecal/types/ecal_config_types.h>
 #include <ecal/ecal_os.h>
 
 /**********************************************************************************************/
 /*                                     config settings                                        */
 /**********************************************************************************************/
 /* base data path name */
-constexpr char ECAL_HOME_PATH_WINDOWS[] = "";
-constexpr char ECAL_HOME_PATH_WINDOWS[] = "";
-constexpr char ECAL_HOME_PATH_LINUX[]   = ".ecal";
-constexpr char ECAL_LOG_PATH[]          = "logs";
-constexpr char ECAL_SETTINGS_PATH[]     = "cfg";
+constexpr const char* ECAL_HOME_PATH_WINDOWS = "";
+constexpr const char* ECAL_HOME_PATH_LINUX   = ".ecal";
+constexpr const char* ECAL_LOG_PATH          = "logs";
+constexpr const char* ECAL_SETTINGS_PATH     = "cfg";
 
 /* ini file name */
-constexpr char ECAL_DEFAULT_CFG[]       = "ecal.ini";
+constexpr const char* ECAL_DEFAULT_CFG       = "ecal.ini";
 
 /**********************************************************************************************/
 /*                                     monitor settings                                       */
 /**********************************************************************************************/
 /* timeout for automatic removing monitoring topics in ms */
-constexpr unsigned int MON_TIMEOUT      = 5000U;
+constexpr unsigned int MON_TIMEOUT        = 5000U;
 /* topics blacklist as regular expression (will not be monitored) */
-constexpr char MON_FILTER_EXCL[]        =    "^__.*$";
+constexpr const char* MON_FILTER_EXCL     =    "^__.*$";
 /* topics whitelist as regular expression (will be monitored only) */
-constexpr char MON_FILTER_INCL[]        =    "";
+constexpr const char* MON_FILTER_INCL     =    "";
 
 /* logging filter settings */
-constexpr char MON_LOG_FILTER_CON[]     = "info,warning,error,fatal";
-constexpr char MON_LOG_FILTER_FILE[]    = "";
-constexpr char MON_LOG_FILTER_UDP[]     = "info,warning,error,fatal";
+constexpr const char* MON_LOG_FILTER_CON  = "info,warning,error,fatal";
+constexpr const char* MON_LOG_FILTER_FILE = "";
+constexpr const char* MON_LOG_FILTER_UDP  = "info,warning,error,fatal";
 
 
 /**********************************************************************************************/
 /*                                     sys settings                                       */
 /**********************************************************************************************/
 /* sys app witch will not be imported from cloud */
-constexpr char SYS_FILTER_EXCL[]        = "^eCALSysClient$|^eCALSysGUI$|^eCALSys$*";
+constexpr const char* SYS_FILTER_EXCL     = "^eCALSysClient$|^eCALSysGUI$|^eCALSys$*";
 
 /**********************************************************************************************/
 /*                                     network settings                                       */
@@ -68,20 +66,20 @@ constexpr char SYS_FILTER_EXCL[]        = "^eCALSysClient$|^eCALSysGUI$|^eCALSys
 constexpr bool NET_ENABLED              = false;
 
 /* eCAL udp multicast defines */
-constexpr char NET_UDP_MULTICAST_CONFIG_VERSION[]         = "v1";
-constexpr char NET_UDP_MULTICAST_GROUP[]                  = "239.0.0.1";
-constexpr char NET_UDP_MULTICAST_MASK[]                   = "0.0.0.15";
-constexpr unsigned int NET_UDP_MULTICAST_PORT             = 14000;
-constexpr unsigned int NET_UDP_MULTICAST_TTL              = 3;
-constexpr unsigned int NET_UDP_MULTICAST_PORT_REG_OFF     = 0;
-constexpr unsigned int NET_UDP_MULTICAST_PORT_LOG_OFF     = 1;
-constexpr unsigned int NET_UDP_MULTICAST_PORT_SAMPLE_OFF  = 2;
-constexpr unsigned int NET_UDP_MULTICAST_SNDBUF           = (5*1024*1024);  /* 5 MByte */
-constexpr unsigned int NET_UDP_MULTICAST_RCVBUF           = (5*1024*1024);  /* 5 MByte */
+constexpr const char* NET_UDP_MULTICAST_CONFIG_VERSION    = "v1";
+constexpr const char* NET_UDP_MULTICAST_GROUP             = "239.0.0.1";
+constexpr const char* NET_UDP_MULTICAST_MASK              = "0.0.0.15";
+constexpr unsigned int NET_UDP_MULTICAST_PORT             = 14000U;
+constexpr unsigned int NET_UDP_MULTICAST_TTL              = 3U;
+constexpr unsigned int NET_UDP_MULTICAST_PORT_REG_OFF     = 0U;
+constexpr unsigned int NET_UDP_MULTICAST_PORT_LOG_OFF     = 1U;
+constexpr unsigned int NET_UDP_MULTICAST_PORT_SAMPLE_OFF  = 2U;
+constexpr unsigned int NET_UDP_MULTICAST_SNDBUF           = (5U*1024U*1024U);  /* 5 MByte */
+constexpr unsigned int NET_UDP_MULTICAST_RCVBUF           = (5U*1024U*1024U);  /* 5 MByte */
 constexpr bool NET_UDP_MULTICAST_JOIN_ALL_IF_ENABLED      = false;
 
-constexpr unsigned int NET_UDP_RECBUFFER_TIMEOUT          = 1000;  /* ms */
-constexpr unsigned int NET_UDP_RECBUFFER_CLEANUP          = 10;    /* ms */
+constexpr unsigned int NET_UDP_RECBUFFER_TIMEOUT          = 1000U;  /* ms */
+constexpr unsigned int NET_UDP_RECBUFFER_CLEANUP          = 10U;    /* ms */
 
 /* overall udp multicast bandwidth limitation in bytes/s, -1 == no limitation*/
 constexpr int NET_BANDWIDTH_MAX_UDP                       = (-1);
@@ -93,39 +91,39 @@ constexpr bool NET_UDP_MC_REC_ENABLED                     = true;
 
 constexpr bool NET_NPCAP_ENABLED                          = false;
 
-constexpr unsigned int NET_TCP_PUBSUB_NUM_EXECUTOR_READER = 4;
-constexpr unsigned int NET_TCP_PUBSUB_NUM_EXECUTOR_WRITER = 4;
-constexpr unsigned int NET_TCP_PUBSUB_MAX_RECONNECTIONS   = 5;
+constexpr unsigned int NET_TCP_PUBSUB_NUM_EXECUTOR_READER = 4U;
+constexpr unsigned int NET_TCP_PUBSUB_NUM_EXECUTOR_WRITER = 4U;
+constexpr unsigned int NET_TCP_PUBSUB_MAX_RECONNECTIONS   = 5U;
 
 /* common host group name that enables interprocess mechanisms across (virtual) host borders (e.g, Docker); by default equivalent to local host name */
-constexpr char NET_HOST_GROUP_NAME[]                      = "";
+constexpr const char* NET_HOST_GROUP_NAME                 = "";
 
 /**********************************************************************************************/
 /*                                     publisher settings                                     */
 /**********************************************************************************************/
 /* use shared memory transport layer [auto = 2, on = 1, off = 0] */
-constexpr unsigned int PUB_USE_SHM                        = 2;
+constexpr unsigned int PUB_USE_SHM                        = 2U;
 /* use tcp transport layer           [auto = 2, on = 1, off = 0] */
-constexpr unsigned int PUB_USE_TCP                        = 0;
+constexpr unsigned int PUB_USE_TCP                        = 0U;
 /* use udp multicast transport layer [auto = 2, on = 1, off = 0] */
-constexpr unsigned int PUB_USE_UDP_MC                     = 2;
+constexpr unsigned int PUB_USE_UDP_MC                     = 2U;
 
 /* share topic type                  [          on = 1, off = 0] */
-constexpr unsigned int PUB_SHARE_TTYPE                    = 1;
+constexpr unsigned int PUB_SHARE_TTYPE                    = 1U;
 /* share topic description           [          on = 1, off = 0] */
-constexpr unsigned int PUB_SHARE_TDESC                    = 1;
+constexpr unsigned int PUB_SHARE_TDESC                    = 1U;
 
 /* minimum size for created shared memory files */
-constexpr unsigned int PUB_MEMFILE_MINSIZE                = (4*1024);
+constexpr unsigned int PUB_MEMFILE_MINSIZE                = (4U*1024U);
 /* reserve buffer size before reallocation in % */
-constexpr unsigned int PUB_MEMFILE_RESERVE                = 50;
+constexpr unsigned int PUB_MEMFILE_RESERVE                = 50U;
 
 /* timeout for create / open a memory file using mutex lock in ms */
-constexpr unsigned int PUB_MEMFILE_CREATE_TO              = 200;
-constexpr unsigned int PUB_MEMFILE_OPEN_TO                = 200;
+constexpr unsigned int PUB_MEMFILE_CREATE_TO              = 200U;
+constexpr unsigned int PUB_MEMFILE_OPEN_TO                = 200U;
 
 /* timeout for memory read acknowledge signal from data reader in ms */
-constexpr unsigned int PUB_MEMFILE_ACK_TO                 = 0;  /* ms */
+constexpr unsigned int PUB_MEMFILE_ACK_TO                 = 0U;  /* ms */
 
 /* defines number of memory files handle by the publisher for a 1:n connection
    a higher number will increase data throughput, but will also increase the size of used memory, number of semaphores
@@ -133,54 +131,54 @@ constexpr unsigned int PUB_MEMFILE_ACK_TO                 = 0;  /* ms */
    higher values than 3 are not recommended
    values > 1 will break local IPC compatibility to eCAL 5.9 and older
 */
-constexpr unsigned int PUB_MEMFILE_BUF_COUNT              = 1;
+constexpr unsigned int PUB_MEMFILE_BUF_COUNT              = 1U;
 
 /* allow subscriber to access memory file without copying content in advance (zero copy)
    this memory file is blocked for other readers wihle processed by the user callback function
    this option is fully IPC compatible to all eCAL 5.x versions
 */
-constexpr unsigned int PUB_MEMFILE_ZERO_COPY              = 0;
+constexpr unsigned int PUB_MEMFILE_ZERO_COPY              = 0U;
 
 /**********************************************************************************************/
 /*                                     service settings                                       */
 /**********************************************************************************************/
 /* support service protocol v0, eCAL 5.11 and older (0 = off, 1 = on) */
-constexpr unsigned int SERVICE_PROTOCOL_V0                = 1;
+constexpr unsigned int SERVICE_PROTOCOL_V0                = 1U;
 
 /* support service protocol v1, eCAL 5.12 and newer (0 = off, 1 = on) */
-constexpr unsigned int SERVICE_PROTOCOL_V1                = 1;
+constexpr unsigned int SERVICE_PROTOCOL_V1                = 1U;
 
 /**********************************************************************************************/
 /*                                     time settings                                          */
 /**********************************************************************************************/
-constexpr char TIME_SYNC_MOD_RT[]                         = "";
-constexpr char TIME_SYNC_MOD_REPLAY[]                     = "";
+constexpr const char* TIME_SYNC_MOD_RT                    = "";
+constexpr const char* TIME_SYNC_MOD_REPLAY                = "";
 
 /**********************************************************************************************/
 /*                                     process settings                                       */
 /**********************************************************************************************/
-constexpr char PROCESS_TERMINAL_EMULATOR[]                = "";
+constexpr const char* PROCESS_TERMINAL_EMULATOR           = "";
 
 /**********************************************************************************************/
 /*                                     ecal internal timings                                  */
 /**********************************************************************************************/
 /* timeout for automatic removing registered topics and memory files in global database in ms */
-constexpr unsigned int CMN_REGISTRATION_TO                  = (60*1000);
+constexpr unsigned int CMN_REGISTRATION_TO                  = (60U*1000U);
 
 /* time for resend registration info from publisher/subscriber in ms */
-constexpr unsigned int CMN_REGISTRATION_REFRESH             = 1000;
+constexpr unsigned int CMN_REGISTRATION_REFRESH             = 1000U;
 
 /* delta time to check timeout for data readers in ms */
-constexpr unsigned int CMN_DATAREADER_TIMEOUT_RESOLUTION_MS = 100;
+constexpr unsigned int CMN_DATAREADER_TIMEOUT_RESOLUTION_MS = 100U;
 
 /* cylce time udp receive threads in ms */
-constexpr unsigned int CMN_UDP_RECEIVE_THREAD_CYCLE_TIME_MS = 1000;
+constexpr unsigned int CMN_UDP_RECEIVE_THREAD_CYCLE_TIME_MS = 1000U;
 
 /**********************************************************************************************/
 /*                                     events                                                 */
 /**********************************************************************************************/
 /* common stop event prefix to shut down a local user process */
-constexpr char EVENT_SHUTDOWN_PROC[]                        = "ecal_shutdown_process";
+constexpr const char* EVENT_SHUTDOWN_PROC                   = "ecal_shutdown_process";
 
 /**********************************************************************************************/
 /*                                     experimental                                           */
@@ -190,11 +188,11 @@ constexpr bool EXP_SHM_MONITORING_ENABLED                   = false;
 /* disable distribution of monitoring/registration information via network (default) */
 constexpr bool EXP_NETWORK_MONITORING_DISABLED              = false;
 /* queue size of monitoring/registration events  */
-constexpr unsigned int EXP_SHM_MONITORING_QUEUE_SIZE        = 1024;
+constexpr unsigned int EXP_SHM_MONITORING_QUEUE_SIZE        = 1024U;
 /* domain name for shared memory based monitoring/registration */
-constexpr char EXP_SHM_MONITORING_DOMAIN[]                  = "ecal_monitoring";
+constexpr const char* EXP_SHM_MONITORING_DOMAIN             = "ecal_monitoring";
 /* memory file access timeout */
-constexpr unsigned int EXP_MEMFILE_ACCESS_TIMEOUT           = 100;
+constexpr unsigned int EXP_MEMFILE_ACCESS_TIMEOUT           = 100U;
 
 /* enable dropping of payload messages that arrive out of order */
 constexpr bool EXP_DROP_OUT_OF_ORDER_MESSAGES               = false;

--- a/ecal/core/src/ecal_def_ini.h
+++ b/ecal/core/src/ecal_def_ini.h
@@ -20,7 +20,7 @@
 /**
  * @brief  eCAL ini file keys
 **/
-
+// TODO PG: Delete - deprecated
 #pragma once
 
 /////////////////////////////////////

--- a/ecal/core/src/ecal_def_ini.h
+++ b/ecal/core/src/ecal_def_ini.h
@@ -20,111 +20,111 @@
 /**
  * @brief  eCAL ini file keys
 **/
-// TODO PG: Delete - deprecated
+
 #pragma once
 
 /////////////////////////////////////
 // common
 /////////////////////////////////////
-#define  CMN_SECTION_S                             "common"
-#define  CMN_REGISTRATION_TO_S                     "registration_timeout"
-#define  CMN_REGISTRATION_REFRESH_S                "registration_refresh"
+constexpr const char*   CMN_SECTION_S                             = "common";
+constexpr const char*   CMN_REGISTRATION_TO_S                     = "registration_timeout";
+constexpr const char*   CMN_REGISTRATION_REFRESH_S                = "registration_refresh";
 
 /////////////////////////////////////
 // network
 /////////////////////////////////////
-#define  NET_SECTION_S                             "network"
+constexpr const char*   NET_SECTION_S                             = "network";
 
-#define  NET_ENABLED_S                             "network_enabled"
+constexpr const char*   NET_ENABLED_S                             = "network_enabled";
 
-#define  NET_UDP_MULTICAST_CONFIG_VERSION_S        "multicast_config_version"
-#define  NET_UDP_MULTICAST_GROUP_S                 "multicast_group"
-#define  NET_UDP_MULTICAST_MASK_S                  "multicast_mask"
-#define  NET_UDP_MULTICAST_PORT_S                  "multicast_port"
-#define  NET_UDP_MULTICAST_TTL_S                   "multicast_ttl"
+constexpr const char*   NET_UDP_MULTICAST_CONFIG_VERSION_S        = "multicast_config_version";
+constexpr const char*   NET_UDP_MULTICAST_GROUP_S                 = "multicast_group";
+constexpr const char*   NET_UDP_MULTICAST_MASK_S                  = "multicast_mask";
+constexpr const char*   NET_UDP_MULTICAST_PORT_S                  = "multicast_port";
+constexpr const char*   NET_UDP_MULTICAST_TTL_S                   = "multicast_ttl";
 
-#define  NET_UDP_MULTICAST_SNDBUF_S                "multicast_sndbuf"
-#define  NET_UDP_MULTICAST_RCVBUF_S                "multicast_rcvbuf"
+constexpr const char*   NET_UDP_MULTICAST_SNDBUF_S                = "multicast_sndbuf";
+constexpr const char*   NET_UDP_MULTICAST_RCVBUF_S                = "multicast_rcvbuf";
 
-#define  NET_UDP_MULTICAST_JOIN_ALL_IF_ENABLED_S   "multicast_join_all_if"
+constexpr const char*   NET_UDP_MULTICAST_JOIN_ALL_IF_ENABLED_S   = "multicast_join_all_if";
 
-#define  NET_UDP_MC_REC_ENABLED_S                  "udp_mc_rec_enabled"
-#define  NET_SHM_REC_ENABLED_S                     "shm_rec_enabled"
-#define  NET_TCP_REC_ENABLED_S                     "tcp_rec_enabled"
+constexpr const char*   NET_UDP_MC_REC_ENABLED_S                  = "udp_mc_rec_enabled";
+constexpr const char*   NET_SHM_REC_ENABLED_S                     = "shm_rec_enabled";
+constexpr const char*   NET_TCP_REC_ENABLED_S                     = "tcp_rec_enabled";
 
-#define  NET_NPCAP_ENABLED_S                       "npcap_enabled"
+constexpr const char*   NET_NPCAP_ENABLED_S                       = "npcap_enabled";
 
-#define  NET_TCP_PUBSUB_NUM_EXECUTOR_READER_S      "tcp_pubsub_num_executor_reader"
-#define  NET_TCP_PUBSUB_NUM_EXECUTOR_WRITER_S      "tcp_pubsub_num_executor_writer"
-#define  NET_TCP_PUBSUB_MAX_RECONNECTIONS_S        "tcp_pubsub_max_reconnections"
+constexpr const char*   NET_TCP_PUBSUB_NUM_EXECUTOR_READER_S      = "tcp_pubsub_num_executor_reader";
+constexpr const char*   NET_TCP_PUBSUB_NUM_EXECUTOR_WRITER_S      = "tcp_pubsub_num_executor_writer";
+constexpr const char*   NET_TCP_PUBSUB_MAX_RECONNECTIONS_S        = "tcp_pubsub_max_reconnections";
 
-#define  NET_HOST_GROUP_NAME_S                     "host_group_name"
+constexpr const char*   NET_HOST_GROUP_NAME_S                     = "host_group_name";
 
 /////////////////////////////////////
 // time
 /////////////////////////////////////
-#define  TIME_SECTION_S                            "time"
-#define  TIME_SYNC_MOD_RT_S                        "timesync_module_rt"
-#define  TIME_SYNC_MOD_REPLAY_S                    "timesync_module_replay"
+constexpr const char*   TIME_SECTION_S                            = "time";
+constexpr const char*   TIME_SYNC_MOD_RT_S                        = "timesync_module_rt";
+constexpr const char*   TIME_SYNC_MOD_REPLAY_S                    = "timesync_module_replay";
 
 /////////////////////////////////////
 // process
 /////////////////////////////////////
-#define  PROCESS_SECTION_S                         "process"
-#define  PROCESS_TERMINAL_EMULATOR_S               "terminal_emulator"
+constexpr const char*   PROCESS_SECTION_S                         = "process";
+constexpr const char*   PROCESS_TERMINAL_EMULATOR_S               = "terminal_emulator";
 
 /////////////////////////////////////
 // monitoring
 /////////////////////////////////////
-#define  MON_SECTION_S                             "monitoring"
+constexpr const char*   MON_SECTION_S                             = "monitoring";
 
-#define  MON_TIMEOUT_S                             "timeout"
-#define  MON_FILTER_EXCL_S                         "filter_excl"
-#define  MON_FILTER_INCL_S                         "filter_incl"
+constexpr const char*   MON_TIMEOUT_S                             = "timeout";
+constexpr const char*   MON_FILTER_EXCL_S                         = "filter_excl";
+constexpr const char*   MON_FILTER_INCL_S                         = "filter_incl";
 
-#define  MON_LOG_FILTER_CON_S                      "filter_log_con"
-#define  MON_LOG_FILTER_FILE_S                     "filter_log_file"
-#define  MON_LOG_FILTER_UDP_S                      "filter_log_udp"
+constexpr const char*   MON_LOG_FILTER_CON_S                      = "filter_log_con";
+constexpr const char*   MON_LOG_FILTER_FILE_S                     = "filter_log_file";
+constexpr const char*   MON_LOG_FILTER_UDP_S                      = "filter_log_udp";
 
 /////////////////////////////////////
 // sys
 /////////////////////////////////////
-#define  SYS_SECTION_S                             "sys"
-#define  SYS_FILTER_EXCL_S                         "filter_excl"
+constexpr const char*   SYS_SECTION_S                             = "sys";
+constexpr const char*   SYS_FILTER_EXCL_S                         = "filter_excl";
 
 /////////////////////////////////////
 // publisher
 /////////////////////////////////////
-#define  PUB_SECTION_S                             "publisher"
+constexpr const char*   PUB_SECTION_S                             = "publisher";
 
-#define  PUB_USE_UDP_MC_S                          "use_udp_mc"
-#define  PUB_USE_SHM_S                             "use_shm"
-#define  PUB_USE_TCP_S                             "use_tcp"
+constexpr const char*   PUB_USE_UDP_MC_S                          = "use_udp_mc";
+constexpr const char*   PUB_USE_SHM_S                             = "use_shm";
+constexpr const char*   PUB_USE_TCP_S                             = "use_tcp";
 
-#define  PUB_MEMFILE_MINSIZE_S                     "memfile_minsize"
-#define  PUB_MEMFILE_RESERVE_S                     "memfile_reserve"
-#define  PUB_MEMFILE_ACK_TO_S                      "memfile_ack_timeout"
-#define  PUB_MEMFILE_ZERO_COPY_S                   "memfile_zero_copy"
-#define  PUB_MEMFILE_BUF_COUNT_S                   "memfile_buffer_count"
+constexpr const char*   PUB_MEMFILE_MINSIZE_S                     = "memfile_minsize";
+constexpr const char*   PUB_MEMFILE_RESERVE_S                     = "memfile_reserve";
+constexpr const char*   PUB_MEMFILE_ACK_TO_S                      = "memfile_ack_timeout";
+constexpr const char*   PUB_MEMFILE_ZERO_COPY_S                   = "memfile_zero_copy";
+constexpr const char*   PUB_MEMFILE_BUF_COUNT_S                   = "memfile_buffer_count";
 
-#define  PUB_SHARE_TTYPE_S                         "share_ttype"
-#define  PUB_SHARE_TDESC_S                         "share_tdesc"
+constexpr const char*   PUB_SHARE_TTYPE_S                         = "share_ttype";
+constexpr const char*   PUB_SHARE_TDESC_S                         = "share_tdesc";
 
 /////////////////////////////////////
 // service
 /////////////////////////////////////
-#define  SERVICE_SECTION_S                         "service"
+constexpr const char*   SERVICE_SECTION_S                         = "service";
 
-#define  SERVICE_PROTOCOL_V0_S                     "protocol_v0"
-#define  SERVICE_PROTOCOL_V1_S                     "protocol_v1"
+constexpr const char*   SERVICE_PROTOCOL_V0_S                     = "protocol_v0";
+constexpr const char*   SERVICE_PROTOCOL_V1_S                     = "protocol_v1";
 
 /////////////////////////////////////
 // experimental
 /////////////////////////////////////
-#define  EXP_SECTION_S                             "experimental"
+constexpr const char*   EXP_SECTION_S                             = "experimental";
 
-#define  EXP_SHM_MONITORING_ENABLED_S              "shm_monitoring_enabled"
-#define  EXP_NETWORK_MONITORING_DISABLED_S         "network_monitoring_disabled"
-#define  EXP_SHM_MONITORING_QUEUE_SIZE_S           "shm_monitoring_queue_size"
-#define  EXP_SHM_MONITORING_DOMAIN_S               "shm_monitoring_domain"
-#define  EXP_DROP_OUT_OF_ORDER_MESSAGES_S          "drop_out_of_order_messages"
+constexpr const char*   EXP_SHM_MONITORING_ENABLED_S              = "shm_monitoring_enabled";
+constexpr const char*   EXP_NETWORK_MONITORING_DISABLED_S         = "network_monitoring_disabled";
+constexpr const char*   EXP_SHM_MONITORING_QUEUE_SIZE_S           = "shm_monitoring_queue_size";
+constexpr const char*   EXP_SHM_MONITORING_DOMAIN_S               = "shm_monitoring_domain";
+constexpr const char*   EXP_DROP_OUT_OF_ORDER_MESSAGES_S          = "drop_out_of_order_messages";


### PR DESCRIPTION
### Description
ecal_def.h and ecal_def_ini.h converted from defines to use constexpr.
In addition, ecal_config_reader.h/.cpp got a unsigned int and size_t read function.

