### PR TITLE
[core] active entity unregistration in descgate

### DIFF
--- a/ecal/core/include/ecal/cimpl/ecal_util_cimpl.h
+++ b/ecal/core/include/ecal/cimpl/ecal_util_cimpl.h
@@ -151,6 +151,57 @@ extern "C"
    * @return  Response description buffer length or zero if failed.
   **/
   ECALC_API int eCAL_Util_GetServiceResponseDescription(const char* service_name_, const char* method_name_, void* resp_desc_, int resp_desc_len_);
+
+  /**
+   * @brief Gets client method request type name.
+   *
+   * @param       client_name_   Client name.
+   * @param       method_name_   Method name.
+   * @param [out] req_type_      Pointer to store the request type.
+   * @param       req_type_len_  Length of allocated buffer or ECAL_ALLOCATE_4ME if
+   *                             eCAL should allocate the buffer for you (see eCAL_FreeMem).
+   *
+   * @return  Type name buffer length or zero if failed.
+  **/
+  ECALC_API int eCAL_Util_GetClientRequestTypeName(const char* client_name_, const char* method_name_, void* req_type_, int req_type_len_);
+
+  /**
+   * @brief Gets client method response type name.
+   *
+   * @param       client_name_   Client name.
+   * @param       method_name_   Method name.
+   * @param [out] resp_type_     Pointer to store the response type.
+   * @param       resp_type_len_ Length of allocated buffer or ECAL_ALLOCATE_4ME if
+   *
+   * @return  Type name buffer length or zero if failed.
+  **/
+  ECALC_API int eCAL_Util_GetClientResponseTypeName(const char* client_name_, const char* method_name_, void* resp_type_, int resp_type_len_);
+
+  /**
+   * @brief Gets client method request description.
+   *
+   * @param       client_name_   Client name.
+   * @param       method_name_   Method name.
+   * @param [out] req_desc_      Pointer to store the request description.
+   * @param       req_desc_len_  Length of allocated buffer or ECAL_ALLOCATE_4ME if
+   *                             eCAL should allocate the buffer for you (see eCAL_FreeMem).
+   *
+   * @return  Request description buffer length or zero if failed.
+  **/
+  ECALC_API int eCAL_Util_GetClientRequestDescription(const char* client_name_, const char* method_name_, void* req_desc_, int req_desc_len_);
+
+  /**
+   * @brief Gets client method response description.
+   *
+   * @param       client_name_   Client name.
+   * @param       method_name_   Method name.
+   * @param [out] resp_desc_     Pointer to store the response description.
+   * @param       resp_desc_len_ Length of allocated buffer or ECAL_ALLOCATE_4ME if
+   *                             eCAL should allocate the buffer for you (see eCAL_FreeMem).
+   *
+   * @return  Response description buffer length or zero if failed.
+  **/
+  ECALC_API int eCAL_Util_GetClientResponseDescription(const char* client_name_, const char* method_name_, void* resp_desc_, int resp_desc_len_);
 #ifdef __cplusplus
 }
 #endif /*__cplusplus*/

--- a/ecal/core/include/ecal/ecal_util.h
+++ b/ecal/core/include/ecal/ecal_util.h
@@ -161,7 +161,7 @@ namespace eCAL
      *
      * @param service_method_names_ Vector to store the service/method tuples (Vector { (ServiceName, MethodName) }).
     **/
-    ECAL_API void GetServiceNames(std::vector<std::tuple<std::string, std::string>>& service_method_names_);
+    ECAL_API void GetServiceMethodNames(std::vector<std::tuple<std::string, std::string>>& service_method_names_);
 
     /**
      * @brief Gets service method request and response type names.
@@ -186,6 +186,45 @@ namespace eCAL
      * @return  True if succeeded.
     **/
     ECAL_API bool GetServiceDescription(const std::string& service_name_, const std::string& method_name_, std::string& req_desc_, std::string& resp_desc_);
+
+    /**
+     * @brief Get complete client map (including request and response types and descriptions).
+     *
+     * @param client_info_map_  Map to store the datatype descriptions.
+     *                          Map { (ClientName, MethodName) -> ( (ReqType, ReqDescription), (RespType, RespDescription) ) } mapping of all currently known clients.
+    **/
+    ECAL_API void GetClients(std::map<std::tuple<std::string, std::string>, SServiceMethodInformation>& client_info_map_);
+
+    /**
+     * @brief Get all client/method names.
+     *
+     * @param client_method_names_ Vector to store the client/method tuples (Vector { (ClientName, MethodName) }).
+    **/
+    ECAL_API void GetClientMethodNames(std::vector<std::tuple<std::string, std::string>>& client_method_names_);
+
+    /**
+     * @brief Gets client method request and response type names.
+     *
+     * @param client_name_  Client name.
+     * @param method_name_  Method name.
+     * @param req_type_     String to store request type.
+     * @param resp_type_    String to store response type.
+     *
+     * @return  True if succeeded.
+    **/
+    ECAL_API bool GetClientTypeNames(const std::string& client_name_, const std::string& method_name_, std::string& req_type_, std::string& resp_type_);
+
+    /**
+     * @brief Gets client method request and response descriptions.
+     *
+     * @param client_name_  Client name.
+     * @param method_name_  Method name.
+     * @param req_desc_     String to store request description.
+     * @param resp_desc_    String to store response description.
+     *
+     * @return  True if succeeded.
+    **/
+    ECAL_API bool GetClientDescription(const std::string& client_name_, const std::string& method_name_, std::string& req_desc_, std::string& resp_desc_);
 
     /**
      * @brief Splits the topic type (eCAL < 5.12) into encoding and types (>= eCAL 5.12)

--- a/ecal/core/src/cimpl/ecal_util_cimpl.cpp
+++ b/ecal/core/src/cimpl/ecal_util_cimpl.cpp
@@ -148,4 +148,60 @@ extern "C"
     }
     return 0;
   }
+
+  ECALC_API int eCAL_Util_GetClientRequestTypeName(const char* client_name_, const char* method_name_, void* req_type_, int req_type_len_)
+  {
+    if (client_name_ == nullptr) return(0);
+    if (method_name_ == nullptr) return(0);
+    if (req_type_ == nullptr)    return(0);
+    std::string req_type;
+    std::string resp_type;
+    if (eCAL::Util::GetClientTypeNames(client_name_, method_name_, req_type, resp_type))
+    {
+      return(CopyBuffer(req_type_, req_type_len_, req_type));
+    }
+    return 0;
+  }
+
+  ECALC_API int eCAL_Util_GetClientResponseTypeName(const char* client_name_, const char* method_name_, void* resp_type_, int resp_type_len_)
+  {
+    if (client_name_ == nullptr) return(0);
+    if (method_name_ == nullptr) return(0);
+    if (resp_type_ == nullptr)   return(0);
+    std::string req_type;
+    std::string resp_type;
+    if (eCAL::Util::GetClientTypeNames(client_name_, method_name_, req_type, resp_type))
+    {
+      return(CopyBuffer(resp_type_, resp_type_len_, resp_type));
+    }
+    return 0;
+  }
+
+  ECALC_API int eCAL_Util_GetClientRequestDescription(const char* client_name_, const char* method_name_, void* req_desc_, int req_desc_len_)
+  {
+    if (client_name_ == nullptr) return(0);
+    if (method_name_ == nullptr) return(0);
+    if (req_desc_ == nullptr)    return(0);
+    std::string req_desc;
+    std::string resp_desc;
+    if (eCAL::Util::GetClientDescription(client_name_, method_name_, req_desc, resp_desc))
+    {
+      return(CopyBuffer(req_desc_, req_desc_len_, req_desc));
+    }
+    return 0;
+  }
+
+  ECALC_API int eCAL_Util_GetClientResponseDescription(const char* client_name_, const char* method_name_, void* resp_desc_, int resp_desc_len_)
+  {
+    if (client_name_ == nullptr) return(0);
+    if (method_name_ == nullptr) return(0);
+    if (resp_desc_ == nullptr)   return(0);
+    std::string req_desc;
+    std::string resp_desc;
+    if (eCAL::Util::GetClientDescription(client_name_, method_name_, req_desc, resp_desc))
+    {
+      return(CopyBuffer(resp_desc_, resp_desc_len_, resp_desc));
+    }
+    return 0;
+  }
 }

--- a/ecal/core/src/ecal_descgate.cpp
+++ b/ecal/core/src/ecal_descgate.cpp
@@ -39,10 +39,24 @@ namespace
       quality |= eCAL::CDescGate::QualityFlags::TYPE_AVAILABLE;
     if (!(request_info_.descriptor.empty() && response_info_.descriptor.empty()))
       quality |= eCAL::CDescGate::QualityFlags::DESCRIPTION_AVAILABLE;
+    quality |= eCAL::CDescGate::QualityFlags::INFO_COMES_FROM_PRODUCER;
 
     return quality;
   }
 
+  // TODO: remove me with new CDescGate
+  eCAL::CDescGate::QualityFlags GetClientMethodQuality(const eCAL::SDataTypeInformation& request_info_, const eCAL::SDataTypeInformation& response_info_)
+  {
+    eCAL::CDescGate::QualityFlags quality = eCAL::CDescGate::QualityFlags::NO_QUALITY;
+    if (!(request_info_.name.empty() && response_info_.name.empty()))
+      quality |= eCAL::CDescGate::QualityFlags::TYPE_AVAILABLE;
+    if (!(request_info_.descriptor.empty() && response_info_.descriptor.empty()))
+      quality |= eCAL::CDescGate::QualityFlags::DESCRIPTION_AVAILABLE;
+
+    return quality;
+  }
+
+  // TODO: remove me with new CDescGate
   eCAL::CDescGate::QualityFlags GetPublisherQuality(const eCAL::SDataTypeInformation& topic_info_)
   {
     eCAL::CDescGate::QualityFlags quality = eCAL::CDescGate::QualityFlags::NO_QUALITY;
@@ -56,6 +70,7 @@ namespace
     return quality;
   }
 
+  // TODO: remove me with new CDescGate
   eCAL::CDescGate::QualityFlags GetSubscriberQuality(const eCAL::SDataTypeInformation& topic_info_)
   {
     eCAL::CDescGate::QualityFlags quality = eCAL::CDescGate::QualityFlags::NO_QUALITY;
@@ -73,7 +88,8 @@ namespace eCAL
 {
   CDescGate::CDescGate() :
     m_topic_info_map(std::chrono::milliseconds(Config::GetMonitoringTimeoutMs())),
-    m_service_info_map(std::chrono::milliseconds(Config::GetMonitoringTimeoutMs()))
+    m_service_info_map(std::chrono::milliseconds(Config::GetMonitoringTimeoutMs())),
+    m_client_info_map(std::chrono::milliseconds(Config::GetMonitoringTimeoutMs()))
   {
   }
   CDescGate::~CDescGate() = default;
@@ -140,58 +156,42 @@ namespace eCAL
 
   void CDescGate::GetServices(std::map<std::tuple<std::string, std::string>, SServiceMethodInformation>& service_info_map_)
   {
-    std::map<std::tuple<std::string, std::string>, SServiceMethodInformation> map;
-
-    const std::lock_guard<std::mutex> lock(m_service_info_map.sync);
-    m_service_info_map.map->remove_deprecated();
-
-    for (const auto& service_info : (*m_service_info_map.map))
-    {
-      map.emplace(service_info.first, service_info.second.info);
-    }
-    service_info_map_.swap(map);
+    GetServices(service_info_map_, m_service_info_map);
   }
 
-  void CDescGate::GetServiceNames(std::vector<std::tuple<std::string, std::string>>& service_method_names_)
+  void CDescGate::GetServiceMethodNames(std::vector<std::tuple<std::string, std::string>>& service_method_names_)
   {
-    service_method_names_.clear();
-
-    const std::lock_guard<std::mutex> lock(m_service_info_map.sync);
-    m_service_info_map.map->remove_deprecated();
-    service_method_names_.reserve(m_service_info_map.map->size());
-
-    for (const auto& service_info : (*m_service_info_map.map))
-    {
-      service_method_names_.emplace_back(service_info.first);
-    }
+    GetServiceMethodNames(service_method_names_, m_service_info_map);
   }
 
   bool CDescGate::GetServiceTypeNames(const std::string& service_name_, const std::string& method_name_, std::string& req_type_name_, std::string& resp_type_name_)
   {
-    std::tuple<std::string, std::string> service_method_tuple = std::make_tuple(service_name_, method_name_);
-
-    const std::lock_guard<std::mutex> lock(m_service_info_map.sync);
-    m_service_info_map.map->remove_deprecated();
-    auto service_info_map_it = m_service_info_map.map->find(service_method_tuple);
-
-    if (service_info_map_it == m_service_info_map.map->end()) return false;
-    req_type_name_  = (*service_info_map_it).second.info.request_type.name;
-    resp_type_name_ = (*service_info_map_it).second.info.response_type.name;
-    return true;
+    return GetServiceTypeNames(service_name_, method_name_, req_type_name_, resp_type_name_, m_service_info_map);
   }
 
   bool CDescGate::GetServiceDescription(const std::string& service_name_, const std::string& method_name_, std::string& req_type_desc_, std::string& resp_type_desc_)
   {
-    std::tuple<std::string, std::string> service_method_tuple = std::make_tuple(service_name_, method_name_);
+    return GetServiceDescription(service_name_, method_name_, req_type_desc_, resp_type_desc_, m_service_info_map);
+  }
 
-    const std::lock_guard<std::mutex> lock(m_service_info_map.sync);
-    m_service_info_map.map->remove_deprecated();
-    auto service_info_map_it = m_service_info_map.map->find(service_method_tuple);
+  void CDescGate::GetClients(std::map<std::tuple<std::string, std::string>, SServiceMethodInformation>& service_info_map_)
+  {
+    GetServices(service_info_map_, m_client_info_map);
+  }
 
-    if (service_info_map_it == m_service_info_map.map->end()) return false;
-    req_type_desc_  = (*service_info_map_it).second.info.request_type.descriptor;
-    resp_type_desc_ = (*service_info_map_it).second.info.response_type.descriptor;
-    return true;
+  void CDescGate::GetClientMethodNames(std::vector<std::tuple<std::string, std::string>>& client_method_names_)
+  {
+    GetServiceMethodNames(client_method_names_, m_client_info_map);
+  }
+
+  bool CDescGate::GetClientTypeNames(const std::string& service_name_, const std::string& method_name_, std::string& req_type_name_, std::string& resp_type_name_)
+  {
+    return GetServiceTypeNames(service_name_, method_name_, req_type_name_, resp_type_name_, m_client_info_map);
+  }
+
+  bool CDescGate::GetClientDescription(const std::string& service_name_, const std::string& method_name_, std::string& req_type_desc_, std::string& resp_type_desc_)
+  {
+    return GetServiceDescription(service_name_, method_name_, req_type_desc_, resp_type_desc_, m_client_info_map);
   }
 
   bool CDescGate::ApplySample(const Registration::Sample& sample_, eTLayerType /*layer_*/)
@@ -215,42 +215,41 @@ namespace eCAL
         response_type.name       = method.resp_type;
         response_type.descriptor = method.resp_desc;
 
-        ApplyServiceDescription(sample_.service.sname, method.mname, request_type, response_type, GetServiceMethodQuality(request_type, response_type));
+        ApplyServiceDescription(m_service_info_map, sample_.service.sname, sample_.service.sid, method.mname, request_type, response_type, GetServiceMethodQuality(request_type, response_type));
       }
     }
     break;
     case bct_unreg_service:
-      // TODO: Implement fast unregistration
+      RemServiceDescription(m_service_info_map, sample_.service.sname, sample_.service.sid);
       break;
     case bct_reg_client:
-      // TODO: Implement this after client methods are available
-      //for (const auto& method : sample_.client.methods)
-      //{
-      //  SDataTypeInformation request_type;
-      //  request_type.name       = method.req_type;
-      //  request_type.descriptor = method.req_desc;
+      for (const auto& method : sample_.client.methods)
+      {
+        SDataTypeInformation request_type;
+        request_type.name       = method.req_type;
+        request_type.descriptor = method.req_desc;
 
-      //  SDataTypeInformation response_type{};
-      //  response_type.name       = method.resp_type;
-      //  response_type.descriptor = method.resp_desc;
+        SDataTypeInformation response_type{};
+        response_type.name       = method.resp_type;
+        response_type.descriptor = method.resp_desc;
 
-      //  ApplyClientDescription(sample_.service.sname, method.mname, request_type, response_type, GetQuality(sample_));
-      //}
+        ApplyServiceDescription(m_client_info_map, sample_.client.sname, sample_.client.sid, method.mname, request_type, response_type, GetClientMethodQuality(request_type, response_type));
+      }
       break;
     case bct_unreg_client:
-      // TODO: Implement fast unregistration
+      RemServiceDescription(m_client_info_map, sample_.client.sname, sample_.client.sid);
       break;
     case bct_reg_publisher:
-      ApplyTopicDescription(sample_.topic.tname, sample_.topic.tdatatype, GetPublisherQuality(sample_.topic.tdatatype));
+      ApplyTopicDescription(sample_.topic.tname, sample_.topic.tid, sample_.topic.tdatatype, GetPublisherQuality(sample_.topic.tdatatype));
       break;
     case bct_unreg_publisher:
-      // TODO: Implement fast unregistration
+      RemTopicDescription(sample_.topic.tname, sample_.topic.tid);
       break;
     case bct_reg_subscriber:
-      ApplyTopicDescription(sample_.topic.tname, sample_.topic.tdatatype, GetSubscriberQuality(sample_.topic.tdatatype));
+      ApplyTopicDescription(sample_.topic.tname, sample_.topic.tid, sample_.topic.tdatatype, GetSubscriberQuality(sample_.topic.tdatatype));
       break;
     case bct_unreg_subscriber:
-      // TODO: Implement fast unregistration
+      RemTopicDescription(sample_.topic.tname, sample_.topic.tid);
       break;
     default:
     {
@@ -262,7 +261,7 @@ namespace eCAL
     return true;
   }
 
-  bool CDescGate::ApplyTopicDescription(const std::string& topic_name_, const SDataTypeInformation& topic_info_, const QualityFlags description_quality_)
+  bool CDescGate::ApplyTopicDescription(const std::string& topic_name_, const std::string& topic_id_, const SDataTypeInformation& topic_info_, const QualityFlags description_quality_)
   {
     const std::unique_lock<std::mutex> lock(m_topic_info_map.sync);
     m_topic_info_map.map->remove_deprecated();
@@ -274,6 +273,7 @@ namespace eCAL
     {
       // create a new topic entry
       STopicInfoQuality& topic_info = (*m_topic_info_map.map)[topic_name_];
+      topic_info.id = topic_id_;
       topic_info.info = topic_info_;
       topic_info.quality = description_quality_;
       return true;
@@ -294,6 +294,7 @@ namespace eCAL
     if (description_quality_ > topic_info.quality)
     {
       // overwrite attributes
+      topic_info.id = topic_id_;
       topic_info.info = topic_info_;
       topic_info.quality = description_quality_;
 
@@ -303,6 +304,7 @@ namespace eCAL
     }
 
     // this is the same topic (topic name, topic type name, topic type description)
+    // independing from the unique id
     if (topic_info.info == topic_info_)
     {
       // update timestamp (by just accessing the entry) and return
@@ -402,7 +404,27 @@ namespace eCAL
     return false;
   }
 
-  bool CDescGate::ApplyServiceDescription(const std::string& service_name_
+  bool CDescGate::RemTopicDescription(const std::string& topic_name_, const std::string& topic_id_)
+  {
+    const std::unique_lock<std::mutex> lock(m_topic_info_map.sync);
+    m_topic_info_map.map->remove_deprecated();
+
+    const auto topic_info_it = m_topic_info_map.map->find(topic_name_);
+    if (topic_info_it != m_topic_info_map.map->end())
+    {
+      STopicInfoQuality& topic_info = (*m_topic_info_map.map)[topic_name_];
+      if (topic_info.id == topic_id_)
+      {
+        m_topic_info_map.map->erase(topic_name_);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool CDescGate::ApplyServiceDescription(SServiceMethodInfoMap& service_method_map_
+    , const std::string& service_name_
+    , const std::string& service_id_
     , const std::string& method_name_
     , const SDataTypeInformation& request_type_information_
     , const SDataTypeInformation& response_type_information_
@@ -410,35 +432,126 @@ namespace eCAL
   {
     std::tuple<std::string, std::string> service_method_tuple = std::make_tuple(service_name_, method_name_);
 
-    const std::lock_guard<std::mutex> lock(m_service_info_map.sync);
-    m_service_info_map.map->remove_deprecated();
+    const std::lock_guard<std::mutex> lock(service_method_map_.sync);
+    service_method_map_.map->remove_deprecated();
 
-    auto service_info_map_it = m_service_info_map.map->find(service_method_tuple);
-    if (service_info_map_it == m_service_info_map.map->end())
+    SServiceMethodInfoQuality req_service_info;
+    req_service_info.id = service_id_;
+    req_service_info.info.request_type = request_type_information_;
+    req_service_info.info.response_type = response_type_information_;
+    req_service_info.quality = description_quality_;
+
+    // create a new entry if service is not existing and return
+    auto service_info_map_it = service_method_map_.map->find(service_method_tuple);
+    if (service_info_map_it == service_method_map_.map->end())
     {
-      // create a new service entry
-      SServiceMethodInfoQuality& service_info = (*m_service_info_map.map)[service_method_tuple];
-      service_info.info.request_type = request_type_information_;
-      service_info.info.response_type = response_type_information_;
-      service_info.quality = description_quality_;
+      (*service_method_map_.map)[service_method_tuple] = req_service_info;
       return true;
     }
 
-    // let's check whether the current information has a higher quality
-    // if it has a higher quality, we overwrite it
-    bool ret_value(false);
+    // service is existing, the requested service has a higher quality
+    // overwrite the existing entry with the new attributes
     SServiceMethodInfoQuality service_info = (*service_info_map_it).second;
     if (description_quality_ > service_info.quality)
     {
-      service_info.info.request_type = request_type_information_;
-      service_info.info.response_type = response_type_information_;
-      service_info.quality = description_quality_;
-      ret_value = true;
+      (*service_method_map_.map)[service_method_tuple] = req_service_info;
+      return true;
     }
 
-    // update service entry (and its timestamp)
-    (*m_service_info_map.map)[service_method_tuple] = service_info;
+    // the entry is existing, the requested quality is not higher
+    // update the existing entry if it has the same attributes (independing from the unique id)
+    if (service_info.info == req_service_info.info)
+    {
+      (*service_method_map_.map)[service_method_tuple] = req_service_info;
+      return true;
+    }
 
-    return ret_value;
+    return false;
+  }
+
+  bool CDescGate::RemServiceDescription(SServiceMethodInfoMap& service_method_map_, const std::string& service_name_, const std::string& service_id_)
+  {
+    std::list<std::tuple<std::string, std::string>> service_method_tuple_to_remove;
+
+    const std::lock_guard<std::mutex> lock(service_method_map_.sync);
+    service_method_map_.map->remove_deprecated();
+
+    bool success(false);
+    for (auto&& service : *service_method_map_.map)
+    {
+      auto service_method_tuple = service.first;
+      if (std::get<0>(service_method_tuple) == service_name_)
+      {
+        auto service_info = service.second;
+        if (service_info.id == service_id_)
+        {
+          service_method_tuple_to_remove.push_back(service_method_tuple);
+          success =  true;
+        }
+      }
+    }
+
+    for (const auto& service_method_tuple : service_method_tuple_to_remove)
+    {
+      (*service_method_map_.map).erase(service_method_tuple);
+    }
+
+    return success;
+  }
+
+  void CDescGate::GetServices(std::map<std::tuple<std::string, std::string>, SServiceMethodInformation>& service_info_map_, const SServiceMethodInfoMap& service_method_map_)
+  {
+    std::map<std::tuple<std::string, std::string>, SServiceMethodInformation> map;
+
+    const std::lock_guard<std::mutex> lock(service_method_map_.sync);
+    service_method_map_.map->remove_deprecated();
+
+    for (const auto& service_info : (*service_method_map_.map))
+    {
+      map.emplace(service_info.first, service_info.second.info);
+    }
+    service_info_map_.swap(map);
+  }
+
+  void CDescGate::GetServiceMethodNames(std::vector<std::tuple<std::string, std::string>>& method_names_, const SServiceMethodInfoMap& service_method_map_)
+  {
+    method_names_.clear();
+
+    const std::lock_guard<std::mutex> lock(service_method_map_.sync);
+    service_method_map_.map->remove_deprecated();
+    method_names_.reserve(service_method_map_.map->size());
+
+    for (const auto& service_info : (*service_method_map_.map))
+    {
+      method_names_.emplace_back(service_info.first);
+    }
+  }
+
+  bool CDescGate::GetServiceTypeNames(const std::string& service_name_, const std::string& method_name_, std::string& req_type_name_, std::string& resp_type_name_, const SServiceMethodInfoMap& service_method_map_)
+  {
+    std::tuple<std::string, std::string> service_method_tuple = std::make_tuple(service_name_, method_name_);
+
+    const std::lock_guard<std::mutex> lock(service_method_map_.sync);
+    service_method_map_.map->remove_deprecated();
+    auto service_info_map_it = service_method_map_.map->find(service_method_tuple);
+
+    if (service_info_map_it == service_method_map_.map->end()) return false;
+    req_type_name_ = (*service_info_map_it).second.info.request_type.name;
+    resp_type_name_ = (*service_info_map_it).second.info.response_type.name;
+    return true;
+  }
+
+  bool CDescGate::GetServiceDescription(const std::string& service_name_, const std::string& method_name_, std::string& req_type_desc_, std::string& resp_type_desc_, const SServiceMethodInfoMap& service_method_map_)
+  {
+    std::tuple<std::string, std::string> service_method_tuple = std::make_tuple(service_name_, method_name_);
+
+    const std::lock_guard<std::mutex> lock(service_method_map_.sync);
+    service_method_map_.map->remove_deprecated();
+    auto service_info_map_it = service_method_map_.map->find(service_method_tuple);
+
+    if (service_info_map_it == service_method_map_.map->end()) return false;
+    req_type_desc_ = (*service_info_map_it).second.info.request_type.descriptor;
+    resp_type_desc_ = (*service_info_map_it).second.info.response_type.descriptor;
+    return true;
   }
 }

--- a/ecal/core/src/ecal_descgate.cpp
+++ b/ecal/core/src/ecal_descgate.cpp
@@ -459,10 +459,10 @@ namespace eCAL
     }
 
     // the entry is existing, the requested quality is not higher
-    // update the existing entry if it has the same attributes (independing from the unique id)
+    // update the timestamp of the existing entry
     if (service_info.info == req_service_info.info)
     {
-      (*service_method_map_.map)[service_method_tuple] = req_service_info;
+      (*service_method_map_.map)[service_method_tuple] = service_info;
       return true;
     }
 

--- a/ecal/core/src/ecal_descgate.h
+++ b/ecal/core/src/ecal_descgate.h
@@ -72,26 +72,20 @@ namespace eCAL
     bool GetDataTypeInformation(const std::string& topic_name_, SDataTypeInformation& topic_info_);
 
     void GetServices(std::map<std::tuple<std::string, std::string>, SServiceMethodInformation>& service_info_map_);
-    void GetServiceNames(std::vector<std::tuple<std::string, std::string>>& service_method_names_);
+    void GetServiceMethodNames(std::vector<std::tuple<std::string, std::string>>& service_method_names_);
     bool GetServiceTypeNames(const std::string& service_name_, const std::string& method_name_, std::string& req_type_name_, std::string& resp_type_name_);
     bool GetServiceDescription(const std::string& service_name_, const std::string& method_name_, std::string& req_type_desc_, std::string& resp_type_desc_);
 
+    void GetClients(std::map<std::tuple<std::string, std::string>, SServiceMethodInformation>& client_info_map_);
+    void GetClientMethodNames(std::vector<std::tuple<std::string, std::string>>& client_method_names_);
+    bool GetClientTypeNames(const std::string& client_name_, const std::string& method_name_, std::string& req_type_name_, std::string& resp_type_name_);
+    bool GetClientDescription(const std::string& client_name_, const std::string& method_name_, std::string& req_type_desc_, std::string& resp_type_desc_);
+
   protected:
-    bool ApplySample(const Registration::Sample& sample_, eTLayerType layer_);
-      
-    bool ApplyTopicDescription(const std::string& topic_name_, 
-                               const SDataTypeInformation& topic_info_,
-                               QualityFlags description_quality_);
-
-    bool ApplyServiceDescription(const std::string& service_name_, 
-                                 const std::string& method_name_, 
-                                 const SDataTypeInformation& request_type_information_,
-                                 const SDataTypeInformation& response_type_information_,
-                                 QualityFlags description_quality_);
-
     struct STopicInfoQuality
     {
       SDataTypeInformation info;                                                    //!< Topic info struct with type encoding, name and descriptor.
+      std::string          id;                                                      //!< Topic ID
       QualityFlags         quality               = QualityFlags::NO_QUALITY;        //!< QualityFlags to determine whether we may overwrite the current data with better one. E.g. we prefer the description sent by a publisher over one sent by a subscriber. 
       bool                 type_missmatch_logged = false;                           //!< Whether we have already logged a type-missmatch
     };
@@ -99,6 +93,7 @@ namespace eCAL
     struct SServiceMethodInfoQuality
     {
       SServiceMethodInformation info;                                               //!< Service info struct with type names and descriptors for request and response.
+      std::string               id;                                                 //!< Service ID
       QualityFlags              quality = QualityFlags::NO_QUALITY;                 //!< The Quality of the Info
     };
 
@@ -127,6 +122,34 @@ namespace eCAL
       std::unique_ptr<ServiceMethodInfoMap> map;                                   //!< Map containing information about each known service
     };
     SServiceMethodInfoMap m_service_info_map;
+    SServiceMethodInfoMap m_client_info_map;
+
+    bool ApplySample(const Registration::Sample& sample_, eTLayerType layer_);
+      
+    bool ApplyTopicDescription(const std::string& topic_name_,
+                               const std::string& topic_id_,
+                               const SDataTypeInformation& topic_info_,
+                               QualityFlags description_quality_);
+
+    bool RemTopicDescription(const std::string& topic_name_,
+                               const std::string& topic_id_);
+
+    bool ApplyServiceDescription(SServiceMethodInfoMap& service_method_map_,
+                                 const std::string& service_name_,
+                                 const std::string& service_id_,
+                                 const std::string& method_name_,
+                                 const SDataTypeInformation& request_type_information_,
+                                 const SDataTypeInformation& response_type_information_,
+                                 QualityFlags description_quality_);
+
+    bool RemServiceDescription(SServiceMethodInfoMap& service_method_map_,
+                                 const std::string& service_name_,
+                                 const std::string& service_id_);
+
+    void GetServices(std::map<std::tuple<std::string, std::string>, SServiceMethodInformation>& service_info_map_, const SServiceMethodInfoMap& service_method_map_);
+    void GetServiceMethodNames(std::vector<std::tuple<std::string, std::string>>& method_names_, const SServiceMethodInfoMap& service_method_map_);
+    bool GetServiceTypeNames(const std::string& service_name_, const std::string& method_name_, std::string& req_type_name_, std::string& resp_type_name_, const SServiceMethodInfoMap& service_method_map_);
+    bool GetServiceDescription(const std::string& service_name_, const std::string& method_name_, std::string& req_type_desc_, std::string& resp_type_desc_, const SServiceMethodInfoMap& service_method_map_);
   };
 
   constexpr inline CDescGate::QualityFlags  operator~  (CDescGate::QualityFlags  a)                            { return static_cast<CDescGate::QualityFlags>( ~static_cast<std::underlying_type<CDescGate::QualityFlags>::type>(a) ); }

--- a/ecal/core/src/ecal_util.cpp
+++ b/ecal/core/src/ecal_util.cpp
@@ -192,10 +192,10 @@ namespace eCAL
       g_descgate()->GetServices(service_info_map_);
     }
 
-    void GetServiceNames(std::vector<std::tuple<std::string, std::string>>& service_method_names_)
+    void GetServiceMethodNames(std::vector<std::tuple<std::string, std::string>>& service_method_names_)
     {
       if (g_descgate() == nullptr) return;
-      g_descgate()->GetServiceNames(service_method_names_);
+      g_descgate()->GetServiceMethodNames(service_method_names_);
     }
 
     bool GetServiceTypeNames(const std::string& service_name_, const std::string& method_name_, std::string& req_type_, std::string& resp_type_)
@@ -208,6 +208,30 @@ namespace eCAL
     {
       if (g_descgate() == nullptr) return(false);
       return(g_descgate()->GetServiceDescription(service_name_, method_name_, req_desc_, resp_desc_));
+    }
+
+    void GetClients(std::map<std::tuple<std::string, std::string>, SServiceMethodInformation>& client_info_map_)
+    {
+      if (g_descgate() == nullptr) return;
+      g_descgate()->GetClients(client_info_map_);
+    }
+
+    void GetClientMethodNames(std::vector<std::tuple<std::string, std::string>>& client_method_names_)
+    {
+      if (g_descgate() == nullptr) return;
+      g_descgate()->GetClientMethodNames(client_method_names_);
+    }
+
+    bool GetClientTypeNames(const std::string& client_name_, const std::string& method_name_, std::string& req_type_, std::string& resp_type_)
+    {
+      if (g_descgate() == nullptr) return(false);
+      return(g_descgate()->GetClientTypeNames(client_name_, method_name_, req_type_, resp_type_));
+    }
+
+    bool GetClientDescription(const std::string& client_name_, const std::string& method_name_, std::string& req_desc_, std::string& resp_desc_)
+    {
+      if (g_descgate() == nullptr) return(false);
+      return(g_descgate()->GetClientDescription(client_name_, method_name_, req_desc_, resp_desc_));
     }
 
     std::pair<std::string, std::string> SplitCombinedTopicType(const std::string& combined_topic_type_)

--- a/ecal/samples/cpp/monitoring/monitoring_get_services/src/monitoring_get_services.cpp
+++ b/ecal/samples/cpp/monitoring/monitoring_get_services/src/monitoring_get_services.cpp
@@ -52,14 +52,14 @@ int main(int argc, char **argv)
       std::cout << std::endl;
     }
 
-    // GetServiceNames
+    // GetServiceMethodNames
     {
       std::vector<std::tuple<std::string, std::string>> service_method_names;
 
       start_time = std::chrono::steady_clock::now();
       for (run = 0; run < runs; ++run)
       {
-        eCAL::Util::GetServiceNames(service_method_names);
+        eCAL::Util::GetServiceMethodNames(service_method_names);
       }
 
       auto num_services = service_method_names.size();

--- a/ecal/tests/cpp/clientserver_test/CMakeLists.txt
+++ b/ecal/tests/cpp/clientserver_test/CMakeLists.txt
@@ -25,7 +25,6 @@ create_targets_protobuf()
 
 set(${PROJECT_NAME}_src
   src/atomic_signalable.h
-  src/clientserver_getservices.cpp
   src/clientserver_test.cpp
 )
 

--- a/ecal/tests/cpp/expmap_test/src/expmap_test.cpp
+++ b/ecal/tests/cpp/expmap_test/src/expmap_test.cpp
@@ -27,7 +27,7 @@
 
 #include <gtest/gtest.h>
 
-TEST(core_cpp_util, ExpMap_SetGet)
+TEST(core_cpp_core, ExpMap_SetGet)
 {
   // create the map with 2500 ms expiration
   eCAL::Util::CExpMap<std::string, int> expmap(std::chrono::milliseconds(200));
@@ -86,7 +86,7 @@ TEST(core_cpp_util, ExpMap_SetGet)
   std::this_thread::sleep_for(std::chrono::milliseconds(150));
 }
 
-TEST(core_cpp_util, ExpMap_Insert)
+TEST(core_cpp_core, ExpMap_Insert)
 {
   eCAL::Util::CExpMap<std::string, int> expmap(std::chrono::milliseconds(200));
   auto ret = expmap.insert(std::make_pair("A", 1));
@@ -106,7 +106,7 @@ TEST(core_cpp_util, ExpMap_Insert)
 }
 
 // This tests uses find to find an element
-TEST(core_cpp_util, ExpMap_Find)
+TEST(core_cpp_core, ExpMap_Find)
 {
   eCAL::Util::CExpMap<std::string, int> expmap(std::chrono::milliseconds(200));
 
@@ -125,7 +125,7 @@ TEST(core_cpp_util, ExpMap_Find)
 }
 
 // This test assures that find can be called on a const CExpMap and returns an CExpMap::const_iterator
-TEST(core_cpp_util, ExpMap_FindConst)
+TEST(core_cpp_core, ExpMap_FindConst)
 {
   eCAL::Util::CExpMap<std::string, int> expmap(std::chrono::milliseconds(200));
 
@@ -146,7 +146,7 @@ TEST(core_cpp_util, ExpMap_FindConst)
   EXPECT_EQ(0, expmap.size());
 }
 
-TEST(core_cpp_util, ExpMap_Iterate)
+TEST(core_cpp_core, ExpMap_Iterate)
 {
   // create the map with 2500 ms expiration
   eCAL::Util::CExpMap<std::string, int> expmap(std::chrono::milliseconds(200));
@@ -180,7 +180,7 @@ void ConstRefIterate(const eCAL::Util::CExpMap<std::string, int>& map)
   EXPECT_EQ(1, value);
 }
 
-TEST(core_cpp_util, ExpMap_ConstExpMapIterate)
+TEST(core_cpp_core, ExpMap_ConstExpMapIterate)
 {
   // create the map with 2500 ms expiration
   eCAL::Util::CExpMap<std::string, int> expmap(std::chrono::milliseconds(200));
@@ -189,7 +189,7 @@ TEST(core_cpp_util, ExpMap_ConstExpMapIterate)
   ConstRefIterate(expmap);
 }
 
-TEST(core_cpp_util, ExpMap_Empty)
+TEST(core_cpp_core, ExpMap_Empty)
 {
   eCAL::Util::CExpMap<std::string, int> expmap(std::chrono::milliseconds(200));
   EXPECT_EQ(true, expmap.empty());
@@ -197,7 +197,7 @@ TEST(core_cpp_util, ExpMap_Empty)
   EXPECT_EQ(false, expmap.empty());
 }
 
-TEST(core_cpp_util, ExpMap_Size)
+TEST(core_cpp_core, ExpMap_Size)
 {
   eCAL::Util::CExpMap<std::string, int> expmap(std::chrono::milliseconds(200));
   EXPECT_EQ(0, expmap.size());
@@ -205,7 +205,7 @@ TEST(core_cpp_util, ExpMap_Size)
   EXPECT_EQ(1, expmap.size());
 }
 
-TEST(core_cpp_util, ExpMap_Remove)
+TEST(core_cpp_core, ExpMap_Remove)
 {
   eCAL::Util::CExpMap<std::string, int> expmap(std::chrono::milliseconds(200));
   expmap["A"] = 1;

--- a/ecal/tests/cpp/pubsub_test/CMakeLists.txt
+++ b/ecal/tests/cpp/pubsub_test/CMakeLists.txt
@@ -23,7 +23,6 @@ find_package(GTest REQUIRED)
 
 set(pubsub_test_src
   src/pubsub_acknowledge.cpp
-  src/pubsub_gettopics.cpp
   src/pubsub_multibuffer.cpp
   src/pubsub_receive_test.cpp
   src/pubsub_test.cpp

--- a/ecal/tests/cpp/util_test/CMakeLists.txt
+++ b/ecal/tests/cpp/util_test/CMakeLists.txt
@@ -21,7 +21,11 @@ project(test_util)
 find_package(Threads REQUIRED)
 find_package(GTest REQUIRED)
 
+
 set(util_test_src
+  src/util_getclients.cpp
+  src/util_getservices.cpp
+  src/util_gettopics.cpp
   src/util_test.cpp
 )
 

--- a/ecal/tests/cpp/util_test/src/util_getclients.cpp
+++ b/ecal/tests/cpp/util_test/src/util_getclients.cpp
@@ -1,0 +1,160 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2019 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+#include <ecal/ecal.h>
+#include <ecal/ecal_types.h>
+
+#include <gtest/gtest.h>
+
+#define CMN_REGISTRATION_REFRESH 1000
+#define CMN_MONITORING_TIMEOUT   5000
+
+TEST(core_cpp_util, GetClients)
+{
+  // initialize eCAL API
+  eCAL::Initialize(0, nullptr, "util_getclients");
+
+  std::map<std::tuple<std::string, std::string>, eCAL::SServiceMethodInformation> client_info_map;
+  
+  // add and expire simple client
+  {
+    // create client
+    eCAL::SServiceMethodInformation service_method_info;
+    service_method_info.request_type.name        = "foo::req_type1";
+    service_method_info.request_type.descriptor  = "foo::req_desc1";
+    service_method_info.response_type.name       = "foo::resp_type1";
+    service_method_info.response_type.descriptor = "foo::resp_desc1";
+    eCAL::CServiceClient client("foo::service", { {"foo::method", service_method_info} });
+
+    // get all clients
+    eCAL::Util::GetClients(client_info_map);
+
+    // check size
+    EXPECT_EQ(client_info_map.size(), 1);
+
+    // let's wait a monitoring timeout long
+    eCAL::Process::SleepMS(CMN_MONITORING_TIMEOUT);
+
+    // get all clients again, client should not be expired
+    eCAL::Util::GetClients(client_info_map);
+
+    // check size
+    EXPECT_EQ(client_info_map.size(), 1);
+  }
+
+  // get all clients again, all clients 
+  // should be removed from the map
+  eCAL::Util::GetClients(client_info_map);
+
+  // check size
+  EXPECT_EQ(client_info_map.size(), 0);
+
+  // create 2 clients
+  {
+    // create client 1
+    eCAL::SServiceMethodInformation service_method_info1;
+    service_method_info1.request_type.name        = "foo::req_type1";
+    service_method_info1.request_type.descriptor  = "foo::req_desc1";
+    service_method_info1.response_type.name       = "foo::resp_type1";
+    service_method_info1.response_type.descriptor = "foo::resp_desc1";
+    eCAL::CServiceClient client1("foo::service", { {"foo::method", service_method_info1} });
+
+    // get all clients
+    eCAL::Util::GetClients(client_info_map);
+
+    // check size
+    EXPECT_EQ(client_info_map.size(), 1);
+
+    // check attributes
+    std::string req_type, resp_type;
+    std::string req_desc, resp_desc;
+
+    eCAL::Util::GetClientTypeNames("foo::service", "foo::method", req_type, resp_type);
+    EXPECT_EQ(req_type,  "foo::req_type1");
+    EXPECT_EQ(resp_type, "foo::resp_type1");
+    eCAL::Util::GetClientDescription("foo::service", "foo::method", req_desc, resp_desc);
+    EXPECT_EQ(req_desc,  "foo::req_desc1");
+    EXPECT_EQ(resp_desc, "foo::resp_desc1");
+
+    // check client/method names
+    std::vector<std::tuple<std::string, std::string>> client_method_names;
+    eCAL::Util::GetClientMethodNames(client_method_names);
+    EXPECT_EQ(client_method_names.size(), 1);
+    for (const auto& method_name : client_method_names)
+    {
+      EXPECT_EQ(std::get<0>(method_name), "foo::service");
+      EXPECT_EQ(std::get<1>(method_name), "foo::method");
+    }
+
+    // create client 2
+    // this will not overwrite the attributes from client1
+    eCAL::SServiceMethodInformation service_method_info2;
+    service_method_info2.request_type.name        = "foo::req_type2";
+    service_method_info2.request_type.descriptor  = "foo::req_desc2";
+    service_method_info2.response_type.name       = "foo::resp_type2";
+    service_method_info2.response_type.descriptor = "foo::resp_desc2";
+    eCAL::CServiceClient client2("foo::service", { {"foo::method", service_method_info2} });
+
+    // check attributes
+    eCAL::Util::GetClientTypeNames("foo::service", "foo::method", req_type, resp_type);
+    EXPECT_EQ(req_type,  "foo::req_type1");
+    EXPECT_EQ(resp_type, "foo::resp_type1");
+    eCAL::Util::GetClientDescription("foo::service", "foo::method", req_desc, resp_desc);
+    EXPECT_EQ(req_desc,  "foo::req_desc1");
+    EXPECT_EQ(resp_desc, "foo::resp_desc1");
+
+    // check size (client1 replaced by client2)
+    EXPECT_EQ(client_info_map.size(), 1);
+
+    // let's wait a monitoring timeout long
+    eCAL::Process::SleepMS(CMN_MONITORING_TIMEOUT);
+
+    // get all clients again, client should not be expired
+    eCAL::Util::GetClients(client_info_map);
+
+    // check size
+    EXPECT_EQ(client_info_map.size(), 1);
+
+    // destroy client 1
+    client1.Destroy();
+
+    // check attributes (client 1 is still in the map)
+    eCAL::Util::GetClientTypeNames("foo::service", "foo::method", req_type, resp_type);
+    EXPECT_EQ(req_type, "foo::req_type1");
+    EXPECT_EQ(resp_type, "foo::resp_type1");
+
+    // let's wait a registration cylce long
+    eCAL::Process::SleepMS(CMN_REGISTRATION_REFRESH);
+
+    // check attributes (client 1 should be replaced by client 2 now)
+    eCAL::Util::GetClientTypeNames("foo::service", "foo::method", req_type, resp_type);
+    EXPECT_EQ(req_type, "foo::req_type2");
+    EXPECT_EQ(resp_type, "foo::resp_type2");
+  }
+
+  // get all clients again, all clients
+  // should be removed from the map
+  eCAL::Util::GetClients(client_info_map);
+
+  // check size
+  EXPECT_EQ(client_info_map.size(), 0);
+
+  // finalize eCAL API
+  eCAL::Finalize();
+}

--- a/ecal/tests/cpp/util_test/src/util_getservices.cpp
+++ b/ecal/tests/cpp/util_test/src/util_getservices.cpp
@@ -24,10 +24,10 @@
 
 #define CMN_MONITORING_TIMEOUT 5000
 
-TEST(core_cpp_clientserver, GetServices)
+TEST(core_cpp_util, GetServices)
 {
   // initialize eCAL API
-  eCAL::Initialize(0, nullptr, "clientserver_getservices");
+  eCAL::Initialize(0, nullptr, "util_getservices");
 
   std::map<std::tuple<std::string, std::string>, eCAL::SServiceMethodInformation> service_info_map;
   
@@ -54,10 +54,8 @@ TEST(core_cpp_clientserver, GetServices)
     // check size
     EXPECT_EQ(service_info_map.size(), 1);
   }
-  // let's unregister them
-  eCAL::Process::SleepMS(CMN_MONITORING_TIMEOUT + 1000);
 
-  // get all services again, now all services 
+  // get all services again, all services 
   // should be removed from the map
   eCAL::Util::GetServices(service_info_map);
 
@@ -125,10 +123,8 @@ TEST(core_cpp_clientserver, GetServices)
     // check size
     EXPECT_EQ(service_info_map.size(), 1);
   }
-  // let's unregister them
-  eCAL::Process::SleepMS(CMN_MONITORING_TIMEOUT + 1000);
 
-  // get all services again, now all services 
+  // get all services again, all services 
   // should be removed from the map
   eCAL::Util::GetServices(service_info_map);
 

--- a/ecal/tests/cpp/util_test/src/util_test.cpp
+++ b/ecal/tests/cpp/util_test/src/util_test.cpp
@@ -21,7 +21,6 @@
 #include <util/frequency_calculator.h>
 
 #include <vector>
-#include <thread>
 
 #include <gtest/gtest.h>
 
@@ -193,70 +192,4 @@ TEST(core_cpp_util, Freq_ResettableFrequencyCalculator)
       }
     }
   }
-}
-
-TEST(core_cpp_util, ParallelGetTopics)
-{
-  constexpr const int max_publisher_count(2000);
-  constexpr const int waiting_time_thread(1000);
-  constexpr const int parallel_threads(1);
-
-  eCAL::Initialize();
-
-  auto create_publishers = [&]() {
-    std::string topic_name = "Test.ParallelUtilFunctions";
-    std::atomic<int> call_back_count{ 0 };
-
-    std::vector<std::unique_ptr<eCAL::CPublisher>> publishers;
-    for (int pub_count = 0; pub_count < max_publisher_count; pub_count++) {
-      std::unique_ptr<eCAL::CPublisher> publisher = std::make_unique<eCAL::CPublisher>(topic_name + std::to_string(pub_count));
-      publishers.push_back(std::move(publisher));
-    }
-    std::this_thread::sleep_for(std::chrono::milliseconds(waiting_time_thread));
-    };
-
-  auto get_topics_from_ecal = [&]() {
-    size_t found_topics = 0;
-    std::vector<std::string> tmp_topic_names;
-    std::unordered_map<std::string, eCAL::SDataTypeInformation> topics;
-    do {
-      eCAL::Util::GetTopicNames(tmp_topic_names);
-      eCAL::Util::GetTopics(topics);
-
-      found_topics = tmp_topic_names.size();
-      std::cout << "Number of topics found by ecal: " << found_topics << "\n";
-      std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    } while (found_topics < max_publisher_count);
-
-    // do it again until all publishers are deleted
-    do {
-      eCAL::Util::GetTopicNames(tmp_topic_names);
-      eCAL::Util::GetTopics(topics);
-
-      found_topics = tmp_topic_names.size();
-      std::cout << "Number of topics found by ecal: " << found_topics << "\n";
-      std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    } while (found_topics != 0);
-    };
-
-  std::vector<std::thread> threads_container;
-  threads_container.push_back(std::thread(create_publishers));
-
-  for (size_t i = 0; i < parallel_threads; i++) {
-    threads_container.push_back(std::thread(get_topics_from_ecal));
-  }
-
-  for (auto& th : threads_container) {
-    th.join();
-  }
-
-  std::vector<std::string> final_topic_names;
-  std::unordered_map<std::string, eCAL::SDataTypeInformation> final_topics;
-  eCAL::Util::GetTopicNames(final_topic_names);
-  eCAL::Util::GetTopics(final_topics);
-
-  EXPECT_EQ(final_topic_names.size(), 0);
-  EXPECT_EQ(final_topics.size(), 0);
-
-  eCAL::Finalize();
 }


### PR DESCRIPTION
### Description
DescGate is currently collecting descriptions (type encodings, type names, type descriptors) for publisher, subscriber and services. 

This PR:
* extends it to collect descriptions for clients too
* introduces active removal of descriptions triggered by unregistration events (samples)

The existing removal is based on expiration, configured with a default timeout of 5s (monitoring timeout). The new active removal removes entries immediately.
