### PR TITLE
[Mon] Fix service collisions on ecal_mon_gui (5.13)

### DIFF
--- a/app/mon/mon_gui/src/widgets/models/service_tree_item.cpp
+++ b/app/mon/mon_gui/src/widgets/models/service_tree_item.cpp
@@ -213,7 +213,7 @@ int ServiceTreeItem::type() const
 
 std::string ServiceTreeItem::generateIdentifier(const eCAL::pb::Service& service, const eCAL::pb::Method& method)
 {
-  return std::to_string(service.pid()) + "@" + service.hname() + "@" + method.mname();
+  return std::to_string(service.pid()) + "@" + service.hname() + "@" + service.sname() + "@" + method.mname();
 }
 
 std::string ServiceTreeItem::identifier() const


### PR DESCRIPTION
Very simple fix. Adds the service name to the `ServiceTreeItem` identifier so that different services running on the same host/process with the same methods don't get accidentally de-duped in `ecal_mon_gui`.

### Description
This PR fixes the following bug:

#### Working example to demonstrate issue

This Python program creates two different eCAL services with the same PID, host, and method name.
```
import ecal.core.core as ecal_core
import ecal.core.service as ecal_service
import sys, time

def callback():
      pass

ecal_core.initialize(sys.argv, "BugDemo")
server1 = ecal_service.Server("MyService1")
server1.add_method_callback("GetConfig", "string", "string", callback)
server2 = ecal_service.Server("MyService2")
server2.add_method_callback("GetConfig", "string", "string", callback)

try:
    while True:
        time.sleep(1)
except KeyboardInterrupt:
    pass
finally:
    server1.destroy()
    server2.destroy()
    ecal_core.finalize()
```

#### Expected behavior
`ecal_mon_gui` should show both services on the service widget.

#### Actual behavior
`ecal_mon_gui` only shows one service (the most recent one):

![image](https://github.com/eclipse-ecal/ecal/assets/114191318/c768808c-c84a-48fa-8895-de9edac76cf5)

#### The fix
This issue occurs because each of these service listings is a `ServiceTreeItem`, and the Service widget tracks and prunes `ServiceTreeItems` based on their generated identifier. The identifier currently only includes the PID, host, and method name. This fix adds the service name as well, so that services that only differ in their name still show up separately.

Now both services show up as expected:

![image](https://github.com/eclipse-ecal/ecal/assets/114191318/bd14e24f-037f-4fb7-8ade-bc036ece1ec7)

### Related issues
<!-- Type "Fixes #123" to automatically close that issue, when this PR is merged -->
- None (searched the open issues for `GUI`, none seemed related.)

### Cherry-pick to
<!-- Leave empty, if you don't know. For master-only changes use "none"
- _none_
- 5.11 (old stable)
- 5.12 (current stable)
-->
