### PR TITLE
Python 3.9 downgrade for macOS GH runner removed

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -25,7 +25,7 @@ jobs:
         target: 'desktop'
 
     - name: Install Dependencies
-      run: brew install ninja doxygen graphviz protobuf hdf5@1.10 pkg-config
+      run: brew install ninja doxygen graphviz protobuf hdf5 pkg-config
 
     - name: Install Cap’n Proto
       run: |

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-macos:
-    runs-on: macos-latest
+    runs-on: 	macos-13
 
     steps:
     - name: Install Dependencies

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -11,12 +11,6 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - name: Downgrade Python version
-      uses: actions/setup-python@v4
-      id: cp39
-      with:
-        python-version: '3.9'
-
     - name: Install Qt
       uses: jurplel/install-qt-action@v3
       with:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -11,15 +11,14 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - name: Install Qt
-      uses: jurplel/install-qt-action@v3
-      with:
-        setup-python: false
-        version: '5.15.2'
-        target: 'desktop'
-
     - name: Install Dependencies
-      run: brew install ninja doxygen graphviz protobuf hdf5@1.10 pkg-config
+      run: brew install ninja doxygen graphviz protobuf hdf5@1.10 pkg-config qt
+
+    - name: Downgrade Python version
+      uses: actions/setup-python@v5
+      id: cp312
+      with:
+        python-version: '3.12'
 
     - name: Install Cap’n Proto
       run: |

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -8,17 +8,24 @@ on:
 
 jobs:
   build-macos:
-    runs-on: 	macos-13
+    runs-on: macos-latest
 
     steps:
-    - name: Install Dependencies
-      run: brew install ninja doxygen graphviz protobuf hdf5@1.10 pkg-config qt
-
     - name: Downgrade Python version
-      uses: actions/setup-python@v5
-      id: cp312
+      uses: actions/setup-python@v4
+      id: cp12
       with:
         python-version: '3.12'
+
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v3
+      with:
+        setup-python: false
+        version: '5.15.2'
+        target: 'desktop'
+
+    - name: Install Dependencies
+      run: brew install ninja doxygen graphviz protobuf hdf5@1.10 pkg-config
 
     - name: Install Cap’n Proto
       run: |
@@ -32,7 +39,7 @@ jobs:
         sudo make install
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
       with:
         submodules:  'true'
         fetch-depth: 0
@@ -79,7 +86,6 @@ jobs:
         -DECAL_THIRDPARTY_BUILD_QWT=ON \
         -DECAL_THIRDPARTY_BUILD_YAML-CPP=ON \
         -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_PREFIX_PATH=/usr/local/opt/hdf5@1.10 \
         -DCMAKE_CXX_STANDARD=17 \
         -DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON \
         -DPython_FIND_STRATEGY=LOCATION \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -490,5 +490,6 @@ message(STATUS "ECAL_THIRDPARTY_BUILD_TINYXML2                 : ${ECAL_THIRDPAR
 message(STATUS "ECAL_THIRDPARTY_BUILD_UDPCAP                   : ${ECAL_THIRDPARTY_BUILD_UDPCAP}")
 message(STATUS "ECAL_THIRDPARTY_BUILD_YAML-CPP                 : ${ECAL_THIRDPARTY_BUILD_YAML-CPP}")
 message(STATUS "ECAL_LINK_HDF5_SHARED                          : ${ECAL_LINK_HDF5_SHARED}")
+message(STATUS "CMAKE_CROSSCOMPILING                           : ${CMAKE_CROSSCOMPILING}")
 message(STATUS "CPACK_PACK_WITH_INNOSETUP                      : ${CPACK_PACK_WITH_INNOSETUP}")
 message(STATUS "--------------------------------------------------------------------------------")

--- a/contrib/ecalhdf5/CMakeLists.txt
+++ b/contrib/ecalhdf5/CMakeLists.txt
@@ -93,6 +93,10 @@ if (${ECAL_LINK_HDF5_SHARED})
     target_link_libraries(${PROJECT_NAME} PRIVATE
       HDF5::C
     )
+  elseif (TARGET hdf5::hdf5)
+    target_link_libraries(${PROJECT_NAME} PRIVATE
+      hdf5::hdf5
+    )    
   else()
     target_include_directories(${PROJECT_NAME} PRIVATE ${HDF5_INCLUDE_DIRS})
     target_link_libraries(${PROJECT_NAME} PRIVATE
@@ -109,6 +113,10 @@ else()
     target_link_libraries(${PROJECT_NAME} PRIVATE
       HDF5::C
     )
+  elseif (TARGET hdf5::hdf5)
+    target_link_libraries(${PROJECT_NAME} PRIVATE
+      hdf5::hdf5
+    )       
   else()
     message(FATAL_ERROR "eCAL build configured to link HDF5 statically, however static libs are not available. Consider building with ECAL_LINK_HDF5_SHARED=ON") 
   endif()

--- a/contrib/ecalhdf5/CMakeLists.txt
+++ b/contrib/ecalhdf5/CMakeLists.txt
@@ -19,7 +19,7 @@
 project(hdf5 LANGUAGES C CXX)
 
 if(NOT CMAKE_CROSSCOMPILING)
-  find_package(HDF5 COMPONENTS C CXX REQUIRED)
+  find_package(HDF5 COMPONENTS C REQUIRED)
   find_package(Threads REQUIRED)
 else()
   find_library(hdf5_path NAMES hdf5 REQUIRED PATH_SUFFIXES hdf5/serial)

--- a/contrib/ecalhdf5/CMakeLists.txt
+++ b/contrib/ecalhdf5/CMakeLists.txt
@@ -19,7 +19,7 @@
 project(hdf5 LANGUAGES C CXX)
 
 if(NOT CMAKE_CROSSCOMPILING)
-  find_package(HDF5 COMPONENTS C REQUIRED)
+  find_package(HDF5 COMPONENTS C CXX REQUIRED)
   find_package(Threads REQUIRED)
 else()
   find_library(hdf5_path NAMES hdf5 REQUIRED PATH_SUFFIXES hdf5/serial)


### PR DESCRIPTION
### Description
As the title says .. Python 3.9 ARM64 no more available for macOS GH runner. See https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
