### PR TITLE
downgrade macos version.

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-macos:
-    runs-on: macos-latest
+    runs-on: macos-13
 
     steps:
     - name: Downgrade Python version


### PR DESCRIPTION
### Description
The github runners were updated to macos-13, which is not able to build ecal.
