### PR TITLE
[app] ecalmon layer detection logic

### DIFF
--- a/app/mon/mon_gui/src/widgets/models/topic_tree_item.cpp
+++ b/app/mon/mon_gui/src/widgets/models/topic_tree_item.cpp
@@ -209,22 +209,25 @@ QVariant TopicTreeItem::data(Columns column, Qt::ItemDataRole role) const
       for (const auto& layer : layer_pb)
       {
         QString this_layer_string;
-        switch (layer.type())
+        if (layer.confirmed())
         {
-        case eCAL::pb::eTLayerType::tl_ecal_tcp:
-          this_layer_string = "tcp";
-          break;
-        case eCAL::pb::eTLayerType::tl_ecal_udp_mc:
-          this_layer_string = "udp_mc";
-          break;
-        case eCAL::pb::eTLayerType::tl_ecal_shm:
-          this_layer_string = "shm";
-          break;
-        case eCAL::pb::eTLayerType::tl_all:
-          this_layer_string = "all";
-          break;
-        default:
-          this_layer_string = ("Unknown (" + QString::number((int)layer.type()) + ")");
+          switch (layer.type())
+          {
+          case eCAL::pb::eTLayerType::tl_ecal_tcp:
+            this_layer_string = "tcp";
+            break;
+          case eCAL::pb::eTLayerType::tl_ecal_udp_mc:
+            this_layer_string = "udp_mc";
+            break;
+          case eCAL::pb::eTLayerType::tl_ecal_shm:
+            this_layer_string = "shm";
+            break;
+          case eCAL::pb::eTLayerType::tl_all:
+            this_layer_string = "all";
+            break;
+          default:
+            this_layer_string = ("Unknown (" + QString::number((int)layer.type()) + ")");
+          }
         }
 
         if (!layer_string.isEmpty() && !this_layer_string.isEmpty())

--- a/app/mon/mon_tui/src/model/monitor.hpp
+++ b/app/mon/mon_tui/src/model/monitor.hpp
@@ -204,7 +204,10 @@ class MonitorModel
       topic.type_descriptor = std::move(*t.mutable_tdatatype()->mutable_desc());
       for(auto &tl: t.tlayer())
       {
-        topic.transport_layers.emplace_back(TopicTransportLayer(tl.type()));
+        if (tl.confirmed())
+        {
+          topic.transport_layers.emplace_back(TopicTransportLayer(tl.type()));
+        }
       }
       topic.size = t.tsize();
       topic.local_connections_count = t.connections_loc();


### PR DESCRIPTION
### Description
Current (master) monitoring gui/tui apps visualize all transport layer as active independently from their confirmed state. Issue is not existing in 5.12/5.13 series.

![image](https://github.com/eclipse-ecal/ecal/assets/49162693/925f119f-79af-4025-a4c3-782c9bac90aa)

![image](https://github.com/eclipse-ecal/ecal/assets/49162693/09139810-2bf5-4f61-aa00-15a33aabc112)

