### PR TITLE
[core] writer refactoring based on unique ptr

### DIFF
--- a/ecal/core/src/readwrite/ecal_writer.h
+++ b/ecal/core/src/readwrite/ecal_writer.h
@@ -48,6 +48,7 @@
 #include "tcp/ecal_writer_tcp.h"
 #endif
 
+#include <memory>
 #include <mutex>
 #include <string>
 #include <atomic>
@@ -198,18 +199,18 @@ namespace eCAL
         bool              confirmed = false;
       };
 
-      SWriterMode                          udp_mc_mode;
+      SWriterMode                          udp_mode;
       SWriterMode                          tcp_mode;
       SWriterMode                          shm_mode;
 
 #if ECAL_CORE_TRANSPORT_UDP
-      CDataWriterUdpMC                     udp_mc;
+      std::unique_ptr<CDataWriterUdpMC>    udp;
 #endif
 #if ECAL_CORE_TRANSPORT_SHM
-      CDataWriterSHM                       shm;
+      std::unique_ptr<CDataWriterSHM>      shm;
 #endif
 #if ECAL_CORE_TRANSPORT_TCP
-      CDataWriterTCP                       tcp;
+      std::unique_ptr<CDataWriterTCP>      tcp;
 #endif
     };
     SWriter                                m_writer;

--- a/ecal/core/src/readwrite/ecal_writer_base.h
+++ b/ecal/core/src/readwrite/ecal_writer_base.h
@@ -38,13 +38,9 @@ namespace eCAL
   class CDataWriterBase
   {
   public:
-    CDataWriterBase() : m_created(false) {};
     virtual ~CDataWriterBase() = default;
 
     virtual SWriterInfo GetInfo() = 0;
-
-    virtual bool Create(const std::string& host_name_, const std::string& topic_name_, const std::string & topic_id_) = 0;
-    virtual bool Destroy() = 0;
 
     virtual void AddLocConnection(const std::string& /*process_id_*/, const std::string& /*topic_id_*/, const std::string& /*conn_par_*/) {};
     virtual void RemLocConnection(const std::string& /*process_id_*/, const std::string& /*topic_id_*/) {};
@@ -62,7 +58,5 @@ namespace eCAL
     std::string        m_host_name;
     std::string        m_topic_name;
     std::string        m_topic_id;
-
-    std::atomic<bool>  m_created;
   };
 }

--- a/ecal/core/src/readwrite/shm/ecal_writer_shm.h
+++ b/ecal/core/src/readwrite/shm/ecal_writer_shm.h
@@ -36,15 +36,9 @@ namespace eCAL
   class CDataWriterSHM : public CDataWriterBase
   {
   public:
-    CDataWriterSHM() = default;
-    ~CDataWriterSHM() override;
+    CDataWriterSHM(const std::string& host_name_, const std::string& topic_name_, const std::string& topic_id_);
 
     SWriterInfo GetInfo() override;
-
-    bool Create(const std::string& host_name_, const std::string& topic_name_, const std::string & topic_id_) override;
-    // this virtual function is called during construction/destruction,
-    // so, mark it as final to ensure that no derived classes override it.
-    bool Destroy() final;
 
     bool SetBufferCount(size_t buffer_count_);
 

--- a/ecal/core/src/readwrite/tcp/ecal_writer_tcp.cpp
+++ b/ecal/core/src/readwrite/tcp/ecal_writer_tcp.cpp
@@ -21,10 +21,10 @@
  * @brief  tcp writer
 **/
 
+#include <ecal/ecal_config.h>
+
 #include "config/ecal_config_reader_hlp.h"
 #include "serialization/ecal_serialize_sample_payload.h"
-
-#include <ecal/ecal_config.h>
 
 #include "ecal_writer_tcp.h"
 #include "ecal_tcp_pubsub_logger.h"
@@ -38,31 +38,7 @@ namespace eCAL
   std::mutex                            CDataWriterTCP::g_tcp_writer_executor_mtx;
   std::shared_ptr<tcp_pubsub::Executor> CDataWriterTCP::g_tcp_writer_executor;
 
-  CDataWriterTCP::CDataWriterTCP() : m_port(0)
-  {
-  }
-
-  CDataWriterTCP::~CDataWriterTCP()
-  {
-    Destroy();
-  }
-
-  SWriterInfo CDataWriterTCP::GetInfo()
-  {
-    SWriterInfo info_;
-
-    info_.name                 = "tcp";
-    info_.description          = "tcp data writer";
-
-    info_.has_mode_local       = true;
-    info_.has_mode_cloud       = true;
-
-    info_.send_size_max        = -1;
-
-    return info_;
-  }
-
-  bool CDataWriterTCP::Create(const std::string& host_name_, const std::string& topic_name_, const std::string& topic_id_)
+  CDataWriterTCP::CDataWriterTCP(const std::string& host_name_, const std::string& topic_name_, const std::string& topic_id_)
   {
     {
       const std::lock_guard<std::mutex> lock(g_tcp_writer_executor_mtx);
@@ -80,19 +56,21 @@ namespace eCAL
     m_host_name  = host_name_;
     m_topic_name = topic_name_;
     m_topic_id   = topic_id_;
-
-    return true;
   }
 
-  bool CDataWriterTCP::Destroy()
+  SWriterInfo CDataWriterTCP::GetInfo()
   {
-    if(!m_publisher) return true;
+    SWriterInfo info_;
 
-    // destroy publisher
-    m_publisher = nullptr;
-    m_port      = 0;
+    info_.name           = "tcp";
+    info_.description    = "tcp data writer";
 
-    return true;
+    info_.has_mode_local = true;
+    info_.has_mode_cloud = true;
+
+    info_.send_size_max  = -1;
+
+    return info_;
   }
 
   bool CDataWriterTCP::Write(const void* const buf_, const SWriterAttr& attr_)

--- a/ecal/core/src/readwrite/tcp/ecal_writer_tcp.h
+++ b/ecal/core/src/readwrite/tcp/ecal_writer_tcp.h
@@ -38,15 +38,9 @@ namespace eCAL
   class CDataWriterTCP : public CDataWriterBase
   {
   public:
-    CDataWriterTCP();
-    ~CDataWriterTCP() override;
+    CDataWriterTCP(const std::string& host_name_, const std::string& topic_name_, const std::string& topic_id_);
 
     SWriterInfo GetInfo() override;
-
-    bool Create(const std::string& host_name_, const std::string& topic_name_, const std::string & topic_id_) override;
-    // this virtual function is called during construction/destruction,
-    // so, mark it as final to ensure that no derived classes override it.
-    bool Destroy() final;
 
     bool Write(const void* buf_, const SWriterAttr& attr_) override;
 
@@ -59,6 +53,6 @@ namespace eCAL
     static std::shared_ptr<tcp_pubsub::Executor> g_tcp_writer_executor;
 
     std::shared_ptr<tcp_pubsub::Publisher>       m_publisher;
-    uint16_t                                     m_port;
+    uint16_t                                     m_port = 0;
   };
 }

--- a/ecal/core/src/readwrite/udp/ecal_writer_udp_mc.cpp
+++ b/ecal/core/src/readwrite/udp/ecal_writer_udp_mc.cpp
@@ -21,42 +21,19 @@
  * @brief  udp data writer
 **/
 
-#include <cstddef>
 #include <ecal/ecal_config.h>
 #include <ecal/ecal_log.h>
-#include <memory>
-#include <string>
 
 #include "ecal_writer_udp_mc.h"
 #include "io/udp/ecal_udp_configurations.h"
 #include "serialization/ecal_serialize_sample_payload.h"
 
+#include <cstddef>
+
 namespace eCAL
 {
-  CDataWriterUdpMC::~CDataWriterUdpMC()
+  CDataWriterUdpMC::CDataWriterUdpMC(const std::string& host_name_, const std::string& topic_name_, const std::string& topic_id_)
   {
-    Destroy();
-  }
-
-  SWriterInfo CDataWriterUdpMC::GetInfo()
-  {
-    SWriterInfo info_;
-
-    info_.name                 = "udp";
-    info_.description          = "udp multicast data writer";
-
-    info_.has_mode_local       = true;
-    info_.has_mode_cloud       = true;
-
-    info_.send_size_max        = -1;
-
-    return info_;
-  }
-
-  bool CDataWriterUdpMC::Create(const std::string & host_name_, const std::string & topic_name_, const std::string & topic_id_)
-  {
-    if (m_created) return true;
-
     m_host_name   = host_name_;
     m_topic_name  = topic_name_;
     m_topic_id    = topic_id_;
@@ -76,26 +53,25 @@ namespace eCAL
     // create udp/sample sender without activated loop-back
     attr.loopback = false;
     m_sample_sender_no_loopback = std::make_shared<UDP::CSampleSender>(attr);
-
-    m_created = true;
-    return true;
   }
 
-  bool CDataWriterUdpMC::Destroy()
+  SWriterInfo CDataWriterUdpMC::GetInfo()
   {
-    if (!m_created) return true;
+    SWriterInfo info_;
 
-    m_sample_sender_loopback.reset();
-    m_sample_sender_no_loopback.reset();
+    info_.name                 = "udp";
+    info_.description          = "udp multicast data writer";
 
-    m_created = false;
-    return true;
+    info_.has_mode_local       = true;
+    info_.has_mode_cloud       = true;
+
+    info_.send_size_max        = -1;
+
+    return info_;
   }
 
   bool CDataWriterUdpMC::Write(const void* const buf_, const SWriterAttr& attr_)
   {
-    if (!m_created) return false;
-
     // create new sample
     Payload::Sample ecal_sample;
     ecal_sample.cmd_type = eCmdType::bct_set_sample;

--- a/ecal/core/src/readwrite/udp/ecal_writer_udp_mc.h
+++ b/ecal/core/src/readwrite/udp/ecal_writer_udp_mc.h
@@ -35,14 +35,9 @@ namespace eCAL
   class CDataWriterUdpMC : public CDataWriterBase
   {
   public:
-    ~CDataWriterUdpMC() override;
+    CDataWriterUdpMC(const std::string& host_name_, const std::string& topic_name_, const std::string& topic_id_);
 
     SWriterInfo GetInfo() override;
-
-    bool Create(const std::string& host_name_, const std::string& topic_name_, const std::string & topic_id_) override;
-    // this virtual function is called during construction/destruction,
-    // so, mark it as final to ensure that no derived classes override it.
-    bool Destroy() final;
 
     bool Write(const void* buf_, const SWriterAttr& attr_) override;
 


### PR DESCRIPTION
### Description
All eCAL writer Create/Destroy functions removed. Constructor and destructor should be used to construct writers for udp, shm, tcp.

### Related issues
<!-- Type "Fixes #123" to automatically close that issue, when this PR is merged -->
Fixes #1475
