### PR TITLE
[Core Tests] Added missing include

### DIFF
--- a/ecal/tests/cpp/util_test/src/util_gettopics.cpp
+++ b/ecal/tests/cpp/util_test/src/util_gettopics.cpp
@@ -21,6 +21,7 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <chrono>
 #include <memory>
 #include <thread>


### PR DESCRIPTION
### Description
The include is required for Compiling on Ubuntu 20.04 with gcc 9.4.0