### PR TITLE
[cmake] move find_package(Protobuf) to bottom

### DIFF
--- a/cmake/eCALConfig.cmake.in
+++ b/cmake/eCALConfig.cmake.in
@@ -30,20 +30,11 @@ set(eCAL_VERSION_STRING @eCAL_VERSION_STRING@)
 set(CMAKE_MAP_IMPORTED_CONFIG_MINSIZEREL Release "")
 set(CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO Release "")
 
-find_package(Protobuf REQUIRED)
-
 include("@PACKAGE_eCAL_install_cmake_dir@/helper_functions/ecal_add_functions.cmake")
 include("@PACKAGE_eCAL_install_cmake_dir@/helper_functions/ecal_helper_functions.cmake")
 include("@PACKAGE_eCAL_install_cmake_dir@/helper_functions/ecal_install_functions.cmake")
 include("@PACKAGE_eCAL_install_cmake_dir@/eCALTargets.cmake")
 
-# careful, this is a Windows hack to find protobuf etc. with the eCAL installation
-# To be removed if there is a better solution like Conan e.g.
-#if(WIN32)
-#  list(APPEND CMAKE_MODULE_PATH "${PACKAGE_PREFIX_DIR}/../../../../cmake")
-#  list(APPEND CMAKE_PREFIX_PATH "${PACKAGE_PREFIX_DIR}/../../../../cmake")
-#endif()
-
 find_package(CMakeFunctions REQUIRED)
-
 find_package(Threads REQUIRED)
+find_package(Protobuf REQUIRED)


### PR DESCRIPTION
... as abseil (required in newer protobuf versions) somehow messes with paths, and then the following includes fail.
