### PR TITLE
[.clangtidy] Disabled readability-use-anyofallof warning

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -54,12 +54,13 @@ Checks: "-*,
   
   readability-*,
   -readability-braces-around-statements,
+  -readability-else-after-return,
+  -readability-function-cognitive-complexity,
   -readability-identifier-length,
   -readability-magic-numbers,
   -readability-redundant-access-specifiers,
-  -readability-function-cognitive-complexity,
-  -readability-else-after-return,
   -readability-uppercase-literal-suffix,
+  -readability-use-anyofallof,
 "
 WarningsAsErrors: ''
 HeaderFilterRegex: '^((?!/thirdparty/|/_deps/).)*$'


### PR DESCRIPTION
The code that clang tidy suggests is available in C++20 and later only.
Also, I don't agree that the suggestions are more readable.
