### PR TITLE
[core] Move eCAL::protobuf::CDynamicJSONSubscriber

### DIFF
--- a/ecal/samples/cpp/pubsub/protobuf/proto_dyn_json_rec/CMakeLists.txt
+++ b/ecal/samples/cpp/pubsub/protobuf/proto_dyn_json_rec/CMakeLists.txt
@@ -1,6 +1,6 @@
 # ========================= eCAL LICENSE =================================
 #
-# Copyright (C) 2016 - 2019 Continental Corporation
+# Copyright (C) 2016 - 2024 Continental Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ target_link_libraries(${PROJECT_NAME}
     eCAL::core_protobuf
 )
 
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 
 ecal_install_sample(${PROJECT_NAME})
 

--- a/ecal/samples/cpp/pubsub/protobuf/proto_dyn_json_rec/src/proto_dyn_json_rec.cpp
+++ b/ecal/samples/cpp/pubsub/protobuf/proto_dyn_json_rec/src/proto_dyn_json_rec.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,10 +25,9 @@
 
 const std::string MESSAGE_NAME("person");
 
-void ProtoMsgCallback(const char* topic_name_, const eCAL::SReceiveCallbackData* msg_)
+void ProtoMsgCallback(const char* topic_name_, const std::string& msg_, long long /*time_*/, long long /*clock_*/, long long /*id_*/)
 {
-  std::string content((char*)msg_->buf, msg_->size);
-  std::cout << topic_name_ << " : " << content << std::endl;
+  std::cout << topic_name_ << " : " << msg_ << std::endl;
   std::cout << std::endl;
 }
 


### PR DESCRIPTION
 based on CDynamicMessageSubscriber

### Description
eCAL::protobuf::CDynamicJSON Subscriber is now based on CDynamicMessageSubscriber, which greatly simplifies code.

API break: the message callback API is now changed, which should be fine for eCAL 6.

