### PR TITLE
[GH] Adding Ubuntu 24.04 to GH workflows

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04]
+        os: [ubuntu-24.04, ubuntu-22.04, ubuntu-20.04]
 
     runs-on: ${{ matrix.os }}
     


### PR DESCRIPTION
Added Ubuntu 24.04 (currently in beta) to GH workflows. 

Info: https://github.blog/changelog/2024-05-14-github-hosted-runners-public-beta-of-ubuntu-24-04-is-now-available/ 
