### PR TITLE
[core] expmap performance improvement

### DIFF
--- a/ecal/core/src/util/ecal_expmap.h
+++ b/ecal/core/src/util/ecal_expmap.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -305,11 +305,19 @@ namespace eCAL
       // Maybe pass the iterator instead of the key? or at least only get k once
       void update_timestamp(const Key& k)
       {
-        _key_tracker.erase(_key_to_value.at(k).second);
-        auto new_iterator = _key_tracker.emplace(_key_tracker.end(), std::make_pair(get_curr_time(), k));
-        _key_to_value.at(k).second = new_iterator;
-      }
+        auto it_in_map = _key_to_value.find(k);
+        if (it_in_map != _key_to_value.end())
+        {
+          auto& it_in_list = it_in_map->second.second;
 
+          // move the element to the end of the list
+          _key_tracker.splice(_key_tracker.end(), _key_tracker, it_in_list);
+
+          // update the timestamp
+          it_in_list->first = get_curr_time();
+        }
+      }
+      
       // Record a fresh key-value pair in the cache 
       std::pair<typename key_to_value_type::iterator, bool> insert(const Key& k, const T& v)
       {

--- a/ecal/core/src/util/ecal_expmap.h
+++ b/ecal/core/src/util/ecal_expmap.h
@@ -289,15 +289,8 @@ namespace eCAL
       // Remove all elements from the cache 
       void clear()
       {
-        // Assert method is never called when cache is empty 
-        //assert(!_key_tracker.empty());
-        auto it(_key_tracker.begin());
-
-        while (it != _key_tracker.end())
-        {
-          _key_to_value.erase(it->second); // erase the element from the map 
-          it = _key_tracker.erase(it);     // erase the element from the list
-        }
+        _key_to_value.clear(); // erase all elements from the map 
+        _key_tracker.clear();  // erase all elements from the list
       }
 
     private:

--- a/ecal/samples/cpp/monitoring/monitoring_get_topics/src/monitoring_get_topics.cpp
+++ b/ecal/samples/cpp/monitoring/monitoring_get_topics/src/monitoring_get_topics.cpp
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <string>
 #include <set>
+#include <thread>
 
 int main(int argc, char **argv)
 {

--- a/ecal/samples/cpp/monitoring/monitoring_get_topics/src/monitoring_get_topics.cpp
+++ b/ecal/samples/cpp/monitoring/monitoring_get_topics/src/monitoring_get_topics.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@
 
 int main(int argc, char **argv)
 {
-  int                                   run(0), runs(1000);
+  int                                   run(0), runs(10);
   std::chrono::steady_clock::time_point start_time;
 
   // initialize eCAL core API
@@ -48,8 +48,8 @@ int main(int argc, char **argv)
       auto num_topics = topic_info_map.size();
       auto diff_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time);
       std::cout << "GetTopics      : " << static_cast<double>(diff_time.count()) / runs << " ms" << " (" << num_topics << " topics)" << std::endl;
-      std::cout << std::endl;
     }
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
     // GetTopicNames
     {
@@ -66,6 +66,7 @@ int main(int argc, char **argv)
       std::cout << "GetTopicsNames : " << static_cast<double>(diff_time.count()) / runs << " ms" << " (" << num_topics << " topics)" << std::endl;
       std::cout << std::endl;
     }
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
   }
 
   // finalize eCAL API


### PR DESCRIPTION
### Description
For large maps the `update_timestamps` function is not performing well.

### Changes:
* Utilization of find Function: The find function is used to search for the key k in the `_key_to_value` map, rather than using at, which would throw an exception if the key is not found.
* Splicing Instead of Erasing and Inserting: Instead of erasing and re-inserting elements into the `_key_tracker` list, the new version uses the splice function to move the element to the end of the list, improving efficiency.
* Timestamp Update Improvement: The timestamp update logic has been simplified and made more explicit by directly assigning the current time to the timestamp associated with the key k.
* Simplified Clear Functionality: Just clearing the internal map and list without iterating over their elements.
