### PR TITLE
[CMake] Remove references to ${CMAKE_PROJECT_DIR} ...

### DIFF
--- a/ecal/CMakeLists.txt
+++ b/ecal/CMakeLists.txt
@@ -1,6 +1,6 @@
 # ========================= eCAL LICENSE =================================
 #
-# Copyright (C) 2016 - 2019 Continental Corporation
+# Copyright (C) 2016 - 2024 Continental Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 # ========================= eCAL LICENSE =================================
 
 cmake_minimum_required(VERSION 3.13)
+
+set(ECAL_CORE_PROJECT_ROOT ${CMAKE_CURRENT_LIST_DIR})
 
 # --------------------------------------------------------
 # core

--- a/ecal/tests/cpp/config_test/CMakeLists.txt
+++ b/ecal/tests/cpp/config_test/CMakeLists.txt
@@ -23,9 +23,9 @@ find_package(GTest REQUIRED)
 find_package(tclap REQUIRED)
 
 set(cmd_parser_src
-  ${CMAKE_SOURCE_DIR}/ecal/core/src/config/ecal_cmd_parser.cpp
-  ${CMAKE_SOURCE_DIR}/lib/ecal_utils/src/filesystem.cpp
-  ${CMAKE_SOURCE_DIR}/lib/ecal_utils/src/str_convert.cpp
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/config/ecal_cmd_parser.cpp
+  ${ECAL_PROJECT_ROOT}/lib/ecal_utils/src/filesystem.cpp   # Ideally we should reference relatively to ECAL_CORE_PROJECT_ROOT
+  ${ECAL_PROJECT_ROOT}/lib/ecal_utils/src/str_convert.cpp 
 )
 
 set(config_test_src
@@ -38,7 +38,7 @@ ecal_add_gtest(${PROJECT_NAME} ${config_test_src})
 target_include_directories(${PROJECT_NAME} PRIVATE 
   $<TARGET_PROPERTY:eCAL::core,INCLUDE_DIRECTORIES>
   ${CMAKE_CURRENT_LIST_DIR}/src
-  ${CMAKE_SOURCE_DIR}/ecal/core/src/config
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/config
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/ecal/tests/cpp/descgate_test/CMakeLists.txt
+++ b/ecal/tests/cpp/descgate_test/CMakeLists.txt
@@ -1,6 +1,6 @@
 # ========================= eCAL LICENSE =================================
 #
-# Copyright (C) 2016 - 2019 Continental Corporation
+# Copyright (C) 2016 - 2024 Continental Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ find_package(GTest REQUIRED)
 
 set(descgate_test_src
   src/getpublisher.cpp
-  ../../../core/src/ecal_descgate.cpp
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/ecal_descgate.cpp
 )
 
 ecal_add_gtest(${PROJECT_NAME} ${descgate_test_src})

--- a/ecal/tests/cpp/event_test/CMakeLists.txt
+++ b/ecal/tests/cpp/event_test/CMakeLists.txt
@@ -1,6 +1,6 @@
 # ========================= eCAL LICENSE =================================
 #
-# Copyright (C) 2016 - 2019 Continental Corporation
+# Copyright (C) 2016 - 2024 Continental Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ find_package(GTest REQUIRED)
 
 set(event_test_src
   src/event_test.cpp
-  ../../../core/src/ecal_event.cpp
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/ecal_event.cpp
 )
 
 ecal_add_gtest(${PROJECT_NAME} ${event_test_src})

--- a/ecal/tests/cpp/io_memfile_test/CMakeLists.txt
+++ b/ecal/tests/cpp/io_memfile_test/CMakeLists.txt
@@ -1,6 +1,6 @@
 # ========================= eCAL LICENSE =================================
 #
-# Copyright (C) 2016 - 2019 Continental Corporation
+# Copyright (C) 2016 - 2024 Continental Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,23 +24,23 @@ find_package(GTest REQUIRED)
 set(memfile_test_src
     src/memfile_test.cpp
     src/memfile_naming_test.cpp
-    ../../../core/src/io/mtx/ecal_named_mutex.cpp
-    ../../../core/src/io/shm/ecal_memfile.cpp
-    ../../../core/src/io/shm/ecal_memfile_db.cpp
-    ../../../core/src/io/shm/ecal_memfile_naming.cpp
+    ${ECAL_CORE_PROJECT_ROOT}/core/src/io/mtx/ecal_named_mutex.cpp
+    ${ECAL_CORE_PROJECT_ROOT}/core/src/io/shm/ecal_memfile.cpp
+    ${ECAL_CORE_PROJECT_ROOT}/core/src/io/shm/ecal_memfile_db.cpp
+    ${ECAL_CORE_PROJECT_ROOT}/core/src/io/shm/ecal_memfile_naming.cpp
 )
 
 if(UNIX)
 set(memfile_test_os_src
-    ../../../core/src/io/mtx/linux/ecal_named_mutex_impl.cpp
-    ../../../core/src/io/shm/linux/ecal_memfile_os.cpp
+    ${ECAL_CORE_PROJECT_ROOT}/core/src/io/mtx/linux/ecal_named_mutex_impl.cpp
+    ${ECAL_CORE_PROJECT_ROOT}/core/src/io/shm/linux/ecal_memfile_os.cpp
 )
 endif()
 
 if(WIN32)
 set(memfile_test_os_src
-    ../../../core/src/io/mtx/win32/ecal_named_mutex_impl.cpp
-    ../../../core/src/io/shm/win32/ecal_memfile_os.cpp
+    ${ECAL_CORE_PROJECT_ROOT}/core/src/io/mtx/win32/ecal_named_mutex_impl.cpp
+    ${ECAL_CORE_PROJECT_ROOT}/core/src/io/shm/win32/ecal_memfile_os.cpp
 )
 endif()
 

--- a/ecal/tests/cpp/serialization_test/CMakeLists.txt
+++ b/ecal/tests/cpp/serialization_test/CMakeLists.txt
@@ -1,6 +1,6 @@
 # ========================= eCAL LICENSE =================================
 #
-# Copyright (C) 2016 - 2019 Continental Corporation
+# Copyright (C) 2016 - 2024 Continental Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,51 +22,51 @@ find_package(Threads REQUIRED)
 find_package(GTest REQUIRED)
 
 set(nanopb_lib_src
-  ../../../core/src/serialization/nanopb/nanopb/pb.h
-  ../../../core/src/serialization/nanopb/nanopb/pb_common.c
-  ../../../core/src/serialization/nanopb/nanopb/pb_common.h
-  ../../../core/src/serialization/nanopb/nanopb/pb_decode.c
-  ../../../core/src/serialization/nanopb/nanopb/pb_decode.h
-  ../../../core/src/serialization/nanopb/nanopb/pb_encode.c
-  ../../../core/src/serialization/nanopb/nanopb/pb_encode.h
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/nanopb/nanopb/pb.h
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/nanopb/nanopb/pb_common.c
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/nanopb/nanopb/pb_common.h
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/nanopb/nanopb/pb_decode.c
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/nanopb/nanopb/pb_decode.h
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/nanopb/nanopb/pb_encode.c
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/nanopb/nanopb/pb_encode.h
 )
 
 set(nanopb_generated_src
-  ../../../core/src/serialization/nanopb/ecal.pb.c
-  ../../../core/src/serialization/nanopb/ecal.pb.h
-  ../../../core/src/serialization/nanopb/host.pb.c
-  ../../../core/src/serialization/nanopb/host.pb.h
-  ../../../core/src/serialization/nanopb/layer.pb.c
-  ../../../core/src/serialization/nanopb/layer.pb.h
-  ../../../core/src/serialization/nanopb/logging.pb.c
-  ../../../core/src/serialization/nanopb/logging.pb.h
-  ../../../core/src/serialization/nanopb/monitoring.pb.c
-  ../../../core/src/serialization/nanopb/monitoring.pb.h
-  ../../../core/src/serialization/nanopb/process.pb.c
-  ../../../core/src/serialization/nanopb/process.pb.h
-  ../../../core/src/serialization/nanopb/service.pb.c
-  ../../../core/src/serialization/nanopb/service.pb.h
-  ../../../core/src/serialization/nanopb/topic.pb.c
-  ../../../core/src/serialization/nanopb/topic.pb.h
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/nanopb/ecal.pb.c
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/nanopb/ecal.pb.h
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/nanopb/host.pb.c
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/nanopb/host.pb.h
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/nanopb/layer.pb.c
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/nanopb/layer.pb.h
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/nanopb/logging.pb.c
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/nanopb/logging.pb.h
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/nanopb/monitoring.pb.c
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/nanopb/monitoring.pb.h
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/nanopb/process.pb.c
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/nanopb/process.pb.h
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/nanopb/service.pb.c
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/nanopb/service.pb.h
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/nanopb/topic.pb.c
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/nanopb/topic.pb.h
 )
 
 set(ecal_serialize_src
-  ../../../core/src/serialization/ecal_serialize_common.cpp
-  ../../../core/src/serialization/ecal_serialize_common.h
-  ../../../core/src/serialization/ecal_serialize_logging.cpp
-  ../../../core/src/serialization/ecal_serialize_logging.h
-  ../../../core/src/serialization/ecal_serialize_monitoring.cpp
-  ../../../core/src/serialization/ecal_serialize_monitoring.h
-  ../../../core/src/serialization/ecal_serialize_sample_payload.cpp
-  ../../../core/src/serialization/ecal_serialize_sample_payload.h
-  ../../../core/src/serialization/ecal_serialize_sample_registration.cpp
-  ../../../core/src/serialization/ecal_serialize_sample_registration.h
-  ../../../core/src/serialization/ecal_serialize_service.cpp
-  ../../../core/src/serialization/ecal_serialize_service.h
-  ../../../core/src/serialization/ecal_struct_sample_common.h
-  ../../../core/src/serialization/ecal_struct_sample_payload.h
-  ../../../core/src/serialization/ecal_struct_sample_registration.h
-  ../../../core/src/serialization/ecal_struct_service.h
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/ecal_serialize_common.cpp
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/ecal_serialize_common.h
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/ecal_serialize_logging.cpp
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/ecal_serialize_logging.h
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/ecal_serialize_monitoring.cpp
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/ecal_serialize_monitoring.h
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/ecal_serialize_sample_payload.cpp
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/ecal_serialize_sample_payload.h
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/ecal_serialize_sample_registration.cpp
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/ecal_serialize_sample_registration.h
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/ecal_serialize_service.cpp
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/ecal_serialize_service.h
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/ecal_struct_sample_common.h
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/ecal_struct_sample_payload.h
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/ecal_struct_sample_registration.h
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/serialization/ecal_struct_service.h
 )
 
 set(unit_test_src
@@ -96,9 +96,7 @@ ecal_add_gtest(${PROJECT_NAME} ${nanopb_lib_src} ${nanopb_generated_src} ${ecal_
 
 target_include_directories(${PROJECT_NAME}
   PRIVATE 
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../../core/src/serialization/nanopb/nanopb>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../../core/src/serialization/nanopb>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../../core/include>
+    $<TARGET_PROPERTY:eCAL::core,INCLUDE_DIRECTORIES>
 )
 
 target_link_libraries(${PROJECT_NAME}


### PR DESCRIPTION
..  and upward references to source files.

Usage of ${CMAKE_PROJECT_DIR} causes the eCAL build to break when eCAL is included via `add_subdirectory`.
