### PR TITLE
const keyword removed from send functions

### DIFF
--- a/ecal/core/include/ecal/ecal_publisher.h
+++ b/ecal/core/include/ecal/ecal_publisher.h
@@ -194,7 +194,7 @@ namespace eCAL
      *
      * @return  Number of bytes sent. 
     **/
-    ECAL_API size_t Send(const void* buf_, size_t len_, long long time_ = DEFAULT_TIME_ARGUMENT) const;
+    ECAL_API size_t Send(const void* buf_, size_t len_, long long time_ = DEFAULT_TIME_ARGUMENT);
 
     /**
      * @brief Send a message to all subscribers.
@@ -204,7 +204,7 @@ namespace eCAL
      *
      * @return  Number of bytes sent.
     **/
-    ECAL_API size_t Send(CPayloadWriter& payload_, long long time_ = DEFAULT_TIME_ARGUMENT) const;
+    ECAL_API size_t Send(CPayloadWriter& payload_, long long time_ = DEFAULT_TIME_ARGUMENT);
 
     /**
      * @brief Send a message to all subscribers.
@@ -214,7 +214,7 @@ namespace eCAL
      *
      * @return  Number of bytes sent.
     **/
-    ECAL_API size_t Send(const std::string& s_, long long time_ = DEFAULT_TIME_ARGUMENT) const;
+    ECAL_API size_t Send(const std::string& s_, long long time_ = DEFAULT_TIME_ARGUMENT);
 
     /**
      * @brief Add callback function for publisher events.

--- a/ecal/core/src/pubsub/ecal_publisher.cpp
+++ b/ecal/core/src/pubsub/ecal_publisher.cpp
@@ -151,13 +151,13 @@ namespace eCAL
     return(true);
   }
 
-  size_t CPublisher::Send(const void* const buf_, const size_t len_, const long long time_ /* = DEFAULT_TIME_ARGUMENT */) const
+  size_t CPublisher::Send(const void* const buf_, const size_t len_, const long long time_ /* = DEFAULT_TIME_ARGUMENT */) 
   {
     CBufferPayloadWriter payload{ buf_, len_ };
     return Send(payload, time_);
   }
   
-  size_t CPublisher::Send(CPayloadWriter& payload_, long long time_) const
+  size_t CPublisher::Send(CPayloadWriter& payload_, long long time_)
   {
      if (!m_created) return(0);
 
@@ -180,7 +180,7 @@ namespace eCAL
      return written_bytes;
   }
 
-  size_t CPublisher::Send(const std::string& s_, long long time_) const
+  size_t CPublisher::Send(const std::string& s_, long long time_)
   {
     return(Send(s_.data(), s_.size(), time_));
   }


### PR DESCRIPTION
### Description
<!-- What does your PR change? -->

### Related issues
<!-- Type "Fixes #123" to automatically close that issue, when this PR is merged -->
- 

### Cherry-pick to
<!-- Leave empty, if you don't know. For master-only changes use "none"
- _none_
- 5.11 (old stable)
- 5.12 (current stable)
-->
