### PR TITLE
[core] shm-monitoring-performance

### DIFF
--- a/ecal/core/include/ecal/config/monitoring.h
+++ b/ecal/core/include/ecal/config/monitoring.h
@@ -30,18 +30,6 @@ namespace eCAL
 {
   namespace Monitoring
   {
-    namespace Types
-    {
-      enum Mode
-      {
-        none = 0,
-        udp_monitoring = 1 << 0,
-        shm_monitoring = 1 << 1
-      };
-
-      using Mode_Filter = char;
-    }
-
     namespace UDP
     {
       struct Configuration
@@ -60,9 +48,7 @@ namespace eCAL
 
     struct Configuration
     {
-      Types::Mode_Filter                           monitoring_mode{};         //!< Specify which monitoring is enabled (Default: none)
       eCAL::Types::ConstrainedInteger<1000, 1000>  monitoring_timeout{};      //!< Timeout for topic monitoring in ms (Default: 5000)
-      bool                                         network_monitoring{};      //!< Enable distribution of monitoring/registration information via network (Default: true)
       UDP::Configuration                           udp_options{};
       SHM::Configuration                           shm_options{};
 

--- a/ecal/core/src/config/ecal_config.cpp
+++ b/ecal/core/src/config/ecal_config.cpp
@@ -181,8 +181,6 @@ namespace eCAL
 
     namespace Experimental
     {
-      ECAL_API bool              IsShmMonitoringEnabled             () { return (GetConfiguration().monitoring.monitoring_mode & Monitoring::Types::Mode::shm_monitoring) != 0; }
-      ECAL_API bool              IsNetworkMonitoringDisabled        () { return !GetConfiguration().monitoring.network_monitoring; }
       ECAL_API size_t            GetShmMonitoringQueueSize          () { return GetConfiguration().monitoring.shm_options.shm_monitoring_queue_size; }
       ECAL_API std::string       GetShmMonitoringDomain             () { return GetConfiguration().monitoring.shm_options.shm_monitoring_domain;}
       ECAL_API bool              GetDropOutOfOrderMessages          () { return GetConfiguration().transport_layer.drop_out_of_order_messages; }

--- a/ecal/core/src/config/ecal_config_initializer.cpp
+++ b/ecal/core/src/config/ecal_config_initializer.cpp
@@ -155,10 +155,7 @@ namespace eCAL
 
       // monitoring options
       auto& monitoringOptions = monitoring;
-      auto  monitoringMode                          = iniConfig.get(EXPERIMENTAL, "shm_monitoring_enabled",      false) ? Monitoring::Types::Mode::shm_monitoring :  Monitoring::Types::Mode::none;
-      monitoringOptions.monitoring_mode             = static_cast<Monitoring::Types::Mode_Filter>(monitoringMode);
       monitoringOptions.monitoring_timeout          = iniConfig.get(MONITORING,   "timeout", MON_TIMEOUT);;
-      monitoringOptions.network_monitoring          = iniConfig.get(EXPERIMENTAL, "network_monitoring", EXP_NETWORK_MONITORING_ENABLED);
       monitoringOptions.filter_excl                 = iniConfig.get(MONITORING,   "filter_excl",                 MON_FILTER_EXCL);
       monitoringOptions.filter_incl                 = iniConfig.get(MONITORING,   "filter_incl",                 MON_FILTER_INCL);
 

--- a/ecal/core/src/ecal_def.h
+++ b/ecal/core/src/ecal_def.h
@@ -187,10 +187,6 @@ constexpr const char* EVENT_SHUTDOWN_PROC                   = "ecal_shutdown_pro
 /**********************************************************************************************/
 /*                                     experimental                                           */
 /**********************************************************************************************/
-/* enable distribution of monitoring/registration information via shared memory */
-constexpr bool EXP_SHM_MONITORING_ENABLED                   = false;
-/* enable distribution of monitoring/registration information via network (default) */
-constexpr bool EXP_NETWORK_MONITORING_ENABLED              = true;
 /* queue size of monitoring/registration events  */
 constexpr unsigned int EXP_SHM_MONITORING_QUEUE_SIZE        = 1024U;
 /* domain name for shared memory based monitoring/registration */
@@ -200,5 +196,3 @@ constexpr unsigned int EXP_MEMFILE_ACCESS_TIMEOUT           = 100U;
 
 /* enable dropping of payload messages that arrive out of order */
 constexpr bool EXP_DROP_OUT_OF_ORDER_MESSAGES               = false;
-
-constexpr eCAL::Monitoring::Types::Mode EXP_MONITORING_MODE  = eCAL::Monitoring::Types::Mode::none;

--- a/ecal/core/src/ecal_descgate.cpp
+++ b/ecal/core/src/ecal_descgate.cpp
@@ -183,14 +183,12 @@ namespace eCAL
     topic_quality_info.quality = topic_quality_;
 
     const std::unique_lock<std::mutex> lock(topic_info_map_.mtx);
-    topic_info_map_.map.erase_expired();
     topic_info_map_.map[topic_info_key] = topic_quality_info;
   }
 
   void CDescGate::RemTopicDescription(SQualityTopicIdMap& topic_info_map_, const std::string& topic_name_, const Util::TopicId& topic_id_)
   {
     const std::unique_lock<std::mutex> lock(topic_info_map_.mtx);
-    topic_info_map_.map.erase_expired();
     topic_info_map_.map.erase(STopicIdKey{ topic_name_, topic_id_ });
   }
 
@@ -213,7 +211,6 @@ namespace eCAL
     service_quality_info.response_quality   = response_type_quality_;
 
     const std::lock_guard<std::mutex> lock(service_method_info_map_.mtx);
-    service_method_info_map_.map.erase_expired();
     service_method_info_map_.map[service_method_info_key] = service_quality_info;
   }
 
@@ -222,7 +219,6 @@ namespace eCAL
     std::list<SServiceIdKey> service_method_infos_to_remove;
 
     const std::lock_guard<std::mutex> lock(service_method_info_map_.mtx);
-    service_method_info_map_.map.erase_expired();
 
     for (auto&& service_it : service_method_info_map_.map)
     {

--- a/ecal/core/src/registration/ecal_registration_provider.cpp
+++ b/ecal/core/src/registration/ecal_registration_provider.cpp
@@ -62,9 +62,9 @@ namespace eCAL
   {
     if(m_created) return;
 
-    // send registration to shared memory and to udp
-    m_use_registration_udp = !Config::Experimental::IsNetworkMonitoringDisabled();
-    m_use_registration_shm = Config::Experimental::IsShmMonitoringEnabled();
+    // send registration over udp or shared memory
+    m_use_registration_udp = Config::IsNetworkEnabled;
+    m_use_registration_shm = !m_use_registration_udp;
 
     if (m_use_registration_udp)
     {

--- a/ecal/core/src/registration/ecal_registration_receiver.cpp
+++ b/ecal/core/src/registration/ecal_registration_receiver.cpp
@@ -69,9 +69,9 @@ namespace eCAL
   {
     if(m_created) return;
 
-    // receive registration from shared memory and or udp
-    m_use_registration_udp = !Config::Experimental::IsNetworkMonitoringDisabled();
-    m_use_registration_shm     = Config::Experimental::IsShmMonitoringEnabled();
+    // receive registration via udp or shared memory
+    m_use_registration_udp = Config::IsNetworkEnabled;
+    m_use_registration_shm = !m_use_registration_udp;
 
     if (m_use_registration_udp)
     {

--- a/ecal/samples/CMakeLists.txt
+++ b/ecal/samples/CMakeLists.txt
@@ -1,6 +1,6 @@
 # ========================= eCAL LICENSE =================================
 #
-# Copyright (C) 2016 - 2019 Continental Corporation
+# Copyright (C) 2016 - 2024 Continental Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -66,6 +66,7 @@ endif()
 
 if(ECAL_CORE_PUBLISHER AND ECAL_CORE_SUBSCRIBER)
   add_subdirectory(cpp/benchmarks/perftool)
+  add_subdirectory(cpp/benchmarks/massive_pub_sub)
 endif()
 
 # misc

--- a/ecal/samples/cpp/benchmarks/massive_pub_sub/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/massive_pub_sub/CMakeLists.txt
@@ -1,0 +1,41 @@
+# ========================= eCAL LICENSE =================================
+#
+# Copyright (C) 2016 - 2024 Continental Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ========================= eCAL LICENSE =================================
+
+cmake_minimum_required(VERSION 3.10)
+
+set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
+
+project(massive_pub_sub)
+
+find_package(eCAL REQUIRED)
+
+set(massive_pub_sub_src
+    src/massive_pub_sub.cpp
+)
+
+ecal_add_sample(${PROJECT_NAME} ${massive_pub_sub_src})
+
+target_link_libraries(${PROJECT_NAME}
+  eCAL::core
+)
+
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
+
+ecal_install_sample(${PROJECT_NAME})
+
+set_property(TARGET ${PROJECT_NAME} PROPERTY FOLDER samples/cpp/benchmarks/massive_pub_sub)

--- a/ecal/samples/cpp/benchmarks/massive_pub_sub/src/massive_pub_sub.cpp
+++ b/ecal/samples/cpp/benchmarks/massive_pub_sub/src/massive_pub_sub.cpp
@@ -1,0 +1,128 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2024 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+#include <ecal/ecal.h>
+
+#include <iostream>
+#include <chrono>
+#include <sstream>
+#include <thread>
+#include <vector>
+
+const int subscriber_number                    (5000);
+
+const int publisher_number                     (5000);
+const int publisher_type_encoding_size_bytes   (10*1024);
+const int publisher_type_descriptor_size_bytes (10*1024);
+
+const int in_between_sleep_sec                 (5);
+const int final_sleep_sec                      (120);
+
+std::string GenerateSizedString(const std::string& name, size_t totalSize)
+{
+  if (name.empty() || totalSize == 0) {
+    return "";
+  }
+
+  std::string result;
+  result.reserve(totalSize);
+
+  while (result.size() + name.size() <= totalSize) {
+    result += name;
+  }
+
+  if (result.size() < totalSize) {
+    result += name.substr(0, totalSize - result.size());
+  }
+
+  return result;
+}
+
+int main(int argc, char** argv)
+{
+  // initialize eCAL API
+  eCAL::Initialize(argc, argv, "massive_pub_sub");
+
+  eCAL::Util::EnableLoopback(true);
+
+  // create subscriber
+  std::vector<eCAL::CSubscriber> vector_of_subscriber;
+  std::cout << "Subscriber creation started. (" << subscriber_number << ")" << std::endl;
+  {
+    // start time measurement
+    auto start_time = std::chrono::high_resolution_clock::now();
+
+    for (int i = 0; i < subscriber_number; i++)
+    {
+      // publisher topic name
+      std::stringstream tname;
+      tname << "TOPIC_" << i;
+
+      // create subscriber
+      vector_of_subscriber.emplace_back(tname.str());
+    }
+    // stop time measurement
+    auto end_time = std::chrono::high_resolution_clock::now();
+
+    // calculate the duration
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count();
+    std::cout << "Time taken for subscriber creation: " << duration << " milliseconds" << std::endl;
+  }
+
+  // sleep for a few seconds
+  std::this_thread::sleep_for(std::chrono::seconds(in_between_sleep_sec));
+
+  // create publisher
+  std::vector<eCAL::CPublisher> vector_of_publisher;
+  std::cout << "Publisher creation started. (" << publisher_number << ")" << std::endl;
+  {
+    // start time measurement
+    auto start_time = std::chrono::high_resolution_clock::now();
+
+    eCAL::SDataTypeInformation data_type_info;
+    data_type_info.name       = "TOPIC_TYPE_NAME";
+    data_type_info.encoding   = GenerateSizedString("TOPIC_TYPE_ENCODING",   publisher_type_encoding_size_bytes);
+    data_type_info.descriptor = GenerateSizedString("TOPIC_TYPE_DESCRIPTOR", publisher_type_descriptor_size_bytes);
+
+    for (int i = 0; i < publisher_number; i++)
+    {
+      // publisher topic name
+      std::stringstream tname;
+      tname << "TOPIC_" << i;
+
+      // create publisher
+      vector_of_publisher.emplace_back(tname.str(), data_type_info);
+    }
+    // stop time measurement
+    auto end_time = std::chrono::high_resolution_clock::now();
+
+    // calculate the duration
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count();
+    std::cout << "Time taken for publisher creation: " << duration << " milliseconds" << std::endl;
+  }
+  std::cout << std::endl;
+
+  // sleep for a few seconds
+  std::this_thread::sleep_for(std::chrono::seconds(final_sleep_sec));
+
+  // finalize eCAL API
+  eCAL::Finalize();
+
+  return(0);
+}


### PR DESCRIPTION
### Description

- shm_monitoring logic simplified, based on "network_enabled" only
- parallel shm_monitoring AND udp_monitoring feature removed massive_pub_sub sample added to test creation performance of  pub/sub for large scenarios and monitoring performance
- no more remvoval of expired values (erase_expired) in ApplyPub/Sub/Server/ClientDescription because of bad performance
