### PR TITLE
[gh-actions] kill-xprotect-scan-macos

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -11,6 +11,13 @@ jobs:
     runs-on: macos-13
 
     steps:
+      # XProtect can cause random failures if it decides that the DMG we create
+      # during the packaging phase is malware.
+      # See https://github.com/actions/runner-images/issues/7522 and https://github.com/servo/servo/pull/30779
+    - name: Kill XProtectBehaviorService
+      run: |
+          echo Killing XProtect.; sudo pkill -9 XProtect >/dev/null || true;
+
     - name: Downgrade Python version
       uses: actions/setup-python@v4
       id: cp39


### PR DESCRIPTION
### Description
Kill XProtect to avoid malware scan of dmg image.

### Related issues
See https://github.com/actions/runner-images/issues/7522