### PR TITLE
[core] new-pub-sub-matching-compatibility-5

### DIFF
--- a/ecal/core/CMakeLists.txt
+++ b/ecal/core/CMakeLists.txt
@@ -217,6 +217,10 @@ endif()
 ######################################
 # readwrite
 ######################################
+set(ecal_readwrite_src
+    src/readwrite/ecal_transport_layer.h
+)
+
 if(ECAL_CORE_PUBLISHER)
   set(ecal_writer_src
       src/readwrite/ecal_writer.cpp
@@ -537,6 +541,7 @@ set(ecal_sources
     ${ecal_monitoring_src}
     ${ecal_pub_src}
     ${ecal_sub_src}
+    ${ecal_readwrite_src}
     ${ecal_writer_src}
     ${ecal_reader_src}
     ${ecal_registration_src}

--- a/ecal/core/src/pubsub/ecal_pubgate.cpp
+++ b/ecal/core/src/pubsub/ecal_pubgate.cpp
@@ -129,7 +129,9 @@ namespace eCAL
     CDataWriter::SLayerStates layer_states;
     for (const auto& layer : ecal_topic.tlayer)
     {
-      if (layer.enabled)
+      // transport layer versions 0 and 1 did not support dynamic layer enable feature
+      // so we set assume layer is enabled if we receive a registration in this case
+      if (layer.enabled || (layer.version < 2))
       {
         switch (layer.type)
         {

--- a/ecal/core/src/pubsub/ecal_subgate.cpp
+++ b/ecal/core/src/pubsub/ecal_subgate.cpp
@@ -232,7 +232,9 @@ namespace eCAL
     CDataReader::SLayerStates layer_states;
     for (const auto& layer : ecal_topic.tlayer)
     {
-      if (layer.enabled)
+      // transport layer versions 0 and 1 did not support dynamic layer enable feature
+      // so we set assume layer is enabled if we receive a registration in this case
+      if (layer.enabled || layer.version < 2)
       {
         switch (layer.type)
         {

--- a/ecal/core/src/readwrite/ecal_reader.cpp
+++ b/ecal/core/src/readwrite/ecal_reader.cpp
@@ -32,6 +32,7 @@
 #include "ecal_reader.h"
 #include "ecal_global_accessors.h"
 #include "ecal_reader_layer.h"
+#include "ecal_transport_layer.h"
 
 #if ECAL_CORE_TRANSPORT_UDP
 #include "udp/ecal_reader_udp.h"
@@ -589,9 +590,9 @@ namespace eCAL
     {
       Registration::TLayer udp_tlayer;
       udp_tlayer.type      = tl_ecal_udp;
-      udp_tlayer.version   = 1;
+      udp_tlayer.version   = ecal_transport_layer_version;
       udp_tlayer.enabled   = m_layers.udp.read_enabled;
-      udp_tlayer.active = m_layers.udp.active;
+      udp_tlayer.active    = m_layers.udp.active;
       ecal_reg_sample_topic.tlayer.push_back(udp_tlayer);
     }
 #endif
@@ -601,9 +602,9 @@ namespace eCAL
     {
       Registration::TLayer shm_tlayer;
       shm_tlayer.type      = tl_ecal_shm;
-      shm_tlayer.version   = 1;
+      shm_tlayer.version   = ecal_transport_layer_version;
       shm_tlayer.enabled   = m_layers.shm.read_enabled;
-      shm_tlayer.active = m_layers.shm.active;
+      shm_tlayer.active    = m_layers.shm.active;
       ecal_reg_sample_topic.tlayer.push_back(shm_tlayer);
     }
 #endif
@@ -613,9 +614,9 @@ namespace eCAL
     {
       Registration::TLayer tcp_tlayer;
       tcp_tlayer.type      = tl_ecal_tcp;
-      tcp_tlayer.version   = 1;
+      tcp_tlayer.version   = ecal_transport_layer_version;
       tcp_tlayer.enabled   = m_layers.tcp.read_enabled;
-      tcp_tlayer.active = m_layers.tcp.active;
+      tcp_tlayer.active    = m_layers.tcp.active;
       ecal_reg_sample_topic.tlayer.push_back(tcp_tlayer);
     }
 #endif

--- a/ecal/core/src/readwrite/ecal_transport_layer.h
+++ b/ecal/core/src/readwrite/ecal_transport_layer.h
@@ -1,0 +1,29 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2024 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+/**
+ * @brief  transport layer settings
+**/
+
+#pragma once
+
+namespace eCAL
+{
+  constexpr int ecal_transport_layer_version = 2;
+}

--- a/ecal/core/src/readwrite/ecal_writer.cpp
+++ b/ecal/core/src/readwrite/ecal_writer.cpp
@@ -35,8 +35,7 @@
 #include "ecal_writer.h"
 #include "ecal_writer_base.h"
 #include "ecal_writer_buffer_payload.h"
-
-#include "pubsub/ecal_pubgate.h"
+#include "ecal_transport_layer.h"
 
 #include <chrono>
 #include <functional>
@@ -643,9 +642,9 @@ namespace eCAL
     {
       eCAL::Registration::TLayer udp_tlayer;
       udp_tlayer.type                      = tl_ecal_udp;
-      udp_tlayer.version                   = 1;
+      udp_tlayer.version                   = ecal_transport_layer_version;
       udp_tlayer.enabled                   = m_layers.udp.write_enabled;
-      udp_tlayer.active                 = m_layers.udp.active;
+      udp_tlayer.active                    = m_layers.udp.active;
       udp_tlayer.par_layer.layer_par_udpmc = m_writer_udp->GetConnectionParameter().layer_par_udpmc;
       ecal_reg_sample_topic.tlayer.push_back(udp_tlayer);
     }
@@ -657,9 +656,9 @@ namespace eCAL
     {
       eCAL::Registration::TLayer shm_tlayer;
       shm_tlayer.type                    = tl_ecal_shm;
-      shm_tlayer.version                 = 1;
+      shm_tlayer.version                 = ecal_transport_layer_version;
       shm_tlayer.enabled                 = m_layers.shm.write_enabled;
-      shm_tlayer.active               = m_layers.shm.active;
+      shm_tlayer.active                  = m_layers.shm.active;
       shm_tlayer.par_layer.layer_par_shm = m_writer_shm->GetConnectionParameter().layer_par_shm;
       ecal_reg_sample_topic.tlayer.push_back(shm_tlayer);
     }
@@ -671,9 +670,9 @@ namespace eCAL
     {
       eCAL::Registration::TLayer tcp_tlayer;
       tcp_tlayer.type                    = tl_ecal_tcp;
-      tcp_tlayer.version                 = 1;
+      tcp_tlayer.version                 = ecal_transport_layer_version;
       tcp_tlayer.enabled                 = m_layers.tcp.write_enabled;
-      tcp_tlayer.active               = m_layers.tcp.active;
+      tcp_tlayer.active                  = m_layers.tcp.active;
       tcp_tlayer.par_layer.layer_par_tcp = m_writer_tcp->GetConnectionParameter().layer_par_tcp;
       ecal_reg_sample_topic.tlayer.push_back(tcp_tlayer);
     }


### PR DESCRIPTION
### Description
Transport layer version is increased from 1 to 2 for eCAL6. This allows to recognize registrations of old transport layer configurations not containing the new dynamic enabling feature. In this case the transport layer is interpreted as enabled and the communication eCAL5 <> eCAL6 is kept compatible.
