### PR TITLE
[core] registration-sender-datarace-fix

### DIFF
--- a/ecal/core/src/registration/shm/ecal_registration_sender_shm.cpp
+++ b/ecal/core/src/registration/shm/ecal_registration_sender_shm.cpp
@@ -54,12 +54,13 @@ bool eCAL::CRegistrationSenderSHM::SendSampleList(const Registration::SampleList
 {
   bool return_value{true};
   // serialize whole sample list
-  if (SerializeToBuffer(sample_list, m_sample_list_buffer))
+  std::vector<char> sample_list_buffer;
+  if (SerializeToBuffer(sample_list, sample_list_buffer))
   {
-    if (!m_sample_list_buffer.empty())
+    if (!sample_list_buffer.empty())
     {
       // broadcast sample list over shm
-      return_value &= m_memfile_broadcast_writer.Write(m_sample_list_buffer.data(), m_sample_list_buffer.size());
+      return_value &= m_memfile_broadcast_writer.Write(sample_list_buffer.data(), sample_list_buffer.size());
     }
   }
   return return_value;

--- a/ecal/core/src/registration/shm/ecal_registration_sender_shm.h
+++ b/ecal/core/src/registration/shm/ecal_registration_sender_shm.h
@@ -51,7 +51,6 @@ namespace eCAL
     bool SendSampleList(const Registration::SampleList& sample_list) override;
 
   private:
-    std::vector<char>                   m_sample_list_buffer;
     CMemoryFileBroadcast                m_memfile_broadcast;
     CMemoryFileBroadcastWriter          m_memfile_broadcast_writer;
   };

--- a/ecal/core/src/registration/udp/ecal_registration_sender_udp.cpp
+++ b/ecal/core/src/registration/udp/ecal_registration_sender_udp.cpp
@@ -61,10 +61,11 @@ namespace eCAL
   bool CRegistrationSenderUDP::SendSample(const Registration::Sample& sample_)
   {
     // serialize single sample
-    if (SerializeToBuffer(sample_, m_sample_buffer))
+    std::vector<char> sample_buffer;
+    if (SerializeToBuffer(sample_, sample_buffer))
     {
       // send single sample over udp
-      return m_reg_sample_snd.Send("reg_sample", m_sample_buffer) != 0;
+      return m_reg_sample_snd.Send("reg_sample", sample_buffer) != 0;
     }
     return false;
   }

--- a/ecal/core/src/registration/udp/ecal_registration_sender_udp.h
+++ b/ecal/core/src/registration/udp/ecal_registration_sender_udp.h
@@ -50,6 +50,5 @@ namespace eCAL
     bool SendSample(const Registration::Sample& sample_);
 
     UDP::CSampleSender m_reg_sample_snd;
-    std::vector<char>  m_sample_buffer;
   };
 }


### PR DESCRIPTION
### Description
Class member variable (sample list buffer) moved into local function scope to avoid dataraces when calling SendSampleList() out of different threads.