### PR TITLE
[core] missing-include-ecal-writer

### DIFF
--- a/ecal/core/src/readwrite/ecal_writer.cpp
+++ b/ecal/core/src/readwrite/ecal_writer.cpp
@@ -36,6 +36,7 @@
 #include "ecal_global_accessors.h"
 #include "ecal_transport_layer.h"
 
+#include <algorithm>
 #include <chrono>
 #include <functional>
 #include <mutex>


### PR DESCRIPTION
### Description
missing include (std::find)