### PR TITLE
[core] remove monitoring timeout

### DIFF
--- a/ecal/core/include/ecal/config/monitoring.h
+++ b/ecal/core/include/ecal/config/monitoring.h
@@ -32,7 +32,6 @@ namespace eCAL
   {
     struct Configuration
     {
-      eCAL::Types::ConstrainedInteger<1000, 1000> timeout     { 5000U };     //!< Timeout for topic monitoring in ms (Default: 5000)
       std::string                                 filter_excl {  "^__.*$" }; //!< Topics blacklist as regular expression (will not be monitored) (Default: "^__.*$")
       std::string                                 filter_incl { "" };        //!< Topics whitelist as regular expression (will be monitored only) (Default: "")
     };

--- a/ecal/core/include/ecal/config/registration.h
+++ b/ecal/core/include/ecal/config/registration.h
@@ -64,7 +64,7 @@ namespace eCAL
 
     struct Configuration
     {
-      unsigned int         registration_timeout { 60000U };                           //!< Timeout for topic registration in ms (internal) (Default: 60000)
+      unsigned int         registration_timeout { 10000U };                           //!< Timeout for topic registration in ms (internal) (Default: 10000)
       unsigned int         registration_refresh { 1000U };                            //!< Topic registration refresh cylce (has to be smaller then registration timeout!) (Default: 1000)                                   
 
       bool                 network_enabled      { false };                            /*!< true  = all eCAL components communicate over network boundaries

--- a/ecal/core/include/ecal/ecal_config.h
+++ b/ecal/core/include/ecal/ecal_config.h
@@ -96,7 +96,6 @@ namespace eCAL
     // monitoring
     /////////////////////////////////////
 
-    ECAL_API int                      GetMonitoringTimeoutMs               ();
     ECAL_API std::string              GetMonitoringFilterExcludeList       ();
     ECAL_API std::string              GetMonitoringFilterIncludeList       ();
     ECAL_API eCAL_Logging_Filter      GetConsoleLogFilter                  ();

--- a/ecal/core/src/builder/monitoring_attribute_builder.cpp
+++ b/ecal/core/src/builder/monitoring_attribute_builder.cpp
@@ -27,7 +27,6 @@ namespace eCAL
     {
       SAttributes attributes;
 
-      attributes.timeout     = config_.timeout;
       attributes.filter_excl = config_.filter_excl;
       attributes.filter_incl = config_.filter_incl;
       

--- a/ecal/core/src/builder/registration_attribute_builder.cpp
+++ b/ecal/core/src/builder/registration_attribute_builder.cpp
@@ -25,6 +25,7 @@ namespace eCAL
   {
     Registration::SAttributes attr;
     
+    attr.timeout           = std::chrono::milliseconds(reg_config_.registration_timeout);
     attr.refresh           = reg_config_.registration_refresh;
     attr.network_enabled   = reg_config_.network_enabled;
     attr.loopback          = reg_config_.loopback;

--- a/ecal/core/src/config/configuration_to_yaml.cpp
+++ b/ecal/core/src/config/configuration_to_yaml.cpp
@@ -189,7 +189,6 @@ namespace YAML
   Node convert<eCAL::Monitoring::Configuration>::encode(const eCAL::Monitoring::Configuration& config_)
   {
     Node node;
-    node["timeout"]    << config_.timeout;
     node["filter_excl"] = config_.filter_excl;
     node["filter_incl"] = config_.filter_incl;
 
@@ -198,7 +197,6 @@ namespace YAML
 
   bool convert<eCAL::Monitoring::Configuration>::decode(const Node& node_, eCAL::Monitoring::Configuration& config_)
   {
-    AssignValue<unsigned int>(config_.timeout, node_, "timeout");
     AssignValue<std::string>(config_.filter_excl, node_, "filter_excl");
     AssignValue<std::string>(config_.filter_incl, node_, "filter_incl");
     return true;

--- a/ecal/core/src/config/default_configuration.cpp
+++ b/ecal/core/src/config/default_configuration.cpp
@@ -166,8 +166,6 @@ namespace eCAL
       ss << R"()"                                                                                                                   << "\n";
       ss << R"(# Monitoring configuration)"                                                                                         << "\n";
       ss << R"(monitoring:)"                                                                                                        << "\n";
-      ss << R"(  # Timeout for topic monitoring in ms (Default: 5000), increase in 1000er steps)"                                   << "\n";
-      ss << R"(  timeout: )"                                         << config_.monitoring.timeout                                  << "\n";
       ss << R"(  # Topics blacklist as regular expression (will not be monitored))"                                                 << "\n";
       ss << R"(  filter_excl: )"                                     << quoteString(config_.monitoring.filter_excl)                 << "\n";
       ss << R"(  # Topics whitelist as regular expression (will be monitored only) (Default: ""))"                                  << "\n";

--- a/ecal/core/src/config/ecal_config.cpp
+++ b/ecal/core/src/config/ecal_config.cpp
@@ -81,7 +81,6 @@ namespace eCAL
     // monitoring
     /////////////////////////////////////
     
-    ECAL_API int                 GetMonitoringTimeoutMs             () { return GetConfiguration().monitoring.timeout; }
     ECAL_API std::string         GetMonitoringFilterExcludeList     () { return GetConfiguration().monitoring.filter_excl; }
     ECAL_API std::string         GetMonitoringFilterIncludeList     () { return GetConfiguration().monitoring.filter_incl; }
     ECAL_API eCAL_Logging_Filter GetConsoleLogFilter                () { return GetConfiguration().logging.sinks.console.filter_log_con; }

--- a/ecal/core/src/registration/attributes/registration_attributes.h
+++ b/ecal/core/src/registration/attributes/registration_attributes.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <string>
 #include <ecal/types/ecal_custom_data_types.h>
 
@@ -50,13 +51,14 @@ namespace eCAL
 
     struct SAttributes
     {
-      bool         network_enabled;
-      bool         loopback;
-      bool         shm_enabled;
-      bool         udp_enabled;
-      unsigned int refresh;
-      std::string  host_group_name;
-      int          process_id;
+      std::chrono::milliseconds timeout;
+      bool                      network_enabled;
+      bool                      loopback;
+      bool                      shm_enabled;
+      bool                      udp_enabled;
+      unsigned int              refresh;
+      std::string               host_group_name;
+      int                       process_id;
 
       SUDPAttributes     udp;
       SSHMAttributes     shm;

--- a/ecal/core/src/registration/ecal_registration_receiver.cpp
+++ b/ecal/core/src/registration/ecal_registration_receiver.cpp
@@ -85,7 +85,7 @@ namespace eCAL
     if(m_created) return;
 
     m_timeout_provider = std::make_unique<Registration::CTimeoutProvider<std::chrono::steady_clock>>(
-      std::chrono::milliseconds(Config::GetMonitoringTimeoutMs()),
+      m_attributes.timeout,
       [this](const Registration::Sample& sample_)
       {
         return m_sample_applier.ApplySample(sample_);

--- a/ecal/tests/cpp/config_test/src/config_test.cpp
+++ b/ecal/tests/cpp/config_test/src/config_test.cpp
@@ -67,7 +67,6 @@ TEST(core_cpp_config /*unused*/, user_config_passing /*unused*/)
     custom_config.transport_layer.udp.network.group           = ip_address;
     custom_config.transport_layer.udp.send_buffer             = upd_snd_buff;
     
-    custom_config.monitoring.timeout                          = mon_timeout;
     custom_config.monitoring.filter_excl                      = mon_filter_excl;
     custom_config.logging.sinks.console.filter_log_con        = mon_log_filter_con;
 
@@ -94,9 +93,6 @@ TEST(core_cpp_config /*unused*/, user_config_passing /*unused*/)
   // Test UDP send buffer assignment, default is 5242880
   EXPECT_EQ(upd_snd_buff, eCAL::GetConfiguration().transport_layer.udp.send_buffer);
 
-  // Test monitoring timeout assignment, default is 5000U
-  EXPECT_EQ(mon_timeout, eCAL::GetConfiguration().monitoring.timeout);
-
   // Test monitoring filter exclude assignment, default is "_.*"
   EXPECT_EQ(mon_filter_excl, eCAL::GetConfiguration().monitoring.filter_excl);
 
@@ -106,7 +102,7 @@ TEST(core_cpp_config /*unused*/, user_config_passing /*unused*/)
   // Test publisher sendmode assignment, default is eCAL::TLayer::eSendMode::smode_auto
   EXPECT_EQ(pub_use_shm, eCAL::GetConfiguration().publisher.layer.shm.enable);
 
-  // Test registration option assignment, default timeout is 60000U and default refresh is 1000U
+  // Test registration option assignment, default timeout is 10000U and default refresh is 1000U
   EXPECT_EQ(registration_timeout, eCAL::GetConfiguration().registration.registration_timeout);
   EXPECT_EQ(registration_refresh, eCAL::GetConfiguration().registration.registration_refresh);
 


### PR DESCRIPTION
### Description
Remove the monitoring timeout from Config (+API function) because it is no longer used within eCAL.
Additionally, the default registration timeout is set to 10 seconds as a compromise between a stable connection and up to date display in eCAL Monitor.