### PR TITLE
[core] Make STopicId available in subscriber callbacks

### DIFF
--- a/ecal/core/include/ecal/ecal_callback.h
+++ b/ecal/core/include/ecal/ecal_callback.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -124,12 +124,21 @@ namespace eCAL
   };
 
   /**
-   * @brief Raw data receive callback function type.
+   * @brief Receive callback function type with topic name and data struct.
    *
    * @param topic_name_  The topic name of the received message.
    * @param data_        Data struct containing payload, timestamp and publication clock.
   **/
   using ReceiveCallbackT = std::function<void (const char *, const struct SReceiveCallbackData *)>;
+
+  /**
+   * @brief Receive callback function type with topic id and data struct. The topic id contains the topic name, the process
+   *          name, the host name and a uniques topic identifier.
+   *
+   * @param topic_id_    The topic id struct of the received message.
+   * @param data_        Data struct containing payload, timestamp and publication clock.
+  **/
+  using ReceiveIDCallbackT = std::function<void(const Registration::STopicId&, const SReceiveCallbackData&)>;
 
   /**
    * @brief Timer callback function type.

--- a/ecal/core/include/ecal/ecal_publisher.h
+++ b/ecal/core/include/ecal/ecal_publisher.h
@@ -264,6 +264,13 @@ namespace eCAL
     ECAL_API std::string GetTopicName() const;
 
     /**
+     * @brief Gets a unique ID of this Publisher
+     *
+     * @return  The topic id.
+    **/
+    ECAL_API Registration::STopicId GetId() const;
+
+    /**
      * @brief Gets description of the connected topic.
      *
      * @return  The topic information.

--- a/ecal/core/include/ecal/ecal_subscriber.h
+++ b/ecal/core/include/ecal/ecal_subscriber.h
@@ -209,6 +209,15 @@ namespace eCAL
     ECAL_API bool AddReceiveCallback(ReceiveCallbackT callback_);
 
     /**
+     * @brief Add callback function for incoming receives.
+     *
+     * @param callback_  The callback function to add.
+      *
+      * @return  True if succeeded, false if not.
+     **/
+    ECAL_API bool AddReceiveCallback(ReceiveIDCallbackT callback_);
+
+    /**
      * @brief Remove callback function for incoming receives. 
      *
      * @return  True if succeeded, false if not. 
@@ -261,6 +270,13 @@ namespace eCAL
      * @return  The topic name. 
     **/
     ECAL_API std::string GetTopicName() const;
+
+    /**
+     * @brief Gets a unique ID of this Subscriber
+     *
+     * @return  The topic id.
+    **/
+    ECAL_API Registration::STopicId GetId() const;
 
     /**
      * @brief Gets description of the connected topic.

--- a/ecal/core/include/ecal/ecal_types.h
+++ b/ecal/core/include/ecal/ecal_types.h
@@ -25,6 +25,7 @@
 #pragma once
 #include <string>
 #include <tuple>
+#include <iostream>
 
 namespace eCAL
 {
@@ -87,27 +88,38 @@ namespace eCAL
   {
     struct SEntityId
     {
-      std::string  entity_id;         // unique id within that process
+      std::string  entity_id;         // unique id within that process (it should already be unique within the whole system)
       int32_t      process_id = 0;    // process id which produced the sample
       std::string  host_name;         // host which produced the sample
 
       bool operator==(const SEntityId& other) const {
-        return entity_id  == other.entity_id  &&
-               process_id == other.process_id &&
-               host_name  == other.host_name;
+        return entity_id == other.entity_id;
       }
 
       bool operator<(const SEntityId& other) const
       {
-        return std::tie(process_id, entity_id, host_name)
-          < std::tie(other.process_id, other.entity_id, other.host_name);
+        return entity_id < other.entity_id;
       }
     };
+
+    // Overload the << operator for SEntityId
+    inline std::ostream& operator<<(std::ostream& os, const SEntityId& id)
+    {
+      os << "SEntityId(entity_id: " << id.entity_id
+        << ", process_id: " << id.process_id
+        << ", host_name: " << id.host_name << ")";
+      return os;
+    }
 
     struct STopicId
     {
       SEntityId    topic_id;
       std::string  topic_name;
+
+      bool operator==(const STopicId& other) const
+      {
+        return topic_id == other.topic_id && topic_name == other.topic_name;
+      }
 
       bool operator<(const STopicId& other) const
       {
@@ -115,11 +127,23 @@ namespace eCAL
       }
     };
 
+    inline std::ostream& operator<<(std::ostream& os, const STopicId& id)
+    {
+      os << "STopicId(topic_id: " << id.topic_id
+        << ", topic_name: " << id.topic_name << ")";
+      return os;
+    }
+
     struct SServiceId
     {
       SEntityId    service_id;
       std::string  service_name;
       std::string  method_name;
+
+      bool operator==(const SServiceId& other) const
+      {
+        return service_id == other.service_id && service_name == other.service_name && method_name == other.method_name;
+      }
 
       bool operator<(const SServiceId& other) const
       {

--- a/ecal/core/src/io/shm/ecal_memfile_pool.h
+++ b/ecal/core/src/io/shm/ecal_memfile_pool.h
@@ -42,7 +42,7 @@
 
 namespace eCAL
 {
-  using MemFileDataCallbackT = std::function<size_t (const std::string &, const std::string &, const char *, size_t, long long, long long, long long, size_t)>;
+  using MemFileDataCallbackT = std::function<size_t (const char *, size_t, long long, long long, long long, size_t)>;
 
   ////////////////////////////////////////
   // CMemFileObserver
@@ -61,14 +61,14 @@ namespace eCAL
     bool Create(const std::string& memfile_name_, const std::string& memfile_event_);
     bool Destroy();
 
-    bool Start(const std::string& topic_name_, const std::string& topic_id_, int timeout_, const MemFileDataCallbackT& callback_);
+    bool Start(int timeout_, const MemFileDataCallbackT& callback_);
     bool Stop();
     bool IsObserving() {return(m_is_observing);};
 
     bool ResetTimeout();
 
   protected:
-    void Observe(const std::string& topic_name_, const std::string& topic_id_, int timeout_);
+    void Observe(int timeout_);
     bool ReadFileHeader(SMemFileHeader& memfile_hdr);
 
     std::atomic<bool>       m_created;
@@ -97,7 +97,7 @@ namespace eCAL
     void Start();
     void Stop();
 
-    bool ObserveFile(const std::string& memfile_name_, const std::string& memfile_event_, const std::string& topic_name_, const std::string& topic_id_, int timeout_observation_ms, const MemFileDataCallbackT& callback_);
+    bool ObserveFile(const std::string& memfile_name_, const std::string& memfile_event_, int timeout_observation_ms, const MemFileDataCallbackT& callback_);
 
   protected:
     void CleanupPoolThread();

--- a/ecal/core/src/pubsub/ecal_publisher.cpp
+++ b/ecal/core/src/pubsub/ecal_publisher.cpp
@@ -220,6 +220,12 @@ namespace eCAL
     return(m_datawriter->GetTopicName());
   }
 
+  Registration::STopicId CPublisher::GetId() const
+  {
+    if (m_datawriter == nullptr) return{};
+    return(m_datawriter->GetId());
+  }
+
   SDataTypeInformation CPublisher::GetDataTypeInformation() const
   {
     if (m_datawriter == nullptr) return(SDataTypeInformation{});

--- a/ecal/core/src/pubsub/ecal_subgate.cpp
+++ b/ecal/core/src/pubsub/ecal_subgate.cpp
@@ -124,7 +124,7 @@ namespace eCAL
       if (layer_ == eTLayerType::tl_none)
       {
         // log it
-        Logging::Log(log_level_error, ecal_sample.topic.tname + " : payload received without layer definition !");
+        Logging::Log(log_level_error, ecal_sample.topic_info.tname + " : payload received without layer definition !");
       }
 #endif
 
@@ -153,7 +153,7 @@ namespace eCAL
       {
         // apply sample to data reader
         const std::shared_lock<std::shared_timed_mutex> lock(m_topic_name_datareader_sync);
-        auto res = m_topic_name_datareader_map.equal_range(ecal_sample.topic.tname);
+        auto res = m_topic_name_datareader_map.equal_range(ecal_sample.topic_info.tname);
         std::transform(
           res.first, res.second, std::back_inserter(readers_to_apply), [](const auto& match) { return match.second; }
         );
@@ -163,7 +163,7 @@ namespace eCAL
       for (const auto& reader : readers_to_apply)
       {
         applied_size = reader->ApplySample(
-          ecal_sample.topic.tid,
+          ecal_sample.topic_info,
           payload_addr,
           payload_size,
           ecal_sample_content.id,
@@ -182,7 +182,7 @@ namespace eCAL
     return (applied_size > 0);
   }
 
-  bool CSubGate::ApplySample(const std::string& topic_name_, const std::string& topic_id_, const char* buf_, size_t len_, long long id_, long long clock_, long long time_, size_t hash_, eTLayerType layer_)
+  bool CSubGate::ApplySample(const Payload::TopicInfo& topic_info_, const char* buf_, size_t len_, long long id_, long long clock_, long long time_, size_t hash_, eTLayerType layer_)
   {
     if (!m_created) return false;
 
@@ -194,7 +194,7 @@ namespace eCAL
     // Apply the samples to the readers afterwards.
     {
       const std::shared_lock<std::shared_timed_mutex> lock(m_topic_name_datareader_sync);
-      auto res = m_topic_name_datareader_map.equal_range(topic_name_);
+      auto res = m_topic_name_datareader_map.equal_range(topic_info_.tname);
       std::transform(
         res.first, res.second, std::back_inserter(readers_to_apply), [](const auto& match) { return match.second; }
       );
@@ -203,7 +203,7 @@ namespace eCAL
 
     for (const auto& reader : readers_to_apply)
     {
-      applied_size = reader->ApplySample(topic_id_, buf_, len_, id_, clock_, time_, hash_, layer_);
+      applied_size = reader->ApplySample(topic_info_, buf_, len_, id_, clock_, time_, hash_, layer_);
     }
 
     return (applied_size > 0);

--- a/ecal/core/src/pubsub/ecal_subgate.h
+++ b/ecal/core/src/pubsub/ecal_subgate.h
@@ -49,7 +49,7 @@ namespace eCAL
     bool HasSample(const std::string& sample_name_);
 
     bool ApplySample(const char* serialized_sample_data_, size_t serialized_sample_size_, eTLayerType layer_);
-    bool ApplySample(const std::string& topic_name_, const std::string& topic_id_, const char* buf_, size_t len_, long long id_, long long clock_, long long time_, size_t hash_, eTLayerType layer_);
+    bool ApplySample(const Payload::TopicInfo& topic_info_, const char* buf_, size_t len_, long long id_, long long clock_, long long time_, size_t hash_, eTLayerType layer_);
 
     void ApplyPubRegistration(const Registration::Sample& ecal_sample_);
     void ApplyPubUnregistration(const Registration::Sample& ecal_sample_);

--- a/ecal/core/src/pubsub/ecal_subscriber.cpp
+++ b/ecal/core/src/pubsub/ecal_subscriber.cpp
@@ -148,7 +148,16 @@ namespace eCAL
 
   bool CSubscriber::AddReceiveCallback(ReceiveCallbackT callback_)
   {
-    if(m_datareader == nullptr) return(false);
+    auto id_callback = [callback_](const Registration::STopicId& topic_id_, const SReceiveCallbackData& data_)
+    {
+      callback_(topic_id_.topic_name.c_str(), &data_);
+    };
+    return AddReceiveCallback(id_callback);
+  }
+
+  bool CSubscriber::AddReceiveCallback(ReceiveIDCallbackT callback_)
+  {
+    if (m_datareader == nullptr) return(false);
     RemReceiveCallback();
     return(m_datareader->AddReceiveCallback(std::move(callback_)));
   }
@@ -188,6 +197,12 @@ namespace eCAL
   {
     if(m_datareader == nullptr) return("");
     return(m_datareader->GetTopicName());
+  }
+
+  Registration::STopicId CSubscriber::GetId() const
+  {
+    if (m_datareader == nullptr) return{};
+    return(m_datareader->GetId());
   }
   
   SDataTypeInformation CSubscriber::GetDataTypeInformation() const

--- a/ecal/core/src/readwrite/ecal_reader.h
+++ b/ecal/core/src/readwrite/ecal_reader.h
@@ -70,7 +70,7 @@ namespace eCAL
 
     bool Read(std::string& buf_, long long* time_ = nullptr, int rcv_timeout_ms_ = 0);
 
-    bool AddReceiveCallback(ReceiveCallbackT callback_);
+    bool AddReceiveCallback(ReceiveIDCallbackT callback_);
     bool RemReceiveCallback();
 
     bool AddEventCallback(eCAL_Subscriber_Event type_, SubEventCallbackT callback_);
@@ -92,12 +92,22 @@ namespace eCAL
     bool IsPublished() const;
     size_t GetPublisherCount() const;
 
+    Registration::STopicId GetId() const
+    {
+      Registration::STopicId id;
+      id.topic_name          = m_topic_name;
+      id.topic_id.entity_id  = m_topic_id;
+      id.topic_id.host_name  = m_host_name;
+      id.topic_id.process_id = m_pid;
+      return id;
+    }
+
     std::string          GetTopicName()           const { return(m_topic_name); }
     std::string          GetTopicID()             const { return(m_topic_id); }
     SDataTypeInformation GetDataTypeInformation() const { return(m_topic_info); }
 
     void InitializeLayers();
-    size_t ApplySample(const std::string& tid_, const char* payload_, size_t size_, long long id_, long long clock_, long long time_, size_t hash_, eTLayerType layer_);
+    size_t ApplySample(const Payload::TopicInfo& topic_info_, const char* payload_, size_t size_, long long id_, long long clock_, long long time_, size_t hash_, eTLayerType layer_);
 
     std::string Dump(const std::string& indent_ = "");
 
@@ -150,7 +160,7 @@ namespace eCAL
     long long                                 m_read_time = 0;
 
     std::mutex                                m_receive_callback_mtx;
-    ReceiveCallbackT                          m_receive_callback;
+    ReceiveIDCallbackT                        m_receive_callback;
     std::atomic<int>                          m_receive_time;
 
     std::deque<size_t>                        m_sample_hash_queue;

--- a/ecal/core/src/readwrite/ecal_writer.h
+++ b/ecal/core/src/readwrite/ecal_writer.h
@@ -100,6 +100,16 @@ namespace eCAL
     bool IsSubscribed() const;
     size_t GetSubscriberCount() const;
 
+    Registration::STopicId GetId() const
+    {
+      Registration::STopicId id;
+      id.topic_name          = m_topic_name;
+      id.topic_id.entity_id  = m_topic_id;
+      id.topic_id.host_name  = m_host_name;
+      id.topic_id.process_id = m_pid;
+      return id;
+    }
+
     const std::string&          GetTopicName()           const { return(m_topic_name); }
     const SDataTypeInformation& GetDataTypeInformation() const { return m_topic_info; }
 

--- a/ecal/core/src/readwrite/shm/ecal_reader_shm.h
+++ b/ecal/core/src/readwrite/shm/ecal_reader_shm.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@
 
 #include "ecal_def.h"
 #include "readwrite/ecal_reader_layer.h"
+#include "serialization/ecal_struct_sample_payload.h"
 
 #include <cstddef>
 #include <memory>
@@ -48,6 +49,6 @@ namespace eCAL
     void SetConnectionParameter(SReaderLayerPar& par_) override;
 
   private:
-    size_t OnNewShmFileContent(const std::string& topic_name_, const std::string& topic_id_, const char* buf_, size_t len_, long long id_, long long clock_, long long time_, size_t hash_);
+    size_t OnNewShmFileContent(const Payload::TopicInfo& topic_info_, const char* buf_, size_t len_, long long id_, long long clock_, long long time_, size_t hash_);
   };
 }

--- a/ecal/core/src/readwrite/tcp/ecal_reader_tcp.cpp
+++ b/ecal/core/src/readwrite/tcp/ecal_reader_tcp.cpp
@@ -105,12 +105,11 @@ namespace eCAL
       if (g_subgate() != nullptr)
       {
         // use this intermediate variables as optimization
-        const auto& ecal_header_topic   = m_ecal_header.topic;
-        const auto& ecal_header_content = m_ecal_header.content;
-        // apply sample
+        const auto& ecal_header_topic_info = m_ecal_header.topic_info;
+        const auto& ecal_header_content    = m_ecal_header.content;
+
         g_subgate()->ApplySample(
-          ecal_header_topic.tname,
-          ecal_header_topic.tid,
+          ecal_header_topic_info,
           data_payload,
           static_cast<size_t>(ecal_header_content.size),
           ecal_header_content.id,

--- a/ecal/core/src/readwrite/tcp/ecal_writer_tcp.cpp
+++ b/ecal/core/src/readwrite/tcp/ecal_writer_tcp.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@
 **/
 
 #include <ecal/ecal_config.h>
+#include <ecal/ecal_process.h>
 
 #include "serialization/ecal_serialize_sample_payload.h"
 
@@ -79,7 +80,7 @@ namespace eCAL
 
     // create new payload sample (header information only, no payload)
     Payload::Sample proto_header;
-    auto& proto_header_topic = proto_header.topic;
+    auto& proto_header_topic = proto_header.topic_info;
     proto_header_topic.tname = m_topic_name;
     proto_header_topic.tid   = m_topic_id;
 

--- a/ecal/core/src/readwrite/udp/ecal_writer_udp.cpp
+++ b/ecal/core/src/readwrite/udp/ecal_writer_udp.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@
 **/
 
 #include <ecal/ecal_log.h>
+#include <ecal/ecal_process.h>
 
 #include "ecal_writer_udp.h"
 #include "io/udp/ecal_udp_configurations.h"
@@ -77,10 +78,11 @@ namespace eCAL
     Payload::Sample ecal_sample;
     ecal_sample.cmd_type = eCmdType::bct_set_sample;
 
-    auto& ecal_sample_topic = ecal_sample.topic;
-    ecal_sample_topic.hname = m_host_name;
-    ecal_sample_topic.tname = m_topic_name;
-    ecal_sample_topic.tid   = m_topic_id;
+    // fill sample info
+    auto& ecal_sample_topic_info = ecal_sample.topic_info;
+    ecal_sample_topic_info.hname = m_host_name;
+    ecal_sample_topic_info.tname = m_topic_name;
+    ecal_sample_topic_info.tid   = m_topic_id;
 
     // append content
     auto& ecal_sample_content = ecal_sample.content;
@@ -100,14 +102,14 @@ namespace eCAL
       {
         if (m_sample_sender_loopback)
         {
-          sent = m_sample_sender_loopback->Send(ecal_sample.topic.tname, m_sample_buffer);
+          sent = m_sample_sender_loopback->Send(ecal_sample.topic_info.tname, m_sample_buffer);
         }
       }
       else
       {
         if (m_sample_sender_no_loopback)
         {
-          sent = m_sample_sender_no_loopback->Send(ecal_sample.topic.tname, m_sample_buffer);
+          sent = m_sample_sender_no_loopback->Send(ecal_sample.topic_info.tname, m_sample_buffer);
         }
       }
     }

--- a/ecal/core/src/serialization/ecal_serialize_sample_payload.cpp
+++ b/ecal/core/src/serialization/ecal_serialize_sample_payload.cpp
@@ -74,6 +74,8 @@ namespace
     pb_sample_.has_topic = true;
     // hname
     eCAL::nanopb::encode_string(pb_sample_.topic.hname, payload_.topic_info.hname);
+    // pid
+    pb_sample_.topic.pid = payload_.topic_info.pid;
     // tid
     eCAL::nanopb::encode_string(pb_sample_.topic.tid, payload_.topic_info.tid);
     // tname
@@ -176,6 +178,9 @@ namespace
     ///////////////////////////////////////////////
     // command type
     payload_.cmd_type = static_cast<eCAL::eCmdType>(pb_sample.cmd_type);
+
+    // pid
+    payload_.topic_info.pid = pb_sample.topic.pid;
 
     // topic content
     payload_.content.id    = pb_sample.content.id;

--- a/ecal/core/src/serialization/ecal_serialize_sample_payload.cpp
+++ b/ecal/core/src/serialization/ecal_serialize_sample_payload.cpp
@@ -73,11 +73,11 @@ namespace
     // topic information
     pb_sample_.has_topic = true;
     // hname
-    eCAL::nanopb::encode_string(pb_sample_.topic.hname, payload_.topic.hname);
+    eCAL::nanopb::encode_string(pb_sample_.topic.hname, payload_.topic_info.hname);
     // tid
-    eCAL::nanopb::encode_string(pb_sample_.topic.tid, payload_.topic.tid);
+    eCAL::nanopb::encode_string(pb_sample_.topic.tid, payload_.topic_info.tid);
     // tname
-    eCAL::nanopb::encode_string(pb_sample_.topic.tname, payload_.topic.tname);
+    eCAL::nanopb::encode_string(pb_sample_.topic.tname, payload_.topic_info.tname);
 
     // topic content
     pb_sample_.has_content = true;
@@ -148,11 +148,11 @@ namespace
     // assign decoder
     ///////////////////////////////////////////////
     // hname
-    eCAL::nanopb::decode_string(pb_sample.topic.hname, payload_.topic.hname);
+    eCAL::nanopb::decode_string(pb_sample.topic.hname, payload_.topic_info.hname);
     // tid
-    eCAL::nanopb::decode_string(pb_sample.topic.tid, payload_.topic.tid);
+    eCAL::nanopb::decode_string(pb_sample.topic.tid, payload_.topic_info.tid);
     // tname
-    eCAL::nanopb::decode_string(pb_sample.topic.tname, payload_.topic.tname);
+    eCAL::nanopb::decode_string(pb_sample.topic.tname, payload_.topic_info.tname);
     // topic content payload
     payload_.content.payload.type = eCAL::Payload::pl_vec;
     eCAL::nanopb::decode_bytes(pb_sample.content.payload, payload_.content.payload.vec);

--- a/ecal/core/src/serialization/ecal_struct_sample_payload.h
+++ b/ecal/core/src/serialization/ecal_struct_sample_payload.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,11 +37,12 @@ namespace eCAL
   namespace Payload
   {
     // Topic information
-    struct Topic
+    struct TopicInfo
     {
       std::string                         hname;                        // host name
       std::string                         tid;                          // topic id
       std::string                         tname;                        // topic name
+      int32_t                             pid = 0;                      // process id
     };
 
     // Topic content payload
@@ -75,7 +76,7 @@ namespace eCAL
     struct Sample
     {
       eCmdType                            cmd_type = bct_none;          // payload command type
-      Topic                               topic;                        // topic information
+      TopicInfo                           topic_info;                   // topic information
       Content                             content;                      // topic content
       std::vector<char>                   padding;                      // padding to artificially increase the size of the message. This is a workaround for TCP topics, to get the actual user-payload 8-byte-aligned. REMOVE ME IN ECAL6
     };

--- a/ecal/samples/cpp/benchmarks/many_connections_rec/src/many_connections_rec.cpp
+++ b/ecal/samples/cpp/benchmarks/many_connections_rec/src/many_connections_rec.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,11 @@ public:
       std::ostringstream tname;
       tname << std::setw(5) << std::setfill('0') << i;
       subscribers.emplace_back("Topic" + tname.str(), eCAL::SDataTypeInformation{ ttype, "", tdesc });
-      subscribers.at(i).AddReceiveCallback(std::bind(&SubscriberCreator::Receive, this));
+      auto on_receive = [this](const eCAL::Registration::STopicId&, const eCAL::SReceiveCallbackData&)
+      {
+        Receive();
+      };
+      subscribers.at(i).AddReceiveCallback(on_receive);
     }
   }
 

--- a/ecal/tests/cpp/pubsub_test/CMakeLists.txt
+++ b/ecal/tests/cpp/pubsub_test/CMakeLists.txt
@@ -37,6 +37,7 @@ if(ECAL_CORE_TRANSPORT_UDP)
 endif()
 
 set(pubsub_test_src
+  src/pubsub_callback_topicid.cpp
   src/pubsub_receive_test.cpp
   src/pubsub_test.cpp
   ${pubsub_test_src_shm}

--- a/ecal/tests/cpp/pubsub_test/src/pubsub_callback_topicid.cpp
+++ b/ecal/tests/cpp/pubsub_test/src/pubsub_callback_topicid.cpp
@@ -1,0 +1,180 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2024 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+#include <ecal/ecal.h>
+#include <ecal/msg/string/publisher.h>
+#include <ecal/msg/string/subscriber.h>
+
+#include <atomic>
+#include <thread>
+#include <gtest/gtest.h>
+
+namespace eCAL
+{
+  void PrintTo(const Configuration& config, std::ostream* os) {
+    *os << "Config Layers: ";
+    if (config.publisher.layer.shm.enable)
+      *os << "SHM ";
+    if (config.publisher.layer.tcp.enable)
+      *os << "TCP ";
+    if (config.publisher.layer.udp.enable)
+      *os << "UDP ";
+  }
+}
+
+
+enum {
+  DATA_FLOW_TIME_MS = 100
+};
+
+eCAL::Configuration GetTestingConfig()
+{
+  eCAL::Configuration config;
+  config.registration.registration_refresh = 100;
+  config.registration.registration_timeout = 200;
+
+  config.publisher.layer.shm.enable = false;
+  config.publisher.layer.udp.enable = false;
+  config.publisher.layer.tcp.enable = false;
+
+  config.subscriber.layer.shm.enable = false;
+  config.subscriber.layer.udp.enable = false;
+  config.subscriber.layer.tcp.enable = false;
+
+  return config;
+}
+
+eCAL::Configuration EnableUDP(const eCAL::Configuration& config_)
+{
+  eCAL::Configuration config(config_);
+  config.publisher.layer.udp.enable = true;
+  config.subscriber.layer.udp.enable = true;
+  return config;
+}
+
+
+eCAL::Configuration EnableTCP(const eCAL::Configuration& config_)
+{
+  eCAL::Configuration config(config_);
+  config.publisher.layer.tcp.enable = true;
+  config.subscriber.layer.tcp.enable = true;
+  return config;
+}
+
+eCAL::Configuration EnableSHM(const eCAL::Configuration& config_)
+{
+  eCAL::Configuration config(config_);
+  config.publisher.layer.shm.enable = true;
+  config.subscriber.layer.shm.enable = true;
+  return config;
+}
+
+
+// test fixture class
+class TestFixture : public ::testing::TestWithParam<eCAL::Configuration>
+{
+protected:
+  eCAL::Configuration config;
+
+  void SetUp() override
+  {
+    config = GetParam();
+    eCAL::Initialize(config, "callback_topic_id");
+  }
+
+  void TearDown() override
+  {
+    eCAL::Finalize();
+  }
+};
+
+TEST_P(TestFixture, OnePubSub)
+{
+  eCAL::CPublisher  publisher ("foo");
+  eCAL::CSubscriber subscriber("foo");
+
+  eCAL::Registration::STopicId callback_topic_id;
+  int                          callback_count{ 0 };
+
+  subscriber.AddReceiveCallback([&callback_topic_id, &callback_count](const eCAL::Registration::STopicId& topic_id_, const eCAL::SReceiveCallbackData&)
+    {
+      ++callback_count;
+      callback_topic_id = topic_id_;
+    }
+  );
+  const auto pub_id = publisher.GetId();
+
+  // let them match
+  eCAL::Process::SleepMS(2 * config.registration.registration_refresh);
+  // send data
+  publisher.Send("abc");
+  // make sure data was received
+  std::this_thread::sleep_for(std::chrono::milliseconds(DATA_FLOW_TIME_MS));
+
+  EXPECT_EQ(callback_topic_id, pub_id);
+}
+
+TEST_P(TestFixture, MultiplePubSub)
+{
+  const int num_publishers = 4;
+
+  std::vector<eCAL::CPublisher> publishers;
+  for (int i = 0; i < num_publishers; ++i)
+  {
+    publishers.emplace_back("foo");
+  }
+  eCAL::CSubscriber subscriber("foo");
+
+  eCAL::Registration::STopicId callback_topic_id;
+  int                          callback_count{ 0 };
+
+  subscriber.AddReceiveCallback([&callback_topic_id, &callback_count](const eCAL::Registration::STopicId& topic_id_, const eCAL::SReceiveCallbackData&)
+    {
+      ++callback_count;
+      callback_topic_id = topic_id_;
+    }
+  );
+
+  // let them match
+  eCAL::Process::SleepMS(2 * config.registration.registration_refresh);
+
+  for (int i = 0; i < num_publishers; ++i)
+  {
+    auto& publisher = publishers[i];
+    const auto pub_id = publisher.GetId();
+
+    // send data
+    publisher.Send("abc");
+    // make sure data was received
+    std::this_thread::sleep_for(std::chrono::milliseconds(DATA_FLOW_TIME_MS));
+
+    EXPECT_EQ(callback_topic_id, pub_id);
+  }
+}
+
+// Define the test parameters
+INSTANTIATE_TEST_SUITE_P(
+  core_cpp_pubsub_callback_topid_id,
+  TestFixture,
+  ::testing::Values(
+    EnableSHM(GetTestingConfig()),
+    EnableUDP(GetTestingConfig()),
+    EnableTCP(GetTestingConfig())
+  )
+);

--- a/ecal/tests/cpp/serialization_test/src/payload_compare.cpp
+++ b/ecal/tests/cpp/serialization_test/src/payload_compare.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,10 +31,11 @@ namespace eCAL
         return false;
       }
 
-      // compare topic
-      if (sample1.topic.hname != sample2.topic.hname ||
-          sample1.topic.tid   != sample2.topic.tid ||
-          sample1.topic.tname != sample2.topic.tname) {
+      // compare topic info
+      if (sample1.topic_info.hname != sample2.topic_info.hname ||
+          sample1.topic_info.pid   != sample2.topic_info.pid ||
+          sample1.topic_info.tid   != sample2.topic_info.tid ||
+          sample1.topic_info.tname != sample2.topic_info.tname) {
         return false;
       }
 

--- a/ecal/tests/cpp/serialization_test/src/payload_generate.cpp
+++ b/ecal/tests/cpp/serialization_test/src/payload_generate.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,10 +29,11 @@ namespace eCAL
   namespace Payload
   {
     // generate Topic
-    Topic GenerateTopic()
+    TopicInfo GenerateTopic()
     {
-      Topic topic;
+      TopicInfo topic;
       topic.hname = GenerateString(8);
+      topic.pid   = rand() % 1000;
       topic.tid   = GenerateString(5);
       topic.tname = GenerateString(10);
 
@@ -92,9 +93,9 @@ namespace eCAL
     Sample GeneratePayloadSample(const char* payload_addr, size_t payload_size)
     {
       Sample sample;
-      sample.cmd_type = static_cast<eCmdType>(rand() % 17);  //  command type
-      sample.topic    = GenerateTopic();
-      sample.content  = GenerateContent(payload_addr, payload_size);
+      sample.cmd_type   = static_cast<eCmdType>(rand() % 17);  //  command type
+      sample.topic_info = GenerateTopic();
+      sample.content    = GenerateContent(payload_addr, payload_size);
 
       return sample;
     }
@@ -103,10 +104,10 @@ namespace eCAL
     Sample GeneratePayloadSample(const std::vector<char>& payload_vec)
     {
       Sample sample;
-      sample.cmd_type = static_cast<eCmdType>(rand() % 17);  //  command type
-      sample.topic    = GenerateTopic();
-      sample.content  = GenerateContent(payload_vec);
-      sample.padding  = GenerateRandomVector(8);
+      sample.cmd_type   = static_cast<eCmdType>(rand() % 17);  //  command type
+      sample.topic_info = GenerateTopic();
+      sample.content    = GenerateContent(payload_vec);
+      sample.padding    = GenerateRandomVector(8);
 
       return sample;
     }


### PR DESCRIPTION
- Add new Callback Type which includes STopicId (ecal_callback.h)
- Remove topic_name and topic_id from memfile_pool
- Subgate applies Payload::Topic

TODO: take care of PID for TCP and UDP layer.

### Description
We don't yet have the information in callbacks about *who* sent a message, we only receive the topic name. This PR fixes this in a way that callbacks receive an `STopicID` containing both topic name and additional information (unique sender id).