### PR TITLE
[config] Move host_group_name logic

### DIFF
--- a/ecal/core/include/ecal/config/registration.h
+++ b/ecal/core/include/ecal/config/registration.h
@@ -70,7 +70,7 @@ namespace eCAL
                                                                  false = local host only communication (Default: false) */
       bool                 loopback             { true };   //!< enable to receive udp messages on the same local machine (Default: true)
       std::string          host_group_name      { "" };     /*!< Common host group name that enables interprocess mechanisms across 
-                                                                 (virtual) host borders (e.g, Docker); by default equivalent to local host name (Default: CurrentHostName) */
+                                                                 (virtual) host borders (e.g, Docker); by default equivalent to local host name (Default: "") */
       Layer::Configuration layer;
     };
   }

--- a/ecal/core/include/ecal/config/registration.h
+++ b/ecal/core/include/ecal/config/registration.h
@@ -25,7 +25,6 @@
 #pragma once
 
 #include "ecal/ecal_os.h"
-#include "ecal/ecal_process.h"
 
 #include <stdexcept>
 #include <string>
@@ -64,14 +63,14 @@ namespace eCAL
 
     struct Configuration
     {
-      unsigned int         registration_timeout { 10000U };                           //!< Timeout for topic registration in ms (internal) (Default: 10000)
-      unsigned int         registration_refresh { 1000U };                            //!< Topic registration refresh cylce (has to be smaller then registration timeout!) (Default: 1000)                                   
+      unsigned int         registration_timeout { 10000U }; //!< Timeout for topic registration in ms (internal) (Default: 10000)
+      unsigned int         registration_refresh { 1000U };  //!< Topic registration refresh cylce (has to be smaller then registration timeout!) (Default: 1000)                                   
 
-      bool                 network_enabled      { false };                            /*!< true  = all eCAL components communicate over network boundaries
-                                                                                           false = local host only communication (Default: false) */
-      bool                 loopback             { true };                             //!< enable to receive udp messages on the same local machine (Default: true)
-      std::string          host_group_name      { eCAL::Process::GetHostName() };     /*!< Common host group name that enables interprocess mechanisms across 
-                                                                                           (virtual) host borders (e.g, Docker); by default equivalent to local host name (Default: CurrentHostName) */
+      bool                 network_enabled      { false };  /*!< true  = all eCAL components communicate over network boundaries
+                                                                 false = local host only communication (Default: false) */
+      bool                 loopback             { true };   //!< enable to receive udp messages on the same local machine (Default: true)
+      std::string          host_group_name      { "" };     /*!< Common host group name that enables interprocess mechanisms across 
+                                                                 (virtual) host borders (e.g, Docker); by default equivalent to local host name (Default: CurrentHostName) */
       Layer::Configuration layer;
     };
   }

--- a/ecal/core/src/builder/registration_attribute_builder.cpp
+++ b/ecal/core/src/builder/registration_attribute_builder.cpp
@@ -18,6 +18,7 @@
 */
 
 #include "registration_attribute_builder.h"
+#include "ecal/ecal_process.h"
 
 namespace eCAL
 {
@@ -29,7 +30,17 @@ namespace eCAL
     attr.refresh           = reg_config_.registration_refresh;
     attr.network_enabled   = reg_config_.network_enabled;
     attr.loopback          = reg_config_.loopback;
-    attr.host_group_name   = reg_config_.host_group_name;
+    
+    // TODO: Check the usage further down of host_group_name -> logic currenty missleading
+    if (reg_config_.host_group_name.empty())
+    {
+      attr.host_group_name = eCAL::Process::GetHostName();
+    }
+    else
+    {
+      attr.host_group_name = reg_config_.host_group_name;
+    }
+
     attr.process_id        = process_id_;
 
     attr.shm_enabled       = reg_config_.layer.shm.enable;


### PR DESCRIPTION
### Description
The registration.host_group_name now will be set by default to an empty string. Instead, the ProcessName gets added in the registration attribute builder, if the string is empty. The logic behind the host_group_name needs to get checked later on.
