### PR TITLE
Hotfix/remove unused methods

### DIFF
--- a/ecal/core/include/ecal/config/transport_layer.h
+++ b/ecal/core/include/ecal/config/transport_layer.h
@@ -84,7 +84,7 @@ namespace eCAL
       {
         size_t number_executor_reader { 4 }; //!< Reader amount of threads that shall execute workload (Default: 4)
         size_t number_executor_writer { 4 }; //!< Writer amount of threads that shall execute workload (Default: 4)
-        size_t max_reconnections      { 5 }; //!< Reconnection attemps the session will try to reconnect in (Default: 5)
+        int    max_reconnections      { 5 }; //!< Reconnection attemps the session will try to reconnect in (Default: 5)
       };
     }
 

--- a/ecal/core/include/ecal/ecal_config.h
+++ b/ecal/core/include/ecal/ecal_config.h
@@ -75,7 +75,7 @@ namespace eCAL
 
     ECAL_API size_t                   GetTcpPubsubReaderThreadpoolSize     ();
     ECAL_API size_t                   GetTcpPubsubWriterThreadpoolSize     ();
-    ECAL_API size_t                   GetTcpPubsubMaxReconnectionAttemps   ();
+    ECAL_API int                      GetTcpPubsubMaxReconnectionAttemps   ();
 
     ECAL_API std::string              GetHostGroupName                     ();
 

--- a/ecal/core/src/config/ecal_config.cpp
+++ b/ecal/core/src/config/ecal_config.cpp
@@ -60,7 +60,7 @@ namespace eCAL
 
     ECAL_API size_t            GetTcpPubsubReaderThreadpoolSize     () { return GetConfiguration().transport_layer.tcp.number_executor_reader;}
     ECAL_API size_t            GetTcpPubsubWriterThreadpoolSize     () { return GetConfiguration().transport_layer.tcp.number_executor_writer;}
-    ECAL_API size_t            GetTcpPubsubMaxReconnectionAttemps   () { return GetConfiguration().transport_layer.tcp.max_reconnections;}
+    ECAL_API int               GetTcpPubsubMaxReconnectionAttemps   () { return GetConfiguration().transport_layer.tcp.max_reconnections;}
 
     ECAL_API std::string       GetHostGroupName                     () { return GetConfiguration().registration.host_group_name; }
     

--- a/ecal/core/src/config/ecal_config_initializer.cpp
+++ b/ecal/core/src/config/ecal_config_initializer.cpp
@@ -320,12 +320,6 @@ namespace eCAL
 // Utils definitions from former ecal_config_reader.cpp
 namespace
 {
-  bool fileexists(const std::string& fname_)
-  {
-    const std::ifstream infile(fname_);
-    return infile.good();
-  }
-
   bool direxists(const std::string& path_)
   {
     const EcalUtils::Filesystem::FileStatus status(path_, EcalUtils::Filesystem::Current);

--- a/ecal/core/src/ecal_globals.cpp
+++ b/ecal/core/src/ecal_globals.cpp
@@ -46,7 +46,7 @@ namespace eCAL
     Finalize();
   }
 
-  int CGlobals::Initialize(unsigned int components_, std::vector<std::string>* config_keys_ /*= nullptr*/)
+  int CGlobals::Initialize(unsigned int components_)
   {
     // will be set if any new module was initialized
     bool new_initialization(false);

--- a/ecal/core/src/ecal_globals.h
+++ b/ecal/core/src/ecal_globals.h
@@ -61,7 +61,7 @@ namespace eCAL
     CGlobals();
     ~CGlobals();
 
-    int Initialize     ( unsigned int components_, std::vector<std::string>* config_keys_ = nullptr);
+    int Initialize     ( unsigned int components_);
     bool IsInitialized ( unsigned int component_  );
     
     unsigned int GetComponents() const { return(components); };

--- a/ecal/core/src/registration/ecal_registration_receiver.cpp
+++ b/ecal/core/src/registration/ecal_registration_receiver.cpp
@@ -57,8 +57,8 @@ namespace eCAL
     , m_timeout_provider_thread(nullptr)
     , m_registration_receiver_udp(nullptr)
     , m_registration_receiver_shm(nullptr)   
-    , m_attributes(attr_)
     , m_sample_applier(Registration::SampleApplier::BuildSampleApplierAttributes(attr_))
+    , m_attributes(attr_)
   {
     // Connect User registration callback and gates callback with the sample applier
     m_sample_applier.SetCustomApplySampleCallback("gates", [](const eCAL::Registration::Sample& sample_)

--- a/ecal/core/src/registration/ecal_registration_receiver.h
+++ b/ecal/core/src/registration/ecal_registration_receiver.h
@@ -97,6 +97,6 @@ namespace eCAL
     // The custom user callbacks (who receive serialized samples), e.g. registration events.
     Registration::CSampleApplierUser m_user_applier;
 
-    Registration::SAttributes              m_attributes;
+    Registration::SAttributes        m_attributes;
   };
 }

--- a/ecal/core/src/registration/shm/attributes/registration_shm_attributes.h
+++ b/ecal/core/src/registration/shm/attributes/registration_shm_attributes.h
@@ -30,7 +30,7 @@ namespace eCAL
       struct SAttributes
       {
         std::string  domain;
-        unsigned int queue_size;
+        size_t       queue_size;
       };
     }
   }

--- a/ecal/core/src/registration/udp/ecal_registration_receiver_udp.cpp
+++ b/ecal/core/src/registration/udp/ecal_registration_receiver_udp.cpp
@@ -31,7 +31,7 @@ using namespace eCAL;
 eCAL::CRegistrationReceiverUDP::CRegistrationReceiverUDP(RegistrationApplySampleCallbackT apply_sample_callback, const Registration::UDP::SReceiverAttributes& attr_)
   : m_registration_receiver(std::make_unique<UDP::CSampleReceiver>(
     Registration::UDP::ConvertToIOUDPReceiverAttributes(attr_),
-    [](const std::string& sample_name_) {return true; },
+    [](const std::string& /*sample_name_*/) {return true; },
     [apply_sample_callback](const char* serialized_sample_data_, size_t serialized_sample_size_) {
       Registration::Sample sample;
       if (!DeserializeFromBuffer(serialized_sample_data_, serialized_sample_size_, sample)) return false;


### PR DESCRIPTION
### Description
For specific platform builds warning are treated as errors. To fix those:
- removed unused methods
- commented unused parameter
- changed "MaxReconnectionAttempts" back to int, as also the logic needs -1 for infinite attempts
- removed config-keys from globals init (as its also not used anymore and the functionality itself is gone)
