### PR TITLE
[config] Move complete memfile config to publisher

### DIFF
--- a/doc/rst/configuration/options.rst
+++ b/doc/rst/configuration/options.rst
@@ -254,21 +254,6 @@ Transportlayer settings are listed in the section ``transport_layer``
 
         Reconnection attemps the session will try to reconnect in case of an issue
 
-    .. option:: shm
-
-      .. option:: memfile_min_size_bytes           
-    
-        ``x * 4096 kB`` default ``4096`` 
-        
-        Default memory file size for new publisher
-              
-
-      .. option:: memfile_reserve_percent           
-
-        ``20 .. x`` default ``50``
-        
-        Dynamic file size reserve before recreating memory file if topic size changes
- 
 
 Publisher settings are listed in the section ``publisher``
 ----------------------------------------------------------
@@ -303,6 +288,19 @@ Publisher settings are listed in the section ``publisher``
         ``1 + x`` default ``1``
 
         Maximum number of used buffers (needs to be greater than 0, default = 1)
+
+      .. option:: memfile_min_size_bytes           
+    
+        ``x * 4096 kB`` default ``4096`` 
+        
+        Default memory file size for new publisher
+              
+
+      .. option:: memfile_reserve_percent           
+
+        ``20 .. x`` default ``50``
+        
+        Dynamic file size reserve before recreating memory file if topic size changes
 
     .. option:: udp
       

--- a/doc/rst/configuration/runtime_configuration.rst
+++ b/doc/rst/configuration/runtime_configuration.rst
@@ -35,18 +35,18 @@ The size object can be used like a normal integer.
   eCAL::Types::ConstrainedInteger<1024, 512, 8192> size_4mb = 1024 + 6 * 512;
   std::cout << size_4mb << "\n";
 
-For specifying sizes in the ecal configuration object, refer to the .ini file or "ecal/config/configuration.h" for the limitations.
+For specifying sizes in the ecal configuration object, refer to the .yaml file or "ecal/config/configuration.h" for the limitations.
 
 Global configuration initialization
 ===================================
 
 The configuration will be first initialized with the default values specified by eCAL.
-If you want to use the systems eCAL .ini file, call the ``InitConfigWithDefaultYaml()`` function of the config object.
+If you want to use the systems eCAL .yaml file, call the ``InitFromConfig()`` function of the config object.
 
-In case the .ini to use is specified via command line parameter, this one is chosen instead. 
-The object will throw an error, in case the specified .ini file cannot be found.
+In case the .yaml to use is specified via command line parameter, this one is chosen instead. 
+The object will throw an error, in case the specified .yaml file cannot be found.
 
-It is also possible to specify the .ini by calling the function ``checkForValidConfigFilePath(const std::string yaml_path_)`` of the config object.
+It is also possible to specify the .yaml by calling the function ``InitFromFile(const std::string yaml_path_)`` of the config object.
 
 * |fa-file-alt| :file:`hello_config/main.cpp`:
 

--- a/doc/rst/configuration/src/hello_config/main.cpp
+++ b/doc/rst/configuration/src/hello_config/main.cpp
@@ -8,15 +8,15 @@ int main(int argc, char** argv)
   // Create a configuration object with the command line arguments
   eCAL::Configuration custom_config(argc, argv);
 
-  // Use the .yaml file of the system if available
-  custom_config.InitConfigWithDefaultYaml();
+  // Use the .yaml file of the system or current folder if available
+  custom_config.InitFromConfig();
 
   // Set the values in a try/catch block, as wrong configuration leads to exceptions
   try
   {
       // In case you decided to specify an own .yaml file to use
       // Configuration based on previous ini file will be overwritten
-    custom_config.InitConfigFromFile("C:\\eCAL_local.yaml");
+    custom_config.InitFromFile("C:\\eCAL_local.yaml");
 
     // Set the communication layer to network
     custom_config.registration.network_enabled = true;

--- a/ecal/core/include/ecal/config/publisher.h
+++ b/ecal/core/include/ecal/config/publisher.h
@@ -105,12 +105,14 @@ namespace eCAL
       {
         struct Configuration
         {
-          bool         enable                 { true };  //!< enable layer 
+          bool                                  enable                  { true };  //!< enable layer 
 
-          bool         zero_copy_mode         { false }; //!< Enable zero copy shared memory transport mode 
-          unsigned int acknowledge_timeout_ms { 0U };    /*!< Force connected subscribers to send acknowledge event after processing the message.
-                                                              The publisher send call is blocked on this event with this timeout (0 == no handshake).*/
-          unsigned int memfile_buffer_count   { 1U };    /*!< Maximum number of used buffers (needs to be greater than 1, default = 1) */
+          bool                                  zero_copy_mode          { false }; //!< Enable zero copy shared memory transport mode 
+          unsigned int                          acknowledge_timeout_ms  { 0U };    /*!< Force connected subscribers to send acknowledge event after processing the message.
+                                                                                        The publisher send call is blocked on this event with this timeout (0 == no handshake).*/
+          unsigned int                          memfile_buffer_count    { 1U };    /*!< Maximum number of used buffers (needs to be greater than 1, default = 1) */
+          Types::ConstrainedInteger<4096, 4096> memfile_min_size_bytes  { 4096 };  //!< Default memory file size for new publisher (Default: 4096)
+          Types::ConstrainedInteger<50, 1, 100> memfile_reserve_percent { 50 };    //!< Dynamic file size reserve before recreating memory file if topic size changes (Default: 50)
         };
       }
 

--- a/ecal/core/include/ecal/config/transport_layer.h
+++ b/ecal/core/include/ecal/config/transport_layer.h
@@ -88,20 +88,10 @@ namespace eCAL
       };
     }
 
-    namespace SHM 
-    {
-      struct Configuration
-      {
-        Types::ConstrainedInteger<4096, 4096> memfile_min_size_bytes  { 4096 }; //!< Default memory file size for new publisher (Default: 4096)
-        Types::ConstrainedInteger<50, 1, 100> memfile_reserve_percent { 50 };   //!< Dynamic file size reserve before recreating memory file if topic size changes (Default: 50)
-      };
-    }
-
     struct Configuration
     {
       UDP::Configuration udp;
       TCP::Configuration tcp;
-      SHM::Configuration shm;
     };
   }
 }

--- a/ecal/core/src/config/configuration_to_yaml.cpp
+++ b/ecal/core/src/config/configuration_to_yaml.cpp
@@ -210,22 +210,6 @@ namespace YAML
     /_/ /_/  \_,_/_//_/___/ .__/\___/_/  \__/____/\_,_/\_, /\__/_/   
                          /_/                          /___/          
   */
-  
-  Node convert<eCAL::TransportLayer::SHM::Configuration>::encode(const eCAL::TransportLayer::SHM::Configuration& config_)
-  {
-    Node node;
-    node["memfile_min_size_bytes"]  << config_.memfile_min_size_bytes;
-    node["memfile_reserve_percent"] << config_.memfile_reserve_percent;
-    return node;
-  }
-
-  bool convert<eCAL::TransportLayer::SHM::Configuration>::decode(const Node& node_, eCAL::TransportLayer::SHM::Configuration& config_)
-  {
-    AssignValue<unsigned int>(config_.memfile_min_size_bytes, node_, "memfile_min_size_bytes");
-    AssignValue<unsigned int>(config_.memfile_reserve_percent, node_, "memfile_reserve_percent");
-    return true;
-  }
-  
   Node convert<eCAL::TransportLayer::TCP::Configuration>::encode(const eCAL::TransportLayer::TCP::Configuration& config_)
   {
     Node node;
@@ -296,7 +280,6 @@ namespace YAML
   Node convert<eCAL::TransportLayer::Configuration>::encode(const eCAL::TransportLayer::Configuration& config_)
   {
     Node node;
-    node["shm"] = config_.shm;
     node["udp"] = config_.udp;
     node["tcp"] = config_.tcp;
 
@@ -305,7 +288,6 @@ namespace YAML
 
   bool convert<eCAL::TransportLayer::Configuration>::decode(const Node& node_, eCAL::TransportLayer::Configuration& config_)
   {
-    AssignValue<eCAL::TransportLayer::SHM::Configuration>(config_.shm, node_, "shm");
     AssignValue<eCAL::TransportLayer::UDP::Configuration>(config_.udp, node_, "udp");
     AssignValue<eCAL::TransportLayer::TCP::Configuration>(config_.tcp, node_, "tcp");
     return true;
@@ -322,10 +304,12 @@ namespace YAML
   Node convert<eCAL::Publisher::Layer::SHM::Configuration>::encode(const eCAL::Publisher::Layer::SHM::Configuration& config_)
   {
     Node node;
-    node["enable"]                 = config_.enable;
-    node["zero_copy_mode"]         = config_.zero_copy_mode;
-    node["acknowledge_timeout_ms"] = config_.acknowledge_timeout_ms;
-    node["memfile_buffer_count"]   = config_.memfile_buffer_count;
+    node["enable"]                   = config_.enable;
+    node["zero_copy_mode"]           = config_.zero_copy_mode;
+    node["acknowledge_timeout_ms"]   = config_.acknowledge_timeout_ms;
+    node["memfile_buffer_count"]     = config_.memfile_buffer_count;
+    node["memfile_min_size_bytes"]  << config_.memfile_min_size_bytes;
+    node["memfile_reserve_percent"] << config_.memfile_reserve_percent;
     return node;
   }
 
@@ -335,6 +319,8 @@ namespace YAML
     AssignValue<bool>(config_.zero_copy_mode, node_, "zero_copy_mode");
     AssignValue<unsigned int>(config_.acknowledge_timeout_ms, node_, "acknowledge_timeout_ms");
     AssignValue<unsigned int>(config_.memfile_buffer_count, node_, "memfile_buffer_count");
+    AssignValue<unsigned int>(config_.memfile_min_size_bytes, node_, "memfile_min_size_bytes");
+    AssignValue<unsigned int>(config_.memfile_reserve_percent, node_, "memfile_reserve_percent");
     return true;
   }
   

--- a/ecal/core/src/config/configuration_to_yaml.h
+++ b/ecal/core/src/config/configuration_to_yaml.h
@@ -102,14 +102,6 @@ namespace YAML
                          /_/                          /___/          
   */
   template<>
-  struct convert<eCAL::TransportLayer::SHM::Configuration>
-  {
-    static Node encode(const eCAL::TransportLayer::SHM::Configuration& config_);
-
-    static bool decode(const Node& node_, eCAL::TransportLayer::SHM::Configuration& config_);
-  };
-
-  template<>
   struct convert<eCAL::TransportLayer::TCP::Configuration>
   {
     static Node encode(const eCAL::TransportLayer::TCP::Configuration& config_);

--- a/ecal/core/src/config/default_configuration.cpp
+++ b/ecal/core/src/config/default_configuration.cpp
@@ -214,12 +214,6 @@ namespace eCAL
       ss << R"(    # Reconnection attemps the session will try to reconnect in case of an issue)"                                   << "\n";
       ss << R"(    max_reconnections: )"                             << config_.transport_layer.tcp.max_reconnections               << "\n";
       ss << R"()"                                                                                                                   << "\n";
-      ss << R"(  shm:)"                                                                                                             << "\n";
-      ss << R"(    # Default memory file size for new publisher)"                                                                   << "\n";
-      ss << R"(    memfile_min_size_bytes: )"                        << config_.transport_layer.shm.memfile_min_size_bytes          << "\n";
-      ss << R"(    # Dynamic file size reserve before recreating memory file if topic size changes)"                                << "\n";
-      ss << R"(    memfile_reserve_percent: )"                       << config_.transport_layer.shm.memfile_reserve_percent         << "\n";
-      ss << R"()"                                                                                                                   << "\n";
       ss << R"()"                                                                                                                   << "\n";
       ss << R"(# Publisher specific base settings)"                                                                                 << "\n";
       ss << R"(publisher:)"                                                                                                         << "\n";
@@ -235,6 +229,10 @@ namespace eCAL
       ss << R"(      acknowledge_timeout_ms: )"                      << config_.publisher.layer.shm.acknowledge_timeout_ms          << "\n";
       ss << R"(      # Maximum number of used buffers (needs to be greater than 1, default = 1))"                                   << "\n";
       ss << R"(      memfile_buffer_count: )"                        << config_.publisher.layer.shm.memfile_buffer_count            << "\n";
+      ss << R"(      # Default memory file size for new publisher)"                                                                 << "\n";
+      ss << R"(      memfile_min_size_bytes: )"                      << config_.publisher.layer.shm.memfile_min_size_bytes          << "\n";
+      ss << R"(      # Dynamic file size reserve before recreating memory file if topic size changes)"                              << "\n";
+      ss << R"(      memfile_reserve_percent: )"                     << config_.publisher.layer.shm.memfile_reserve_percent         << "\n";
       ss << R"()"                                                                                                                   << "\n";
       ss << R"(    # Base configuration for UDP publisher)"                                                                         << "\n";
       ss << R"(    udp:)"                                                                                                           << "\n";

--- a/ecal/core/src/readwrite/shm/ecal_writer_shm.cpp
+++ b/ecal/core/src/readwrite/shm/ecal_writer_shm.cpp
@@ -125,8 +125,8 @@ namespace eCAL
 
     // prepare memfile attributes
     SSyncMemoryFileAttr memory_file_attr = {};
-    memory_file_attr.min_size        = GetConfiguration().transport_layer.shm.memfile_min_size_bytes;
-    memory_file_attr.reserve         = GetConfiguration().transport_layer.shm.memfile_reserve_percent;
+    memory_file_attr.min_size        = m_config.memfile_min_size_bytes;
+    memory_file_attr.reserve         = m_config.memfile_reserve_percent;
     memory_file_attr.timeout_open_ms = PUB_MEMFILE_OPEN_TO;
     memory_file_attr.timeout_ack_ms  = m_config.acknowledge_timeout_ms;
 


### PR DESCRIPTION
### Description
The memfile settings where split between transport_layer and publisher config. Now all is available only in the publisher config to enable individual configuration for each publisher.