### PR TITLE
Hotfix/innosetup config path handling

### DIFF
--- a/cpack/innosetup/ecal_setup.iss.in
+++ b/cpack/innosetup/ecal_setup.iss.in
@@ -75,9 +75,13 @@ Source: "{#ComponentStagingDir}\runtime\*";           DestDir: "{app}";      Fla
 Source: "{#ComponentStagingDir}\Unspecified\*";       DestDir: "{app}";      Flags: ignoreversion recursesubdirs; Components: runtime
 Source: "{#ComponentStagingDir}\libraries\bin\*";     DestDir: "{app}\bin\"; Flags: ignoreversion recursesubdirs; Components: runtime
 
-Source: "{#ComponentStagingDir}\_configuration\cfg\ecal.yaml";     DestDir: "{commonappdata}\eCAL\"; Tasks: not replaceconf; Flags: ignoreversion confirmoverwrite; Components: runtime
-Source: "{#ComponentStagingDir}\_configuration\cfg\ecal.yaml";     DestDir: "{commonappdata}\eCAL\"; Tasks: replaceconf;     Flags: ignoreversion;                  Components: runtime
-Source: "{#ComponentStagingDir}\_configuration\cfg\ecaltime.ini"; DestDir: "{commonappdata}\eCAL\";                         Flags: ignoreversion;                  Components: runtime
+; Source: "{#ComponentStagingDir}\_configuration\cfg\ecal.yaml";    DestDir: "{commonappdata}\eCAL\"; Tasks: not replaceconf; Flags: ignoreversion confirmoverwrite; Components: runtime
+; Source: "{#ComponentStagingDir}\_configuration\cfg\ecal.yaml";    DestDir: "{commonappdata}\eCAL\"; Tasks: replaceconf;     Flags: ignoreversion;                  Components: runtime
+; Source: "{#ComponentStagingDir}\_configuration\cfg\ecaltime.ini"; DestDir: "{commonappdata}\eCAL\";                         Flags: ignoreversion;                  Components: runtime
+
+Source: "{#ComponentStagingDir}\*configuration\cfg\ecal.yaml";    DestDir: "{commonappdata}\eCAL\"; Tasks: not replaceconf; Flags: ignoreversion confirmoverwrite; Components: runtime
+Source: "{#ComponentStagingDir}\*configuration\cfg\ecal.yaml";    DestDir: "{commonappdata}\eCAL\"; Tasks: replaceconf;     Flags: ignoreversion;                  Components: runtime
+Source: "{#ComponentStagingDir}\*configuration\cfg\ecaltime.ini"; DestDir: "{commonappdata}\eCAL\";                         Flags: ignoreversion;                  Components: runtime
 
 ; applications
 Source: "{#ComponentStagingDir}\app\*";               DestDir: "{app}";                   Flags: ignoreversion recursesubdirs;     Components: applications
@@ -118,11 +122,13 @@ Source: "{#DebugSdkStagingDir}\protobuf-export\*";    DestDir: "{app}";         
 ; Source: "{#DebugSdkStagingDir}\protoc\*";           DestDir: "{app}";                   Flags: ignoreversion recursesubdirs;     Components: sdk\protobuf
 
 ; sdk\hdf5
-Source: "{#ComponentStagingDir}\_configinstall\*";    DestDir: "{app}";                   Flags: ignoreversion recursesubdirs;     Components: sdk\hdf5
+; Source: "{#ComponentStagingDir}\_configinstall\*";    DestDir: "{app}";                   Flags: ignoreversion recursesubdirs;     Components: sdk\hdf5
+Source: "{#ComponentStagingDir}\*configinstall\*";    DestDir: "{app}";                   Flags: ignoreversion recursesubdirs;     Components: sdk\hdf5
 Source: "{#ComponentStagingDir}\headers\*";           DestDir: "{app}";                   Flags: ignoreversion recursesubdirs;     Components: sdk\hdf5
 Source: "{#ComponentStagingDir}\libraries\lib\*";     DestDir: "{app}\lib";               Flags: ignoreversion recursesubdirs;     Components: sdk\hdf5
 
-Source: "{#DebugSdkStagingDir}\_configinstall\*";     DestDir: "{app}";                   Flags: ignoreversion recursesubdirs;     Components: sdk\hdf5
+; Source: "{#DebugSdkStagingDir}\_configinstall\*";     DestDir: "{app}";                   Flags: ignoreversion recursesubdirs;     Components: sdk\hdf5
+Source: "{#DebugSdkStagingDir}\*configinstall\*";     DestDir: "{app}";                   Flags: ignoreversion recursesubdirs;     Components: sdk\hdf5
 Source: "{#DebugSdkStagingDir}\libraries\lib\*";      DestDir: "{app}\lib";               Flags: ignoreversion recursesubdirs;     Components: sdk\hdf5
 Source: "{#DebugSdkStagingDir}\libraries\bin\*";      DestDir: "{app}\bin\";              Flags: ignoreversion recursesubdirs;     Components: sdk\hdf5
 

--- a/cpack/innosetup/ecal_setup.iss.in
+++ b/cpack/innosetup/ecal_setup.iss.in
@@ -79,9 +79,9 @@ Source: "{#ComponentStagingDir}\libraries\bin\*";     DestDir: "{app}\bin\"; Fla
 ; Source: "{#ComponentStagingDir}\_configuration\cfg\ecal.yaml";    DestDir: "{commonappdata}\eCAL\"; Tasks: replaceconf;     Flags: ignoreversion;                  Components: runtime
 ; Source: "{#ComponentStagingDir}\_configuration\cfg\ecaltime.ini"; DestDir: "{commonappdata}\eCAL\";                         Flags: ignoreversion;                  Components: runtime
 
-Source: "{#ComponentStagingDir}\*configuration\cfg\ecal.yaml";    DestDir: "{commonappdata}\eCAL\"; Tasks: not replaceconf; Flags: ignoreversion confirmoverwrite; Components: runtime
-Source: "{#ComponentStagingDir}\*configuration\cfg\ecal.yaml";    DestDir: "{commonappdata}\eCAL\"; Tasks: replaceconf;     Flags: ignoreversion;                  Components: runtime
-Source: "{#ComponentStagingDir}\*configuration\cfg\ecaltime.ini"; DestDir: "{commonappdata}\eCAL\";                         Flags: ignoreversion;                  Components: runtime
+Source: "{#ComponentStagingDir}\configuration\cfg\ecal.yaml";    DestDir: "{commonappdata}\eCAL\"; Tasks: not replaceconf; Flags: ignoreversion confirmoverwrite; Components: runtime
+Source: "{#ComponentStagingDir}\configuration\cfg\ecal.yaml";    DestDir: "{commonappdata}\eCAL\"; Tasks: replaceconf;     Flags: ignoreversion;                  Components: runtime
+Source: "{#ComponentStagingDir}\configuration\cfg\ecaltime.ini"; DestDir: "{commonappdata}\eCAL\";                         Flags: ignoreversion;                  Components: runtime
 
 ; applications
 Source: "{#ComponentStagingDir}\app\*";               DestDir: "{app}";                   Flags: ignoreversion recursesubdirs;     Components: applications
@@ -123,12 +123,12 @@ Source: "{#DebugSdkStagingDir}\protobuf-export\*";    DestDir: "{app}";         
 
 ; sdk\hdf5
 ; Source: "{#ComponentStagingDir}\_configinstall\*";    DestDir: "{app}";                   Flags: ignoreversion recursesubdirs;     Components: sdk\hdf5
-Source: "{#ComponentStagingDir}\*configinstall\*";    DestDir: "{app}";                   Flags: ignoreversion recursesubdirs;     Components: sdk\hdf5
+Source: "{#ComponentStagingDir}\configinstall\*";     DestDir: "{app}";                   Flags: ignoreversion recursesubdirs;     Components: sdk\hdf5
 Source: "{#ComponentStagingDir}\headers\*";           DestDir: "{app}";                   Flags: ignoreversion recursesubdirs;     Components: sdk\hdf5
 Source: "{#ComponentStagingDir}\libraries\lib\*";     DestDir: "{app}\lib";               Flags: ignoreversion recursesubdirs;     Components: sdk\hdf5
 
 ; Source: "{#DebugSdkStagingDir}\_configinstall\*";     DestDir: "{app}";                   Flags: ignoreversion recursesubdirs;     Components: sdk\hdf5
-Source: "{#DebugSdkStagingDir}\*configinstall\*";     DestDir: "{app}";                   Flags: ignoreversion recursesubdirs;     Components: sdk\hdf5
+Source: "{#DebugSdkStagingDir}\configinstall\*";      DestDir: "{app}";                   Flags: ignoreversion recursesubdirs;     Components: sdk\hdf5
 Source: "{#DebugSdkStagingDir}\libraries\lib\*";      DestDir: "{app}\lib";               Flags: ignoreversion recursesubdirs;     Components: sdk\hdf5
 Source: "{#DebugSdkStagingDir}\libraries\bin\*";      DestDir: "{app}\bin\";              Flags: ignoreversion recursesubdirs;     Components: sdk\hdf5
 


### PR DESCRIPTION
### Description
Changing back to cpack generated paths used in the inno setup compiler script from

_configuration -> configuration
_configinstall -> configinstall