### PR TITLE
[protobuf] Improved protobuf reflection for empty submessages

### DIFF
--- a/ecal/msg/protobuf/src/ecal_proto_decoder.cpp
+++ b/ecal/msg/protobuf/src/ecal_proto_decoder.cpp
@@ -270,10 +270,8 @@ namespace protobuf
                 // do not process default messages to avoid infinite recursions.
                 std::vector<const google::protobuf::FieldDescriptor*> msg_fields;
                 msg.GetReflection()->ListFields(msg, &msg_fields);
-                if (msg_fields.size() > 0)
-                {
-                  ProcProtoMsg(msg, name.str(), complete_message_name, true, fnum);
-                }
+                
+                ProcProtoMsg(msg, name.str(), complete_message_name, true, fnum);
               }
             }
           }
@@ -284,10 +282,8 @@ namespace protobuf
             // do not process default messages to avoid infinite recursions.
             std::vector<const google::protobuf::FieldDescriptor*> msg_fields;
             msg.GetReflection()->ListFields(msg, &msg_fields);
-            if (msg_fields.size() > 0)
-            {
-              ProcProtoMsg(msg, field->name(), complete_message_name, false, field->number());
-            }
+            
+            ProcProtoMsg(msg, field->name(), complete_message_name, false, field->number());
           }
         }
         break;

--- a/ecal/samples/cpp/pubsub/protobuf/proto_dyn_rec/src/proto_dyn_rec.cpp
+++ b/ecal/samples/cpp/pubsub/protobuf/proto_dyn_rec/src/proto_dyn_rec.cpp
@@ -243,10 +243,8 @@ void ProcProtoMsg(const google::protobuf::Message& msg_, const std::string& pref
               // do not process default messages to avoid infinite recursions.
               std::vector<const google::protobuf::FieldDescriptor*> msg_fields;
               msg.GetReflection()->ListFields(msg, &msg_fields);
-              if (msg_fields.size() > 0)
-              {
-                ProcProtoMsg(msg, prefix);
-              }
+              
+              ProcProtoMsg(msg, prefix);
             }
           }
           else
@@ -258,10 +256,8 @@ void ProcProtoMsg(const google::protobuf::Message& msg_, const std::string& pref
             // do not process default messages to avoid infinite recursions.
             std::vector<const google::protobuf::FieldDescriptor*> msg_fields;
             msg.GetReflection()->ListFields(msg, &msg_fields);
-            if (msg_fields.size() > 0)
-            {
-              ProcProtoMsg(msg, prefix);
-            }
+
+            ProcProtoMsg(msg, prefix);
           }
         }
         break;


### PR DESCRIPTION
### Description
Removed size check on cpp message types in protobuf reflection.

Impact: Empty message fields are visible, e.g. in eCAL monitor protobuf reflection plugin
