### PR TITLE
[protobuf] Readded msg_size and field name check to ProcProtoMsg recursion

### DIFF
--- a/ecal/msg/protobuf/src/ecal_proto_decoder.cpp
+++ b/ecal/msg/protobuf/src/ecal_proto_decoder.cpp
@@ -26,6 +26,7 @@
 #include <ecal/msg/protobuf/ecal_proto_hlp.h>
 #include <ecal/msg/protobuf/ecal_proto_message_filter.h>
 #include <ecal/msg/protobuf/ecal_proto_visitor.h>
+#include <iostream>
 
 #include <sstream>
 
@@ -271,7 +272,8 @@ namespace protobuf
                 std::vector<const google::protobuf::FieldDescriptor*> msg_fields;
                 msg.GetReflection()->ListFields(msg, &msg_fields);
                 
-                ProcProtoMsg(msg, name.str(), complete_message_name, true, fnum);
+                if (prefix_.find(field->name()) == std::string::npos || msg_fields.size() > 0)
+                  ProcProtoMsg(msg, name.str(), complete_message_name, true, fnum);
               }
             }
           }
@@ -283,7 +285,11 @@ namespace protobuf
             std::vector<const google::protobuf::FieldDescriptor*> msg_fields;
             msg.GetReflection()->ListFields(msg, &msg_fields);
             
-            ProcProtoMsg(msg, field->name(), complete_message_name, false, field->number());
+            auto msg_type = msg.GetTypeName();
+            auto msg__type = msg_.GetTypeName();
+
+            if (prefix_.find(field->name()) == std::string::npos || msg_fields.size() > 0)
+              ProcProtoMsg(msg, field->name(), complete_message_name, false, field->number());
           }
         }
         break;

--- a/ecal/msg/protobuf/src/ecal_proto_decoder.cpp
+++ b/ecal/msg/protobuf/src/ecal_proto_decoder.cpp
@@ -272,7 +272,7 @@ namespace protobuf
                 std::vector<const google::protobuf::FieldDescriptor*> msg_fields;
                 msg.GetReflection()->ListFields(msg, &msg_fields);
                 
-                if (prefix_.find(field->name()) == std::string::npos || msg_fields.size() > 0)
+                if (prefix_.find(field->name()) == std::string::npos || !msg_fields.empty())
                   ProcProtoMsg(msg, name.str(), complete_message_name, true, fnum);
               }
             }
@@ -284,11 +284,8 @@ namespace protobuf
             // do not process default messages to avoid infinite recursions.
             std::vector<const google::protobuf::FieldDescriptor*> msg_fields;
             msg.GetReflection()->ListFields(msg, &msg_fields);
-            
-            auto msg_type = msg.GetTypeName();
-            auto msg__type = msg_.GetTypeName();
 
-            if (prefix_.find(field->name()) == std::string::npos || msg_fields.size() > 0)
+            if (prefix_.find(field->name()) == std::string::npos || !msg_fields.empty())
               ProcProtoMsg(msg, field->name(), complete_message_name, false, field->number());
           }
         }

--- a/ecal/samples/cpp/pubsub/protobuf/proto_dyn_rec/src/proto_dyn_rec.cpp
+++ b/ecal/samples/cpp/pubsub/protobuf/proto_dyn_rec/src/proto_dyn_rec.cpp
@@ -244,7 +244,7 @@ void ProcProtoMsg(const google::protobuf::Message& msg_, const std::string& pref
               std::vector<const google::protobuf::FieldDescriptor*> msg_fields;
               msg.GetReflection()->ListFields(msg, &msg_fields);
               
-              if (prefix_.find(field->name()) == std::string::npos || msg_fields.size() > 0)
+              if (prefix_.find(field->name()) == std::string::npos || !msg_fields.empty())
                 ProcProtoMsg(msg, prefix);
             }
           }
@@ -258,7 +258,7 @@ void ProcProtoMsg(const google::protobuf::Message& msg_, const std::string& pref
             std::vector<const google::protobuf::FieldDescriptor*> msg_fields;
             msg.GetReflection()->ListFields(msg, &msg_fields);
 
-            if (prefix_.find(field->name()) == std::string::npos || msg_fields.size() > 0)
+            if (prefix_.find(field->name()) == std::string::npos || !msg_fields.empty())
               ProcProtoMsg(msg, prefix);
           }
         }

--- a/ecal/samples/cpp/pubsub/protobuf/proto_dyn_rec/src/proto_dyn_rec.cpp
+++ b/ecal/samples/cpp/pubsub/protobuf/proto_dyn_rec/src/proto_dyn_rec.cpp
@@ -244,7 +244,8 @@ void ProcProtoMsg(const google::protobuf::Message& msg_, const std::string& pref
               std::vector<const google::protobuf::FieldDescriptor*> msg_fields;
               msg.GetReflection()->ListFields(msg, &msg_fields);
               
-              ProcProtoMsg(msg, prefix);
+              if (prefix_.find(field->name()) == std::string::npos || msg_fields.size() > 0)
+                ProcProtoMsg(msg, prefix);
             }
           }
           else
@@ -257,7 +258,8 @@ void ProcProtoMsg(const google::protobuf::Message& msg_, const std::string& pref
             std::vector<const google::protobuf::FieldDescriptor*> msg_fields;
             msg.GetReflection()->ListFields(msg, &msg_fields);
 
-            ProcProtoMsg(msg, prefix);
+            if (prefix_.find(field->name()) == std::string::npos || msg_fields.size() > 0)
+              ProcProtoMsg(msg, prefix);
           }
         }
         break;


### PR DESCRIPTION
### Description
To avoid infinite recursive for recursive proto definitions readded the msg_size check and additionally a field name find check. The later enables the msg to show at least one default submsg, even if every field is just a default value.
