### PR TITLE
[core] provide SDataTypeInformation in callbacks

### DIFF
--- a/ecal/core/include/ecal/ecal_callback.h
+++ b/ecal/core/include/ecal/ecal_callback.h
@@ -138,7 +138,7 @@ namespace eCAL
    * @param topic_id_    The topic id struct of the received message.
    * @param data_        Data struct containing payload, timestamp and publication clock.
   **/
-  using ReceiveIDCallbackT = std::function<void(const Registration::STopicId&, const SReceiveCallbackData&)>;
+  using ReceiveIDCallbackT = std::function<void(const Registration::STopicId&, const SDataTypeInformation&, const SReceiveCallbackData&)>;
 
   /**
    * @brief Timer callback function type.

--- a/ecal/core/src/pubsub/ecal_subscriber.cpp
+++ b/ecal/core/src/pubsub/ecal_subscriber.cpp
@@ -148,7 +148,7 @@ namespace eCAL
 
   bool CSubscriber::AddReceiveCallback(ReceiveCallbackT callback_)
   {
-    auto id_callback = [callback_](const Registration::STopicId& topic_id_, const SReceiveCallbackData& data_)
+    auto id_callback = [callback_](const Registration::STopicId& topic_id_, const SDataTypeInformation&, const SReceiveCallbackData& data_)
     {
       callback_(topic_id_.topic_name.c_str(), &data_);
     };

--- a/ecal/core/src/readwrite/ecal_reader.cpp
+++ b/ecal/core/src/readwrite/ecal_reader.cpp
@@ -532,8 +532,14 @@ namespace eCAL
         topic_id.topic_id.entity_id  = topic_info_.tid;
         topic_id.topic_id.process_id = topic_info_.pid;
 
+        SPublicationInfo pub_info;
+        pub_info.entity_id  = topic_info_.tid;
+        pub_info.host_name  = topic_info_.hname;
+        pub_info.process_id = topic_info_.pid;
+
         // execute it
-        (m_receive_callback)(topic_id, cb_data);
+        std::lock_guard<std::mutex> lock(m_connection_map_mtx);
+        (m_receive_callback)(topic_id, m_connection_map[pub_info].data_type_info, cb_data);
         processed = true;
       }
     }

--- a/ecal/core/src/readwrite/ecal_reader.h
+++ b/ecal/core/src/readwrite/ecal_reader.h
@@ -148,9 +148,9 @@ namespace eCAL
       SLayerStates         layer_states;
       bool                 state = false;
     };
-    using PublicationMapT = std::map<SPublicationInfo, SConnection>;
+    using ConnectionMapT = std::map<SPublicationInfo, SConnection>;
     mutable std::mutex                        m_connection_map_mtx;
-    PublicationMapT                           m_connection_map;
+    ConnectionMapT                            m_connection_map;
     std::atomic<size_t>                       m_connection_count{ 0 };
 
     mutable std::mutex                        m_read_buf_mtx;

--- a/ecal/core/src/serialization/ecal_struct_sample_registration.h
+++ b/ecal/core/src/serialization/ecal_struct_sample_registration.h
@@ -241,16 +241,14 @@ namespace eCAL
       int32_t                            process_id = 0;                // process id which produced the sample
       std::string                        host_name;                     // host which produced the sample
 
+      // This is a hack that assumes the entity_id is unique within the whole ecal system (which it should be)
       bool operator==(const SampleIdentifier& other) const {
-        return entity_id == other.entity_id &&
-          process_id == other.process_id &&
-          host_name == other.host_name;
+        return entity_id == other.entity_id;
       }
 
       bool operator<(const SampleIdentifier& other) const
       {
-        return std::tie(process_id, entity_id, host_name)
-          < std::tie(other.process_id, other.entity_id, other.host_name);
+        return entity_id < other.entity_id;
       }
     };
 

--- a/ecal/samples/cpp/benchmarks/many_connections_rec/src/many_connections_rec.cpp
+++ b/ecal/samples/cpp/benchmarks/many_connections_rec/src/many_connections_rec.cpp
@@ -39,7 +39,7 @@ public:
       std::ostringstream tname;
       tname << std::setw(5) << std::setfill('0') << i;
       subscribers.emplace_back("Topic" + tname.str(), eCAL::SDataTypeInformation{ ttype, "", tdesc });
-      auto on_receive = [this](const eCAL::Registration::STopicId&, const eCAL::SReceiveCallbackData&)
+      auto on_receive = [this](const eCAL::Registration::STopicId&, const eCAL::SDataTypeInformation&, const eCAL::SReceiveCallbackData&)
       {
         Receive();
       };


### PR DESCRIPTION
We now have the possibility to provide the DatatypeInformation in Callbacks, which makes it much easier for dynamic subscribers to deserialize data, without needing to look it up elsewhere.


@rex-schilasky 
I now have a few questions:
- We only provide this information for the callbacks. What about the `Receive` method?
- What about callback and receive signatures for protobuf subscribers and dynamic subscribiers?