### PR TITLE
[python] Bugfix mon_monitoring() crash

### DIFF
--- a/lang/python/core/src/ecal_wrap.cxx
+++ b/lang/python/core/src/ecal_wrap.cxx
@@ -1079,13 +1079,13 @@ namespace
       val = Py_BuildValue("i", topic.tsize);
       PyDict_SetItemString(topicDict, "tsize", val); Py_DECREF(val);
 
-      val = Py_BuildValue("connections_loc", topic.tsize);
+      val = Py_BuildValue("i", topic.connections_loc);
       PyDict_SetItemString(topicDict, "connections_loc", val); Py_DECREF(val);
 
-      val = Py_BuildValue("connections_ext", topic.tsize);
+      val = Py_BuildValue("i", topic.connections_ext);
       PyDict_SetItemString(topicDict, "connections_ext", val); Py_DECREF(val);
 
-      val = Py_BuildValue("message_drops", topic.tsize);
+      val = Py_BuildValue("i", topic.message_drops);
       PyDict_SetItemString(topicDict, "message_drops", val); Py_DECREF(val);
 
       val = Py_BuildValue("i", topic.did);


### PR DESCRIPTION
### Description
Use correct values for ecal_wrap.cxx connections_loc/ext and message_drops.
Also set ecal_wrap.cxx connections_loc/ext and message_drops to int, otherwise mon_monitoring() function will cause the algo to crash.
