### PR TITLE
[core] Introduce CMonitoringFilter class, that takes the task of filtering the topics to be included in the monitoring struct.

### DIFF
--- a/ecal/core/CMakeLists.txt
+++ b/ecal/core/CMakeLists.txt
@@ -193,6 +193,8 @@ if(ECAL_CORE_MONITORING)
 set(ecal_monitoring_src
     src/monitoring/ecal_monitoring_def.cpp
     src/monitoring/ecal_monitoring_def.h
+    src/monitoring/ecal_monitoring_filter.cpp
+    src/monitoring/ecal_monitoring_filter.h
     src/monitoring/ecal_monitoring_impl.cpp
     src/monitoring/ecal_monitoring_impl.h
 )

--- a/ecal/core/src/monitoring/ecal_monitoring_filter.cpp
+++ b/ecal/core/src/monitoring/ecal_monitoring_filter.cpp
@@ -120,7 +120,7 @@ void eCAL::CMonitoringFilter::SetInclFilter(const std::string& filter_)
   m_attributes.filter_incl = filter_;
 }
 
-bool eCAL::CMonitoringFilter::AcceptTopic(const std::string& topic_name)
+bool eCAL::CMonitoringFilter::AcceptTopic(const std::string& topic_name) const
 {
   // topics are rejected if:
   // a) they are matched by the exclude list
@@ -131,7 +131,7 @@ bool eCAL::CMonitoringFilter::AcceptTopic(const std::string& topic_name)
   if (reject_because_excluded)
     return false;
 
-  if (!m_exclude_filters.empty())
+  if (!m_include_filters.empty())
   {
     bool topic_is_included = MatchAnyRegex(topic_name, m_include_filters);
     if (!topic_is_included)

--- a/ecal/core/src/monitoring/ecal_monitoring_filter.cpp
+++ b/ecal/core/src/monitoring/ecal_monitoring_filter.cpp
@@ -1,0 +1,154 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2024 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+/**
+ * @brief  Filter that checks if a topic / service is to be listed in the monitoring.
+**/
+
+#include <monitoring/ecal_monitoring_filter.h>
+
+#include <mutex>
+#include <set>
+
+#include <ecal/ecal_os.h>
+
+#ifdef ECAL_OS_LINUX
+#include <strings.h>  // strcasecmp
+#endif
+
+namespace
+{
+  struct InsensitiveCompare
+  {
+    bool operator() (const std::string& a, const std::string& b) const
+    {
+#ifdef ECAL_OS_WINDOWS
+      return _stricmp(a.c_str(), b.c_str()) < 0;
+#endif
+#ifdef ECAL_OS_LINUX
+      return strcasecmp(a.c_str(), b.c_str()) < 0;
+#endif
+    }
+  };
+
+  using StrICaseSetT = std::set<std::string, InsensitiveCompare>;
+
+  void Tokenize(const std::string& str, StrICaseSetT& tokens, const std::string& delimiters, bool trimEmpty)
+  {
+    std::string::size_type pos = 0;
+    std::string::size_type lastPos = 0;
+
+    for (;;)
+    {
+      pos = str.find_first_of(delimiters, lastPos);
+      if (pos == std::string::npos)
+      {
+        pos = str.length();
+        if (pos != lastPos || !trimEmpty)
+        {
+          tokens.emplace(std::string(str.data() + lastPos, pos - lastPos));
+        }
+        break;
+      }
+      else
+      {
+        if (pos != lastPos || !trimEmpty)
+        {
+          tokens.emplace(std::string(str.data() + lastPos, pos - lastPos));
+        }
+      }
+      lastPos = pos + 1;
+    }
+  }
+
+  std::vector<std::regex> CreateRegexVector(const std::string& filter_)
+  {
+    std::vector<std::regex> regex_vector;
+    StrICaseSetT compare_set;
+    Tokenize(filter_, compare_set, ",;", true);
+    for (const auto& it : compare_set)
+    {
+      regex_vector.push_back(std::regex(it, std::regex::icase));
+    }
+    return regex_vector;
+  }
+
+  bool MatchAnyRegex(const std::string& topic_name, const std::vector<std::regex>& regexes)
+  {
+    for (const auto& regex : regexes)
+    {
+      if (std::regex_match(topic_name, regex))
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+}
+
+
+
+eCAL::CMonitoringFilter::CMonitoringFilter(const Monitoring::SAttributes& attr_)
+  : m_attributes(attr_)
+{
+  ActivateFilter();
+}
+
+void eCAL::CMonitoringFilter::SetExclFilter(const std::string& filter_)
+{
+  m_attributes.filter_excl = filter_;
+}
+
+void eCAL::CMonitoringFilter::SetInclFilter(const std::string& filter_)
+{
+  m_attributes.filter_incl = filter_;
+}
+
+bool eCAL::CMonitoringFilter::AcceptTopic(const std::string& topic_name)
+{
+  // topics are rejected if:
+  // a) they are matched by the exclude list
+  // b) there exists an include list, and they are not in the include list
+  // topics are accepted if they are not rejected.
+
+  bool reject_because_excluded = MatchAnyRegex(topic_name, m_exclude_filters);
+  if (reject_because_excluded)
+    return false;
+
+  if (!m_exclude_filters.empty())
+  {
+    bool topic_is_included = MatchAnyRegex(topic_name, m_include_filters);
+    if (!topic_is_included)
+      return false;
+  }
+
+  return true;
+}
+
+void eCAL::CMonitoringFilter::ActivateFilter()
+{
+  m_exclude_filters = CreateRegexVector(m_attributes.filter_excl);
+  m_include_filters = CreateRegexVector(m_attributes.filter_incl);
+}
+
+void eCAL::CMonitoringFilter::DeactivateFilter()
+{
+  m_exclude_filters.clear();
+  m_include_filters.clear();
+}

--- a/ecal/core/src/monitoring/ecal_monitoring_filter.h
+++ b/ecal/core/src/monitoring/ecal_monitoring_filter.h
@@ -39,7 +39,7 @@ namespace eCAL
     void SetInclFilter(const std::string& filter_);
 
     // Returns true if topic is accepted by the filter, false otherwise
-    bool AcceptTopic(const std::string& topic_name);
+    bool AcceptTopic(const std::string& topic_name) const;
 
     void ActivateFilter();
     void DeactivateFilter();

--- a/ecal/core/src/monitoring/ecal_monitoring_filter.h
+++ b/ecal/core/src/monitoring/ecal_monitoring_filter.h
@@ -17,19 +17,36 @@
  * ========================= eCAL LICENSE =================================
 */
 
-#pragma once
+/**
+ * @brief  Filter that checks if a topic / service is to be listed in the monitoring.
+**/
 
+#include <regex>
 #include <string>
+#include <vector>
+
+#include "monitoring/attributes/monitoring_attributes.h"
 
 namespace eCAL
 {
-  namespace Monitoring
+  class CMonitoringFilter
   {
-    struct SAttributes
-    {
-      std::string  filter_excl;
-      std::string  filter_incl;
-    };
+  public:
+    CMonitoringFilter(const Monitoring::SAttributes& attr_);
 
-  }
+    // Sets the filters. The user needs to call activate filter, after setting them.
+    void SetExclFilter(const std::string& filter_);
+    void SetInclFilter(const std::string& filter_);
+
+    // Returns true if topic is accepted by the filter, false otherwise
+    bool AcceptTopic(const std::string& topic_name);
+
+    void ActivateFilter();
+    void DeactivateFilter();
+
+  private:
+    Monitoring::SAttributes m_attributes;
+    std::vector<std::regex> m_include_filters;
+    std::vector<std::regex> m_exclude_filters;
+  };
 }

--- a/ecal/core/src/monitoring/ecal_monitoring_impl.h
+++ b/ecal/core/src/monitoring/ecal_monitoring_impl.h
@@ -26,7 +26,8 @@
 #include <ecal/types/monitoring.h>
 
 #include "ecal_def.h"
-#include "attributes/monitoring_attributes.h"
+#include "monitoring/attributes/monitoring_attributes.h"
+#include "monitoring/ecal_monitoring_filter.h"
 
 #include "serialization/ecal_serialize_sample_registration.h"
 
@@ -35,10 +36,6 @@
 #include <mutex>
 #include <set>
 #include <string>
-
-#ifdef ECAL_OS_LINUX
-#include <strings.h>  // strcasecmp
-#endif
 
 namespace eCAL
 {
@@ -126,20 +123,6 @@ namespace eCAL
       std::unique_ptr<ClientMonMapT>  map;
     };
 
-    struct InsensitiveCompare
-    {
-      bool operator() (const std::string& a, const std::string& b) const
-      {
-#ifdef ECAL_OS_WINDOWS
-        return _stricmp(a.c_str(), b.c_str()) < 0;
-#endif
-#ifdef ECAL_OS_LINUX
-        return strcasecmp(a.c_str(), b.c_str()) < 0;
-#endif
-      }
-    };
-    using StrICaseSetT = std::set<std::string, InsensitiveCompare>;
-
     STopicMonMap* GetMap(enum ePubSub pubsub_type_);
 
     void MonitorProcs(Monitoring::SMonitoring& monitoring_);
@@ -147,17 +130,10 @@ namespace eCAL
     void MonitorClients(Monitoring::SMonitoring& monitoring_);
     void MonitorTopics(STopicMonMap& map_, Monitoring::SMonitoring& monitoring_, const std::string& direction_);
 
-    void Tokenize(const std::string& str, StrICaseSetT& tokens, const std::string& delimiters, bool trimEmpty);
-
     bool                                         m_init;
 
-    Monitoring::SAttributes                      m_attributes;
-
-    std::mutex                                   m_topic_filter_excl_mtx;
-    StrICaseSetT                                 m_topic_filter_excl;
-
-    std::mutex                                   m_topic_filter_incl_mtx;
-    StrICaseSetT                                 m_topic_filter_incl;
+    std::mutex                                   m_monitoring_filter_mtx;
+    CMonitoringFilter                            m_monitoring_filter;
 
     // database
     SProcessMonMap                               m_process_map;

--- a/ecal/tests/CMakeLists.txt
+++ b/ecal/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ endif()
 
 add_subdirectory(cpp/event_test)
 add_subdirectory(cpp/expmap_test)
+add_subdirectory(cpp/monitoring_test)
 add_subdirectory(cpp/serialization_test)
 add_subdirectory(cpp/topic2mcast_test)
 add_subdirectory(cpp/util_test)

--- a/ecal/tests/cpp/monitoring_test/CMakeLists.txt
+++ b/ecal/tests/cpp/monitoring_test/CMakeLists.txt
@@ -1,0 +1,43 @@
+# ========================= eCAL LICENSE =================================
+#
+# Copyright (C) 2016 - 2024 Continental Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ========================= eCAL LICENSE =================================
+
+project(test_monitoring)
+
+find_package(Threads REQUIRED)
+find_package(GTest REQUIRED)
+
+set(test_monitoring_src
+  src/monitoring_filter_test.cpp
+  ${ECAL_CORE_PROJECT_ROOT}/core/src/monitoring/ecal_monitoring_filter.cpp  
+)
+
+ecal_add_gtest(${PROJECT_NAME} ${test_monitoring_src})
+
+target_include_directories(${PROJECT_NAME} PRIVATE $<TARGET_PROPERTY:eCAL::core,INCLUDE_DIRECTORIES>)
+
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    eCAL::core
+    Threads::Threads
+)
+
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
+
+ecal_install_gtest(${PROJECT_NAME})
+
+set_property(TARGET ${PROJECT_NAME} PROPERTY FOLDER tests/cpp/core)

--- a/ecal/tests/cpp/monitoring_test/src/monitoring_filter_test.cpp
+++ b/ecal/tests/cpp/monitoring_test/src/monitoring_filter_test.cpp
@@ -1,0 +1,94 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2024 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <monitoring/ecal_monitoring_filter.h>
+
+// Unit test class for CExpandingVector
+class CMonitoringFilterTest : public ::testing::Test {
+protected:
+  std::vector<std::string> topic_names;  // Create a vector of MyElement type
+
+  void SetUp() override {
+    // Add some initial values
+    topic_names.push_back("topic_1");
+    topic_names.push_back("topic_2");
+    topic_names.push_back("topic_3");
+    topic_names.push_back("apple");
+    topic_names.push_back("banana");
+    topic_names.push_back("__internal");
+  }
+};
+
+using core_cpp_monitoring_filter = CMonitoringFilterTest;
+
+void EvaluateFilter(const eCAL::CMonitoringFilter& filter, const std::vector<std::string>& input, const std::vector<bool>& expected_outcome)
+{
+  for (size_t i = 0; i < input.size() && i < expected_outcome.size(); ++i)
+  {
+    auto accepted = filter.AcceptTopic(input[i]);
+    if (expected_outcome[i])
+      EXPECT_EQ(accepted, expected_outcome[i]) << input[i] << " should be accepted";
+    else
+      EXPECT_EQ(accepted, expected_outcome[i]) << input[i] << " should not be accepted";
+  }
+}
+
+
+// Test push_back and size functionality
+TEST_F(core_cpp_monitoring_filter, DefaultFilter) {
+  // A default filter should accept all topics
+  eCAL::CMonitoringFilter filter{ eCAL::Monitoring::SAttributes() };
+  std::vector<bool> expected = { true, true, true, true, true, true };
+
+  EvaluateFilter(filter, topic_names, expected);
+}
+
+TEST_F(core_cpp_monitoring_filter, ExcludeFilter) {
+  // A default filter should accept all topics
+  eCAL::Monitoring::SAttributes attr;
+  attr.filter_excl = "^__.*$";
+  attr.filter_incl = "";
+  eCAL::CMonitoringFilter filter{ attr };
+  std::vector<bool> expected = { true, true, true, true, true, false };
+  EvaluateFilter(filter, topic_names, expected);
+}
+
+TEST_F(core_cpp_monitoring_filter, IncludeFilter) {
+  // A default filter should accept all topics
+  eCAL::Monitoring::SAttributes attr;
+  attr.filter_excl = "";
+  attr.filter_incl = "^topic_.*$";
+  eCAL::CMonitoringFilter filter{ attr };
+  std::vector<bool> expected = { true, true, true, false, false, false };
+  EvaluateFilter(filter, topic_names, expected);
+}
+
+TEST_F(core_cpp_monitoring_filter, IncludeExcludeFilter) {
+  // A default filter should accept all topics
+  eCAL::Monitoring::SAttributes attr;
+  attr.filter_excl = "^topic_1$";
+  attr.filter_incl = "^topic_.*$";
+  eCAL::CMonitoringFilter filter{ attr };
+  std::vector<bool> expected = { false, true, true, false, false, false };
+  EvaluateFilter(filter, topic_names, expected);
+}


### PR DESCRIPTION
### Description
This PR moves the implementation of the filtering of samples which are applied to the monitoring to it's own class, called CMonitoringFilter. It provides methods to set the filters (via an include and exclude list), and a method to check if a given topic name is accepted or filtered out.

At the same time it also provides some performance improvements over the original implementation, where a regex was "compiled" for every incoming sample, which is a very expensive operation. Now the regular expressions themselves are created once, and they are matched every time a sample is applied.

This give significant performance improvement, however, the performance of performing a the matching is still significant.
We should consider either not providing a filtering mechanism for the monitoring, or, to give that mechanism to the user, to be applied when iterating over the data, which might be performed less often than the sample application.
Reverting to faster filtering mechanisms (like startswith..) might also be an alternative.

In a "massive pubsub scenario", with the system idling, there is significant performance spend for the monitoring component.
![image](https://github.com/user-attachments/assets/7025d35c-7c05-4264-a2cc-acee83f25cdc)
e.g. 7.5% of time spend for monitoring, and 2.7% of all execution time spend only for matching the regex within monitoring. That's quite expensive.