### PR TITLE
Fix memory leaks in Python wrapper by adding missing Py_DECREF.

### DIFF
--- a/lang/python/core/src/ecal_wrap.cxx
+++ b/lang/python/core/src/ecal_wrap.cxx
@@ -1301,7 +1301,8 @@ PyObject* mon_monitoring(PyObject* /*self*/, PyObject* /*args*/)
     }
   }
 
-  return(Py_BuildValue("iO", 0, retDict));
+  auto* retVal = Py_BuildValue("iO", 0, retDict); Py_DECREF(retDict);
+  return(retVal);
 }
 
 /****************************************/
@@ -1341,7 +1342,8 @@ PyObject* mon_logging(PyObject* /*self*/, PyObject* /*args*/)
     }
   }
 
-  return(Py_BuildValue("iO", 0, retList));
+  auto* retVal = Py_BuildValue("iO", 0, retList); Py_DECREF(retList);
+  return(retVal);
 }
 
 

--- a/lang/python/ecalhdf5/src/ecalhdf5_wrap.cxx
+++ b/lang/python/ecalhdf5/src/ecalhdf5_wrap.cxx
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -178,7 +178,7 @@ static PyObject* Meas_GetChannelNames(Meas *self, PyObject* /*args*/)
   for (const auto& channel : channel_names)
   {
     PyObject* ch = Py_BuildValue("s", channel.c_str());
-    PyList_Append(channels, ch);
+    PyList_Append(channels, ch); Py_DECREF(ch);
   }
 
   return channels;


### PR DESCRIPTION
### Description
When writing Python extensions from C++, objects created with `Py_BuildValue`, `Py_....` need their references decremented unless they are returned directly from the functions.
This PR fixes some occurences where the ref counters where not decreased, which leads to memory leaks.

### Related issues
Fixes #1753
