### PR TITLE
[innosetup] Adapt innosetup script to different cpack conventions.

### DIFF
--- a/cpack/innosetup/ecal_setup.iss.in
+++ b/cpack/innosetup/ecal_setup.iss.in
@@ -75,9 +75,15 @@ Source: "{#ComponentStagingDir}\runtime\*";           DestDir: "{app}";      Fla
 Source: "{#ComponentStagingDir}\Unspecified\*";       DestDir: "{app}";      Flags: ignoreversion recursesubdirs; Components: runtime
 Source: "{#ComponentStagingDir}\libraries\bin\*";     DestDir: "{app}\bin\"; Flags: ignoreversion recursesubdirs; Components: runtime
 
-Source: "{#ComponentStagingDir}\_configuration\cfg\ecal.ini";     DestDir: "{commonappdata}\eCAL\"; Tasks: not replaceconf; Flags: ignoreversion confirmoverwrite; Components: runtime
-Source: "{#ComponentStagingDir}\_configuration\cfg\ecal.ini";     DestDir: "{commonappdata}\eCAL\"; Tasks: replaceconf;     Flags: ignoreversion;                  Components: runtime
-Source: "{#ComponentStagingDir}\_configuration\cfg\ecaltime.ini"; DestDir: "{commonappdata}\eCAL\";                         Flags: ignoreversion;                  Components: runtime
+; we need to change the location of these configuration file (as hotfix we use skipifsourcedoesntexist flag)
+Source: "{#ComponentStagingDir}\configuration\cfg\ecal.ini";      DestDir: "{commonappdata}\eCAL\"; Tasks: not replaceconf; Flags: ignoreversion skipifsourcedoesntexist confirmoverwrite; Components: runtime
+Source: "{#ComponentStagingDir}\configuration\cfg\ecal.ini";      DestDir: "{commonappdata}\eCAL\"; Tasks: replaceconf;     Flags: ignoreversion skipifsourcedoesntexist;                  Components: runtime
+Source: "{#ComponentStagingDir}\configuration\cfg\ecaltime.ini";  DestDir: "{commonappdata}\eCAL\";                         Flags: ignoreversion skipifsourcedoesntexist;                  Components: runtime
+
+; we need to change the location of these configuration file (as hotfix we use skipifsourcedoesntexist flag)
+Source: "{#ComponentStagingDir}\_configuration\cfg\ecal.ini";    DestDir: "{commonappdata}\eCAL\"; Tasks: not replaceconf; Flags: ignoreversion skipifsourcedoesntexist confirmoverwrite; Components: runtime
+Source: "{#ComponentStagingDir}\_configuration\cfg\ecal.ini";    DestDir: "{commonappdata}\eCAL\"; Tasks: replaceconf;     Flags: ignoreversion skipifsourcedoesntexist;                  Components: runtime
+Source: "{#ComponentStagingDir}\_configuration\cfg\ecaltime.ini"; DestDir: "{commonappdata}\eCAL\";                         Flags: ignoreversion skipifsourcedoesntexist;                  Components: runtime
 
 ; applications
 Source: "{#ComponentStagingDir}\app\*";               DestDir: "{app}";                   Flags: ignoreversion recursesubdirs;     Components: applications
@@ -119,11 +125,17 @@ Source: "{#DebugSdkStagingDir}\protobuf-export\*";    DestDir: "{app}";         
 ; Source: "{#DebugSdkStagingDir}\protoc\*";           DestDir: "{app}";                   Flags: ignoreversion recursesubdirs;     Components: sdk\protobuf
 
 ; sdk\hdf5
-Source: "{#ComponentStagingDir}\_configinstall\*";    DestDir: "{app}";                   Flags: ignoreversion recursesubdirs;     Components: sdk\hdf5
+; we need to change the location of these configuration file (as hotfix we use skipifsourcedoesntexist flag)
+Source: "{#ComponentStagingDir}\configinstall\*";     DestDir: "{app}";                   Flags: ignoreversion recursesubdirs skipifsourcedoesntexist;     Components: sdk\hdf5
+Source: "{#ComponentStagingDir}\_configinstall\*";    DestDir: "{app}";                   Flags: ignoreversion recursesubdirs skipifsourcedoesntexist;     Components: sdk\hdf5
+
 Source: "{#ComponentStagingDir}\headers\*";           DestDir: "{app}";                   Flags: ignoreversion recursesubdirs;     Components: sdk\hdf5
 Source: "{#ComponentStagingDir}\libraries\lib\*";     DestDir: "{app}\lib";               Flags: ignoreversion recursesubdirs;     Components: sdk\hdf5
 
-Source: "{#DebugSdkStagingDir}\_configinstall\*";     DestDir: "{app}";                   Flags: ignoreversion recursesubdirs;     Components: sdk\hdf5
+; we need to change the location of these configuration file (as hotfix we use skipifsourcedoesntexist flag)
+Source: "{#DebugSdkStagingDir}\configinstall\*";      DestDir: "{app}";                   Flags: ignoreversion recursesubdirs skipifsourcedoesntexist;     Components: sdk\hdf5
+Source: "{#DebugSdkStagingDir}\_configinstall\*";     DestDir: "{app}";                   Flags: ignoreversion recursesubdirs skipifsourcedoesntexist;     Components: sdk\hdf5
+
 Source: "{#DebugSdkStagingDir}\libraries\lib\*";      DestDir: "{app}\lib";               Flags: ignoreversion recursesubdirs;     Components: sdk\hdf5
 Source: "{#DebugSdkStagingDir}\libraries\bin\*";      DestDir: "{app}\bin\";              Flags: ignoreversion recursesubdirs;     Components: sdk\hdf5
 


### PR DESCRIPTION
### Description
Innosetup takes files from internal cpack install locations, to pack them all together.
Adapt the Innosetup script to reflect different paths for different cpack versions.
