### PR TITLE
[python] Call_method in service now allows threads.

### DIFF
--- a/lang/python/core/src/ecal_wrap.cxx
+++ b/lang/python/core/src/ecal_wrap.cxx
@@ -813,7 +813,9 @@ PyObject* client_call_method(PyObject* /*self*/, PyObject* args)   // (client_ha
   PyArg_ParseTuple(args, "nsy#i", &client_handle, &method_name, &request, &request_len, &timeout);
 
   bool called_method{ false };
-  called_method = client_call_method(client_handle, method_name, request, (int)request_len, timeout);
+  Py_BEGIN_ALLOW_THREADS
+    called_method = client_call_method(client_handle, method_name, request, (int)request_len, timeout);
+  Py_END_ALLOW_THREADS
 
   return(Py_BuildValue("i", called_method));
 }


### PR DESCRIPTION
### Description
If you used a service client and server in the same process (like described in this issue: https://github.com/eclipse-ecal/ecal/issues/1755), the application locks. With this fix, it does not lock anymore and function as expected.
