### PR TITLE
[core] fix bug that processes will not be "unregistered" correctly.

### DIFF
--- a/ecal/core/src/registration/ecal_process_registration.cpp
+++ b/ecal/core/src/registration/ecal_process_registration.cpp
@@ -38,6 +38,9 @@ eCAL::Registration::Sample eCAL::Registration::GetProcessRegisterSample()
   auto& process_sample_identifier = process_sample.identifier;
   process_sample_identifier.host_name  = eCAL::Process::GetHostName();
   process_sample_identifier.process_id = eCAL::Process::GetProcessID();
+  // We need to set the pid as entity_id.
+  // However, we cannot send anything over the wire :(
+  process_sample_identifier.entity_id = std::to_string(process_sample_identifier.process_id);
 
   auto& process_sample_process = process_sample.process;
   process_sample_process.hgname = eCAL::Process::GetHostGroupName();

--- a/ecal/core/src/serialization/ecal_serialize_sample_registration.cpp
+++ b/ecal/core/src/serialization/ecal_serialize_sample_registration.cpp
@@ -407,6 +407,8 @@ namespace
       registration_.process.rclock = pb_sample_.process.rclock;
       // pid
       registration_.identifier.process_id = pb_sample_.process.pid;
+      // tid -> we need to use the PID here, because we don't have a designated field for it
+      registration_.identifier.entity_id = std::to_string(registration_.identifier.process_id);
       // state.severity
       registration_.process.state.severity = static_cast<eCAL::Registration::eProcessSeverity>(pb_sample_.process.state.severity);
       // state.severity_level

--- a/ecal/tests/cpp/serialization_test/src/registration_generate.cpp
+++ b/ecal/tests/cpp/serialization_test/src/registration_generate.cpp
@@ -152,7 +152,7 @@ namespace eCAL
       sample.host.hname = GenerateString(8);
       sample.identifier = GenerateIdentifier();
       // Process samples don't have an id internally, hence it must be 0.
-      sample.identifier.entity_id = "";
+      sample.identifier.entity_id = std::to_string(sample.identifier.process_id);
       sample.process = GenerateProcess();
       return sample;
     }


### PR DESCRIPTION
### Description
Correctly keeps processes in CExpiringMap of unregistration provider.
Now their id is the `process_id` instead of `""`, which lead to process entries overwriting themselves in tthe map kept by the unregistration provider.

### Related issues
Fixes #1763