### PR TITLE
service client connection state handling

### DIFF
--- a/ecal/core/src/service/ecal_clientgate.cpp
+++ b/ecal/core/src/service/ecal_clientgate.cpp
@@ -141,22 +141,6 @@ namespace eCAL
     }
   }
 
-  std::vector<SServiceAttr> CClientGate::GetServiceAttr(const std::string& service_name_)
-  {
-    std::vector<SServiceAttr> ret_vec;
-    const std::shared_lock<std::shared_timed_mutex> lock(m_service_register_map_sync);
-
-    // look for requested services
-    for (auto service : m_service_register_map)
-    {
-      if (service.second.sname == service_name_)
-      {
-        ret_vec.push_back(service.second);
-      }
-    }
-    return(ret_vec);
-  }
-
   void CClientGate::GetRegistrations(Registration::SampleList& reg_sample_list_)
   {
     if (!m_created) return;

--- a/ecal/core/src/service/ecal_clientgate.h
+++ b/ecal/core/src/service/ecal_clientgate.h
@@ -53,8 +53,6 @@ namespace eCAL
 
     void ApplyServiceRegistration(const Registration::Sample& ecal_sample_);
 
-    std::vector<SServiceAttr> GetServiceAttr(const std::string& service_name_);
-
     void GetRegistrations(Registration::SampleList& reg_sample_list_);
 
   protected:

--- a/ecal/core/src/service/ecal_service_client_impl.cpp
+++ b/ecal/core/src/service/ecal_service_client_impl.cpp
@@ -330,7 +330,7 @@ namespace eCAL
       std::lock_guard<std::mutex> const client_map_lock(m_client_map_sync);
       for (const auto& client : m_client_map)
       {
-        auto& client_data = client.second;
+        const auto& client_data = client.second;
 
         if (m_host_name.empty() || (m_host_name == client_data.service_attr.hname))
         {
@@ -400,7 +400,7 @@ namespace eCAL
   void CServiceClientImpl::RegisterService(const std::string& key_, const SServiceAttr& service_)
   {
     // lock client map
-    std::lock_guard<std::mutex> lock(m_client_map_sync);
+    const std::lock_guard<std::mutex> lock(m_client_map_sync);
 
     // add service if it's a new registration
     if (m_client_map.find(key_) == m_client_map.end())
@@ -493,7 +493,7 @@ namespace eCAL
       std::lock_guard<std::mutex> const client_map_lock(m_client_map_sync);
       for (const auto& client : m_client_map)
       {
-        auto& client_data = client.second;
+        const auto& client_data = client.second;
 
         // Only call service if host name matches
         if (m_host_name.empty() || (m_host_name == client_data.service_attr.hname))
@@ -722,7 +722,6 @@ namespace eCAL
 
     for (auto it = m_client_map.begin(); it != m_client_map.end(); )
     {
-      auto& client_key = it->first;
       auto& client_data = it->second;
 
       // get current state of the client session
@@ -735,8 +734,6 @@ namespace eCAL
 
         // call connect event
         {
-          //std::cout << "Fire CONNECT event for " << client_key << std::endl;
-
           std::lock_guard<std::mutex> const lock_cb(m_event_callback_map_sync);
           auto e_iter = m_event_callback_map.find(client_event_connected);
           if (e_iter != m_event_callback_map.end())
@@ -759,8 +756,6 @@ namespace eCAL
 
         // call disconnect event
         {
-          //std::cout << "Fire DISCONNECT event for " << client_key << std::endl;
-
           std::lock_guard<std::mutex> const lock_cb(m_event_callback_map_sync);
           auto e_iter = m_event_callback_map.find(client_event_disconnected);
           if (e_iter != m_event_callback_map.end())

--- a/ecal/core/src/service/ecal_service_client_impl.h
+++ b/ecal/core/src/service/ecal_service_client_impl.h
@@ -102,15 +102,21 @@ namespace eCAL
     void Register();
     void Unregister();
 
-    void CheckForNewServices();
-    void CheckForDisconnectedServices();
+    void UpdateConnectionStates();
 
     void ErrorCallback(const std::string &method_name_, const std::string &error_message_);
 
     void IncrementMethodCallCount(const std::string& method_name_);
 
-    using ClientMapT = std::map<std::string, std::shared_ptr<eCAL::service::ClientSession>>;
+    struct SClient
+    {
+      SServiceAttr                                  service_attr;
+      std::shared_ptr<eCAL::service::ClientSession> client_session;
+      bool                                          connected = false;
+    };
+
     std::mutex            m_client_map_sync;
+    using ClientMapT = std::map<std::string, SClient>;
     ClientMapT            m_client_map;
 
     std::mutex            m_response_callback_sync;
@@ -120,17 +126,13 @@ namespace eCAL
     using EventCallbackMapT = std::map<eCAL_Client_Event, ClientEventCallbackT>;
     EventCallbackMapT     m_event_callback_map;
 
-    std::mutex            m_connected_services_map_sync;
-    using ServiceAttrMapT = std::map<std::string, SServiceAttr>;
-    ServiceAttrMapT       m_connected_services_map;
-
     static constexpr int  m_client_version = 1;
 
     std::string           m_service_name;
     std::string           m_service_id;
     std::string           m_host_name;
 
-    std::mutex                   m_method_sync;
+    std::mutex                   m_method_information_map_sync;
     ServiceMethodInformationMapT m_method_information_map;
 
     using MethodCallCountMapT = std::map<std::string, uint64_t>;

--- a/ecal/samples/cpp/services/minimal_client/src/minimal_client.cpp
+++ b/ecal/samples/cpp/services/minimal_client/src/minimal_client.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,6 +52,14 @@ int main(int argc, char **argv)
   // create minimal service client
   eCAL::CServiceClient minimal_client("service1", { {"echo", eCAL::SServiceMethodInformation()} });
   minimal_client.AddResponseCallback(OnServiceResponse);
+
+  while (!minimal_client.IsConnected())
+  {
+    std::cout << "Waiting for a service .." << std::endl;
+
+    // sleep a second
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+  }
 
   while(eCAL::Ok())
   {


### PR DESCRIPTION
### Description
Service client connection state (IsConnected) now handled correctly. Connection state is true if a matching server (at least one) is connected on lower client/service API level. We might change this API even more to return the states of all matching server.

### Related issues
#1779 

### Cherry-pick to
<!-- Leave empty, if you don't know. For master-only changes use "none"
- 5.13 (current stable)
