### PR TITLE
[config] Changed cwdPath logic to not leak memory

### DIFF
--- a/ecal/core/src/config/ecal_config_initializer.cpp
+++ b/ecal/core/src/config/ecal_config_initializer.cpp
@@ -34,17 +34,22 @@
   #include "configuration_to_yaml.h"
 #endif
 
+
 // for cwd
 #ifdef ECAL_OS_WINDOWS
+  #include <limits>
   #include <direct.h>
   // to remove deprecated warning
   #define getcwd _getcwd
+  constexpr int MAXIMUM_PATH_LENGTH = _MAX_PATH;
 #endif
 #ifdef ECAL_OS_LINUX
   #include <sys/types.h>
   #include <sys/stat.h>
   #include <unistd.h>
   #include <pwd.h>
+  #include <limits.h>
+  constexpr int MAXIMUM_PATH_LENGTH = PATH_MAX;
 #endif
 
 #include "ecal_utils/filesystem.h"
@@ -67,16 +72,15 @@ namespace
 
   bool setPathSep(std::string& file_path_)
   {
-    if (!file_path_.empty())
-    {
-      if (file_path_.back() != path_separator)
-      {
-        file_path_ += path_separator;
-      }
-      return true;
-    }
+    if (file_path_.empty())
+      return false;
 
-    return false;
+    if (file_path_.back() != path_separator)
+    {
+      file_path_ += path_separator;
+    }
+    
+    return true;
   }
 
   std::string eCALDataEnvPath()
@@ -88,10 +92,16 @@ namespace
 
   std::string cwdPath()
   {
-    std::string cwd_path = { getcwd(nullptr, 0) };
-    
-    setPathSep(cwd_path);
-    return cwd_path;
+    char temp[MAXIMUM_PATH_LENGTH];  
+
+    if (getcwd(temp, sizeof(temp)) != nullptr)
+    {
+      std::string cwdPath{temp};
+      setPathSep(cwdPath);
+      return cwdPath;
+    }
+
+    return {};
   }
 
   std::string eCALDataCMakePath()


### PR DESCRIPTION
### Description
If calling the getcwd function with a nullptr, memory gets leaked. This can be avoided by passing a buffer. The buffer size is dependend on the systems maximum size for paths.
