### PR TITLE
[core] Remove ECAL_API occurrences in cpp files.

### DIFF
--- a/ecal/core/src/config/ecal_config.cpp
+++ b/ecal/core/src/config/ecal_config.cpp
@@ -30,80 +30,80 @@ namespace eCAL
     // common
     /////////////////////////////////////
     
-    ECAL_API std::string       GetLoadedEcalIniPath                 () { return GetConfiguration().GetYamlFilePath(); }
-    ECAL_API int               GetRegistrationTimeoutMs             () { return GetConfiguration().registration.registration_timeout; }
-    ECAL_API int               GetRegistrationRefreshMs             () { return GetConfiguration().registration.registration_refresh; }
+    std::string       GetLoadedEcalIniPath                 () { return GetConfiguration().GetYamlFilePath(); }
+    int               GetRegistrationTimeoutMs             () { return GetConfiguration().registration.registration_timeout; }
+    int               GetRegistrationRefreshMs             () { return GetConfiguration().registration.registration_refresh; }
 
     /////////////////////////////////////
     // network
     /////////////////////////////////////
 
-    ECAL_API bool              IsNetworkEnabled                     () { return GetConfiguration().registration.network_enabled; }
-    ECAL_API bool              IsShmRegistrationEnabled             () { return GetConfiguration().registration.layer.shm.enable; }
+    bool              IsNetworkEnabled                     () { return GetConfiguration().registration.network_enabled; }
+    bool              IsShmRegistrationEnabled             () { return GetConfiguration().registration.layer.shm.enable; }
 
-    ECAL_API Types::UdpConfigVersion  GetUdpMulticastConfigVersion  () { return GetConfiguration().transport_layer.udp.config_version; }
+    Types::UdpConfigVersion  GetUdpMulticastConfigVersion  () { return GetConfiguration().transport_layer.udp.config_version; }
 
-    ECAL_API std::string       GetUdpMulticastGroup                 () { return GetConfiguration().transport_layer.udp.network.group; }
-    ECAL_API std::string       GetUdpMulticastMask                  () { return GetConfiguration().transport_layer.udp.mask; }
-    ECAL_API int               GetUdpMulticastPort                  () { return GetConfiguration().transport_layer.udp.port; }
-    ECAL_API int               GetUdpMulticastTtl                   () { return GetConfiguration().transport_layer.udp.network.ttl; }
+    std::string       GetUdpMulticastGroup                 () { return GetConfiguration().transport_layer.udp.network.group; }
+    std::string       GetUdpMulticastMask                  () { return GetConfiguration().transport_layer.udp.mask; }
+    int               GetUdpMulticastPort                  () { return GetConfiguration().transport_layer.udp.port; }
+    int               GetUdpMulticastTtl                   () { return GetConfiguration().transport_layer.udp.network.ttl; }
 
-    ECAL_API int               GetUdpMulticastSndBufSizeBytes       () { return GetConfiguration().transport_layer.udp.send_buffer; }
-    ECAL_API int               GetUdpMulticastRcvBufSizeBytes       () { return GetConfiguration().transport_layer.udp.receive_buffer; }
-    ECAL_API bool              IsUdpMulticastJoinAllIfEnabled       () { return GetConfiguration().transport_layer.udp.join_all_interfaces; }
+    int               GetUdpMulticastSndBufSizeBytes       () { return GetConfiguration().transport_layer.udp.send_buffer; }
+    int               GetUdpMulticastRcvBufSizeBytes       () { return GetConfiguration().transport_layer.udp.receive_buffer; }
+    bool              IsUdpMulticastJoinAllIfEnabled       () { return GetConfiguration().transport_layer.udp.join_all_interfaces; }
 
-    ECAL_API bool              IsUdpMulticastRecEnabled             () { return GetConfiguration().subscriber.layer.udp.enable; }
-    ECAL_API bool              IsShmRecEnabled                      () { return GetConfiguration().subscriber.layer.shm.enable; }
-    ECAL_API bool              IsTcpRecEnabled                      () { return GetConfiguration().subscriber.layer.tcp.enable; }
+    bool              IsUdpMulticastRecEnabled             () { return GetConfiguration().subscriber.layer.udp.enable; }
+    bool              IsShmRecEnabled                      () { return GetConfiguration().subscriber.layer.shm.enable; }
+    bool              IsTcpRecEnabled                      () { return GetConfiguration().subscriber.layer.tcp.enable; }
 
-    ECAL_API bool              IsNpcapEnabled                       () { return GetConfiguration().transport_layer.udp.npcap_enabled; }
+    bool              IsNpcapEnabled                       () { return GetConfiguration().transport_layer.udp.npcap_enabled; }
 
-    ECAL_API size_t            GetTcpPubsubReaderThreadpoolSize     () { return GetConfiguration().transport_layer.tcp.number_executor_reader;}
-    ECAL_API size_t            GetTcpPubsubWriterThreadpoolSize     () { return GetConfiguration().transport_layer.tcp.number_executor_writer;}
-    ECAL_API int               GetTcpPubsubMaxReconnectionAttemps   () { return GetConfiguration().transport_layer.tcp.max_reconnections;}
+    size_t            GetTcpPubsubReaderThreadpoolSize     () { return GetConfiguration().transport_layer.tcp.number_executor_reader;}
+    size_t            GetTcpPubsubWriterThreadpoolSize     () { return GetConfiguration().transport_layer.tcp.number_executor_writer;}
+    int               GetTcpPubsubMaxReconnectionAttemps   () { return GetConfiguration().transport_layer.tcp.max_reconnections;}
 
-    ECAL_API std::string       GetHostGroupName                     () { return GetConfiguration().registration.host_group_name; }
+    std::string       GetHostGroupName                     () { return GetConfiguration().registration.host_group_name; }
     
     /////////////////////////////////////
     // time
     /////////////////////////////////////
     
-    ECAL_API std::string       GetTimesyncModuleName                () { return GetConfiguration().timesync.timesync_module_rt; }
-    ECAL_API std::string       GetTimesyncModuleReplay              () { return GetConfiguration().timesync.timesync_module_replay; }
+    std::string       GetTimesyncModuleName                () { return GetConfiguration().timesync.timesync_module_rt; }
+    std::string       GetTimesyncModuleReplay              () { return GetConfiguration().timesync.timesync_module_replay; }
 
     /////////////////////////////////////
     // process
     /////////////////////////////////////
     
-    ECAL_API std::string       GetTerminalEmulatorCommand           () { return GetConfiguration().application.startup.terminal_emulator; }
+    std::string       GetTerminalEmulatorCommand           () { return GetConfiguration().application.startup.terminal_emulator; }
 
     /////////////////////////////////////
     // monitoring
     /////////////////////////////////////
     
-    ECAL_API std::string         GetMonitoringFilterExcludeList     () { return GetConfiguration().monitoring.filter_excl; }
-    ECAL_API std::string         GetMonitoringFilterIncludeList     () { return GetConfiguration().monitoring.filter_incl; }
-    ECAL_API eCAL_Logging_Filter GetConsoleLogFilter                () { return GetConfiguration().logging.sinks.console.filter_log_con; }
-    ECAL_API eCAL_Logging_Filter GetFileLogFilter                   () { return GetConfiguration().logging.sinks.file.filter_log_file; }
-    ECAL_API eCAL_Logging_Filter GetUdpLogFilter                    () { return GetConfiguration().logging.sinks.udp.filter_log_udp; }
+    std::string         GetMonitoringFilterExcludeList     () { return GetConfiguration().monitoring.filter_excl; }
+    std::string         GetMonitoringFilterIncludeList     () { return GetConfiguration().monitoring.filter_incl; }
+    eCAL_Logging_Filter GetConsoleLogFilter                () { return GetConfiguration().logging.sinks.console.filter_log_con; }
+    eCAL_Logging_Filter GetFileLogFilter                   () { return GetConfiguration().logging.sinks.file.filter_log_file; }
+    eCAL_Logging_Filter GetUdpLogFilter                    () { return GetConfiguration().logging.sinks.udp.filter_log_udp; }
 
     /////////////////////////////////////
     // sys
     /////////////////////////////////////
     
-    ECAL_API std::string       GetEcalSysFilterExcludeList          () { return GetConfiguration().application.sys.filter_excl; }
+    std::string       GetEcalSysFilterExcludeList          () { return GetConfiguration().application.sys.filter_excl; }
 
     /////////////////////////////////////
     // publisher
     /////////////////////////////////////
-    ECAL_API bool              IsTopicTypeSharingEnabled            () { return GetConfiguration().publisher.share_topic_type; }
-    ECAL_API bool              IsTopicDescriptionSharingEnabled     () { return GetConfiguration().publisher.share_topic_description; }
+    bool              IsTopicTypeSharingEnabled            () { return GetConfiguration().publisher.share_topic_type; }
+    bool              IsTopicDescriptionSharingEnabled     () { return GetConfiguration().publisher.share_topic_description; }
 
     /////////////////////////////////////
     // service
     /////////////////////////////////////
-    ECAL_API bool              IsServiceProtocolV0Enabled           () { return GetConfiguration().service.protocol_v0; }
-    ECAL_API bool              IsServiceProtocolV1Enabled           () { return GetConfiguration().service.protocol_v1; }
+    bool              IsServiceProtocolV0Enabled           () { return GetConfiguration().service.protocol_v0; }
+    bool              IsServiceProtocolV1Enabled           () { return GetConfiguration().service.protocol_v1; }
 
     /////////////////////////////////////
     // experimemtal
@@ -111,9 +111,9 @@ namespace eCAL
 
     namespace Experimental
     {
-      ECAL_API size_t            GetShmMonitoringQueueSize          () { return GetConfiguration().registration.layer.shm.queue_size; }
-      ECAL_API std::string       GetShmMonitoringDomain             () { return GetConfiguration().registration.layer.shm.domain;}
-      ECAL_API bool              GetDropOutOfOrderMessages          () { return GetConfiguration().subscriber.drop_out_of_order_messages; }
+      size_t            GetShmMonitoringQueueSize          () { return GetConfiguration().registration.layer.shm.queue_size; }
+      std::string       GetShmMonitoringDomain             () { return GetConfiguration().registration.layer.shm.domain;}
+      bool              GetDropOutOfOrderMessages          () { return GetConfiguration().subscriber.drop_out_of_order_messages; }
     }
   }
 }

--- a/ecal/core/src/config/ecal_config_initializer.cpp
+++ b/ecal/core/src/config/ecal_config_initializer.cpp
@@ -22,6 +22,7 @@
 **/
 
 #include "ecal/ecal_config.h"
+#include "ecal/ecal_util.h"
 
 #include "ecal_global_accessors.h"
 #include "ecal_def.h"
@@ -351,7 +352,7 @@ namespace eCAL
 {
   namespace Util
   {
-    ECAL_API std::string GeteCALConfigPath()
+    std::string GeteCALConfigPath()
     {
       // Check for first directory which contains the ini file.
       const std::vector<std::string> search_directories = getEcalDefaultPaths();
@@ -359,7 +360,7 @@ namespace eCAL
       return findValidConfigPath(search_directories, ECAL_DEFAULT_CFG);
     }
 
-    ECAL_API std::string GeteCALHomePath()
+    std::string GeteCALHomePath()
     {
       std::string home_path;
 
@@ -401,7 +402,7 @@ namespace eCAL
       return(home_path);
     }
 
-    ECAL_API std::string GeteCALUserSettingsPath()
+    std::string GeteCALUserSettingsPath()
     {
       std::string settings_path;
 #ifdef ECAL_OS_WINDOWS
@@ -422,7 +423,7 @@ namespace eCAL
       return(settings_path);
     }
 
-    ECAL_API std::string GeteCALLogPath()
+    std::string GeteCALLogPath()
     {
       std::string log_path;
 #ifdef ECAL_OS_WINDOWS
@@ -444,14 +445,14 @@ namespace eCAL
       return(log_path);
     }
 
-    ECAL_API std::string GeteCALActiveIniFile()
+    std::string GeteCALActiveIniFile()
     {
       std::string ini_file = GeteCALConfigPath();
       ini_file += ECAL_DEFAULT_CFG;
       return ini_file;
     }
 
-    ECAL_API std::string GeteCALDefaultIniFile()
+    std::string GeteCALDefaultIniFile()
     {
       return GeteCALActiveIniFile();
     }

--- a/ecal/core/src/registration/ecal_registration.cpp
+++ b/ecal/core/src/registration/ecal_registration.cpp
@@ -173,13 +173,13 @@ namespace eCAL
       return g_descgate()->GetPublisherInfo(id_, topic_info_);
     }
 
-    ECAL_API CallbackToken AddPublisherEventCallback(const TopicIDCallbackT& callback_)
+    CallbackToken AddPublisherEventCallback(const TopicIDCallbackT& callback_)
     {
       if (g_descgate() == nullptr) return CallbackToken();
       return g_descgate()->AddPublisherEventCallback(callback_);
     }
 
-    ECAL_API void RemPublisherEventCallback(CallbackToken token_)
+    void RemPublisherEventCallback(CallbackToken token_)
     {
       if (g_descgate() == nullptr) return;
       return g_descgate()->RemPublisherEventCallback(token_);
@@ -203,7 +203,7 @@ namespace eCAL
       return g_descgate()->AddSubscriberEventCallback(callback_);
     }
 
-    ECAL_API void RemSubscriberEventCallback(CallbackToken token_)
+    void RemSubscriberEventCallback(CallbackToken token_)
     {
       if (g_descgate() == nullptr) return;
       return g_descgate()->RemSubscriberEventCallback(token_);


### PR DESCRIPTION
### Description
We should use the `ECAL_API` macro in header files only.