### PR TITLE
check event callback before execution

### DIFF
--- a/ecal/service/ecal_service/src/client_session_impl_v0.cpp
+++ b/ecal/service/ecal_service/src/client_session_impl_v0.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -229,7 +229,7 @@ namespace eCAL
                               }
 
                               // Call event callback
-                              me->event_callback_(eCAL::service::ClientEventType::Connected, message);
+                              if(me->event_callback_) me->event_callback_(eCAL::service::ClientEventType::Connected, message);
 
                               // Start sending service requests, if there are any
                               {
@@ -517,7 +517,7 @@ namespace eCAL
         }
       }
 
-      if (call_event_callback)
+      if (call_event_callback && event_callback_)
       {
         event_callback_(eCAL::service::ClientEventType::Disconnected, error_message);
       }

--- a/ecal/service/ecal_service/src/client_session_impl_v1.cpp
+++ b/ecal/service/ecal_service/src/client_session_impl_v1.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -325,7 +325,7 @@ namespace eCAL
                                     me->logger_(LogLevel::Info, "[" + get_connection_info_string(me->socket_) + "] " + message);
 
                                     // Call event callback
-                                    me->event_callback_(eCAL::service::ClientEventType::Connected, message);
+                                    if(me->event_callback_) me->event_callback_(eCAL::service::ClientEventType::Connected, message);
 
                                     // Start sending service requests, if there are any
                                     {
@@ -644,7 +644,7 @@ namespace eCAL
         }
       }
 
-      if (call_event_callback)
+      if (call_event_callback && event_callback_)
       {
         event_callback_(eCAL::service::ClientEventType::Disconnected, error_message);
       }


### PR DESCRIPTION
### Description
eCAL service client is offering event callback functionality. Like this

```c++
const eCAL::service::ClientSession::EventCallbackT event_callback = []
  (eCAL::service::ClientEventType /*event*/, const std::string& /*message*/) -> void
   {
   };
client_session = client_manager->create_client(protocol_version, endpoint_list, event_callback);
```

If the event callback logic is not relevant for your use case I would expect to just pass a nullptr like this
```c++
client_session = client_manager->create_client(protocol_version, endpoint_list, nullptr);
```

but this leads to a crash.

### Related issues
None

### Cherry-pick to
- _none_
