### PR TITLE
[core][bugfix] attributes.unit_name not initialized.

### DIFF
--- a/ecal/core/src/pubsub/config/builder/reader_attribute_builder.cpp
+++ b/ecal/core/src/pubsub/config/builder/reader_attribute_builder.cpp
@@ -35,6 +35,7 @@ namespace eCAL
     attributes.host_group_name            = Process::GetHostGroupName();
     attributes.process_id                 = Process::GetProcessID();
     attributes.process_name               = Process::GetProcessName();
+    attributes.unit_name                  = Process::GetUnitName();
     attributes.share_topic_type           = pub_config_.share_topic_type;
     attributes.share_topic_description    = pub_config_.share_topic_description;
 


### PR DESCRIPTION
### Description
[This commit](https://github.com/eclipse-ecal/ecal/commit/10366571caa6ab7d81d9aa0618254739dca7ab05#diff-2cdf63d88eed3c28f62b4d0f6e7b8769a5117c887e6ed8eef99aa39636b3c9a0) introduced some problems which show in the monitor like this:
![image](https://github.com/user-attachments/assets/253ebc56-d67a-450c-9906-50d53eac9ffc)

The uname of a process is not set properly, it was missed in the attribute builder.
This PR fixes this.