### PR TITLE
hotfix/memfile-ack-logic-deadlock

### DIFF
--- a/ecal/core/src/readwrite/shm/ecal_writer_shm.cpp
+++ b/ecal/core/src/readwrite/shm/ecal_writer_shm.cpp
@@ -97,7 +97,7 @@ namespace eCAL
     }
   }
 
-  void CDataWriterSHM::RemoveSubscription(const std::string& host_name_, const int32_t process_id_, const std::string& topic_id_)
+  void CDataWriterSHM::RemoveSubscription(const std::string& host_name_, const int32_t process_id_, const std::string&  /*topic_id_*/)
   {
     // we accept local disconnections only
     if (host_name_ != m_attributes.host_name) return;

--- a/ecal/core/src/readwrite/shm/ecal_writer_shm.cpp
+++ b/ecal/core/src/readwrite/shm/ecal_writer_shm.cpp
@@ -109,32 +109,31 @@ namespace eCAL
     // we accept local disconnections only
     if (host_name_ != m_attributes.host_name) return;
 
-    // remove topic id from the set for the given process id
+    // remove topic id from the id set for the given process id
     bool memfile_has_subscriptions(true);
     {
       const std::lock_guard<std::mutex> lock(m_process_id_topic_id_set_map_sync);
       auto process_it = m_process_id_topic_id_set_map.find(process_id_);
 
-      // this process id is connected the memory file
+      // this process id is connected to the memory file
       if (process_it != m_process_id_topic_id_set_map.end())
       {
-        // this topic id is in the set and will be removed now
+        // remove it from the id set
         process_it->second.erase(topic_id_);
 
-        // this was the last connected topic id for this process id
-        // that means this process id has no more connection to this memory file
+        // this process id has no more connection to this memory file
         if (process_it->second.empty())
         {
           // we can remove the empty topic id set
           m_process_id_topic_id_set_map.erase(process_it);
-          // memory file has no more subscriptions from process id
+          // and set the subscription state to false for later processing
           memfile_has_subscriptions = false;
         }
       }
     }
 
-    // if memory file is still connected to at least one topic id of this process id
-    // we return and do not call Disconnect for this process id
+    // memory file is still connected to at least one topic id of this process id
+    // no need to Disconnect process id
     if (memfile_has_subscriptions) return;
 
     for (auto& memory_file : m_memory_file_vec)

--- a/ecal/core/src/readwrite/shm/ecal_writer_shm.cpp
+++ b/ecal/core/src/readwrite/shm/ecal_writer_shm.cpp
@@ -97,6 +97,20 @@ namespace eCAL
     }
   }
 
+  void CDataWriterSHM::RemoveSubscription(const std::string& host_name_, const int32_t process_id_, const std::string& topic_id_)
+  {
+    // we accept local disconnections only
+    if (host_name_ != m_attributes.host_name) return;
+
+    for (auto& memory_file : m_memory_file_vec)
+    {
+      memory_file->Disconnect(std::to_string(process_id_));
+#ifndef NDEBUG
+      Logging::Log(log_level_debug1, std::string("CDataWriterSHM::RemoveSubscription - Memory FileName: ") + memory_file->GetName() + " to ProcessId " + std::to_string(process_id_));
+#endif
+    }
+  }
+
   Registration::ConnectionPar CDataWriterSHM::GetConnectionParameter()
   {
     Registration::ConnectionPar connection_par;

--- a/ecal/core/src/readwrite/shm/ecal_writer_shm.h
+++ b/ecal/core/src/readwrite/shm/ecal_writer_shm.h
@@ -47,6 +47,7 @@ namespace eCAL
     bool Write(CPayloadWriter& payload_, const SWriterAttr& attr_) override;
 
     void ApplySubscription(const std::string& host_name_, int32_t process_id_, const std::string& topic_id_, const std::string& conn_par_) override;
+    void RemoveSubscription(const std::string& host_name_, const int32_t process_id_, const std::string& topic_id_) override;
 
     Registration::ConnectionPar GetConnectionParameter() override;
 

--- a/ecal/core/src/readwrite/shm/ecal_writer_shm.h
+++ b/ecal/core/src/readwrite/shm/ecal_writer_shm.h
@@ -47,7 +47,7 @@ namespace eCAL
     bool Write(CPayloadWriter& payload_, const SWriterAttr& attr_) override;
 
     void ApplySubscription(const std::string& host_name_, int32_t process_id_, const std::string& topic_id_, const std::string& conn_par_) override;
-    void RemoveSubscription(const std::string& host_name_, const int32_t process_id_, const std::string& topic_id_) override;
+    void RemoveSubscription(const std::string& host_name_, int32_t process_id_, const std::string& topic_id_) override;
 
     Registration::ConnectionPar GetConnectionParameter() override;
 

--- a/ecal/core/src/readwrite/shm/ecal_writer_shm.h
+++ b/ecal/core/src/readwrite/shm/ecal_writer_shm.h
@@ -29,7 +29,10 @@
 #include "readwrite/ecal_writer_base.h"
 
 #include <cstddef>
+#include <map>
 #include <memory>
+#include <mutex>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -59,5 +62,9 @@ namespace eCAL
     size_t                                        m_write_idx = 0;
     std::vector<std::shared_ptr<CSyncMemoryFile>> m_memory_file_vec;
     static const std::string                      m_memfile_base_name;
+
+    using ProcessIDTopicIDSetT = std::map<int32_t, std::set<std::string>>;
+    std::mutex                                    m_process_id_topic_id_set_map_sync;
+    ProcessIDTopicIDSetT                          m_process_id_topic_id_set_map;
   };
 }


### PR DESCRIPTION
### Description

If the shm data transport layer acknowledgment feature is used and the ack time is set to a large value the publisher send may wait for a this long time on the ack event from the subscriber even the subscriber is no more existing (process is terminated for example). The SHM Datawriter Connect/Disconnect API is locked as long the Datawriter is waiting for the ack signal. That leads to a lock of the Registration layer finally.

Solution:

1. Add `RemoveSubscription` to `CDataWriterSHM` to react on un-registrations from the registration layer in general
2. Decouple `Connect/Disconnect` functionality of `CSyncMemoryFile` from `SyncContent()` to be able to modify the map of the memfile connection events even `SyncContent()` is waiting on a sync event.
