### PR TITLE
[config] API change for ecal_config.h

### DIFF
--- a/ecal/core/include/ecal/ecal_config.h
+++ b/ecal/core/include/ecal/ecal_config.h
@@ -31,15 +31,9 @@
 namespace eCAL
 {
   ECAL_API Configuration&                 GetConfiguration                 ();
-  ECAL_API TransportLayer::Configuration& GetTransportLayerConfiguration   ();
-  ECAL_API Registration::Configuration&   GetRegistrationConfiguration     ();
-  ECAL_API Monitoring::Configuration&     GetMonitoringConfiguration       ();
-  ECAL_API Logging::Configuration&        GetLoggingConfiguration          ();
   ECAL_API Subscriber::Configuration&     GetSubscriberConfiguration       ();
   ECAL_API Publisher::Configuration&      GetPublisherConfiguration        ();
-  ECAL_API Time::Configuration&           GetTimesyncConfiguration         ();
   ECAL_API Service::Configuration&        GetServiceConfiguration          ();
-  ECAL_API Application::Configuration&    GetApplicationConfiguration      ();
 
   namespace Config
   {
@@ -120,16 +114,18 @@ namespace eCAL
     /////////////////////////////////////
     ECAL_API bool                     IsServiceProtocolV0Enabled           ();
     ECAL_API bool                     IsServiceProtocolV1Enabled           ();
+    
+    /////////////////////////////////////
+    // subscriber
+    /////////////////////////////////////
+    ECAL_API bool                     GetDropOutOfOrderMessages            ();
 
     /////////////////////////////////////
-    // experimental
+    // registration
     /////////////////////////////////////
-    namespace Experimental
-    {
-      ECAL_API size_t                 GetShmMonitoringQueueSize          ();
-      ECAL_API std::string            GetShmMonitoringDomain             ();
-      ECAL_API bool                   GetDropOutOfOrderMessages          ();
-    }
+    
+    ECAL_API size_t                   GetShmMonitoringQueueSize            ();
+    ECAL_API std::string              GetShmMonitoringDomain               ();
   }
 }
 //@}

--- a/ecal/core/src/config/ecal_config.cpp
+++ b/ecal/core/src/config/ecal_config.cpp
@@ -83,9 +83,6 @@ namespace eCAL
     
     std::string         GetMonitoringFilterExcludeList     () { return GetConfiguration().monitoring.filter_excl; }
     std::string         GetMonitoringFilterIncludeList     () { return GetConfiguration().monitoring.filter_incl; }
-    eCAL_Logging_Filter GetConsoleLogFilter                () { return GetConfiguration().logging.provider.console.filter_log; }
-    eCAL_Logging_Filter GetFileLogFilter                   () { return GetConfiguration().logging.provider.file.filter_log; }
-    eCAL_Logging_Filter GetUdpLogFilter                    () { return GetConfiguration().logging.provider.udp.filter_log; }
 
     /////////////////////////////////////
     // sys
@@ -96,24 +93,29 @@ namespace eCAL
     /////////////////////////////////////
     // publisher
     /////////////////////////////////////
+    
     bool              IsTopicTypeSharingEnabled            () { return GetConfiguration().publisher.share_topic_type; }
     bool              IsTopicDescriptionSharingEnabled     () { return GetConfiguration().publisher.share_topic_description; }
 
     /////////////////////////////////////
     // service
     /////////////////////////////////////
+    
     bool              IsServiceProtocolV0Enabled           () { return GetConfiguration().service.protocol_v0; }
     bool              IsServiceProtocolV1Enabled           () { return GetConfiguration().service.protocol_v1; }
 
     /////////////////////////////////////
-    // experimemtal
+    // subscriber
     /////////////////////////////////////
+    
+    bool              GetDropOutOfOrderMessages          () { return GetConfiguration().subscriber.drop_out_of_order_messages; }
 
-    namespace Experimental
-    {
-      size_t            GetShmMonitoringQueueSize          () { return GetConfiguration().registration.layer.shm.queue_size; }
-      std::string       GetShmMonitoringDomain             () { return GetConfiguration().registration.layer.shm.domain;}
-      bool              GetDropOutOfOrderMessages          () { return GetConfiguration().subscriber.drop_out_of_order_messages; }
-    }
+    /////////////////////////////////////
+    // registration
+    /////////////////////////////////////
+    
+    size_t            GetShmMonitoringQueueSize          () { return GetConfiguration().registration.layer.shm.queue_size; }
+    std::string       GetShmMonitoringDomain             () { return GetConfiguration().registration.layer.shm.domain;}
+
   }
 }

--- a/ecal/core/src/config/ecal_config_initializer.cpp
+++ b/ecal/core/src/config/ecal_config_initializer.cpp
@@ -22,6 +22,7 @@
 **/
 
 #include "ecal/ecal_config.h"
+#include "ecal_config_internal.h"
 #include "ecal/ecal_util.h"
 
 #include "ecal_global_accessors.h"

--- a/ecal/core/src/ecal_config_internal.h
+++ b/ecal/core/src/ecal_config_internal.h
@@ -1,0 +1,38 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2024 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+#pragma once
+
+#include <cstddef>
+#include <ecal/ecal_log_level.h>
+#include <ecal/ecal_os.h>
+#include <ecal/ecal_tlayer.h>
+#include "ecal/config/configuration.h"
+
+#include <string>
+
+namespace eCAL
+{
+  ECAL_API TransportLayer::Configuration& GetTransportLayerConfiguration ();
+  ECAL_API Registration::Configuration&   GetRegistrationConfiguration   ();
+  ECAL_API Monitoring::Configuration&     GetMonitoringConfiguration     ();
+  ECAL_API Logging::Configuration&        GetLoggingConfiguration        ();
+  ECAL_API Time::Configuration&           GetTimesyncConfiguration       ();
+  ECAL_API Application::Configuration&    GetApplicationConfiguration    ();
+}

--- a/ecal/core/src/ecal_globals.cpp
+++ b/ecal/core/src/ecal_globals.cpp
@@ -33,6 +33,7 @@
 #include "service/ecal_service_singleton_manager.h"
 #endif
 
+#include "ecal_config_internal.h"
 #include "config/builder/registration_attribute_builder.h"
 #include "config/builder/monitoring_attribute_builder.h"
 #include "config/builder/logging_attribute_builder.h"

--- a/ecal/core/src/ecal_process.cpp
+++ b/ecal/core/src/ecal_process.cpp
@@ -208,7 +208,7 @@ namespace eCAL
 #if ECAL_CORE_SUBSCRIBER
       sstream << "------------------------- SUBSCRIPTION LAYER DEFAULTS ------------" << '\n';
       sstream << "Layer Mode UDP MC        : " << LayerMode(Config::IsUdpMulticastRecEnabled()) << '\n';
-      sstream << "Drop out-of-order msgs   : " << (Config::Experimental::GetDropOutOfOrderMessages() ? "on" : "off") << '\n';
+      sstream << "Drop out-of-order msgs   : " << (Config::GetDropOutOfOrderMessages() ? "on" : "off") << '\n';
 #endif
 #ifdef ECAL_CORE_NPCAP_SUPPORT
       sstream << "Npcap UDP Reciever       : " << LayerMode(Config::IsNpcapEnabled());

--- a/ecal/core/src/pubsub/ecal_publisher.cpp
+++ b/ecal/core/src/pubsub/ecal_publisher.cpp
@@ -28,7 +28,7 @@
 #include "readwrite/ecal_writer_buffer_payload.h"
 
 #include "config/builder/writer_attribute_builder.h"
-#include "ecal/ecal_config.h"
+#include "ecal_config_internal.h"
 
 #include <iostream>
 #include <memory>

--- a/ecal/core/src/pubsub/ecal_subscriber.cpp
+++ b/ecal/core/src/pubsub/ecal_subscriber.cpp
@@ -26,6 +26,7 @@
 #include "ecal_globals.h"
 #include "readwrite/ecal_reader.h"
 #include "config/builder/reader_attribute_builder.h"
+#include "ecal_config_internal.h"
 
 #include <iostream>
 #include <set>

--- a/ecal/core/src/readwrite/ecal_reader.cpp
+++ b/ecal/core/src/readwrite/ecal_reader.cpp
@@ -939,7 +939,7 @@ namespace eCAL
         // -----------------------------------
         // drop messages in the wrong order
         // -----------------------------------
-        if (Config::Experimental::GetDropOutOfOrderMessages())
+        if (Config::GetDropOutOfOrderMessages())
         {
           // do not update the internal clock counter
 


### PR DESCRIPTION
### Description
Removed the experimental namespace out of ecal_config.h.
Moved some config Get functions to internal space.

