### PR TITLE
[clang] 2 checks removed

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -40,6 +40,7 @@ Checks: "-*,
   misc-*,
   -misc-non-private-member-variables-in-classes,
   -misc-no-recursion,
+  -misc-include-cleaner,
   
   modernize-*,
   -modernize-pass-by-value,
@@ -61,6 +62,7 @@ Checks: "-*,
   -readability-redundant-access-specifiers,
   -readability-uppercase-literal-suffix,
   -readability-use-anyofallof,
+  -readability-avoid-const-params-in-decls,
 "
 WarningsAsErrors: ''
 HeaderFilterRegex: '^((?!/thirdparty/|/_deps/).)*$'


### PR DESCRIPTION
### Description
`misc-include-cleaner` and `readability-avoid-const-params-in-decls` removed from clang-tidy checks
