### PR TITLE
[core] Change entity_id type from std::string to uint64_t

### DIFF
--- a/ecal/core/include/ecal/ecal_callback.h
+++ b/ecal/core/include/ecal/ecal_callback.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,13 +74,13 @@ namespace eCAL
   **/
   struct SServiceAttr
   {
-    std::string    key;              //!< unique service key (internal)
-    std::string    hname;            //!< host name
-    std::string    pname;            //!< process name
-    std::string    uname;            //!< process unit name
-    std::string    sname;            //!< service name
-    std::string    sid;              //!< service id
-    int            pid         = 0;  //!< process id
+    std::string             key;              //!< unique service key (internal)
+    std::string             hname;            //!< host name
+    std::string             pname;            //!< process name
+    std::string             uname;            //!< process unit name
+    std::string             sname;            //!< service name
+    Registration::EntityIdT sid         = 0;  //!< service id
+    int                     pid         = 0;  //!< process id
 
     // internal protocol specifics
     unsigned int   version     = 0;  //!< service protocol version

--- a/ecal/core/include/ecal/ecal_types.h
+++ b/ecal/core/include/ecal/ecal_types.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,9 +103,11 @@ namespace eCAL
 
   namespace Registration
   {
+    using EntityIdT = uint64_t;
+
     struct SEntityId
     {
-      std::string  entity_id;         // unique id within that process (it should already be unique within the whole system)
+      EntityIdT    entity_id  = 0;    // unique id within that process (it should already be unique within the whole system)
       int32_t      process_id = 0;    // process id which produced the sample
       std::string  host_name;         // host which produced the sample
 

--- a/ecal/core/include/ecal/ecal_types.h
+++ b/ecal/core/include/ecal/ecal_types.h
@@ -23,9 +23,10 @@
 **/
 
 #pragma once
+#include <cstdint>
+#include <iostream>
 #include <string>
 #include <tuple>
-#include <iostream>
 
 namespace eCAL
 {

--- a/ecal/core/include/ecal/types/monitoring.h
+++ b/ecal/core/include/ecal/types/monitoring.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,7 +77,7 @@ namespace eCAL
       int32_t                             pid{0};               //!< process id
       std::string                         pname;                //!< process name
       std::string                         uname;                //!< unit name
-      std::string                         tid;                  //!< topic id
+      Registration::EntityIdT             tid{0};               //!< topic id
       std::string                         tname;                //!< topic name
       std::string                         direction;            //!< direction (publisher, subscriber)
       SDataTypeInformation                tdatatype;            //!< topic datatype information (name, encoding, descriptor)
@@ -155,7 +155,7 @@ namespace eCAL
       int32_t                  pid{0};                          //<! process id
 
       std::string              sname;                           //<! service name
-      std::string              sid;                             //<! service id
+      Registration::EntityIdT  sid{0};                          //<! service id
 
       uint32_t                 version{0};                      //<! service protocol version
       uint32_t                 tcp_port_v0{0};                  //<! the tcp port protocol version 0 used for that service
@@ -166,18 +166,18 @@ namespace eCAL
 
     struct SClientMon                                           //<! eCAL Client struct
     {
-      int32_t      rclock{0};                                   //<! registration clock
-      std::string  hname;                                       //<! host name
-      std::string  pname;                                       //<! process name
-      std::string  uname;                                       //<! unit name
-      int32_t      pid{0};                                      //<! process id
+      int32_t                  rclock{0};                       //<! registration clock
+      std::string              hname;                           //<! host name
+      std::string              pname;                           //<! process name
+      std::string              uname;                           //<! unit name
+      int32_t                  pid{0};                          //<! process id
 
-      std::string  sname;                                       //<! service name
-      std::string  sid;                                         //<! service id
+      std::string              sname;                           //<! service name
+      Registration::EntityIdT  sid{0};                          //<! service id
 
       std::vector<SMethodMon>  methods;                         //<! list of methods
 
-      uint32_t     version{0};                                  //<! client protocol version
+      uint32_t                 version{0};                     //<! client protocol version
     };
 
     struct SMonitoring                                          //<! eCAL Monitoring struct

--- a/ecal/core/src/monitoring/ecal_monitoring_impl.cpp
+++ b/ecal/core/src/monitoring/ecal_monitoring_impl.cpp
@@ -213,7 +213,7 @@ namespace eCAL
       const std::string& host_group_name = sample_topic.hgname;
       const std::string& process_name    = sample_topic.pname;
       const std::string& unit_name       = sample_topic.uname;
-      const std::string& topic_id        = sample_.identifier.entity_id;
+      const auto&        topic_id        = sample_.identifier.entity_id;
       std::string        direction;
       switch (pubsub_type_)
       {
@@ -232,7 +232,7 @@ namespace eCAL
       auto        attr                    = sample_topic.attr;
 
       // try to get topic info
-      const std::string& topic_map_key  = topic_id;
+      const auto& topic_map_key  = topic_id;
       Monitoring::STopicMon& TopicInfo = (*pTopicMap->map)[topic_map_key];
 
       // set static content
@@ -292,7 +292,7 @@ namespace eCAL
 
   bool CMonitoringImpl::UnregisterTopic(const Registration::Sample& sample_, enum ePubSub pubsub_type_)
   {
-    const std::string& topic_map_key = sample_.identifier.entity_id;
+    const auto& topic_map_key = sample_.identifier.entity_id;
 
     // unregister from topic map
     STopicMonMap* pTopicMap = GetMap(pubsub_type_);
@@ -328,13 +328,13 @@ namespace eCAL
     const std::string&    ecal_runtime_version         = sample_process.ecal_runtime_version;
 
     // create map key
-    const std::string process_name_id = process_name + std::to_string(process_id);
+    const auto& process_map_key = sample_.identifier.entity_id;
 
     // acquire access
     const std::lock_guard<std::mutex> lock(m_process_map.sync);
 
     // try to get process info
-    Monitoring::SProcessMon& ProcessInfo = (*m_process_map.map)[process_name_id];
+    Monitoring::SProcessMon& ProcessInfo = (*m_process_map.map)[process_map_key];
 
     // set static content
     ProcessInfo.hname  = host_name;
@@ -360,18 +360,13 @@ namespace eCAL
 
   bool CMonitoringImpl::UnregisterProcess(const Registration::Sample& sample_)
   {
-    const auto& sample_process = sample_.process;
-    const std::string& process_name = sample_process.pname;
-    const int          process_id   = sample_.identifier.process_id;
-
-    // create map key
-    const std::string process_name_id = process_name + std::to_string(process_id);
+    const auto& process_map_key = sample_.identifier.entity_id;
 
     // acquire access
     const std::lock_guard<std::mutex> lock(m_process_map.sync);
 
     // remove process info
-    m_process_map.map->erase(process_name_id);
+    m_process_map.map->erase(process_map_key);
 
     return(true);
   }
@@ -379,7 +374,7 @@ namespace eCAL
   bool CMonitoringImpl::RegisterServer(const Registration::Sample& sample_)
   {
     const auto& sample_identifier = sample_.identifier;
-    const std::string& service_id = sample_identifier.entity_id;
+    const auto&        service_id = sample_.identifier.entity_id;
     const int32_t      process_id = sample_identifier.process_id;
     const std::string& host_name  = sample_identifier.host_name;
 
@@ -392,7 +387,7 @@ namespace eCAL
     const uint32_t     tcp_port_v1  = sample_service.tcp_port_v1;
 
     // create map key
-    const std::string& service_map_key = service_id;
+    const auto& service_map_key = service_id;
 
     // acquire access
     const std::lock_guard<std::mutex> lock(m_server_map.sync);
@@ -431,7 +426,7 @@ namespace eCAL
   bool CMonitoringImpl::UnregisterServer(const Registration::Sample& sample_)
   {
     // create map key
-    const std::string& service_map_key = sample_.identifier.entity_id;
+    const auto& service_map_key = sample_.identifier.entity_id;
 
     // acquire access
     const std::lock_guard<std::mutex> lock(m_server_map.sync);
@@ -445,7 +440,7 @@ namespace eCAL
   bool CMonitoringImpl::RegisterClient(const Registration::Sample& sample_)
   {
     const auto& sample_identifier = sample_.identifier;
-    const std::string& service_id = sample_identifier.entity_id;
+    const auto&        service_id = sample_identifier.entity_id;
     const int32_t      process_id = sample_identifier.process_id;
     const std::string& host_name  = sample_identifier.host_name;
 
@@ -455,7 +450,7 @@ namespace eCAL
     const std::string& unit_name    = sample_client.uname;
 
     // create map key
-    const std::string& client_map_key = service_id;
+    const auto& client_map_key = service_id;
 
     // acquire access
     const std::lock_guard<std::mutex> lock(m_clients_map.sync);
@@ -492,7 +487,7 @@ namespace eCAL
   bool CMonitoringImpl::UnregisterClient(const Registration::Sample& sample_)
   {
     // create map key
-    const std::string& client_map_key = sample_.identifier.entity_id;
+    const auto& client_map_key = sample_.identifier.entity_id;
 
     // acquire access
     const std::lock_guard<std::mutex> lock(m_clients_map.sync);

--- a/ecal/core/src/monitoring/ecal_monitoring_impl.cpp
+++ b/ecal/core/src/monitoring/ecal_monitoring_impl.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -232,8 +232,8 @@ namespace eCAL
       auto        attr                    = sample_topic.attr;
 
       // try to get topic info
-      const std::string topic_name_id  = topic_name + topic_id;
-      Monitoring::STopicMon& TopicInfo = (*pTopicMap->map)[topic_name_id];
+      const std::string& topic_map_key  = topic_id;
+      Monitoring::STopicMon& TopicInfo = (*pTopicMap->map)[topic_map_key];
 
       // set static content
       TopicInfo.hname     = host_name;
@@ -292,9 +292,7 @@ namespace eCAL
 
   bool CMonitoringImpl::UnregisterTopic(const Registration::Sample& sample_, enum ePubSub pubsub_type_)
   {
-    const auto& sample_topic = sample_.topic;
-    const std::string& topic_name = sample_topic.tname;
-    const std::string& topic_id   = sample_.identifier.entity_id;
+    const std::string& topic_map_key = sample_.identifier.entity_id;
 
     // unregister from topic map
     STopicMonMap* pTopicMap = GetMap(pubsub_type_);
@@ -304,8 +302,7 @@ namespace eCAL
       const std::lock_guard<std::mutex> lock(pTopicMap->sync);
 
       // remove topic info
-      const std::string topic_name_id = topic_name + topic_id;
-      pTopicMap->map->erase(topic_name_id);
+      pTopicMap->map->erase(topic_map_key);
     }
 
     return(true);
@@ -395,13 +392,13 @@ namespace eCAL
     const uint32_t     tcp_port_v1  = sample_service.tcp_port_v1;
 
     // create map key
-    const std::string service_name_id = service_name + service_id + std::to_string(process_id);
+    const std::string& service_map_key = service_id;
 
     // acquire access
     const std::lock_guard<std::mutex> lock(m_server_map.sync);
 
     // try to get service info
-    Monitoring::SServerMon& ServerInfo = (*m_server_map.map)[service_name_id];
+    Monitoring::SServerMon& ServerInfo = (*m_server_map.map)[service_map_key];
 
     // set static content
     ServerInfo.hname       = host_name;
@@ -433,21 +430,14 @@ namespace eCAL
 
   bool CMonitoringImpl::UnregisterServer(const Registration::Sample& sample_)
   {
-    const auto& sample_service    = sample_.service;
-    const auto& sample_identifier = sample_.identifier;
-
-    const std::string& service_name = sample_service.sname;
-    const std::string& service_id   = sample_identifier.entity_id;
-    const int          process_id   = sample_identifier.process_id;
-
     // create map key
-    const std::string service_name_id = service_name + service_id + std::to_string(process_id);
+    const std::string& service_map_key = sample_.identifier.entity_id;
 
     // acquire access
     const std::lock_guard<std::mutex> lock(m_server_map.sync);
 
     // remove service info
-    m_server_map.map->erase(service_name_id);
+    m_server_map.map->erase(service_map_key);
 
     return(true);
   }
@@ -465,13 +455,13 @@ namespace eCAL
     const std::string& unit_name    = sample_client.uname;
 
     // create map key
-    const std::string service_name_id = service_name + service_id + std::to_string(process_id);
+    const std::string& client_map_key = service_id;
 
     // acquire access
     const std::lock_guard<std::mutex> lock(m_clients_map.sync);
 
     // try to get service info
-    Monitoring::SClientMon& ClientInfo = (*m_clients_map.map)[service_name_id];
+    Monitoring::SClientMon& ClientInfo = (*m_clients_map.map)[client_map_key];
 
     // set static content
     ClientInfo.hname = host_name;
@@ -501,21 +491,14 @@ namespace eCAL
 
   bool CMonitoringImpl::UnregisterClient(const Registration::Sample& sample_)
   {
-    const auto& sample_identifier = sample_.identifier;
-    const std::string& service_id = sample_identifier.entity_id;
-    const int32_t      process_id = sample_identifier.process_id;
-
-    const auto& sample_client = sample_.client;
-    const std::string& service_name = sample_client.sname;
-
     // create map key
-    const std::string service_name_id = service_name + service_id + std::to_string(process_id);
+    const std::string& client_map_key = sample_.identifier.entity_id;
 
     // acquire access
     const std::lock_guard<std::mutex> lock(m_clients_map.sync);
 
     // remove service info
-    m_clients_map.map->erase(service_name_id);
+    m_clients_map.map->erase(client_map_key);
 
     return(true);
   }

--- a/ecal/core/src/monitoring/ecal_monitoring_impl.h
+++ b/ecal/core/src/monitoring/ecal_monitoring_impl.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,7 +79,7 @@ namespace eCAL
     bool RegisterTopic(const Registration::Sample& sample_, enum ePubSub pubsub_type_);
     bool UnregisterTopic(const Registration::Sample& sample_, enum ePubSub pubsub_type_);
 
-    using TopicMonMapT = std::map<std::string, Monitoring::STopicMon>;
+    using TopicMonMapT = std::map<Registration::EntityIdT, Monitoring::STopicMon>;
     struct STopicMonMap
     {
       explicit STopicMonMap() :
@@ -90,7 +90,7 @@ namespace eCAL
       std::unique_ptr<TopicMonMapT>  map;
     };
 
-    using ProcessMonMapT = std::map<std::string, Monitoring::SProcessMon>;
+    using ProcessMonMapT = std::map<Registration::EntityIdT, Monitoring::SProcessMon>;
     struct SProcessMonMap
     {
       explicit SProcessMonMap() :
@@ -101,7 +101,7 @@ namespace eCAL
       std::unique_ptr<ProcessMonMapT>  map;
     };
 
-    using ServerMonMapT = std::map<std::string, Monitoring::SServerMon>;
+    using ServerMonMapT = std::map<Registration::EntityIdT, Monitoring::SServerMon>;
     struct SServerMonMap
     {
       explicit SServerMonMap() :
@@ -112,7 +112,7 @@ namespace eCAL
       std::unique_ptr<ServerMonMapT>  map;
     };
 
-    using ClientMonMapT = std::map<std::string, Monitoring::SClientMon>;
+    using ClientMonMapT = std::map<Registration::EntityIdT, Monitoring::SClientMon>;
     struct SClientMonMap
     {
       explicit SClientMonMap() :

--- a/ecal/core/src/pubsub/ecal_publisher_impl.cpp
+++ b/ecal/core/src/pubsub/ecal_publisher_impl.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,9 +51,9 @@
 
 struct SSndHash
 {
-  SSndHash(std::string t, long long c) : topic_id(t), snd_clock(c) {}
-  std::string topic_id;
-  long long   snd_clock;
+  SSndHash(const eCAL::Registration::EntityIdT& t, long long c) : topic_id(t), snd_clock(c) {}
+  eCAL::Registration::EntityIdT topic_id;
+  long long                     snd_clock;
 };
 
 namespace std
@@ -63,7 +63,7 @@ namespace std
   public:
     size_t operator()(const SSndHash& h) const
     {
-      const size_t h1 = std::hash<std::string>()(h.topic_id);
+      const size_t h1 = std::hash<eCAL::Registration::EntityIdT>()(h.topic_id);
       const size_t h2 = std::hash<long long>()(h.snd_clock);
       return h1 ^ (h2 << 1);
     }
@@ -109,9 +109,7 @@ namespace eCAL
 #endif
 
     // build topic id
-    std::stringstream counter;
-    counter << std::chrono::steady_clock::now().time_since_epoch().count();
-    m_topic_id = counter.str();
+    m_topic_id = std::chrono::steady_clock::now().time_since_epoch().count();
 
     // mark as created
     m_created = true;

--- a/ecal/core/src/pubsub/ecal_publisher_impl.h
+++ b/ecal/core/src/pubsub/ecal_publisher_impl.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -143,7 +143,7 @@ namespace eCAL
     
     int32_t GetFrequency();
 
-    std::string                            m_topic_id;
+    Registration::EntityIdT                m_topic_id;
     SDataTypeInformation                   m_topic_info;
     std::map<std::string, std::string>     m_attr;
     size_t                                 m_topic_size = 0;

--- a/ecal/core/src/pubsub/ecal_subscriber_impl.cpp
+++ b/ecal/core/src/pubsub/ecal_subscriber_impl.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,9 +81,7 @@ namespace eCAL
 #endif
 
     // build topic id
-    std::stringstream counter;
-    counter << std::chrono::steady_clock::now().time_since_epoch().count();
-    m_topic_id = counter.str();
+    m_topic_id = std::chrono::steady_clock::now().time_since_epoch().count();
 
     // start transport layers
     InitializeLayers();
@@ -852,7 +850,7 @@ namespace eCAL
     return count;
   }
 
-  bool CSubscriberImpl::CheckMessageClock(const std::string& tid_, long long current_clock_)
+  bool CSubscriberImpl::CheckMessageClock(const Registration::EntityIdT& tid_, long long current_clock_)
   {
     auto iter = m_writer_counter_map.find(tid_);
     

--- a/ecal/core/src/pubsub/ecal_subscriber_impl.h
+++ b/ecal/core/src/pubsub/ecal_subscriber_impl.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -107,7 +107,6 @@ namespace eCAL
     }
 
     std::string          GetTopicName()           const { return(m_attributes.topic_name); }
-    std::string          GetTopicID()             const { return(m_topic_id); }
     SDataTypeInformation GetDataTypeInformation() const { return(m_topic_info); }
 
     void InitializeLayers();
@@ -131,11 +130,11 @@ namespace eCAL
     
     size_t GetConnectionCount();
 
-    bool CheckMessageClock(const std::string& tid_, long long current_clock_);
+    bool CheckMessageClock(const Registration::EntityIdT& tid_, long long current_clock_);
 
     int32_t GetFrequency();
 
-    std::string                               m_topic_id;
+    Registration::EntityIdT                   m_topic_id;
     SDataTypeInformation                      m_topic_info;
     std::map<std::string, std::string>        m_attr;
     std::atomic<size_t>                       m_topic_size;
@@ -177,7 +176,7 @@ namespace eCAL
 
     std::set<long long>                       m_id_set;
 
-    using WriterCounterMapT = std::unordered_map<std::string, long long>;
+    using WriterCounterMapT = std::unordered_map<Registration::EntityIdT, long long>;
     WriterCounterMapT                         m_writer_counter_map;
     long long                                 m_message_drops = 0;
 

--- a/ecal/core/src/readwrite/config/builder/tcp_attribute_builder.cpp
+++ b/ecal/core/src/readwrite/config/builder/tcp_attribute_builder.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ namespace eCAL
 
   namespace eCALWriter
   {
-    TCP::SAttributes BuildTCPAttributes(const std::string& topic_id_, const eCALWriter::SAttributes& attr_)
+    TCP::SAttributes BuildTCPAttributes(const uint64_t& topic_id_, const eCALWriter::SAttributes& attr_)
     {
       TCP::SAttributes attributes;
 

--- a/ecal/core/src/readwrite/config/builder/tcp_attribute_builder.h
+++ b/ecal/core/src/readwrite/config/builder/tcp_attribute_builder.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "readwrite/tcp/config/attributes/tcp_reader_layer_attributes.h"
 #include "readwrite/config/attributes/reader_attributes.h"
 

--- a/ecal/core/src/readwrite/config/builder/tcp_attribute_builder.h
+++ b/ecal/core/src/readwrite/config/builder/tcp_attribute_builder.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,6 @@ namespace eCAL
 
   namespace eCALWriter
   {
-    TCP::SAttributes BuildTCPAttributes(const std::string& topic_id_, const eCALWriter::SAttributes& attr_);
+    TCP::SAttributes BuildTCPAttributes(const uint64_t& topic_id_, const eCALWriter::SAttributes& attr_);
   }
 }

--- a/ecal/core/src/readwrite/config/builder/udp_attribute_builder.cpp
+++ b/ecal/core/src/readwrite/config/builder/udp_attribute_builder.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ namespace eCAL
 
   namespace eCALWriter
   {
-    UDP::SAttributes BuildUDPAttributes(const std::string& topic_id_, const eCALWriter::SAttributes& attr_)
+    UDP::SAttributes BuildUDPAttributes(const uint64_t& topic_id_, const eCALWriter::SAttributes& attr_)
     {
       UDP::SAttributes attributes;
 

--- a/ecal/core/src/readwrite/config/builder/udp_attribute_builder.h
+++ b/ecal/core/src/readwrite/config/builder/udp_attribute_builder.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,6 @@ namespace eCAL
 
   namespace eCALWriter
   {
-    UDP::SAttributes BuildUDPAttributes(const std::string& topic_id, const eCALWriter::SAttributes& attr_);
+    UDP::SAttributes BuildUDPAttributes(const uint64_t& topic_id, const eCALWriter::SAttributes& attr_);
   }
 }

--- a/ecal/core/src/readwrite/config/builder/udp_attribute_builder.h
+++ b/ecal/core/src/readwrite/config/builder/udp_attribute_builder.h
@@ -19,6 +19,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "readwrite/udp/config/attributes/reader_udp_attributes.h"
 #include "readwrite/config/attributes/reader_attributes.h"
 

--- a/ecal/core/src/readwrite/ecal_reader_layer.h
+++ b/ecal/core/src/readwrite/ecal_reader_layer.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ namespace eCAL
     std::string                 host_name;
     int32_t                     process_id = 0;
     std::string                 topic_name;
-    std::string                 topic_id;
+    uint64_t                    topic_id = 0;
     Registration::ConnectionPar parameter;
   };
 
@@ -55,10 +55,10 @@ namespace eCAL
     virtual void Initialize(const U& attr_) = 0;
 
     // activate / create a specific subscription
-    virtual void AddSubscription(const std::string& host_name_, const std::string& topic_name_, const std::string& topic_id_) = 0;
+    virtual void AddSubscription(const std::string& host_name_, const std::string& topic_name_, const Registration::EntityIdT& topic_id_) = 0;
 
     // deactivate / destroy a specific subscription
-    virtual void RemSubscription(const std::string& host_name_, const std::string& topic_name_, const std::string& topic_id_) = 0;
+    virtual void RemSubscription(const std::string& host_name_, const std::string& topic_name_, const Registration::EntityIdT& topic_id_) = 0;
 
     // connection parameter from writer side
     virtual void SetConnectionParameter(SReaderLayerPar& par_) = 0;

--- a/ecal/core/src/readwrite/ecal_reader_layer.h
+++ b/ecal/core/src/readwrite/ecal_reader_layer.h
@@ -37,7 +37,7 @@ namespace eCAL
     std::string                 host_name;
     int32_t                     process_id = 0;
     std::string                 topic_name;
-    uint64_t                    topic_id = 0;
+    Registration::EntityIdT     topic_id = 0;
     Registration::ConnectionPar parameter;
   };
 

--- a/ecal/core/src/readwrite/ecal_writer_base.h
+++ b/ecal/core/src/readwrite/ecal_writer_base.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,8 +42,8 @@ namespace eCAL
 
     virtual SWriterInfo GetInfo() = 0;
 
-    virtual void ApplySubscription(const std::string& /*host_name_*/, const int32_t /*process_id_*/, const std::string& /*topic_id_*/, const std::string& /*conn_par_*/) {};
-    virtual void RemoveSubscription(const std::string& /*host_name_*/, const int32_t /*process_id_*/, const std::string& /*topic_id_*/) {};
+    virtual void ApplySubscription(const std::string& /*host_name_*/, const int32_t /*process_id_*/, const Registration::EntityIdT& /*topic_id_*/, const std::string& /*conn_par_*/) {};
+    virtual void RemoveSubscription(const std::string& /*host_name_*/, const int32_t /*process_id_*/, const Registration::EntityIdT& /*topic_id_*/) {};
 
     virtual Registration::ConnectionPar GetConnectionParameter() { return {}; };
 

--- a/ecal/core/src/readwrite/shm/ecal_reader_shm.h
+++ b/ecal/core/src/readwrite/shm/ecal_reader_shm.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,8 +44,8 @@ namespace eCAL
     ~CSHMReaderLayer() override = default;
 
     void Initialize(const eCAL::eCALReader::SHM::SAttributes& attr_) override;
-    void AddSubscription(const std::string& /*host_name_*/, const std::string& /*topic_name_*/, const std::string& /*topic_id_*/) override {}
-    void RemSubscription(const std::string& /*host_name_*/, const std::string& /*topic_name_*/, const std::string& /*topic_id_*/) override {}
+    void AddSubscription(const std::string& /*host_name_*/, const std::string& /*topic_name_*/, const Registration::EntityIdT& /*topic_id_*/) override {}
+    void RemSubscription(const std::string& /*host_name_*/, const std::string& /*topic_name_*/, const Registration::EntityIdT& /*topic_id_*/) override {}
 
     void SetConnectionParameter(SReaderLayerPar& par_) override;
 

--- a/ecal/core/src/readwrite/shm/ecal_writer_shm.cpp
+++ b/ecal/core/src/readwrite/shm/ecal_writer_shm.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,7 +83,7 @@ namespace eCAL
     return sent;
   }
 
-  void CDataWriterSHM::ApplySubscription(const std::string& host_name_, const int32_t process_id_, const std::string& topic_id_, const std::string& /*conn_par_*/)
+  void CDataWriterSHM::ApplySubscription(const std::string& host_name_, const int32_t process_id_, const Registration::EntityIdT& topic_id_, const std::string& /*conn_par_*/)
   {
     // we accept local connections only
     if (host_name_ != m_attributes.host_name) return;
@@ -104,7 +104,7 @@ namespace eCAL
     }
   }
 
-  void CDataWriterSHM::RemoveSubscription(const std::string& host_name_, const int32_t process_id_, const std::string& topic_id_)
+  void CDataWriterSHM::RemoveSubscription(const std::string& host_name_, const int32_t process_id_, const Registration::EntityIdT& topic_id_)
   {
     // we accept local disconnections only
     if (host_name_ != m_attributes.host_name) return;

--- a/ecal/core/src/readwrite/shm/ecal_writer_shm.h
+++ b/ecal/core/src/readwrite/shm/ecal_writer_shm.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,8 +49,8 @@ namespace eCAL
 
     bool Write(CPayloadWriter& payload_, const SWriterAttr& attr_) override;
 
-    void ApplySubscription(const std::string& host_name_, int32_t process_id_, const std::string& topic_id_, const std::string& conn_par_) override;
-    void RemoveSubscription(const std::string& host_name_, int32_t process_id_, const std::string& topic_id_) override;
+    void ApplySubscription(const std::string& host_name_, int32_t process_id_, const Registration::EntityIdT& topic_id_, const std::string& conn_par_) override;
+    void RemoveSubscription(const std::string& host_name_, int32_t process_id_, const Registration::EntityIdT& topic_id_) override;
 
     Registration::ConnectionPar GetConnectionParameter() override;
 
@@ -63,7 +63,7 @@ namespace eCAL
     std::vector<std::shared_ptr<CSyncMemoryFile>> m_memory_file_vec;
     static const std::string                      m_memfile_base_name;
 
-    using ProcessIDTopicIDSetT = std::map<int32_t, std::set<std::string>>;
+    using ProcessIDTopicIDSetT = std::map<int32_t, std::set<Registration::EntityIdT>>;
     std::mutex                                    m_process_id_topic_id_set_map_sync;
     ProcessIDTopicIDSetT                          m_process_id_topic_id_set_map;
   };

--- a/ecal/core/src/readwrite/tcp/config/attributes/data_writer_tcp_attributes.h
+++ b/ecal/core/src/readwrite/tcp/config/attributes/data_writer_tcp_attributes.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ namespace eCAL
       struct SAttributes
       {
         std::string topic_name;
-        std::string topic_id;
+        uint64_t    topic_id;
 
         size_t thread_pool_size;
       };

--- a/ecal/core/src/readwrite/tcp/config/attributes/data_writer_tcp_attributes.h
+++ b/ecal/core/src/readwrite/tcp/config/attributes/data_writer_tcp_attributes.h
@@ -19,8 +19,9 @@
 
 #pragma once
 
-#include <string>
 #include <cstddef>
+#include <cstdint>
+#include <string>
 
 namespace eCAL
 {

--- a/ecal/core/src/readwrite/tcp/ecal_reader_tcp.cpp
+++ b/ecal/core/src/readwrite/tcp/ecal_reader_tcp.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -140,7 +140,7 @@ namespace eCAL
     m_executor = std::make_shared<tcp_pubsub::Executor>(m_attributes.thread_pool_size, tcp_pubsub_logger);
   }
 
-  void CTCPReaderLayer::AddSubscription(const std::string& /*host_name_*/, const std::string& topic_name_, const std::string& /*topic_id_*/)
+  void CTCPReaderLayer::AddSubscription(const std::string& /*host_name_*/, const std::string& topic_name_, const Registration::EntityIdT& /*topic_id_*/)
   {
     const std::string& map_key(topic_name_);
 
@@ -153,7 +153,7 @@ namespace eCAL
     m_datareadertcp_map.insert(std::pair<std::string, std::shared_ptr<CDataReaderTCP>>(map_key, reader));
   }
 
-  void CTCPReaderLayer::RemSubscription(const std::string& /*host_name_*/, const std::string& topic_name_, const std::string& /*topic_id_*/)
+  void CTCPReaderLayer::RemSubscription(const std::string& /*host_name_*/, const std::string& topic_name_, const Registration::EntityIdT& /*topic_id_*/)
   {
     const std::string& map_key(topic_name_);
 

--- a/ecal/core/src/readwrite/tcp/ecal_reader_tcp.h
+++ b/ecal/core/src/readwrite/tcp/ecal_reader_tcp.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,8 +71,8 @@ namespace eCAL
 
     void Initialize(const eCAL::eCALReader::TCPLayer::SAttributes& attr_) override;
 
-    void AddSubscription(const std::string& host_name_, const std::string& topic_name_, const std::string& topic_id_) override;
-    void RemSubscription(const std::string& host_name_, const std::string& topic_name_, const std::string& topic_id_) override;
+    void AddSubscription(const std::string& host_name_, const std::string& topic_name_, const Registration::EntityIdT& topic_id_) override;
+    void RemSubscription(const std::string& host_name_, const std::string& topic_name_, const Registration::EntityIdT& topic_id_) override;
 
     void SetConnectionParameter(SReaderLayerPar& /*par_*/) override;
 

--- a/ecal/core/src/readwrite/udp/config/attributes/writer_udp_attributes.h
+++ b/ecal/core/src/readwrite/udp/config/attributes/writer_udp_attributes.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ namespace eCAL
 
         std::string host_name;
         std::string topic_name;
-        std::string topic_id;
+        uint64_t    topic_id;
       };
     }
   }

--- a/ecal/core/src/readwrite/udp/config/attributes/writer_udp_attributes.h
+++ b/ecal/core/src/readwrite/udp/config/attributes/writer_udp_attributes.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 namespace eCAL

--- a/ecal/core/src/readwrite/udp/ecal_reader_udp.cpp
+++ b/ecal/core/src/readwrite/udp/ecal_reader_udp.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ namespace eCAL
      m_attributes = attr_;
   }
 
-  void CUDPReaderLayer::AddSubscription(const std::string& /*host_name_*/, const std::string& topic_name_, const std::string& /*topic_id_*/)
+  void CUDPReaderLayer::AddSubscription(const std::string& /*host_name_*/, const std::string& topic_name_, const Registration::EntityIdT& /*topic_id_*/)
   {
     if (!m_started)
     {      
@@ -77,7 +77,7 @@ namespace eCAL
     m_topic_name_mcast_map[mcast_address]++;
   }
 
-  void CUDPReaderLayer::RemSubscription(const std::string& /*host_name_*/, const std::string& topic_name_, const std::string& /*topic_id_*/)
+  void CUDPReaderLayer::RemSubscription(const std::string& /*host_name_*/, const std::string& topic_name_, const Registration::EntityIdT& /*topic_id_*/)
   {
     // we use udp broadcast in local mode
     if (m_attributes.broadcast) return;

--- a/ecal/core/src/readwrite/udp/ecal_reader_udp.h
+++ b/ecal/core/src/readwrite/udp/ecal_reader_udp.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,8 +45,8 @@ namespace eCAL
 
     void Initialize(const eCAL::eCALReader::UDP::SAttributes& attr_) override;
 
-    void AddSubscription(const std::string& /*host_name_*/, const std::string& topic_name_, const std::string& /*topic_id_*/) override;
-    void RemSubscription(const std::string& /*host_name_*/, const std::string& topic_name_, const std::string& /*topic_id_*/) override;
+    void AddSubscription(const std::string& /*host_name_*/, const std::string& topic_name_, const Registration::EntityIdT& /*topic_id_*/) override;
+    void RemSubscription(const std::string& /*host_name_*/, const std::string& topic_name_, const Registration::EntityIdT& /*topic_id_*/) override;
 
     void SetConnectionParameter(SReaderLayerPar& /*par_*/) override {}
 

--- a/ecal/core/src/registration/ecal_process_registration.cpp
+++ b/ecal/core/src/registration/ecal_process_registration.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ eCAL::Registration::Sample eCAL::Registration::GetProcessRegisterSample()
   process_sample_identifier.process_id = eCAL::Process::GetProcessID();
   // We need to set the pid as entity_id.
   // However, we cannot send anything over the wire :(
-  process_sample_identifier.entity_id = std::to_string(process_sample_identifier.process_id);
+  process_sample_identifier.entity_id = process_sample_identifier.process_id;
 
   auto& process_sample_process = process_sample.process;
   process_sample_process.hgname = eCAL::Process::GetHostGroupName();

--- a/ecal/core/src/serialization/ecal_serialize_common.cpp
+++ b/ecal/core/src/serialization/ecal_serialize_common.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,6 +75,48 @@ namespace eCAL
     {
       pb_callback.funcs.decode = &decode_string_field; // NOLINT(*-pro-type-union-access)
       pb_callback.arg = &str;
+    }
+
+    bool encode_int_to_string_field(pb_ostream_t* stream, const pb_field_iter_t* field, void* const* arg)
+    {
+      if (arg == nullptr)  return false;
+      if (*arg == nullptr) return false;
+
+      if (!pb_encode_tag_for_field(stream, field))
+        return false;
+
+      auto* int_value = static_cast<uint64_t*>(*arg);
+      auto integer_value_as_string = std::to_string(*int_value);
+      return pb_encode_string(stream, (pb_byte_t*)(integer_value_as_string.data()), integer_value_as_string.size()); // NOLINT(*-pro-type-cstyle-cast)
+    }
+
+    void encode_int_to_string(pb_callback_t& pb_callback, const uint64_t& int_argument)
+    {
+      pb_callback.funcs.encode = &encode_int_to_string_field; // NOLINT(*-pro-type-union-access)
+      pb_callback.arg = (void*)(&int_argument);
+    }
+
+
+    bool decode_int_from_string_field(pb_istream_t* stream, const pb_field_iter_t* /*field*/, void** arg)
+    {
+      if (arg == nullptr)  return false;
+      if (*arg == nullptr) return false;
+
+      size_t len = stream->bytes_left;
+      auto* tgt_integer = static_cast<uint64_t*>(*arg);
+
+      std::string intermediate_string;
+      intermediate_string.resize(len);
+
+      auto ret = pb_read(stream, (pb_byte_t*)(intermediate_string.data()), intermediate_string.size()); // NOLINT(*-pro-type-cstyle-cast)
+      *tgt_integer = std::stoull(intermediate_string);
+      return ret;
+    }
+
+    void decode_int_from_string(pb_callback_t& pb_callback, uint64_t& int_argument)
+    {
+      pb_callback.funcs.decode = &decode_int_from_string_field; // NOLINT(*-pro-type-union-access)
+      pb_callback.arg = (void*)(&int_argument);
     }
 
     ///////////////////////////////////////////////

--- a/ecal/core/src/serialization/ecal_serialize_common.h
+++ b/ecal/core/src/serialization/ecal_serialize_common.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,9 @@ namespace eCAL
 
     void encode_string(pb_callback_t& pb_callback, const std::string& str);
     void decode_string(pb_callback_t& pb_callback, std::string& str);
+
+    void encode_int_to_string(pb_callback_t& pb_callback, const uint64_t& int_argument);
+    void decode_int_from_string(pb_callback_t& pb_callback, uint64_t& int_argument);
 
     void encode_bytes(pb_callback_t& pb_callback, const SNanoBytes& nano_bytes);
     void encode_bytes(pb_callback_t& pb_callback, const std::vector<char>& vec);

--- a/ecal/core/src/serialization/ecal_serialize_monitoring.cpp
+++ b/ecal/core/src/serialization/ecal_serialize_monitoring.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -158,7 +158,7 @@ namespace
     // uname
     eCAL::nanopb::encode_string(pb_topic_.uname, topic_.uname);
     // tid
-    eCAL::nanopb::encode_string(pb_topic_.tid, topic_.tid);
+    eCAL::nanopb::encode_int_to_string(pb_topic_.tid, topic_.tid);
     // tname
     eCAL::nanopb::encode_string(pb_topic_.tname, topic_.tname);
     // direction
@@ -314,7 +314,7 @@ namespace
     // sname
     eCAL::nanopb::encode_string(pb_service_.sname, service_.sname);
     // sid
-    eCAL::nanopb::encode_string(pb_service_.sid, service_.sid);
+    eCAL::nanopb::encode_int_to_string(pb_service_.sid, service_.sid);
     // methods
     encode_mon_service_methods(pb_service_.methods, service_.methods);
     // version
@@ -375,7 +375,7 @@ namespace
     // sname
     eCAL::nanopb::encode_string(pb_client_.sname, client_.sname);
     // sid
-    eCAL::nanopb::encode_string(pb_client_.sid, client_.sid);
+    eCAL::nanopb::encode_int_to_string(pb_client_.sid, client_.sid);
     // methods
     encode_mon_service_methods(pb_client_.methods, client_.methods);
     // version
@@ -615,7 +615,7 @@ namespace
     // uname
     eCAL::nanopb::decode_string(pb_topic_.uname, topic_.uname);
     // tid
-    eCAL::nanopb::decode_string(pb_topic_.tid, topic_.tid);
+    eCAL::nanopb::decode_int_from_string(pb_topic_.tid, topic_.tid);
     // tname
     eCAL::nanopb::decode_string(pb_topic_.tname, topic_.tname);
     // direction
@@ -757,7 +757,7 @@ namespace
     // sname
     eCAL::nanopb::decode_string(pb_service_.sname, service_.sname);
     // sid
-    eCAL::nanopb::decode_string(pb_service_.sid, service_.sid);
+    eCAL::nanopb::decode_int_from_string(pb_service_.sid, service_.sid);
     // methods
     decode_mon_service_methods(pb_service_.methods, service_.methods);
   }
@@ -826,7 +826,7 @@ namespace
     // sname
     eCAL::nanopb::decode_string(pb_client_.sname, client_.sname);
     // sid
-    eCAL::nanopb::decode_string(pb_client_.sid, client_.sid);
+    eCAL::nanopb::decode_int_from_string(pb_client_.sid, client_.sid);
     // methods
     decode_mon_service_methods(pb_client_.methods, client_.methods);
   }

--- a/ecal/core/src/serialization/ecal_serialize_sample_payload.cpp
+++ b/ecal/core/src/serialization/ecal_serialize_sample_payload.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,7 +77,7 @@ namespace
     // pid
     pb_sample_.topic.pid = payload_.topic_info.pid;
     // tid
-    eCAL::nanopb::encode_string(pb_sample_.topic.tid, payload_.topic_info.tid);
+    eCAL::nanopb::encode_int_to_string(pb_sample_.topic.tid, payload_.topic_info.tid);
     // tname
     eCAL::nanopb::encode_string(pb_sample_.topic.tname, payload_.topic_info.tname);
 
@@ -152,7 +152,7 @@ namespace
     // hname
     eCAL::nanopb::decode_string(pb_sample.topic.hname, payload_.topic_info.hname);
     // tid
-    eCAL::nanopb::decode_string(pb_sample.topic.tid, payload_.topic_info.tid);
+    eCAL::nanopb::decode_int_from_string(pb_sample.topic.tid, payload_.topic_info.tid);
     // tname
     eCAL::nanopb::decode_string(pb_sample.topic.tname, payload_.topic_info.tname);
     // topic content payload

--- a/ecal/core/src/serialization/ecal_serialize_sample_registration.cpp
+++ b/ecal/core/src/serialization/ecal_serialize_sample_registration.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,7 +101,7 @@ namespace
     // sname
     eCAL::nanopb::encode_string(pb_service_.sname, registration_service_.sname);
     // sid
-    eCAL::nanopb::encode_string(pb_service_.sid, registration_identifier_.entity_id);
+    eCAL::nanopb::encode_int_to_string(pb_service_.sid, registration_identifier_.entity_id);
     // methods
     eCAL::nanopb::encode_service_methods(pb_service_.methods, registration_service_.methods);
     // version
@@ -133,7 +133,7 @@ namespace
     // sname
     eCAL::nanopb::encode_string(pb_client_.sname, registration_client_.sname);
     // sid
-    eCAL::nanopb::encode_string(pb_client_.sid, registration_producer_.entity_id);
+    eCAL::nanopb::encode_int_to_string(pb_client_.sid, registration_producer_.entity_id);
     // methods
     eCAL::nanopb::encode_service_methods(pb_client_.methods, registration_client_.methods);
     // version
@@ -161,7 +161,7 @@ namespace
     // uname
     eCAL::nanopb::encode_string(pb_topic_.uname, registration_topic_.uname);
     // tid
-    eCAL::nanopb::encode_string(pb_topic_.tid, registration_identifier_.entity_id);
+    eCAL::nanopb::encode_int_to_string(pb_topic_.tid, registration_identifier_.entity_id);
     // tname
     eCAL::nanopb::encode_string(pb_topic_.tname, registration_topic_.tname);
     // direction
@@ -343,7 +343,7 @@ namespace
     // sname
     eCAL::nanopb::decode_string(pb_sample_.service.sname, registration_.service.sname);
     // sid
-    eCAL::nanopb::decode_string(pb_sample_.service.sid, registration_.identifier.entity_id);
+    eCAL::nanopb::decode_int_from_string(pb_sample_.service.sid, registration_.identifier.entity_id);
     // methods
     eCAL::nanopb::decode_service_methods(pb_sample_.service.methods, registration_.service.methods);
 
@@ -359,7 +359,7 @@ namespace
     // sname
     eCAL::nanopb::decode_string(pb_sample_.client.sname, registration_.client.sname);
     // sid
-    eCAL::nanopb::decode_string(pb_sample_.client.sid, registration_.identifier.entity_id);
+    eCAL::nanopb::decode_int_from_string(pb_sample_.client.sid, registration_.identifier.entity_id);
     // methods
     eCAL::nanopb::decode_service_methods(pb_sample_.client.methods, registration_.client.methods);
 
@@ -375,7 +375,7 @@ namespace
     // uname
     eCAL::nanopb::decode_string(pb_sample_.topic.uname, registration_.topic.uname);
     // tid
-    eCAL::nanopb::decode_string(pb_sample_.topic.tid, registration_.identifier.entity_id);
+    eCAL::nanopb::decode_int_from_string(pb_sample_.topic.tid, registration_.identifier.entity_id);
     // tname
     eCAL::nanopb::decode_string(pb_sample_.topic.tname, registration_.topic.tname);
     // direction
@@ -408,7 +408,7 @@ namespace
       // pid
       registration_.identifier.process_id = pb_sample_.process.pid;
       // tid -> we need to use the PID here, because we don't have a designated field for it
-      registration_.identifier.entity_id = std::to_string(registration_.identifier.process_id);
+      registration_.identifier.entity_id = registration_.identifier.process_id;
       // state.severity
       registration_.process.state.severity = static_cast<eCAL::Registration::eProcessSeverity>(pb_sample_.process.state.severity);
       // state.severity_level

--- a/ecal/core/src/serialization/ecal_struct_sample_payload.h
+++ b/ecal/core/src/serialization/ecal_struct_sample_payload.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ namespace eCAL
     struct TopicInfo
     {
       std::string                         hname;                        // host name
-      std::string                         tid;                          // topic id
+      uint64_t                            tid;                          // topic id
       std::string                         tname;                        // topic name
       int32_t                             pid = 0;                      // process id
     };

--- a/ecal/core/src/serialization/ecal_struct_sample_registration.h
+++ b/ecal/core/src/serialization/ecal_struct_sample_registration.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -323,7 +323,7 @@ namespace eCAL
 
     struct SampleIdentifier
     {
-      std::string                        entity_id;                     // unique id within that process
+      uint64_t                           entity_id = 0;                 // unique id within that process
       int32_t                            process_id = 0;                // process id which produced the sample
       std::string                        host_name;                     // host which produced the sample
 
@@ -339,7 +339,7 @@ namespace eCAL
 
       void clear()
       {
-        entity_id.clear();
+        entity_id = 0;
         process_id = 0;
         host_name.clear();
       }

--- a/ecal/core/src/service/ecal_service_client_impl.cpp
+++ b/ecal/core/src/service/ecal_service_client_impl.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -136,9 +136,7 @@ namespace eCAL
     }
 
     // create unique client ID
-    std::stringstream counter;
-    counter << std::chrono::steady_clock::now().time_since_epoch().count();
-    m_client_id = counter.str();
+    m_client_id = std::chrono::steady_clock::now().time_since_epoch().count();
 
     // add event callback
     {

--- a/ecal/core/src/service/ecal_service_client_impl.h
+++ b/ecal/core/src/service/ecal_service_client_impl.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -142,7 +142,7 @@ namespace eCAL
 
     // Service attributes
     std::string                  m_service_name;
-    std::string                  m_client_id;
+    Registration::EntityIdT      m_client_id;
 
     // Client session map and synchronization
     using ClientSessionsMapT = std::map<Registration::SEntityId, SClient>;

--- a/ecal/core/src/service/ecal_service_server_impl.cpp
+++ b/ecal/core/src/service/ecal_service_server_impl.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -170,9 +170,7 @@ namespace eCAL
 #endif
 
     // Create service ID
-    std::stringstream counter;
-    counter << std::chrono::steady_clock::now().time_since_epoch().count();
-    m_service_id = counter.str();
+    m_service_id = std::chrono::steady_clock::now().time_since_epoch().count();
 
     // Get global server manager
     auto server_manager = eCAL::service::ServiceManager::instance()->get_server_manager();

--- a/ecal/core/src/service/ecal_service_server_impl.h
+++ b/ecal/core/src/service/ecal_service_server_impl.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,7 +94,7 @@ namespace eCAL
 
     // Server attributes
     std::string                            m_service_name;
-    std::string                            m_service_id;
+    Registration::EntityIdT                m_service_id;
 
     // Server connection state and synchronization
     mutable std::mutex                     m_connected_mutex; // mutex protecting m_connected (modified by the event callbacks in another thread)

--- a/ecal/service/test/src/ecal_tcp_service_test.cpp
+++ b/ecal/service/test/src/ecal_tcp_service_test.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1898,7 +1898,7 @@ TEST(ecal_service, ErrorCallback_ErrorCallbackNoServer) // NOLINT
               };
 
 
-    EXPECT_EQ(num_client_response_callback_called, 0);
+    EXPECT_EQ(num_client_response_callback_called.get(), 0);
 
     auto client_v1 = eCAL::service::ClientSession::create(io_context, protocol_version, {{ "NonExistingEndpoint", 12345 }}, client_event_callback);
 
@@ -1913,8 +1913,8 @@ TEST(ecal_service, ErrorCallback_ErrorCallbackNoServer) // NOLINT
     
     num_client_response_callback_called.wait_for([](int v) { return v >= 1;} , std::chrono::milliseconds(5000));
 
-    EXPECT_EQ(num_client_response_callback_called, 1);
-    EXPECT_EQ(num_client_event_callback_called,    0);
+    EXPECT_EQ(num_client_response_callback_called.get(), 1);
+    EXPECT_EQ(num_client_event_callback_called.load(),    0);
 
     // join the io_thread
     io_context->stop();

--- a/ecal/tests/cpp/descgate_test/src/descgate_getentities.cpp
+++ b/ecal/tests/cpp/descgate_test/src/descgate_getentities.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ namespace
   {
     eCAL::Registration::Sample reg_sample;
     reg_sample.cmd_type                   = eCAL::bct_reg_publisher;
-    reg_sample.identifier.entity_id       = std::to_string(topic_id_);
+    reg_sample.identifier.entity_id       = topic_id_;
     reg_sample.topic.tname                = topic_name_;
     reg_sample.topic.tdatatype.name       = topic_name_ + "-tdatatype.name";
     reg_sample.topic.tdatatype.encoding   = topic_name_ + "-tdatatype.encoding";
@@ -53,7 +53,7 @@ namespace
   {
     eCAL::Registration::Sample reg_sample;
     reg_sample.cmd_type                   = eCAL::bct_reg_subscriber;
-    reg_sample.identifier.entity_id       = std::to_string(topic_id_);
+    reg_sample.identifier.entity_id       = topic_id_;
     reg_sample.topic.tname                = topic_name_;
     reg_sample.topic.tdatatype.name       = topic_name_ + "-tdatatype.name";
     reg_sample.topic.tdatatype.encoding   = topic_name_ + "-tdatatype.encoding";
@@ -73,7 +73,7 @@ namespace
     eCAL::Registration::Sample reg_sample;
     reg_sample.cmd_type             = eCAL::bct_reg_service;
     reg_sample.service.sname        = service_name_;
-    reg_sample.identifier.entity_id = std::to_string(service_id_);
+    reg_sample.identifier.entity_id = service_id_;
 
     eCAL::Service::Method method;
     method.mname = "method_name";
@@ -93,7 +93,7 @@ namespace
     eCAL::Registration::Sample reg_sample;
     reg_sample.cmd_type               = eCAL::bct_reg_client;
     reg_sample.client.sname           = client_name_;
-    reg_sample.identifier.entity_id   = std::to_string(service_id_);
+    reg_sample.identifier.entity_id   = service_id_;
 
     eCAL::Service::Method method;
     method.mname = "method_name";

--- a/ecal/tests/cpp/registration_test/src/registration_timout_provider_test.cpp
+++ b/ecal/tests/cpp/registration_test/src/registration_timout_provider_test.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,10 +37,10 @@ eCAL::Registration::Sample sub_foo_process_b_register_1;
 eCAL::Registration::Sample sub_foo_process_b_register_2;
 
 // make sure we create unique topic IDs for our testcases
-std::string getUniqueId()
+uint64_t getUniqueId()
 {
-  static int topic_id = 1;
-  return std::to_string(topic_id++);
+  static uint64_t topic_id = 1;
+  return topic_id++;
 }
 
 eCAL::Registration::Sample UpdateTopicSample(const eCAL::Registration::Sample& input_)

--- a/ecal/tests/cpp/serialization_test/src/monitoring_generate.cpp
+++ b/ecal/tests/cpp/serialization_test/src/monitoring_generate.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ namespace eCAL
       topic.pid                  = rand() % 1000;
       topic.pname                = GenerateString(8);
       topic.uname                = GenerateString(6);
-      topic.tid                  = GenerateString(8);
+      topic.tid                  = rand();
       topic.tname                = GenerateString(10);
       topic.direction            = direction;
       topic.tdatatype            = eCAL::Registration::GenerateDataTypeInformation();
@@ -103,7 +103,7 @@ namespace eCAL
       server.uname       = GenerateString(6);
       server.pid         = rand() % 1000;
       server.sname       = GenerateString(10);
-      server.sid         = GenerateString(8);
+      server.sid         = rand();
       server.version     = rand() % 100;
       server.tcp_port_v0 = rand() % 65536;
       server.tcp_port_v1 = rand() % 65536;
@@ -124,7 +124,7 @@ namespace eCAL
       client.uname   = GenerateString(6);
       client.pid     = rand() % 1000;
       client.sname   = GenerateString(10);
-      client.sid     = GenerateString(8);
+      client.sid     = rand();
       client.methods.push_back(GenerateServiceMethod());
       client.methods.push_back(GenerateServiceMethod());
       client.methods.push_back(GenerateServiceMethod());

--- a/ecal/tests/cpp/serialization_test/src/payload_generate.cpp
+++ b/ecal/tests/cpp/serialization_test/src/payload_generate.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ namespace eCAL
       TopicInfo topic;
       topic.hname = GenerateString(8);
       topic.pid   = rand() % 1000;
-      topic.tid   = GenerateString(5);
+      topic.tid   = rand();
       topic.tname = GenerateString(10);
 
       return topic;

--- a/ecal/tests/cpp/serialization_test/src/registration_generate.cpp
+++ b/ecal/tests/cpp/serialization_test/src/registration_generate.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -144,7 +144,7 @@ namespace eCAL
     SampleIdentifier GenerateIdentifier()
     {
       SampleIdentifier identifier;
-      identifier.entity_id = GenerateString(7);
+      identifier.entity_id = rand();
       identifier.process_id = rand() % 100;
       identifier.host_name = GenerateString(8);
       return identifier;
@@ -157,7 +157,7 @@ namespace eCAL
       sample.host.hname = GenerateString(8);
       sample.identifier = GenerateIdentifier();
       // Process samples don't have an id internally, hence it must be 0.
-      sample.identifier.entity_id = std::to_string(sample.identifier.process_id);
+      sample.identifier.entity_id = sample.identifier.process_id;
       sample.process = GenerateProcess();
       return sample;
     }

--- a/lang/python/core/src/ecal_wrap.cxx
+++ b/lang/python/core/src/ecal_wrap.cxx
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1012,7 +1012,7 @@ namespace
       val = Py_BuildValue("s", topic.uname.c_str());
       PyDict_SetItemString(topicDict, "uname", val); Py_DECREF(val);
 
-      val = Py_BuildValue("s", topic.tid.c_str());
+      val = Py_BuildValue("s", std::to_string(topic.tid).c_str());
       PyDict_SetItemString(topicDict, "tid", val); Py_DECREF(val);
 
       val = Py_BuildValue("s", topic.tname.c_str());
@@ -1145,7 +1145,7 @@ PyObject* mon_monitoring(PyObject* /*self*/, PyObject* /*args*/)
         val = Py_BuildValue("s", service.sname.c_str());
         PyDict_SetItemString(serviceDict, "sname", val); Py_DECREF(val);
 
-        val = Py_BuildValue("s", service.sid.c_str());
+        val = Py_BuildValue("s", std::to_string(service.sid).c_str());
         PyDict_SetItemString(serviceDict, "sid", val); Py_DECREF(val);
 
         val = Py_BuildValue("i", service.version);
@@ -1209,7 +1209,7 @@ PyObject* mon_monitoring(PyObject* /*self*/, PyObject* /*args*/)
         val = Py_BuildValue("s", client.sname.c_str());
         PyDict_SetItemString(clientDict, "sname", val); Py_DECREF(val);
 
-        val = Py_BuildValue("s", client.sid.c_str());
+        val = Py_BuildValue("s", std::to_string(client.sid).c_str());
         PyDict_SetItemString(clientDict, "sid", val); Py_DECREF(val);
 
         PyObject* methodsDict = PyDict_New();


### PR DESCRIPTION
Functional change: change map IDs from combined strings to entity_id only (as they are unique within the system)

The serialization format is kept as is for binary compatibility. E.g. while internally being handled as uint64_t, it is converted to a string on the wire, and parsed from the string upon deserialization.

Please review with regard to the following:
Name of EntityID type: `using EntityIdT = uint64_t;` or rather `TEntityID` (similar to `SEntityID` -> bit unhappy about naming here)





