### PR TITLE
[mon_gui] Logging enable, crash fix

### DIFF
--- a/app/mon/mon_gui/src/ecalmon.cpp
+++ b/app/mon/mon_gui/src/ecalmon.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,7 +71,9 @@ Ecalmon::Ecalmon(QWidget *parent)
   , monitor_error_counter_(0)
 {
   // Just make sure that eCAL is initialized
-  eCAL::Initialize("eCALMon", eCAL::Init::Default | eCAL::Init::Monitoring);
+  auto config = eCAL::GetConfiguration();
+  config.logging.receiver.enable = true;
+  eCAL::Initialize(config, "eCALMon", eCAL::Init::Default | eCAL::Init::Monitoring);
   eCAL::Monitoring::SetFilterState(false);
   eCAL::Process::SetState(proc_sev_healthy, proc_sev_level1, "Running");
 

--- a/app/mon/mon_gui/src/widgets/models/log_model.cpp
+++ b/app/mon/mon_gui/src/widgets/models/log_model.cpp
@@ -217,6 +217,8 @@ Qt::ItemFlags LogModel::flags(const QModelIndex &index) const
 void LogModel::insertLogs(const eCAL::pb::LogMessageList& logging_pb)
 {
   int inserted_row_count = logging_pb.log_messages().size();
+  if (inserted_row_count <= 0) return;
+  
   int size_before = logs_.size();
 
   // Remove entries from the top
@@ -241,9 +243,7 @@ void LogModel::insertLogs(const eCAL::pb::LogMessageList& logging_pb)
   // Add new elements to the bottom
   size_before = logs_.size();
   int size_after = (size_before + inserted_row_count < max_entries_ ? size_before + inserted_row_count : max_entries_);
-  bool insert_row = size_before <= size_after - 1;
-  if (insert_row)
-    beginInsertRows(QModelIndex(), size_before, size_after - 1);
+  beginInsertRows(QModelIndex(), size_before, size_after - 1);
 
   int counter = inserted_row_count;
   for (auto& log_message_pb : logging_pb.log_messages())
@@ -265,8 +265,7 @@ void LogModel::insertLogs(const eCAL::pb::LogMessageList& logging_pb)
     counter--;
   }
 
-  if (insert_row)
-    endInsertRows();
+  endInsertRows();
 }
 
 void LogModel::clear()

--- a/app/mon/mon_gui/src/widgets/models/log_model.cpp
+++ b/app/mon/mon_gui/src/widgets/models/log_model.cpp
@@ -1,6 +1,6 @@
 ﻿/* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -241,7 +241,9 @@ void LogModel::insertLogs(const eCAL::pb::LogMessageList& logging_pb)
   // Add new elements to the bottom
   size_before = logs_.size();
   int size_after = (size_before + inserted_row_count < max_entries_ ? size_before + inserted_row_count : max_entries_);
-  beginInsertRows(QModelIndex(), size_before, size_after - 1);
+  bool insert_row = size_before <= size_after - 1;
+  if (insert_row)
+    beginInsertRows(QModelIndex(), size_before, size_after - 1);
 
   int counter = inserted_row_count;
   for (auto& log_message_pb : logging_pb.log_messages())
@@ -263,7 +265,8 @@ void LogModel::insertLogs(const eCAL::pb::LogMessageList& logging_pb)
     counter--;
   }
 
-  endInsertRows();
+  if (insert_row)
+    endInsertRows();
 }
 
 void LogModel::clear()

--- a/ecal/core/src/logging/ecal_log.cpp
+++ b/ecal/core/src/logging/ecal_log.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,8 +53,7 @@ namespace eCAL
     {
       if (g_log_udp_receiver() == nullptr)
         return false;
-      g_log_udp_receiver()->GetLogging(log_);
-      return true;
+      return g_log_udp_receiver()->GetLogging(log_);
     }
 
     /**

--- a/ecal/core/src/logging/ecal_log_receiver.cpp
+++ b/ecal/core/src/logging/ecal_log_receiver.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,8 +75,9 @@ namespace eCAL
       m_created = false;
     }
 
-    void CLogReceiver::GetLogging(std::string& log_msg_list_string_)
+    bool CLogReceiver::GetLogging(std::string& log_msg_list_string_)
     {
+      if (!m_attributes.receive_enabled) return false;
       // clear target list string
       log_msg_list_string_.clear();
 
@@ -88,6 +89,8 @@ namespace eCAL
         // clear message list
         m_log_msglist.log_messages.clear();
       }
+
+      return true;
     }
 
     void CLogReceiver::GetLogging(Logging::SLogging& log_)

--- a/ecal/core/src/logging/ecal_log_receiver.h
+++ b/ecal/core/src/logging/ecal_log_receiver.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,8 +65,10 @@ namespace eCAL
          * @brief Get the log messages.
          *
          * @param log_msg_list_string_ The log messages.
+         * 
+         * @return True if enabled and the message receiving got called.
         **/
-        void GetLogging(std::string& log_msg_list_string_);
+        bool GetLogging(std::string& log_msg_list_string_);
 
         /**
          * @brief Get the log messages.


### PR DESCRIPTION
### Description
Enable logging receiving in mon_gui.
Check size of rows before adding them in log_model.cpp . Without that size check, in debug the monitor crashed through an assert.
