### PR TITLE
[mon_gui] Change font for new topics in mon_gui

### DIFF
--- a/app/mon/mon_gui/src/widgets/ecalmon_tree_widget/topic_widget.cpp
+++ b/app/mon/mon_gui/src/widgets/ecalmon_tree_widget/topic_widget.cpp
@@ -148,6 +148,7 @@ TopicWidget::TopicWidget(QWidget *parent)
   QVector<int> default_visible_columns
   {
     (int)TopicTreeModel::Columns::TOPIC_NAME,
+    (int)TopicTreeModel::Columns::STATUS,
     (int)TopicTreeModel::Columns::DIRECTION,
     (int)TopicTreeModel::Columns::UNIT_NAME,
     (int)TopicTreeModel::Columns::HOST_NAME,
@@ -276,6 +277,7 @@ void TopicWidget::autoSizeColumns()
   {
     ui_.tree_view->resizeColumnToContents(column);
   }
+  ui_.tree_view->setColumnWidth(3, 1);
 
 
   topic_tree_model_->removeItem(example_topic_item);

--- a/app/mon/mon_gui/src/widgets/ecalmon_tree_widget/topic_widget.cpp
+++ b/app/mon/mon_gui/src/widgets/ecalmon_tree_widget/topic_widget.cpp
@@ -148,7 +148,6 @@ TopicWidget::TopicWidget(QWidget *parent)
   QVector<int> default_visible_columns
   {
     (int)TopicTreeModel::Columns::TOPIC_NAME,
-    (int)TopicTreeModel::Columns::STATUS,
     (int)TopicTreeModel::Columns::DIRECTION,
     (int)TopicTreeModel::Columns::UNIT_NAME,
     (int)TopicTreeModel::Columns::HOST_NAME,
@@ -277,8 +276,6 @@ void TopicWidget::autoSizeColumns()
   {
     ui_.tree_view->resizeColumnToContents(column);
   }
-  ui_.tree_view->setColumnWidth(3, 1);
-
 
   topic_tree_model_->removeItem(example_topic_item);
   topic_tree_model_->removeItem(example_group_item);

--- a/app/mon/mon_gui/src/widgets/models/topic_tree_item.cpp
+++ b/app/mon/mon_gui/src/widgets/models/topic_tree_item.cpp
@@ -297,6 +297,37 @@ QVariant TopicTreeItem::data(Columns column, Qt::ItemDataRole role) const
 
   else if (role == Qt::ItemDataRole::FontRole)
   {
+
+    if ((column == Columns::HNAME)
+      || (column == Columns::HGNAME)
+      || (column == Columns::PNAME)
+      || (column == Columns::UNAME)
+      || (column == Columns::TNAME)
+      || (column == Columns::DIRECTION)
+      || (column == Columns::TENCODING)
+      || (column == Columns::TTYPE))
+    {
+      const QString raw_data = data(column, (Qt::ItemDataRole)ItemDataRoles::RawDataRole).toString(); //-V1016
+      if (raw_data.isEmpty())
+      {
+        QFont font;
+        font.setItalic(true);
+        font.setBold(itemfont.bold());
+        return font;
+      }
+    }
+    else if (column == Columns::TDESC)
+    {
+      const std::string& raw_data = topic_.tdatatype().desc();
+      if (raw_data.empty())
+      {
+        QFont font;
+        font.setItalic(true);
+        font.setBold(itemfont.bold());
+        return font;
+      }
+    }
+
     return itemfont;
   }
 

--- a/app/mon/mon_gui/src/widgets/models/topic_tree_item.cpp
+++ b/app/mon/mon_gui/src/widgets/models/topic_tree_item.cpp
@@ -42,7 +42,6 @@ QVariant TopicTreeItem::data(int column, Qt::ItemDataRole role) const
 
 QVariant TopicTreeItem::data(Columns column, Qt::ItemDataRole role) const
 {
-  //qDebug() << "DDAATTTAA";
 
   if (role == (Qt::ItemDataRole)ItemDataRoles::RawDataRole) //-V1016 //-V547
   {
@@ -308,32 +307,7 @@ QVariant TopicTreeItem::data(Columns column, Qt::ItemDataRole role) const
     return itemfont;
   }
 
-  /*/NEU
-  else if (role == Qt::ItemDataRole::BackgroundRole)
-    if (column == Columns::STATUS)
-    {
-      {
-        const long long raw_data = data(Columns::DFREQ, (Qt::ItemDataRole)ItemDataRoles::RawDataRole).toLongLong();
-        QString freq = toFrequencyString(raw_data);
-        if (isNewItem())
-        {
-          return QBrush(color_rgb[Gruen]);  // Grün für neue Publisher/Subscriber
-        }
-        if (freq == "0")
-        {
-          if (std::string(topic_.direction()) == "subscriber")
-          {
-            return QBrush(color_rgb[Gelb]);  // Gelb für subscriber die nix empfangen
-          }
-          if (std::string(topic_.direction()) == "publisher")
-          {
-            return QBrush(color_rgb[Orange]); // rot für publisher die nix senden
-          }
-        }
-        return QVariant(); // Invalid QVariant
-      }
-    }
-  return QVariant(); // Invalid QVariant*/
+  return QVariant(); // Invalid QVariant
 }
 
 bool TopicTreeItem::setFont(const QFont& font)
@@ -341,15 +315,6 @@ bool TopicTreeItem::setFont(const QFont& font)
   itemfont = font;
   return false;
 }
-/*TEST
-bool TopicTreeItem::setFont(const QFont& font)
-{
-  if (role == Qt::ItemDataRole::ForegroundRole)
-  {
-    itemfont = font;
-    return false;
-  }
-}*/
 
 int TopicTreeItem::type() const
 {
@@ -360,9 +325,6 @@ void TopicTreeItem::update(const eCAL::pb::Topic& topic)
 {
   topic_.Clear();
   topic_.CopyFrom(topic);
-  lifetime++;
-  //qDebug() << "UPPPPPDDATTEEE";
-
 }
 
 eCAL::pb::Topic TopicTreeItem::topicPb()
@@ -387,9 +349,4 @@ QString TopicTreeItem::toFrequencyString(long long freq)
 std::string TopicTreeItem::topicId() const
 {
   return topic_.tid();
-}
-
-bool TopicTreeItem::isNewItem() const
-{
-  return lifetime < 15;
 }

--- a/app/mon/mon_gui/src/widgets/models/topic_tree_item.cpp
+++ b/app/mon/mon_gui/src/widgets/models/topic_tree_item.cpp
@@ -19,7 +19,6 @@
 
 #include "topic_tree_item.h"
 
-#include <QBrush>
 #include <QFont>
 #include <QString>
 #include <QByteArray>
@@ -126,11 +125,6 @@ QVariant TopicTreeItem::data(Columns column, Qt::ItemDataRole role) const
     else if (column == Columns::DFREQ)
     {
       return topic_.dfreq();
-    }
-    //neu
-    else if (column == Columns::STATUS)
-    {
-      return QVariant();
     }
     else
     {
@@ -268,7 +262,6 @@ QVariant TopicTreeItem::data(Columns column, Qt::ItemDataRole role) const
       || (column == Columns::MESSAGE_DROPS)
       || (column == Columns::DCLOCK)
       || (column == Columns::DFREQ)
-      || (column == Columns::STATUS)
       )
     {
       return Qt::AlignmentFlag::AlignRight;

--- a/app/mon/mon_gui/src/widgets/models/topic_tree_item.h
+++ b/app/mon/mon_gui/src/widgets/models/topic_tree_item.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@
 #pragma once
 
 #include "CustomQt/QAbstractTreeItem.h"
+#include <QColor>
+#include <QFont>
 
 #ifdef _MSC_VER
 #pragma warning(push)
@@ -45,6 +47,7 @@ public:
     UNAME,
     TID,
     TNAME,
+    STATUS,
     DIRECTION,
     TENCODING,
     TTYPE,
@@ -67,6 +70,8 @@ public:
 
   QVariant data(Columns column, Qt::ItemDataRole role = Qt::ItemDataRole::DisplayRole) const;
 
+  bool setFont(const QFont& font);
+
   int type() const;
 
   void update(const eCAL::pb::Topic& topic);
@@ -76,8 +81,18 @@ public:
   std::string topicId() const;
 
 private:
-  eCAL::pb::Topic topic_;
+  bool isNewItem() const;
 
+  eCAL::pb::Topic topic_;
+  int lifetime = 0;
+  enum colors
+  { 
+    Gruen,
+    Gelb,
+    Orange
+    
+  };
+  QColor color_rgb[3] = {QColor(78,201,176), QColor(220,220,170), QColor(206,145,120)}; // red, yellow, orange
+  QFont itemfont;
   static QString toFrequencyString(long long freq);
 };
-

--- a/app/mon/mon_gui/src/widgets/models/topic_tree_item.h
+++ b/app/mon/mon_gui/src/widgets/models/topic_tree_item.h
@@ -46,7 +46,6 @@ public:
     UNAME,
     TID,
     TNAME,
-    STATUS,
     DIRECTION,
     TENCODING,
     TTYPE,

--- a/app/mon/mon_gui/src/widgets/models/topic_tree_item.h
+++ b/app/mon/mon_gui/src/widgets/models/topic_tree_item.h
@@ -20,7 +20,6 @@
 #pragma once
 
 #include "CustomQt/QAbstractTreeItem.h"
-#include <QColor>
 #include <QFont>
 
 #ifdef _MSC_VER
@@ -81,18 +80,7 @@ public:
   std::string topicId() const;
 
 private:
-  bool isNewItem() const;
-
   eCAL::pb::Topic topic_;
-  int lifetime = 0;
-  enum colors
-  { 
-    Gruen,
-    Gelb,
-    Orange
-    
-  };
-  QColor color_rgb[3] = {QColor(78,201,176), QColor(220,220,170), QColor(206,145,120)}; // red, yellow, orange
   QFont itemfont;
   static QString toFrequencyString(long long freq);
 };

--- a/app/mon/mon_gui/src/widgets/models/topic_tree_model.cpp
+++ b/app/mon/mon_gui/src/widgets/models/topic_tree_model.cpp
@@ -48,16 +48,6 @@ QVariant TopicTreeModel::headerData(int section, Qt::Orientation orientation, in
       return columnLabels.at((Columns)section);
     }
   }
-  //neu
-  if (role == Qt::DecorationRole)
-  {
-    auto it = columnLabels.find(static_cast<Columns>(section));
-    if (it != columnLabels.end()) 
-    {
-      return it->second;
-    }
-  }
-  return QAbstractTreeModel::headerData(section, orientation, role);
 }
 
 int TopicTreeModel::mapColumnToItem(int model_column, int tree_item_type) const
@@ -132,26 +122,8 @@ void TopicTreeModel::monitorUpdated(const eCAL::pb::Monitoring& monitoring_pb)
   {
     if (!topic.second)
     {
-      auto& tree_entry = topic_tree_item_map_.at(topic.first);
-      TopicTreeItem* topic_tree_item = tree_entry.tree_item;
-
-      if (tree_entry.tree_item_counter > 0)
-      {
-        tree_entry.tree_item_counter--;
-        if (!tree_entry.striked_out)
-        {
-          auto fontrole = topic_tree_item->data(1, Qt::ItemDataRole::FontRole);
-          auto font = qvariant_cast<QFont>(fontrole);
-          font.setStrikeOut(true);
-          topic_tree_item->setFont(font);
-          tree_entry.striked_out = true;
-        }
-      }
-      else
-      {
-        removeItemFromGroups(topic_tree_item);
-        topic_tree_item_map_.erase(topic.first);
-      }
+      removeItemFromGroups(topic_tree_item_map_.at(topic.first).tree_item);
+      topic_tree_item_map_.erase(topic.first);
     }
   }
 

--- a/app/mon/mon_gui/src/widgets/models/topic_tree_model.cpp
+++ b/app/mon/mon_gui/src/widgets/models/topic_tree_model.cpp
@@ -76,89 +76,6 @@ int TopicTreeModel::groupColumn() const
   return (int)(Columns::GROUP);
 }
 
-/* Funktionierender Zustand
-void TopicTreeModel::monitorUpdated(const eCAL::pb::Monitoring& monitoring_pb)
-{
-  // Create a list of all topics to check if we have to remove them
-  std::map<std::string, bool> topic_still_existing;
-  for(const auto& topic : topic_tree_item_map_)
-  {
-    topic_still_existing[topic.first] = false;
-  }
-
-  for (const auto& topic : monitoring_pb.topics())
-  {
-    std::string topic_id = topic.tid();
-
-    if (topic_tree_item_map_.find(topic_id) == topic_tree_item_map_.end())
-    {
-      qDebug() << "NEU";
-      TopicTreeItem* topic_tree_item = new TopicTreeItem(topic);
-      insertItemIntoGroups(topic_tree_item);
-      STopicTreeEntry tree_entry;
-      tree_entry.tree_item = topic_tree_item;
-      topic_tree_item_map_[topic_id] = tree_entry;
-
-      //Schriftart ändern bei neuen
-      //auto fontrole = topic_tree_item->data(1, Qt::ItemDataRole::FontRole);
-      //auto font = qvariant_cast<QFont>(fontrole);
-      //font.setBold(true);
-      //topic_tree_item->setFont(font); 
-    }
-    else
-    {
-      auto& tree_entry = topic_tree_item_map_.at(topic_id);
-      auto topic_tree_item = tree_entry.tree_item;
-      if (tree_entry.tree_item_counter < 20)
-      {
-        tree_entry.tree_item_counter++;
-        auto fontrole = topic_tree_item->data(1, Qt::ItemDataRole::FontRole);
-        auto font = qvariant_cast<QFont>(fontrole);
-        font.setBold(true);
-        topic_tree_item->setFont(font);
-        qDebug() << tree_entry.tree_item_counter;
-      }
-      else
-      {
-        auto fontrole = topic_tree_item->data(1, Qt::ItemDataRole::FontRole);
-        auto font = qvariant_cast<QFont>(fontrole);
-        font.setBold(false);
-        topic_tree_item->setFont(font);
-        qDebug() << tree_entry.tree_item_counter;
-      }
-       // Update an existing topic
-      topic_tree_item->update(topic);
-      topic_still_existing[topic_id] = true; 
-    }
-  }
-  // Remove obsolete items
-  for (const auto& topic : topic_still_existing)
-  {
-    if (!topic.second)
-    {
-        auto& tree_entry = topic_tree_item_map_.at(topic.first);
-        TopicTreeItem* topic_tree_item = tree_entry.tree_item;
-
-        if (tree_entry.tree_item_delete_counter < 20)
-        {
-            tree_entry.tree_item_delete_counter++; 
-            auto fontrole = topic_tree_item->data(1, Qt::ItemDataRole::FontRole);
-            auto font = qvariant_cast<QFont>(fontrole);
-            font.setStrikeOut(true);
-            topic_tree_item->setFont(font);
-            qDebug() << "delete_counter:" << tree_entry.tree_item_delete_counter;
-        }
-        else
-        {
-            qDebug() << "DELETE";
-            removeItemFromGroups(topic_tree_item);
-            topic_tree_item_map_.erase(topic.first);
-        }
-    }
-  }
-
-  updateAll();
-}*/
 void TopicTreeModel::monitorUpdated(const eCAL::pb::Monitoring& monitoring_pb)
 {
   // Create a list of all topics to check if we have to remove them
@@ -175,13 +92,11 @@ void TopicTreeModel::monitorUpdated(const eCAL::pb::Monitoring& monitoring_pb)
     if (topic_tree_item_map_.find(topic_id) == topic_tree_item_map_.end())
     {
       // Got a new topic
-      qDebug() << "NEU";
       TopicTreeItem* topic_tree_item = new TopicTreeItem(topic);
       insertItemIntoGroups(topic_tree_item);
       STopicTreeEntry tree_entry;
       tree_entry.tree_item = topic_tree_item;
       topic_tree_item_map_[topic_id] = tree_entry;
-
       auto fontrole = topic_tree_item->data(1, Qt::ItemDataRole::FontRole);
       auto font = qvariant_cast<QFont>(fontrole);
       font.setBold(true);
@@ -206,8 +121,6 @@ void TopicTreeModel::monitorUpdated(const eCAL::pb::Monitoring& monitoring_pb)
           tree_entry.default_font = true;
         }
       }
-      qDebug() << tree_entry.tree_item_counter;
-
       // Update an existing topic
       topic_tree_item->update(topic);
       topic_still_existing[topic_id] = true;
@@ -225,7 +138,6 @@ void TopicTreeModel::monitorUpdated(const eCAL::pb::Monitoring& monitoring_pb)
       if (tree_entry.tree_item_counter > 0)
       {
         tree_entry.tree_item_counter--;
-        qDebug() << tree_entry.striked_out;
         if (!tree_entry.striked_out)
         {
           auto fontrole = topic_tree_item->data(1, Qt::ItemDataRole::FontRole);
@@ -234,11 +146,9 @@ void TopicTreeModel::monitorUpdated(const eCAL::pb::Monitoring& monitoring_pb)
           topic_tree_item->setFont(font);
           tree_entry.striked_out = true;
         }
-        qDebug() << tree_entry.tree_item_counter;
       }
       else
       {
-        qDebug() << "DELETE";
         removeItemFromGroups(topic_tree_item);
         topic_tree_item_map_.erase(topic.first);
       }

--- a/app/mon/mon_gui/src/widgets/models/topic_tree_model.cpp
+++ b/app/mon/mon_gui/src/widgets/models/topic_tree_model.cpp
@@ -129,7 +129,6 @@ void TopicTreeModel::monitorUpdated(const eCAL::pb::Monitoring& monitoring_pb)
     {
       removeItemFromGroups(topic_tree_item_map_.at(topic.first).tree_item);
       topic_tree_item_map_.erase(topic.first);
-      qDebug() << topic_tree_item_map_.size();
     }
   }
 

--- a/app/mon/mon_gui/src/widgets/models/topic_tree_model.cpp
+++ b/app/mon/mon_gui/src/widgets/models/topic_tree_model.cpp
@@ -48,6 +48,7 @@ QVariant TopicTreeModel::headerData(int section, Qt::Orientation orientation, in
       return columnLabels.at((Columns)section);
     }
   }
+  return QAbstractTreeModel::headerData(section, orientation, role);
 }
 
 int TopicTreeModel::mapColumnToItem(int model_column, int tree_item_type) const

--- a/app/mon/mon_gui/src/widgets/models/topic_tree_model.cpp
+++ b/app/mon/mon_gui/src/widgets/models/topic_tree_model.cpp
@@ -118,6 +118,7 @@ void TopicTreeModel::monitorUpdated(const eCAL::pb::Monitoring& monitoring_pb)
     }
   }
 
+
   // Remove obsolete items
   for (const auto& topic : topic_still_existing)
   {

--- a/app/mon/mon_gui/src/widgets/models/topic_tree_model.h
+++ b/app/mon/mon_gui/src/widgets/models/topic_tree_model.h
@@ -136,8 +136,8 @@ private:
   struct STopicTreeEntry
   {
     TopicTreeItem*  tree_item = nullptr;
-    int             tree_item_counter = 0;
     bool            default_font = false;
+    bool            new_topic_timer = false;
   };
   std::map<std::string, STopicTreeEntry> topic_tree_item_map_;
 };

--- a/app/mon/mon_gui/src/widgets/models/topic_tree_model.h
+++ b/app/mon/mon_gui/src/widgets/models/topic_tree_model.h
@@ -37,6 +37,10 @@
 #include <QVector>
 #include <QPair>
 
+#include <QIcon>
+#include <QFileIconProvider>
+
+
 class TopicTreeModel : public GroupTreeModel
 {
   Q_OBJECT
@@ -48,6 +52,7 @@ public:
     GROUP,
     TOPIC_ID,
     TOPIC_NAME,
+    STATUS,
     DIRECTION,
     UNIT_NAME,
     HOST_NAME,
@@ -76,16 +81,20 @@ public:
 
   QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
 
-  QVector<QPair<int, QString>> getTreeItemColumnNameMapping() const;
+  QVector<QPair<int, QVariant>> getTreeItemColumnNameMapping() const;
 
   void monitorUpdated(const eCAL::pb::Monitoring& monitoring_pb) override;
+  //QVariant monitorUpdated(const eCAL::pb::Monitoring& monitoring_pb) const override;
+  //virtual QVariant monitorUpdated(const eCAL::pb::Monitoring& monitoring_pb) const;
+
 
 protected:
   int mapColumnToItem(int model_column, int tree_item_type) const override;
   int groupColumn() const override;
 
 private:
-  std::map<Columns, QString> columnLabels =
+  QFileIconProvider icon_provider;
+  std::map<Columns, QVariant/*QString*/> columnLabels 
   {
     { Columns::GROUP,                  "Group" },
     { Columns::HEARTBEAT,              "Heartbeat" },
@@ -96,6 +105,7 @@ private:
     { Columns::UNIT_NAME,              "Process" },
     { Columns::TOPIC_ID,               "Topic ID" },
     { Columns::TOPIC_NAME,             "Topic" },
+    { Columns::STATUS,                 QIcon(icon_provider.icon(QFileIconProvider::Network)) }, //or Drive
     { Columns::DIRECTION,              "Direction" },
     { Columns::TOPIC_ENCODING,         "Encoding" },
     { Columns::TOPIC_TYPE,             "Topic Type" },
@@ -120,6 +130,7 @@ private:
     { Columns::UNIT_NAME,              (int)TopicTreeItem::Columns::UNAME },
     { Columns::TOPIC_ID,               (int)TopicTreeItem::Columns::TID },
     { Columns::TOPIC_NAME,             (int)TopicTreeItem::Columns::TNAME },
+    { Columns::STATUS,                 (int)TopicTreeItem::Columns::STATUS },
     { Columns::DIRECTION,              (int)TopicTreeItem::Columns::DIRECTION },
     { Columns::TOPIC_ENCODING,         (int)TopicTreeItem::Columns::TENCODING },
     { Columns::TOPIC_TYPE,             (int)TopicTreeItem::Columns::TTYPE },
@@ -133,5 +144,12 @@ private:
     { Columns::DATA_FREQUENCY,         (int)TopicTreeItem::Columns::DFREQ },
   };
 
-  std::map<std::string, TopicTreeItem*> topic_tree_item_map_;
+  struct STopicTreeEntry
+  {
+    TopicTreeItem*  tree_item = nullptr;
+    int             tree_item_counter = 0;
+    bool            default_font = false;
+    bool            striked_out = false;
+  };
+  std::map<std::string, STopicTreeEntry> topic_tree_item_map_;
 };

--- a/app/mon/mon_gui/src/widgets/models/topic_tree_model.h
+++ b/app/mon/mon_gui/src/widgets/models/topic_tree_model.h
@@ -37,10 +37,6 @@
 #include <QVector>
 #include <QPair>
 
-#include <QIcon>
-#include <QFileIconProvider>
-
-
 class TopicTreeModel : public GroupTreeModel
 {
   Q_OBJECT
@@ -52,7 +48,6 @@ public:
     GROUP,
     TOPIC_ID,
     TOPIC_NAME,
-    STATUS,
     DIRECTION,
     UNIT_NAME,
     HOST_NAME,
@@ -90,8 +85,7 @@ protected:
   int groupColumn() const override;
 
 private:
-  QFileIconProvider icon_provider;
-  std::map<Columns, QVariant> columnLabels 
+  std::map<Columns, QString> columnLabels =
   {
     { Columns::GROUP,                  "Group" },
     { Columns::HEARTBEAT,              "Heartbeat" },
@@ -102,7 +96,6 @@ private:
     { Columns::UNIT_NAME,              "Process" },
     { Columns::TOPIC_ID,               "Topic ID" },
     { Columns::TOPIC_NAME,             "Topic" },
-    { Columns::STATUS,                 QIcon(icon_provider.icon(QFileIconProvider::Network)) }, //or Drive
     { Columns::DIRECTION,              "Direction" },
     { Columns::TOPIC_ENCODING,         "Encoding" },
     { Columns::TOPIC_TYPE,             "Topic Type" },
@@ -127,7 +120,6 @@ private:
     { Columns::UNIT_NAME,              (int)TopicTreeItem::Columns::UNAME },
     { Columns::TOPIC_ID,               (int)TopicTreeItem::Columns::TID },
     { Columns::TOPIC_NAME,             (int)TopicTreeItem::Columns::TNAME },
-    { Columns::STATUS,                 (int)TopicTreeItem::Columns::STATUS },
     { Columns::DIRECTION,              (int)TopicTreeItem::Columns::DIRECTION },
     { Columns::TOPIC_ENCODING,         (int)TopicTreeItem::Columns::TENCODING },
     { Columns::TOPIC_TYPE,             (int)TopicTreeItem::Columns::TTYPE },
@@ -146,7 +138,6 @@ private:
     TopicTreeItem*  tree_item = nullptr;
     int             tree_item_counter = 0;
     bool            default_font = false;
-    bool            striked_out = false;
   };
   std::map<std::string, STopicTreeEntry> topic_tree_item_map_;
 };

--- a/app/mon/mon_gui/src/widgets/models/topic_tree_model.h
+++ b/app/mon/mon_gui/src/widgets/models/topic_tree_model.h
@@ -84,9 +84,6 @@ public:
   QVector<QPair<int, QVariant>> getTreeItemColumnNameMapping() const;
 
   void monitorUpdated(const eCAL::pb::Monitoring& monitoring_pb) override;
-  //QVariant monitorUpdated(const eCAL::pb::Monitoring& monitoring_pb) const override;
-  //virtual QVariant monitorUpdated(const eCAL::pb::Monitoring& monitoring_pb) const;
-
 
 protected:
   int mapColumnToItem(int model_column, int tree_item_type) const override;
@@ -94,7 +91,7 @@ protected:
 
 private:
   QFileIconProvider icon_provider;
-  std::map<Columns, QVariant/*QString*/> columnLabels 
+  std::map<Columns, QVariant> columnLabels 
   {
     { Columns::GROUP,                  "Group" },
     { Columns::HEARTBEAT,              "Heartbeat" },


### PR DESCRIPTION
### Description
When new topics appear in the gui, the font is set to bolt.
A variable named "tree_item_counter" is assigned to the new topic, which increases by 2 every monitor update. 
The font stays bolt until the value of the variable exceeds 20, after which the font will return to normal.
