### PR TITLE
Use uint64_t for topic id in hdf5

### DIFF
--- a/contrib/ecalhdf5/src/hdf5_helper.cpp
+++ b/contrib/ecalhdf5/src/hdf5_helper.cpp
@@ -1,3 +1,22 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2024 - 2025 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
 #include "hdf5_helper.h"
 
 bool CreateStringEntryInRoot(hid_t root, const std::string& url, const std::string& dataset_content)

--- a/contrib/ecalhdf5/src/hdf5_helper.h
+++ b/contrib/ecalhdf5/src/hdf5_helper.h
@@ -54,8 +54,7 @@ inline std::string printHex(eCAL::experimental::measurement::base::Channel::id_t
 
 inline eCAL::experimental::measurement::base::Channel::id_t parseHexID(std::string string_id)
 {
-  auto unsigned_value = std::stoull(string_id, 0, 16);
-  return static_cast<eCAL::experimental::measurement::base::Channel::id_t>(unsigned_value);
+  return std::stoull(string_id, 0, 16);
 }
 
 namespace v6

--- a/contrib/ecalhdf5/src/hdf5_helper.h
+++ b/contrib/ecalhdf5/src/hdf5_helper.h
@@ -73,7 +73,7 @@ inline std::string printHex(eCAL::experimental::measurement::base::Channel::id_t
 
 inline eCAL::experimental::measurement::base::Channel::id_t parseHexID(std::string string_id)
 {
-  return std::stoull(string_id, 0, 16);
+  return std::stoull(string_id, nullptr, 16);
 }
 
 namespace v6

--- a/contrib/ecalhdf5/src/hdf5_helper.h
+++ b/contrib/ecalhdf5/src/hdf5_helper.h
@@ -1,3 +1,22 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2024 - 2025 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
 #pragma once
 
 #include <string>

--- a/contrib/measurement/base/include/ecal/measurement/base/types.h
+++ b/contrib/measurement/base/include/ecal/measurement/base/types.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ namespace eCAL
 
         struct Channel
         {
-          using id_t = std::int64_t;
+          using id_t = std::uint64_t;
 
           std::string name = "";
           id_t        id = 0;

--- a/contrib/measurement/base/include/ecal/measurement/base/types.h
+++ b/contrib/measurement/base/include/ecal/measurement/base/types.h
@@ -26,6 +26,7 @@
 
 #include <cstdint>
 #include <set>
+#include <string>
 #include <tuple>
 #include <vector>
 

--- a/tests/contrib/ecalhdf5/hdf5_test/src/hdf5_test.cpp
+++ b/tests/contrib/ecalhdf5/hdf5_test/src/hdf5_test.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1032,7 +1032,6 @@ TEST(HDF5, PrintParseHex)
   std::vector<Channel::id_t> numeric_values =
   {
     0,
-    -1,
     1,
     std::numeric_limits<Channel::id_t>::min(),
     std::numeric_limits<Channel::id_t>::max()


### PR DESCRIPTION
Changes the underlying type of the topic ID (there is no reason for IDs to be of a signed type).
Also add missing license headers.
