### PR TITLE
[rec_core] Record ecalhdf5 v6, respecting topic-id.

### DIFF
--- a/app/rec/rec_client_core/include/rec_client_core/topic_info.h
+++ b/app/rec/rec_client_core/include/rec_client_core/topic_info.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,5 +75,7 @@ namespace eCAL
 
       std::map<std::string, std::set<std::string>> publishers_;
     };
+
+    using TopicInfoMap = std::map<eCAL::Registration::STopicId, TopicInfo>;
   }
 }

--- a/app/rec/rec_client_core/src/ecal_rec_impl.h
+++ b/app/rec/rec_client_core/src/ecal_rec_impl.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -115,14 +115,14 @@ namespace eCAL
 
       std::set<std::string> GetSubscribedTopics() const;
 
-      void EcalMessageReceived(const eCAL::Registration::STopicId& topic_id_, const eCAL::SReceiveCallbackData& data_);
+      void EcalMessageReceived(const Registration::STopicId& topic_id_, const SDataTypeInformation& datatype_info_, const SReceiveCallbackData& callback_data_);
 
       //////////////////////////////////////
       //// API for external threads     ////
       //////////////////////////////////////
       void GarbageCollect();
 
-      void SetTopicInfo(const std::map<std::string, TopicInfo>& topic_info_map);
+      void SetTopicInfo(const TopicInfoMap& topic_info_map);
 
     //////////////////////////////////////////////////////////////////////////////
     //// Private functions                                                    ////
@@ -130,7 +130,7 @@ namespace eCAL
     private:
       void UpdateAndCleanSubscribers();
 
-      std::set<std::string> FilterAvailableTopics_NoLock(const std::map<std::string, TopicInfo>& topic_info_map) const;
+      std::set<std::string> FilterAvailableTopics_NoLock(const TopicInfoMap& topic_info_map) const;
 
       void CreateNewSubscribers_NoLock(const std::set<std::string>& topic_set);
       void RemoveOldSubscribers_NoLock(const std::set<std::string>& topic_set);

--- a/app/rec/rec_client_core/src/frame.h
+++ b/app/rec/rec_client_core/src/frame.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2024 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,16 +32,16 @@ namespace eCAL
     class Frame
     {
     public:
-      Frame(const eCAL::SReceiveCallbackData* const callback_data, const std::string& topic_name, const eCAL::Time::ecal_clock::time_point receive_time, std::chrono::steady_clock::time_point system_receive_time)
-        : ecal_publish_time_(std::chrono::duration_cast<eCAL::Time::ecal_clock::duration>(std::chrono::microseconds(callback_data->time)))
+      Frame(const eCAL::SReceiveCallbackData& callback_data, const Registration::STopicId& topic, const eCAL::Time::ecal_clock::time_point receive_time, std::chrono::steady_clock::time_point system_receive_time)
+        : ecal_publish_time_(std::chrono::duration_cast<eCAL::Time::ecal_clock::duration>(std::chrono::microseconds(callback_data.time)))
         , ecal_receive_time_(receive_time)
         , system_receive_time_(system_receive_time)
-        , topic_name_(topic_name)
-        , clock_(callback_data->clock)
-        , id_(callback_data->id)
+        , topic_(topic)
+        , clock_(callback_data.clock)
+        , id_(callback_data.id)
       {
-        data_.reserve(callback_data->size);
-        data_.assign((char*)callback_data->buf, (char*)callback_data->buf + callback_data->size);
+        data_.reserve(callback_data.size);
+        data_.assign((char*)callback_data.buf, (char*)callback_data.buf + callback_data.size);
       }
 
       Frame()
@@ -57,7 +57,7 @@ namespace eCAL
       eCAL::Time::ecal_clock::time_point    ecal_publish_time_;
       eCAL::Time::ecal_clock::time_point    ecal_receive_time_;
       std::chrono::steady_clock::time_point system_receive_time_;
-      std::string                           topic_name_;
+      Registration::STopicId                topic_;
       long long                             clock_;
       long long                             id_;
     };

--- a/app/rec/rec_client_core/src/job/hdf5_writer_thread.h
+++ b/app/rec/rec_client_core/src/job/hdf5_writer_thread.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ namespace eCAL
     // Constructor & Destructor
     ///////////////////////////////
     public:
-      Hdf5WriterThread(const JobConfig& job_config, const std::map<std::string, TopicInfo>& initial_topic_info_map = {}, const std::deque<std::shared_ptr<Frame>>& initial_frame_buffer = {});
+      Hdf5WriterThread(const JobConfig& job_config, const TopicInfoMap& initial_topic_info_map = {}, const std::deque<std::shared_ptr<Frame>>& initial_frame_buffer = {});
 
       ~Hdf5WriterThread();
 
@@ -53,7 +53,7 @@ namespace eCAL
 
       bool AddFrame(const std::shared_ptr<Frame>& frame);
 
-      void SetTopicInfo(std::map<std::string, TopicInfo> topic_info_map); // CALL BY VALUE (-> copy) IS INTENDED!
+      void SetTopicInfo(TopicInfoMap topic_info_map); // CALL BY VALUE (-> copy) IS INTENDED!
 
       void Flush();
 
@@ -89,12 +89,12 @@ namespace eCAL
       size_t                                written_frames_;
       std::chrono::steady_clock::time_point first_written_frame_timestamp_;
       std::chrono::steady_clock::time_point last_written_frame_timestamp_;
-      std::map<std::string, TopicInfo>      new_topic_info_map_;                /**< The new topic info map that shall be set to the HDF5 writer */
+      TopicInfoMap                          new_topic_info_map_;                /**< The new topic info map that shall be set to the HDF5 writer */
       bool                                  new_topic_info_map_available_;      /**< Telling that a new topic info map has been set from the outside. */
       mutable RecHdf5JobStatus              last_status_;
 
-      mutable std::mutex                                    hdf5_writer_mutex_;
-      std::unique_ptr<eCAL::eh5::v2::HDF5Meas>              hdf5_writer_;
+      mutable std::mutex                    hdf5_writer_mutex_;
+      std::unique_ptr<eCAL::eh5::HDF5Meas>  hdf5_writer_;
 
 
       std::atomic<bool> flushing_;

--- a/app/rec/rec_client_core/src/job/record_job.cpp
+++ b/app/rec/rec_client_core/src/job/record_job.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -283,7 +283,7 @@ namespace eCAL
       return true;
     }
 
-    bool RecordJob::StartRecording(const std::map<std::string, TopicInfo>& initial_topic_info_map, const std::deque<std::shared_ptr<Frame>>& initial_frame_buffer)
+    bool RecordJob::StartRecording(const TopicInfoMap& initial_topic_info_map, const std::deque<std::shared_ptr<Frame>>& initial_frame_buffer)
     {
       std::unique_lock<std::shared_timed_mutex> lock(job_mutex_);
 
@@ -317,7 +317,7 @@ namespace eCAL
     }
 
 
-    bool RecordJob::SaveBuffer(const std::map<std::string, TopicInfo>& topic_info_map, const std::deque<std::shared_ptr<Frame>>& frame_buffer)
+    bool RecordJob::SaveBuffer(const TopicInfoMap& topic_info_map, const std::deque<std::shared_ptr<Frame>>& frame_buffer)
     {
       std::unique_lock<std::shared_timed_mutex> lock(job_mutex_);
 
@@ -344,7 +344,7 @@ namespace eCAL
       return hdf5_writer_thread_->AddFrame(frame);
     }
 
-    void RecordJob::SetTopicInfo(const std::map<std::string, TopicInfo>& topic_info_map)
+    void RecordJob::SetTopicInfo(const TopicInfoMap& topic_info_map)
     {
       std::shared_lock<std::shared_timed_mutex> lock(job_mutex_);
       if ((main_recorder_state_ != JobState::Recording) || !hdf5_writer_thread_)

--- a/app/rec/rec_client_core/src/job/record_job.h
+++ b/app/rec/rec_client_core/src/job/record_job.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,12 +64,12 @@ namespace eCAL
     ///////////////////////////////////////////////
     public:
       bool InitializeMeasurementDirectory();
-      bool StartRecording(const std::map<std::string, TopicInfo>& initial_topic_info_map, const std::deque<std::shared_ptr<Frame>>& initial_frame_buffer);
+      bool StartRecording(const TopicInfoMap& initial_topic_info_map, const std::deque<std::shared_ptr<Frame>>& initial_frame_buffer);
       bool StopRecording ();
-      bool SaveBuffer    (const std::map<std::string, TopicInfo>& topic_info_map,         const std::deque<std::shared_ptr<Frame>>& frame_buffer);
+      bool SaveBuffer    (const TopicInfoMap& topic_info_map,         const std::deque<std::shared_ptr<Frame>>& frame_buffer);
 
       bool AddFrame(const std::shared_ptr<Frame>& frame);
-      void SetTopicInfo(const std::map<std::string, TopicInfo>& topic_info_map);
+      void SetTopicInfo(const TopicInfoMap& topic_info_map);
 
       eCAL::rec::Error Upload(const UploadConfig& upload_config);
 

--- a/app/rec/rec_client_core/src/monitoring_thread.cpp
+++ b/app/rec/rec_client_core/src/monitoring_thread.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,16 +23,6 @@
 
 #include <ecal_utils/ecal_utils.h>
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable: 4100 4127 4146 4505 4800 4189 4592) // disable proto warnings
-#endif
-#include <ecal/core/pb/monitoring.pb.h>
-#include <ecal/core/pb/process.pb.h>
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
-
 #include "rec_client_core/ecal_rec_logger.h"
 #include "ecal_rec_impl.h"
 
@@ -50,156 +40,25 @@ namespace eCAL
 
     void MonitoringThread::Loop()
     {
-      std::string          monitoring_string;
-      eCAL::pb::Monitoring monitoring_pb;
+      TopicInfoMap topic_info_snapshot;
+      auto publisher_ids = eCAL::Registration::GetPublisherIDs();
 
-      if (eCAL::Monitoring::GetMonitoring(monitoring_string))
+      for (const auto& publisher_id : publisher_ids)
       {
-        monitoring_pb.Clear();
-        monitoring_pb.ParseFromString(monitoring_string);
-
-
-        {
-          std::lock_guard<decltype(monitoring_mutex_)> monitoring_lock(monitoring_mutex_);
-
-          // Clear publisher lists of all topics
-          for (auto& topic_info : topic_info_map_)
-          {
-            topic_info.second.publishers_.clear();
-          }
-
-          // Collect all descriptors
-          std::map<std::string, std::pair<int, std::pair<std::string, std::string>>> channel_descriptor_map; // ChannelName -> {Type, Descriptor}
-          std::map<std::string, std::pair<int, std::string>> type_descriptor_map;                            // Type        -> Descriptor           (used for topics that we know the type of, but have no other information available)
-
-          static const int DESCRIPTION_AVAILABLE_QUALITYBIT         = 0x1 << 3;  // Having a descriptor at all is the most important thing
-          static const int INFO_COMES_FROM_CORRECT_TOPIC_QUALITYBIT = 0x1 << 2;  // The information comes from the current topic (and has not been borrowed from another topic)
-          static const int INFO_COMES_FROM_PUBLISHER_QUALITYBIT     = 0x1 << 1;  // A descriptor coming from the publisher is better than one from a subsriber, as we assume that the publisher knows best what he is publishing
-          static const int TYPE_AVAILABLE_QUALITYBIT                = 0x1 << 0;  // Having information about the type's name available is nice but not that important to us.
-
-          for (const auto& topic : monitoring_pb.topics())
-          {
-            // Lookup the topic map entry
-            auto topic_info_map_it = topic_info_map_.find(topic.tname());
-            if (topic_info_map_it == topic_info_map_.end())
-            {
-              // Create a new topic entry
-              topic_info_map_.emplace(topic.tname(), eCAL::rec::TopicInfo("", "", ""));
-              topic_info_map_it = topic_info_map_.find(topic.tname());
-            }
-
-            // Create combined encoding:type type (to be fully compatible to old behavior)
-            std::string combined_enc_type = eCAL::Util::CombinedTopicEncodingAndType(topic.tdatatype().encoding(), topic.tdatatype().name());
-
-            // Evaluate the quality of the current descriptor information
-            int this_topic_info_quality = 0;
-
-            if (!topic.tdatatype().desc().empty())
-            {
-              this_topic_info_quality |= DESCRIPTION_AVAILABLE_QUALITYBIT;
-            }
-
-            this_topic_info_quality |= INFO_COMES_FROM_CORRECT_TOPIC_QUALITYBIT;
-
-            if (EcalUtils::String::Icompare(topic.direction(), "publisher"))
-            {
-              this_topic_info_quality |= INFO_COMES_FROM_PUBLISHER_QUALITYBIT;
-
-              // Also update the publisher list
-              auto existing_publisher_it = topic_info_map_it->second.publishers_.find(topic.hname());
-              if (existing_publisher_it != topic_info_map_it->second.publishers_.end())
-              {
-                existing_publisher_it->second.emplace(topic.uname());
-              }
-              else
-              {
-                topic_info_map_it->second.publishers_.emplace(topic.hname(), std::set<std::string>{topic.uname()});
-              }
-            }
-
-            if (!combined_enc_type.empty())
-            {
-              this_topic_info_quality |= TYPE_AVAILABLE_QUALITYBIT;
-            }
-
-            // Update the channel_descriptor_map
-            {
-              auto channel_descriptor_map_it = channel_descriptor_map.find(topic.tname());
-              if (channel_descriptor_map_it == channel_descriptor_map.end())
-              {
-                // Save the new descriptor
-                channel_descriptor_map.emplace(topic.tname(), std::make_pair(this_topic_info_quality, std::make_pair(combined_enc_type, topic.tdatatype().desc())));
-              }
-              else
-              {
-                if(channel_descriptor_map_it->second.first < this_topic_info_quality)
-                {
-                  // If the old descriptor has a lower quality than the current descriptor, we may overwrite it!
-                  channel_descriptor_map_it->second = std::make_pair(this_topic_info_quality, std::make_pair(combined_enc_type, topic.tdatatype().desc()));
-                }
-              }
-            }
-
-            // Update the type_descriptor_map (can of course only work if we have the type information available)
-            if (!combined_enc_type.empty())
-            {
-              int quality_for_other_channels = (this_topic_info_quality & ~INFO_COMES_FROM_CORRECT_TOPIC_QUALITYBIT);
-
-              auto type_descriptor_map_it = type_descriptor_map.find(combined_enc_type);
-              if (type_descriptor_map_it == type_descriptor_map.end())
-              {
-                // Save the new descriptor
-                type_descriptor_map.emplace(combined_enc_type, std::make_pair(quality_for_other_channels, topic.tdatatype().desc()));
-              }
-              else
-              {
-                if(type_descriptor_map_it->second.first < quality_for_other_channels)
-                {
-                  // If the old descriptor has a lower quality than the current descriptor, we may overwrite it!
-                  type_descriptor_map_it->second = std::make_pair(quality_for_other_channels, topic.tdatatype().desc());
-                }
-              }
-            }
-          }
-
-          // Update the type/descriptor information of the topic_info_map_
-          for (auto& topic_info_map_entry : topic_info_map_)
-          {
-            auto channel_descriptor_entry_it = channel_descriptor_map.find(topic_info_map_entry.first);
-            if ((channel_descriptor_entry_it != channel_descriptor_map.end())
-              && (channel_descriptor_entry_it->second.first >= topic_info_map_entry.second.description_quality_))
-            {
-              topic_info_map_entry.second.SetLegacyType(channel_descriptor_entry_it->second.second.first);
-              topic_info_map_entry.second.tinfo_.descriptor    = channel_descriptor_entry_it->second.second.second;
-              topic_info_map_entry.second.description_quality_ = channel_descriptor_entry_it->second.first;
-            }
-
-            if (!topic_info_map_entry.second.GetLegacyType().empty())
-            {
-              auto type_descriptor_entry_it = type_descriptor_map.find(topic_info_map_entry.second.GetLegacyType());
-              if ((type_descriptor_entry_it != type_descriptor_map.end())
-                && (type_descriptor_entry_it->second.first >= topic_info_map_entry.second.description_quality_)) 
-              {
-                topic_info_map_entry.second.tinfo_.descriptor    = type_descriptor_entry_it->second.second;
-                topic_info_map_entry.second.description_quality_ = type_descriptor_entry_it->second.first;
-              }
-            }
-          }
-        }
-
-        recorder_.SetTopicInfo(topic_info_map_);
+        SDataTypeInformation datatype_info;
+        eCAL::Registration::GetPublisherInfo(publisher_id, datatype_info);
+        topic_info_snapshot.insert({ publisher_id , std::move(datatype_info) });
       }
-      else
-      {
-        EcalRecLogger::Instance()->debug("eCAL::Monitoring::GetMonitoring - failure");
-      }
+
+      std::lock_guard<decltype(monitoring_mutex_)> monitoring_lock(monitoring_mutex_);
+      topic_info_map_ = std::move(topic_info_snapshot);
     }
 
-    TopicInfo MonitoringThread::GetTopicInfo(const std::string& topic_name) const
+    TopicInfo MonitoringThread::GetTopicInfo(const Registration::STopicId& topic) const
     {
       std::lock_guard<decltype(monitoring_mutex_)> monitoring_lock(monitoring_mutex_);
 
-      auto topic_info_map_it = topic_info_map_.find(topic_name);
+      auto topic_info_map_it = topic_info_map_.find(topic);
       if (topic_info_map_it != topic_info_map_.end())
       {
         return topic_info_map_it->second;
@@ -210,7 +69,7 @@ namespace eCAL
       }
     }
 
-    std::map<std::string, TopicInfo> MonitoringThread::GetTopicInfoMap() const
+    TopicInfoMap MonitoringThread::GetTopicInfoMap() const
     {
       std::lock_guard<decltype(monitoring_mutex_)> monitoring_lock(monitoring_mutex_);
       return topic_info_map_;

--- a/app/rec/rec_client_core/src/monitoring_thread.h
+++ b/app/rec/rec_client_core/src/monitoring_thread.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,18 +37,18 @@ namespace eCAL
       MonitoringThread(EcalRecImpl& recorder);
       ~MonitoringThread();
 
-      TopicInfo GetTopicInfo(const std::string& topic_name) const;
+      TopicInfo GetTopicInfo(const Registration::STopicId& topic) const;
 
-      std::map<std::string, TopicInfo> GetTopicInfoMap() const;
+      TopicInfoMap GetTopicInfoMap() const;
 
     protected:
       void Loop() override;
 
     private:
-      EcalRecImpl&                          recorder_;
+      EcalRecImpl&                       recorder_;
 
       mutable std::mutex                 monitoring_mutex_;
-      std::map<std::string, TopicInfo>   topic_info_map_;
+      TopicInfoMap                       topic_info_map_;
     };
   }
 }


### PR DESCRIPTION
We want to record both Publisher and its unque ID within the measurement.
This PR aims to do that.
We do not need to do any kind of quality computation any longer.
Later on, we might be able to play back only topics published by a given publisher.

Currently, it builds, however, nothing is recorded. Need to review why it breaks the recording.