### PR TITLE
[core] service client use datainfo (post fixes)

### DIFF
--- a/ecal/core/include/ecal/ecal_service_info.h
+++ b/ecal/core/include/ecal/ecal_service_info.h
@@ -35,6 +35,16 @@
 namespace eCAL
 {
   /**
+   * @brief Service method information struct containing the request and response type information.
+  **/
+  struct SMethodInfo
+  {
+    std::string              method_name; //!< The name of the method.
+    SDataTypeInformation     req_type;    //!< The type of the method request.
+    SDataTypeInformation     resp_type;   //!< The type of the method response.
+  };
+
+  /**
    * @brief Service response struct containing the (responding) server informations and the response itself. (deprecated)
   **/
   struct SServiceResponse
@@ -82,13 +92,11 @@ namespace eCAL
   /**
    * @brief Service method callback function type (low level server interface).
    *
-   * @param method_     The method name.
-   * @param req_type_   The type of the method request.
-   * @param resp_type_  The type of the method response.
+   * @param method_info The method information struct containing the request and response type information.
    * @param request_    The request.
    * @param response_   The response returned from the method call.
   **/
-  using MethodInfoCallbackT = std::function<int(const std::string& method_, const SDataTypeInformation& req_type_, const SDataTypeInformation& resp_type_, const std::string& request_, std::string& response_)>;
+  using MethodInfoCallbackT = std::function<int(const SMethodInfo& method_info_, const std::string& request_, std::string& response_)>;
 
   /**
    * @brief Service response callback function type (low level client interface). (deprecated)

--- a/ecal/core/src/ecal_descgate.cpp
+++ b/ecal/core/src/ecal_descgate.cpp
@@ -178,8 +178,8 @@ namespace eCAL
     {
       for (const auto& method : sample_.service.methods)
       {
-        SDataTypeInformation request_datatype  = GetDataTypeInformation(method.req_datatype, method.req_type, method.req_desc);
-        SDataTypeInformation response_datatype = GetDataTypeInformation(method.resp_datatype, method.resp_type, method.resp_desc);
+        const SDataTypeInformation request_datatype  = GetDataTypeInformation(method.req_datatype, method.req_type, method.req_desc);
+        const SDataTypeInformation response_datatype = GetDataTypeInformation(method.resp_datatype, method.resp_type, method.resp_desc);
 
         ApplyServiceDescription(m_service_info_map, sample_.identifier, sample_.service.sname, method.mname, request_datatype, response_datatype);
       }
@@ -191,8 +191,8 @@ namespace eCAL
     case bct_reg_client:
       for (const auto& method : sample_.client.methods)
       {
-        SDataTypeInformation request_datatype  = GetDataTypeInformation(method.req_datatype, method.req_type, method.req_desc);
-        SDataTypeInformation response_datatype = GetDataTypeInformation(method.resp_datatype, method.resp_type, method.resp_desc);
+        const SDataTypeInformation request_datatype  = GetDataTypeInformation(method.req_datatype, method.req_type, method.req_desc);
+        const SDataTypeInformation response_datatype = GetDataTypeInformation(method.resp_datatype, method.resp_type, method.resp_desc);
 
         ApplyServiceDescription(m_client_info_map, sample_.identifier, sample_.client.sname, method.mname, request_datatype, response_datatype);
      }
@@ -326,7 +326,7 @@ namespace eCAL
     }
   }
 
-  SDataTypeInformation CDescGate::GetDataTypeInformation(const SDataTypeInformation& datatype_info_, const std::string& legacy_type_, const std::string& legacy_desc_) const
+  SDataTypeInformation CDescGate::GetDataTypeInformation(const SDataTypeInformation& datatype_info_, const std::string& legacy_type_, const std::string& legacy_desc_)
   {
     SDataTypeInformation datatype_info;
 

--- a/ecal/core/src/ecal_descgate.cpp
+++ b/ecal/core/src/ecal_descgate.cpp
@@ -178,32 +178,8 @@ namespace eCAL
     {
       for (const auto& method : sample_.service.methods)
       {
-        SDataTypeInformation request_datatype{};
-        SDataTypeInformation response_datatype{};
-
-        // if the new req_datatype field is set, use it
-        if (!method.req_datatype.name.empty())
-        {
-          request_datatype = method.req_datatype;
-        }
-        // otherwise use the old req_type and req_desc fields
-        else
-        {
-          request_datatype.name       = method.req_type;
-          request_datatype.descriptor = method.req_desc;
-        }
-
-        // if the new resp_datatype field is set, use it
-        if (!method.resp_datatype.name.empty())
-        {
-          response_datatype = method.resp_datatype;
-        }
-        // otherwise use the old resp_type and resp_desc fields
-        else
-        {
-          response_datatype.name       = method.resp_type;
-          response_datatype.descriptor = method.resp_desc;
-        }
+        SDataTypeInformation request_datatype  = GetDataTypeInformation(method.req_datatype, method.req_type, method.req_desc);
+        SDataTypeInformation response_datatype = GetDataTypeInformation(method.resp_datatype, method.resp_type, method.resp_desc);
 
         ApplyServiceDescription(m_service_info_map, sample_.identifier, sample_.service.sname, method.mname, request_datatype, response_datatype);
       }
@@ -215,32 +191,8 @@ namespace eCAL
     case bct_reg_client:
       for (const auto& method : sample_.client.methods)
       {
-        SDataTypeInformation request_datatype{};
-        SDataTypeInformation response_datatype{};
-
-        // if the new req_datatype field is set, use it
-        if (!method.req_datatype.name.empty())
-        {
-          request_datatype = method.req_datatype;
-        }
-        // otherwise use the old req_type and req_desc fields
-        else
-        {
-          request_datatype.name       = method.req_type;
-          request_datatype.descriptor = method.req_desc;
-        }
-
-        // if the new resp_datatype field is set, use it
-        if (!method.resp_datatype.name.empty())
-        {
-          response_datatype = method.resp_datatype;
-        }
-        // otherwise use the old resp_type and resp_desc fields
-        else
-        {
-          response_datatype.name       = method.resp_type;
-          response_datatype.descriptor = method.resp_desc;
-        }
+        SDataTypeInformation request_datatype  = GetDataTypeInformation(method.req_datatype, method.req_type, method.req_desc);
+        SDataTypeInformation response_datatype = GetDataTypeInformation(method.resp_datatype, method.resp_type, method.resp_desc);
 
         ApplyServiceDescription(m_client_info_map, sample_.identifier, sample_.client.sname, method.mname, request_datatype, response_datatype);
      }
@@ -372,6 +324,25 @@ namespace eCAL
     {
       service_method_info_map_.id_map.erase(service_method_info_key);
     }
+  }
+
+  SDataTypeInformation CDescGate::GetDataTypeInformation(const SDataTypeInformation& datatype_info_, const std::string& legacy_type_, const std::string& legacy_desc_) const
+  {
+    SDataTypeInformation datatype_info;
+
+    // if the new datatype_info field is set, use it
+    if (!datatype_info_.name.empty())
+    {
+      datatype_info = datatype_info_;
+    }
+    // otherwise use the old type and desc fields
+    else
+    {
+      datatype_info.name       = legacy_type_;
+      datatype_info.descriptor = legacy_desc_;
+    }
+
+    return datatype_info;
   }
 
   Registration::CallbackToken CDescGate::CreateToken()

--- a/ecal/core/src/ecal_descgate.h
+++ b/ecal/core/src/ecal_descgate.h
@@ -101,7 +101,7 @@ namespace eCAL
     static bool                               GetTopic   (const Registration::STopicId& id_, const STopicIdInfoMap& topic_info_map_, SDataTypeInformation& topic_info_);
 
     static std::set<Registration::SServiceMethodId> GetServiceIDs(const SServiceIdInfoMap& service_method_info_map_);
-    static bool                               GetService   (const Registration::SServiceMethodId& id_, const SServiceIdInfoMap& service_method_info_map_, SServiceMethodInformation& service_method_info_);
+    static bool                                     GetService   (const Registration::SServiceMethodId& id_, const SServiceIdInfoMap& service_method_info_map_, SServiceMethodInformation& service_method_info_);
 
     static void ApplyTopicDescription(STopicIdInfoMap& topic_info_map_,
                                       const STopicIdCallbackMap& topic_callback_map_, 
@@ -125,6 +125,7 @@ namespace eCAL
                                       const Registration::SampleIdentifier& service_id_,
                                       const std::string& service_name_);
 
+    SDataTypeInformation GetDataTypeInformation(const SDataTypeInformation& datatype_info_, const std::string& legacy_type_, const std::string& legacy_desc_) const;
     Registration::CallbackToken CreateToken();
       
     // internal quality topic info publisher/subscriber maps

--- a/ecal/core/src/ecal_descgate.h
+++ b/ecal/core/src/ecal_descgate.h
@@ -125,7 +125,7 @@ namespace eCAL
                                       const Registration::SampleIdentifier& service_id_,
                                       const std::string& service_name_);
 
-    SDataTypeInformation GetDataTypeInformation(const SDataTypeInformation& datatype_info_, const std::string& legacy_type_, const std::string& legacy_desc_) const;
+    static SDataTypeInformation GetDataTypeInformation(const SDataTypeInformation& datatype_info_, const std::string& legacy_type_, const std::string& legacy_desc_);
     Registration::CallbackToken CreateToken();
       
     // internal quality topic info publisher/subscriber maps

--- a/ecal/core/src/service/ecal_service_client.cpp
+++ b/ecal/core/src/service/ecal_service_client.cpp
@@ -106,9 +106,9 @@ namespace eCAL
       try
       {
         // explicitly unpack the pair
-        std::pair<bool, SServiceIDResponse> result = future.get();
+        const std::pair<bool, SServiceIDResponse> result = future.get();
         bool success = result.first;
-        SServiceIDResponse response = result.second;
+        const SServiceIDResponse response = result.second;
 
         // add response to the vector
         service_response_vec_.emplace_back(response);

--- a/ecal/core/src/service/ecal_service_client_v5_impl.cpp
+++ b/ecal/core/src/service/ecal_service_client_v5_impl.cpp
@@ -176,14 +176,14 @@ namespace eCAL
       Logging::Log(log_level_debug1, "v5::CServiceClientImpl: Making a synchronous call to method: " + method_name_);
 
       // Wrap the response callback to filter by host name if necessary
-      ResponseIDCallbackT callback = [this](const Registration::SEntityId& /*entity_id_*/, const struct SServiceIDResponse& service_response_)
+      const ResponseIDCallbackT callback = [this](const Registration::SEntityId& /*entity_id_*/, const struct SServiceIDResponse& service_response_)
         {
           if (m_host_name.empty() || service_response_.service_method_id.service_id.host_name == m_host_name)
           {
             Logging::Log(log_level_debug2, "v5::CServiceClientImpl: Response received for method call.");
             
             // Convert SServiceResponse to SServiceIDResponse
-            SServiceResponse service_response = ConvertToServiceResponse(service_response_);
+            const SServiceResponse service_response = ConvertToServiceResponse(service_response_);
 
             // Call the stored response callback
             m_response_callback(service_response);
@@ -211,7 +211,7 @@ namespace eCAL
 
       // Call the method using the new API
       ServiceIDResponseVecT service_id_responses;
-      bool success = m_service_client_impl->CallWithResponse(method_name_, request_, timeout_, service_id_responses);
+      const bool success = m_service_client_impl->CallWithResponse(method_name_, request_, timeout_, service_id_responses);
 
       // Convert the responses to the old format
       service_response_vec_->clear();
@@ -244,7 +244,7 @@ namespace eCAL
       Logging::Log(log_level_debug1, "v5::CServiceClientImpl: Making an asynchronous call to method: " + method_name_);
 
       // Wrap the response callback to filter by host name if necessary
-      ResponseIDCallbackT wrapped_callback = [this](const Registration::SEntityId& /*entity_id_*/, const struct SServiceIDResponse& service_response_)
+      const ResponseIDCallbackT callback = [this](const Registration::SEntityId& /*entity_id_*/, const struct SServiceIDResponse& service_response_)
         {
           if (m_host_name.empty() || service_response_.service_method_id.service_id.host_name == m_host_name)
           {
@@ -255,7 +255,7 @@ namespace eCAL
         };
 
       // Call the method asynchronously using the new API
-      bool success = m_service_client_impl->CallWithCallbackAsync(method_name_, request_, wrapped_callback);
+      bool success = m_service_client_impl->CallWithCallbackAsync(method_name_, request_, callback);
       Logging::Log(log_level_debug1, "v5::CServiceClientImpl: Async call to method: " + method_name_ + " completed with success: " + std::to_string(success));
       return success;
     }

--- a/ecal/core/src/service/ecal_service_client_v5_impl.cpp
+++ b/ecal/core/src/service/ecal_service_client_v5_impl.cpp
@@ -255,7 +255,7 @@ namespace eCAL
         };
 
       // Call the method asynchronously using the new API
-      bool success = m_service_client_impl->CallWithCallbackAsync(method_name_, request_, callback);
+      const bool success = m_service_client_impl->CallWithCallbackAsync(method_name_, request_, callback);
       Logging::Log(log_level_debug1, "v5::CServiceClientImpl: Async call to method: " + method_name_ + " completed with success: " + std::to_string(success));
       return success;
     }

--- a/ecal/core/src/service/ecal_service_server_impl.cpp
+++ b/ecal/core/src/service/ecal_service_server_impl.cpp
@@ -472,7 +472,7 @@ namespace eCAL
     // execute method (outside lock guard)
     const std::string& request_s = request.request;
     std::string response_s;
-    SMethodInfo method_info{
+    const SMethodInfo method_info{
       method.method.mname,
       method.method.req_datatype,
       method.method.resp_datatype

--- a/ecal/core/src/service/ecal_service_server_impl.cpp
+++ b/ecal/core/src/service/ecal_service_server_impl.cpp
@@ -472,7 +472,12 @@ namespace eCAL
     // execute method (outside lock guard)
     const std::string& request_s = request.request;
     std::string response_s;
-    const int service_return_state = method.callback(method.method.mname, method.method.req_datatype, method.method.resp_datatype, request_s, response_s);
+    SMethodInfo method_info{
+      method.method.mname,
+      method.method.req_datatype,
+      method.method.resp_datatype
+    };
+    const int service_return_state = method.callback(method_info, request_s, response_s);
 
     // set method call state 'executed'
     response_header.state = Service::eMethodCallState::executed;

--- a/ecal/core/src/service/ecal_service_server_v5_impl.cpp
+++ b/ecal/core/src/service/ecal_service_server_v5_impl.cpp
@@ -124,13 +124,11 @@ namespace eCAL
 
       const MethodInfoCallbackT callback =
         [req_type_, resp_type_, callback_](
-          const std::string&          method,
-          const SDataTypeInformation& req_type_info,
-          const SDataTypeInformation& resp_type_info,
-          const std::string&          request,
-          std::string&                response) -> int
+          const SMethodInfo& method_info,
+          const std::string& request,
+          std::string&       response) -> int
         {
-          return callback_(method, req_type_info.name, resp_type_info.name, request, response);
+          return callback_(method_info.method_name, method_info.req_type.name, method_info.resp_type.name, request, response);
         };
 
       return m_service_server_impl->SetMethodCallback(method_, method_info, callback);

--- a/ecal/samples/cpp/services/latency_server/src/latency_server.cpp
+++ b/ecal/samples/cpp/services/latency_server/src/latency_server.cpp
@@ -22,7 +22,7 @@
 #include <chrono>
 #include <thread>
 
-int OnHello(const std::string& /*method_*/, const eCAL::SDataTypeInformation& /*req_type_*/, const eCAL::SDataTypeInformation& /*resp_type_*/, const std::string& /*request_*/, std::string& /*response_*/)
+int OnHello(const eCAL::SMethodInfo& /*method_info_*/, const std::string& /*request_*/, std::string& /*response_*/)
 {
   return 0;
 }

--- a/ecal/samples/cpp/services/minimal_server/src/minimal_server.cpp
+++ b/ecal/samples/cpp/services/minimal_server/src/minimal_server.cpp
@@ -24,10 +24,10 @@
 #include <thread>
 
 // method callback
-int OnMethodCallback(const std::string& method_, const eCAL::SDataTypeInformation& /*req_type_*/, const eCAL::SDataTypeInformation& /*resp_type_*/, const std::string& request_, std::string& response_)
+int OnMethodCallback(const eCAL::SMethodInfo& method_info_, const std::string& request_, std::string& response_)
 {
-  std::cout << "Method called : " << method_    << std::endl;
-  std::cout << "Request       : " << request_   << std::endl << std::endl;
+  std::cout << "Method called : " << method_info_.method_name << std::endl;
+  std::cout << "Request       : " << request_ << std::endl << std::endl;
   response_ = request_;
   return 42;
 }

--- a/ecal/tests/cpp/clientserver_test/src/clientserver_test.cpp
+++ b/ecal/tests/cpp/clientserver_test/src/clientserver_test.cpp
@@ -56,19 +56,19 @@ namespace
   typedef std::vector<std::shared_ptr<eCAL::CServiceClient>> ClientVecT;
 
 #if DO_LOGGING
-  void PrintRequest(const std::string& method_, const eCAL::SDataTypeInformation& req_type_, const eCAL::SDataTypeInformation& resp_type_, const std::string& request_)
+  void PrintRequest(const eCAL::SMethodInfo& method_info_, const std::string& request_)
   {
     std::cout << "------ REQUEST -------" << std::endl;
-    std::cout << "Method name                   : " << method_             << std::endl;
-    std::cout << "Method request type name      : " << req_type_.name      << std::endl;
-    std::cout << "Method request type encoding  : " << req_type_.encoding  << std::endl;
-    std::cout << "Method response type name     : " << resp_type_.name     << std::endl;
-    std::cout << "Method response type encoding : " << resp_type_.encoding << std::endl;
-    std::cout << "Method request                : " << request_            << std::endl;
+    std::cout << "Method name                    : " << method_info_.method_name        << std::endl;
+    std::cout << "Method request  type name      : " << method_info_.req_type.name      << std::endl;
+    std::cout << "Method request  type encoding  : " << method_info_.req_type.encoding  << std::endl;
+    std::cout << "Method response type name      : " << method_info_.resp_type.name     << std::endl;
+    std::cout << "Method response type encoding  : " << method_info_.resp_type.encoding << std::endl;
+    std::cout << "Method request                 : " << request_                        << std::endl;
     std::cout << std::endl;
   }
 #else
-  void PrintRequest(const std::string& /*method_*/, const eCAL::SDataTypeInformation& /*req_type_*/, const eCAL::SDataTypeInformation& /*resp_type_*/, const std::string& /*request_*/)
+  void PrintRequest(const eCAL::SMethodInfo& /*method_info_*/, const std::string& /*request_*/)
   {
   }
 #endif
@@ -259,10 +259,10 @@ TEST(core_cpp_clientserver, ClientServerBaseCallback)
   // method callback function
   std::atomic<int> methods_executed(0);
   std::atomic<int> method_process_time(0);
-  auto method_callback = [&](const std::string& method_, const eCAL::SDataTypeInformation& req_type_, const eCAL::SDataTypeInformation& resp_type_, const std::string& request_, std::string& response_) -> int
+  auto method_callback = [&](const eCAL::SMethodInfo& method_info_, const std::string& request_, std::string& response_) -> int
     {
       eCAL::Process::SleepMS(method_process_time);
-      PrintRequest(method_, req_type_, resp_type_, request_);
+      PrintRequest(method_info_, request_);
       response_ = "I answer on " + request_;
       methods_executed++;
       return 42;
@@ -364,10 +364,10 @@ TEST(core_cpp_clientserver, ClientServerBaseCallbackTimeout)
   // method callback function
   std::atomic<int> methods_executed(0);
   std::atomic<int> method_process_time(0);
-  auto method_callback = [&](const std::string& method_, const eCAL::SDataTypeInformation& req_type_, const eCAL::SDataTypeInformation& resp_type_, const std::string& request_, std::string& response_) -> int
+  auto method_callback = [&](const eCAL::SMethodInfo& method_info_, const std::string& request_, std::string& response_) -> int
     {
       eCAL::Process::SleepMS(method_process_time);
-      PrintRequest(method_, req_type_, resp_type_, request_);
+      PrintRequest(method_info_, request_);
       response_ = "I answer on " + request_;
       methods_executed++;
       return 42;
@@ -520,9 +520,9 @@ TEST(core_cpp_clientserver, ClientServerBaseAsyncCallback)
 
   // method callback function
   std::atomic<int> methods_executed(0);
-  auto method_callback = [&](const std::string& method_, const eCAL::SDataTypeInformation& req_type_, const eCAL::SDataTypeInformation& resp_type_, const std::string& request_, std::string& response_) -> int
+  auto method_callback = [&](const eCAL::SMethodInfo& method_info_, const std::string& request_, std::string& response_) -> int
     {
-      PrintRequest(method_, req_type_, resp_type_, request_);
+      PrintRequest(method_info_, request_);
       response_ = "I answered on " + request_;
       methods_executed++;
       return 42;
@@ -594,10 +594,10 @@ TEST(core_cpp_clientserver, ClientServerBaseAsync)
   atomic_signalable<int> num_service_callbacks_finished(0);
   int service_callback_time_ms(0);
 
-  auto method_callback = [&](const std::string& method_, const eCAL::SDataTypeInformation& req_type_, const eCAL::SDataTypeInformation& resp_type_, const std::string& request_, std::string& response_) -> int
+  auto method_callback = [&](const eCAL::SMethodInfo& method_info_, const std::string& request_, std::string& response_) -> int
     {
       eCAL::Process::SleepMS(service_callback_time_ms);
-      PrintRequest(method_, req_type_, resp_type_, request_);
+      PrintRequest(method_info_, request_);
       response_ = "I answered on " + request_;
       num_service_callbacks_finished++;
       return 42;
@@ -704,9 +704,9 @@ TEST(core_cpp_clientserver, ClientServerBaseBlocking)
 
   // method callback function
   std::atomic<int> methods_executed(0);
-  auto method_callback = [&](const std::string& method_, const eCAL::SDataTypeInformation& req_type_, const eCAL::SDataTypeInformation& resp_type_, const std::string& request_, std::string& response_) -> int
+  auto method_callback = [&](const eCAL::SMethodInfo& method_info_, const std::string& request_, std::string& response_) -> int
     {
-      PrintRequest(method_, req_type_, resp_type_, request_);
+      PrintRequest(method_info_, request_);
       response_ = "I answer on " + request_;
       methods_executed++;
       return 24;
@@ -801,9 +801,9 @@ TEST(core_cpp_clientserver, NestedRPCCall)
 
   // request callback function
   std::atomic<int> methods_executed(0);
-  auto method_callback = [&](const std::string& method_, const eCAL::SDataTypeInformation& req_type_, const eCAL::SDataTypeInformation& resp_type_, const std::string& request_, std::string& response_) -> int
+  auto method_callback = [&](const eCAL::SMethodInfo& method_info_, const std::string& request_, std::string& response_) -> int
     {
-      PrintRequest(method_, req_type_, resp_type_, request_);
+      PrintRequest(method_info_, request_);
       response_ = "I answer on " + request_;
       methods_executed++;
       return 42;


### PR DESCRIPTION
### Description
Simplified

```cpp
using MethodInfoCallbackT = std::function<int(const SMethodInfo& method_info_, const std::string& request_, std::string& response_)>;
```
using new structure:

```cpp
struct SMethodInfo
{
  std::string              method_name; //!< The name of the method.
  SDataTypeInformation     req_type;    //!< The type of the method request.
  SDataTypeInformation     resp_type;   //!< The type of the method response.
};
```

Removed code duplicates for `SDataTypeInformation` conversion in `CDescGate`.