### PR TITLE
[core] Fixup build for Alpine

### DIFF
--- a/ecal/core/src/ecal_process_stub.cpp
+++ b/ecal/core/src/ecal_process_stub.cpp
@@ -18,6 +18,7 @@
 */
 
 #include <errno.h>
+#include <fcntl.h>
 #include <string>
 #include <sys/file.h>
 #include <sys/stat.h>

--- a/lib/ecal_utils/CMakeLists.txt
+++ b/lib/ecal_utils/CMakeLists.txt
@@ -53,6 +53,15 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_14)
 
+# filesystem.cpp uses fts on Linux, some distibutions (i.e: Alpine) have fts as a
+# separate library
+if(LINUX)
+  find_library(libfts NAMES fts)
+  if(NOT "${libfts}" STREQUAL "libfts-NOTFOUND")
+    target_link_libraries(${PROJECT_NAME} PRIVATE "${libfts}")
+  endif()
+endif()
+
 # Create a source tree that mirrors the filesystem
 source_group(TREE "${CMAKE_CURRENT_LIST_DIR}"
     FILES


### PR DESCRIPTION
### Description
<!-- What does your PR change? -->
Makes two small changes to enable building of eCAL core of Alpine
- Add missing include
- Explicitly link fts library if it exists.

### Cherry-pick to
<!-- Leave empty, if you don't know. For master-only changes use "none" -->
- _none_
