### PR TITLE
[core] Get config before eCAL::Initialize through eCAL::Init::Configuration()

### DIFF
--- a/app/mon/mon_cli/src/ecal_mon_cli.cpp
+++ b/app/mon/mon_cli/src/ecal_mon_cli.cpp
@@ -209,8 +209,7 @@ int main(int argc, char** argv)
     }
 
     // initialize eCAL API
-    auto config = eCAL::GetConfiguration();
-    config.InitFromConfig();
+    auto config = eCAL::Init::Configuration();
     config.logging.receiver.enable = true;
     eCAL::Initialize(config, "eCALMon CLI", eCAL::Init::All);
 

--- a/app/mon/mon_gui/src/ecalmon.cpp
+++ b/app/mon/mon_gui/src/ecalmon.cpp
@@ -71,8 +71,7 @@ Ecalmon::Ecalmon(QWidget *parent)
   , monitor_error_counter_(0)
 {
   // Just make sure that eCAL is initialized
-  auto config = eCAL::GetConfiguration();
-  config.InitFromConfig();
+  auto config = eCAL::Init::Configuration();
   config.logging.receiver.enable = true;
   eCAL::Initialize(config, "eCALMon", eCAL::Init::Default | eCAL::Init::Monitoring);
   eCAL::Monitoring::SetFilterState(false);

--- a/app/mon/mon_tui/src/main.cpp
+++ b/app/mon/mon_tui/src/main.cpp
@@ -32,8 +32,7 @@ int main(int argc, char** argv)
 {
   auto args = ParseArgs(argc, argv);
 
-  auto config = eCAL::GetConfiguration();
-  config.InitFromConfig();
+  auto config = eCAL::Init::Configuration();
   config.logging.receiver.enable = true;
   
   auto status = eCAL::Initialize(config, "eCALMon TUI", eCAL::Init::Default | eCAL::Init::Monitoring);

--- a/ecal/core/include/ecal/config/configuration.h
+++ b/ecal/core/include/ecal/config/configuration.h
@@ -1,6 +1,6 @@
 /* =========================== LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ namespace eCAL
     ECAL_API void InitFromConfig();
     ECAL_API void InitFromFile(const std::string& yaml_path_);
 
-    ECAL_API std::string GetYamlFilePath();
+    ECAL_API std::string GetYamlFilePath() const;
 
     protected:
       std::string ecal_yaml_file_path;

--- a/ecal/core/include/ecal/ecal_config.h
+++ b/ecal/core/include/ecal/ecal_config.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,9 +30,9 @@
 //@{ 
 namespace eCAL
 {
-  ECAL_API Configuration&                 GetConfiguration                 ();
-  ECAL_API Subscriber::Configuration&     GetSubscriberConfiguration       ();
-  ECAL_API Publisher::Configuration&      GetPublisherConfiguration        ();
+  ECAL_API const Configuration&              GetConfiguration                 ();
+  ECAL_API const Subscriber::Configuration&  GetSubscriberConfiguration       ();
+  ECAL_API const Publisher::Configuration&   GetPublisherConfiguration        ();
 
   namespace Config
   {

--- a/ecal/core/include/ecal/ecal_init.h
+++ b/ecal/core/include/ecal/ecal_init.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,8 @@
 **/
 
 #pragma once
+
+#include <ecal/config/configuration.h>
 
 namespace eCAL
 {
@@ -49,5 +51,12 @@ namespace eCAL
                                             | TimeSync;
 
     static const unsigned int None       =    0x000;
+  
+    inline eCAL::Configuration Configuration()
+    {
+      eCAL::Configuration config;
+      config.InitFromConfig();
+      return config;
+    } 
   }
 }

--- a/ecal/core/src/config/ecal_config_initializer.cpp
+++ b/ecal/core/src/config/ecal_config_initializer.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -236,52 +236,52 @@ namespace eCAL
 
     Configuration::Configuration() = default;
 
-    std::string Configuration::GetYamlFilePath()
+    std::string Configuration::GetYamlFilePath() const
     {
       return ecal_yaml_file_path;
     }
 
-    Configuration& GetConfiguration()
+    const Configuration& GetConfiguration()
     {
       return g_ecal_configuration;
     }
 
-    TransportLayer::Configuration& GetTransportLayerConfiguration()
+    const TransportLayer::Configuration& GetTransportLayerConfiguration()
     {
       return GetConfiguration().transport_layer;
     }
 
-    Registration::Configuration& GetRegistrationConfiguration()
+    const Registration::Configuration& GetRegistrationConfiguration()
     {
       return GetConfiguration().registration;
     }
 
-    Monitoring::Configuration& GetMonitoringConfiguration()
+    const Monitoring::Configuration& GetMonitoringConfiguration()
     {
       return GetConfiguration().monitoring;
     }
 
-    Logging::Configuration& GetLoggingConfiguration()
+    const Logging::Configuration& GetLoggingConfiguration()
     {
       return GetConfiguration().logging;
     }
 
-    Subscriber::Configuration& GetSubscriberConfiguration()
+    const Subscriber::Configuration& GetSubscriberConfiguration()
     {
       return GetConfiguration().subscriber;
     }
 
-    Publisher::Configuration& GetPublisherConfiguration()
+    const Publisher::Configuration& GetPublisherConfiguration()
     {
       return GetConfiguration().publisher;
     }
 
-    Time::Configuration& GetTimesyncConfiguration()
+    const Time::Configuration& GetTimesyncConfiguration()
     {
       return GetConfiguration().timesync;
     }
 
-    Application::Configuration& GetApplicationConfiguration()
+    const Application::Configuration& GetApplicationConfiguration()
     {
       return GetConfiguration().application;
     }

--- a/ecal/core/src/ecal_config_internal.h
+++ b/ecal/core/src/ecal_config_internal.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,10 +29,10 @@
 
 namespace eCAL
 {
-  ECAL_API TransportLayer::Configuration& GetTransportLayerConfiguration ();
-  ECAL_API Registration::Configuration&   GetRegistrationConfiguration   ();
-  ECAL_API Monitoring::Configuration&     GetMonitoringConfiguration     ();
-  ECAL_API Logging::Configuration&        GetLoggingConfiguration        ();
-  ECAL_API Time::Configuration&           GetTimesyncConfiguration       ();
-  ECAL_API Application::Configuration&    GetApplicationConfiguration    ();
+  ECAL_API const TransportLayer::Configuration& GetTransportLayerConfiguration ();
+  ECAL_API const Registration::Configuration&   GetRegistrationConfiguration   ();
+  ECAL_API const Monitoring::Configuration&     GetMonitoringConfiguration     ();
+  ECAL_API const Logging::Configuration&        GetLoggingConfiguration        ();
+  ECAL_API const Time::Configuration&           GetTimesyncConfiguration       ();
+  ECAL_API const Application::Configuration&    GetApplicationConfiguration    ();
 }


### PR DESCRIPTION
- `eCAL::Init::Configuration()` to be called by user to receive an initialized (by yaml) configuration object, that they can alter
- `eCAL::GetConfiguration()` to return a `const Configuration&` so the user cannot unintentionally alter things.
