### PR TITLE
[core] Change type of id in callbacks for server / client from SServiceMethodId to SServiceId.

### DIFF
--- a/ecal/core/include/ecal/ecal_callback.h
+++ b/ecal/core/include/ecal/ecal_callback.h
@@ -201,7 +201,7 @@ namespace eCAL
      * @param service_id_  The service id struct of the connection that triggered the event.
      * @param data_        Event callback data structure with the event specific information.
     **/
-    using ClientEventCallbackT = std::function<void(const Registration::SServiceMethodId& service_id_, const SClientEventCallbackData& data_)>;
+    using ClientEventCallbackT = std::function<void(const Registration::SServiceId& service_id_, const SClientEventCallbackData& data_)>;
 
     /**
      * @brief eCAL server event callback struct.
@@ -218,6 +218,6 @@ namespace eCAL
      * @param service_id_  The service id struct of the connection that triggered the event.
      * @param data_        Event callback data structure with the event specific information.
     **/
-    using ServerEventCallbackT = std::function<void(const Registration::SServiceMethodId& service_id_, const struct SServerEventCallbackData& data_)>;
+    using ServerEventCallbackT = std::function<void(const Registration::SServiceId& service_id_, const struct SServerEventCallbackData& data_)>;
   }
 }

--- a/ecal/core/src/service/ecal_service_client_impl.cpp
+++ b/ecal/core/src/service/ecal_service_client_impl.cpp
@@ -188,7 +188,7 @@ namespace eCAL
     // Handle timeout event
     if (!response.first && response.second.call_state == eCallState::timeouted)
     {
-      Registration::SServiceMethodId service_id;
+      Registration::SServiceId service_id;
       service_id.service_name = m_service_name;
       service_id.service_id   = entity_id_;
       NotifyEventCallback(service_id, eClientEvent::timeout);
@@ -485,7 +485,7 @@ namespace eCAL
       entity_id.process_id = client_data.service_attr.pid;
       entity_id.host_name  = client_data.service_attr.hname;
 
-      Registration::SServiceMethodId service_id;
+      Registration::SServiceId service_id;
       service_id.service_name = m_service_name;
       service_id.service_id   = entity_id;
 
@@ -515,7 +515,7 @@ namespace eCAL
   }
 
 
-  void CServiceClientImpl::NotifyEventCallback(const Registration::SServiceMethodId& service_id_, eClientEvent event_type_)
+  void CServiceClientImpl::NotifyEventCallback(const Registration::SServiceId& service_id_, eClientEvent event_type_)
   {
 #ifndef NDEBUG
     Logging::Log(Logging::log_level_debug1, "CServiceClientImpl::NotifyEventCallback: Notifying event callback for: " + m_service_name + " Event Type: " + to_string(event_type_));

--- a/ecal/core/src/service/ecal_service_client_impl.h
+++ b/ecal/core/src/service/ecal_service_client_impl.h
@@ -118,7 +118,7 @@ namespace eCAL
     void IncrementMethodCallCount(const std::string& method_name_);
 
     // Notify specific event callback
-    void NotifyEventCallback(const Registration::SServiceMethodId& service_id_, eClientEvent event_type_);
+    void NotifyEventCallback(const Registration::SServiceId& service_id_, eClientEvent event_type_);
 
     // SResponseData struct for handling response callbacks
     struct SResponseData

--- a/ecal/core/src/service/ecal_service_client_v5_impl.cpp
+++ b/ecal/core/src/service/ecal_service_client_v5_impl.cpp
@@ -94,7 +94,7 @@ namespace eCAL
       Logging::Log(Logging::log_level_debug1, "v5::CServiceClientImpl: Creating service client with name: " + service_name_);
 
       // Define the event callback to pass to CServiceClient
-      v6::ClientEventCallbackT event_callback = [this](const Registration::SServiceMethodId& service_id_, const v6::SClientEventCallbackData& data_)
+      v6::ClientEventCallbackT event_callback = [this](const Registration::SServiceId& service_id_, const v6::SClientEventCallbackData& data_)
         {
           Logging::Log(Logging::log_level_debug2, "v5::CServiceClientImpl: Event callback triggered for event type: " + to_string(data_.type));
 

--- a/ecal/core/src/service/ecal_service_server_impl.cpp
+++ b/ecal/core/src/service/ecal_service_server_impl.cpp
@@ -261,9 +261,10 @@ namespace eCAL
       {
         if (auto me = weak_me.lock())
         {
-          Registration::SServiceMethodId service_id;
+          Registration::SServiceId service_id;
           service_id.service_name         = me->m_service_name;
           service_id.service_id.entity_id = me->m_service_id;
+          // TODO: Also fill process ID and hostname?
           me->NotifyEventCallback(service_id, event == eCAL::service::ServerEventType::Connected
             ? eServerEvent::connected
             : eServerEvent::disconnected, message);
@@ -493,7 +494,7 @@ namespace eCAL
     return 0;
   }
 
-  void CServiceServerImpl::NotifyEventCallback(const Registration::SServiceMethodId& service_id_, eServerEvent event_type_, const std::string& /*message_*/)
+  void CServiceServerImpl::NotifyEventCallback(const Registration::SServiceId& service_id_, eServerEvent event_type_, const std::string& /*message_*/)
   {
 #ifndef NDEBUG
     Logging::Log(Logging::log_level_debug1, "CServiceServerImpl::NotifyEventCallback: Notifying event callback for: " + m_service_name + " Event Type: " + to_string(event_type_));

--- a/ecal/core/src/service/ecal_service_server_impl.h
+++ b/ecal/core/src/service/ecal_service_server_impl.h
@@ -91,7 +91,7 @@ namespace eCAL
 
     // Request and event callback methods
     int RequestCallback(const std::string& request_pb_, std::string& response_pb_);
-    void NotifyEventCallback(const Registration::SServiceMethodId& service_id_, eServerEvent event_type_, const std::string& message_);
+    void NotifyEventCallback(const Registration::SServiceId& service_id_, eServerEvent event_type_, const std::string& message_);
 
     // Server version (incremented for protocol or functionality changes)
     static constexpr int                   m_server_version = 1;

--- a/ecal/core/src/service/ecal_service_server_v5_impl.cpp
+++ b/ecal/core/src/service/ecal_service_server_v5_impl.cpp
@@ -57,7 +57,7 @@ namespace eCAL
       }
 
       // Define the event callback to pass to CServiceClient
-      v6::ServerEventCallbackT event_callback = [this](const Registration::SServiceMethodId& service_id_, const v6::SServerEventCallbackData& data_)
+      v6::ServerEventCallbackT event_callback = [this](const Registration::SServiceId& service_id_, const v6::SServerEventCallbackData& data_)
         {
           Logging::Log(Logging::log_level_debug2, "v5::CServiceServerImpl: Event callback triggered for event type: " + to_string(data_.type));
 

--- a/ecal/tests/cpp/clientserver_test/src/clientserver_test.cpp
+++ b/ecal/tests/cpp/clientserver_test/src/clientserver_test.cpp
@@ -116,7 +116,7 @@ TEST(core_cpp_clientserver, ClientConnectEvent)
   // client event callback for connect events
   atomic_signalable<int> event_connected_fired   (0);
   atomic_signalable<int> event_disconnected_fired(0);
-  auto event_callback = [&](const eCAL::Registration::SServiceMethodId& /*service_id_*/, const struct eCAL::SClientEventCallbackData& data_)
+  auto event_callback = [&](const eCAL::Registration::SServiceId& /*service_id_*/, const struct eCAL::SClientEventCallbackData& data_)
     {
       switch (data_.type)
       {
@@ -181,7 +181,7 @@ TEST(core_cpp_clientserver, ServerConnectEvent)
   // server event callback for connect events
   atomic_signalable<int> event_connected_fired   (0);
   atomic_signalable<int> event_disconnected_fired(0);
-  auto event_callback = [&](const eCAL::Registration::SServiceMethodId& /*service_id_*/, const struct eCAL::SServerEventCallbackData& data_) -> void
+  auto event_callback = [&](const eCAL::Registration::SServiceId& /*service_id_*/, const struct eCAL::SServerEventCallbackData& data_) -> void
     {
       switch (data_.type)
       {
@@ -384,7 +384,7 @@ TEST(core_cpp_clientserver, ClientServerBaseCallbackTimeout)
 
   // event callback for timeout event
   std::atomic<int> timeout_fired(0);
-  auto event_callback = [&](const eCAL::Registration::SServiceMethodId& /*service_id_*/, const struct eCAL::SClientEventCallbackData& data_) -> void
+  auto event_callback = [&](const eCAL::Registration::SServiceId& /*service_id_*/, const struct eCAL::SClientEventCallbackData& data_) -> void
     {
       if (data_.type == eCAL::eClientEvent::timeout)
       {


### PR DESCRIPTION
When registering events to see if a Server / Client has connected, the correct datatype to signal this is SServiceId.