### PR TITLE
Disable mon plugin and rec addon sdks by default unless building apps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ option(HAS_MESSAGEPACK                         "Platform supports messagepack li
 
 option(BUILD_DOCS                              "Build the eCAL documentation"                                     OFF)
 option(BUILD_APPS                              "Build the eCAL applications"                                       ON)
+option(BUILD_APP_REC_ADDON_SDK                 "Build eCAL rec addon SDK"                               ${BUILD_APPS})
 option(BUILD_SAMPLES                           "Build the eCAL samples"                                            ON)
 option(BUILD_TIME                              "Build the eCAL time interfaces"                                    ON)
 option(BUILD_PY_BINDING                        "Build eCAL python binding"                                        OFF)
@@ -283,15 +284,17 @@ endif()
 # --------------------------------------------------------
 # ecal mon plugin sdk
 # --------------------------------------------------------
-if(HAS_QT)
+if(HAS_QT AND BUILD_APPS)
   add_subdirectory(app/mon/mon_plugin_lib)
 endif()
 
 # --------------------------------------------------------
 # ecal rec addon sdk
 # --------------------------------------------------------
-add_subdirectory(app/rec/rec_addon_core)
-add_subdirectory(app/rec/rec_addon_dummy)
+if(BUILD_APP_REC_ADDON_SDK)
+  add_subdirectory(app/rec/rec_addon_core)
+  add_subdirectory(app/rec/rec_addon_dummy)
+endif()
 
 # --------------------------------------------------------
 # ecal time


### PR DESCRIPTION
### Description
<!-- What does your PR change? -->
Disables building the monitor plugin and rec addon unless `BUILD_APPS` is on.

These options are not part of eCAL core and aren't needed in a minimal configuration.

An option is made for the rec_addon but not the monitor plugin because the monitor app requires it. I presume it is unlikely one would want to use a local build to make a plugin but not build the gui app itself.

### Related issues
<!-- Type "Fixes #123" to automatically close that issue, when this PR is merged -->
- Fixes #380 

### Cherry-pick to
<!-- Leave empty, if you don't know. For master-only changes use "none"
- _none_
- 5.11 (old stable)
- 5.12 (current stable)
-->
