### PR TITLE
[core] event handling cleanup

### DIFF
--- a/ecal/core/include/ecal/ecal_callback.h
+++ b/ecal/core/include/ecal/ecal_callback.h
@@ -52,20 +52,16 @@ namespace eCAL
     none = 0,
     connected = 1,
     disconnected = 2,
-    dropped = 3,
-    corrupted = 5,
-    update_connection = 6,
+    dropped = 3
   };
 
   inline std::string to_string(eSubscriberEvent event_) {
     switch (event_) {
-    case eSubscriberEvent::none:                   return "NONE";
-    case eSubscriberEvent::connected:              return "CONNECTED";
-    case eSubscriberEvent::disconnected:           return "DISCONNECTED";
-    case eSubscriberEvent::dropped :               return "DROPPED";
-    case eSubscriberEvent::corrupted:              return "CORRUPTED";
-    case eSubscriberEvent::update_connection :     return "UPDATED_CONNECTION";
-    default:            return "Unknown";
+    case eSubscriberEvent::none:         return "NONE";
+    case eSubscriberEvent::connected:    return "CONNECTED";
+    case eSubscriberEvent::disconnected: return "DISCONNECTED";
+    case eSubscriberEvent::dropped :     return "DROPPED";
+    default:                             return "Unknown";
     }
   }
 
@@ -77,18 +73,16 @@ namespace eCAL
     none = 0,
     connected = 1,
     disconnected = 2,
-    dropped = 3,
-    update_connection = 4,
+    dropped = 3
   };
 
   inline std::string to_string(ePublisherEvent event_) {
     switch (event_) {
-    case ePublisherEvent::none:                   return "NONE";
-    case ePublisherEvent::connected:              return "CONNECTED";
-    case ePublisherEvent::disconnected:           return "DISCONNECTED";
-    case ePublisherEvent::dropped:                return "DROPPED";
-    case ePublisherEvent::update_connection:      return "UPDATED_CONNECTION";
-    default:            return "Unknown";
+    case ePublisherEvent::none:         return "NONE";
+    case ePublisherEvent::connected:    return "CONNECTED";
+    case ePublisherEvent::disconnected: return "DISCONNECTED";
+    case ePublisherEvent::dropped:      return "DROPPED";
+    default:                            return "Unknown";
     }
   }
 
@@ -153,10 +147,9 @@ namespace eCAL
     **/
     struct SPubEventCallbackData
     {
-      ePublisherEvent      type{ ePublisherEvent::none };  //!< publisher event type
-      long long            time{ 0 };               //!< publisher event time in µs
-      long long            clock{ 0 };              //!< publisher event clock
-      SDataTypeInformation tdatatype;               //!< datatype description of the connected subscriber            (for pub_event_update_connection only)
+      ePublisherEvent      event_type{ ePublisherEvent::none };  //!< publisher event type
+      long long            event_time{ 0 };                      //!< publisher event time in µs (eCAL time)
+      SDataTypeInformation subscriber_datatype;                  //!< datatype description of the connected subscriber
     };
 
     /**
@@ -172,10 +165,9 @@ namespace eCAL
     **/
     struct SSubEventCallbackData
     {
-      eSubscriberEvent      type{ eSubscriberEvent::none }; //!< subscriber event type
-      long long             time{ 0 };              //!< subscriber event time in µs
-      long long             clock{ 0 };             //!< subscriber event clock
-      SDataTypeInformation  tdatatype;              //!< topic information of the connected subscriber           (for sub_event_update_connection only)
+      eSubscriberEvent      event_type{ eSubscriberEvent::none }; //!< subscriber event type
+      long long             event_time{ 0 };                      //!< subscriber event time in µs (eCAL time)
+      SDataTypeInformation  publisher_datatype;                   //!< topic information of the connected publisher
     };
 
     /**

--- a/ecal/core/src/pubsub/ecal_publisher_impl.h
+++ b/ecal/core/src/pubsub/ecal_publisher_impl.h
@@ -133,7 +133,6 @@ namespace eCAL
     void FireEvent(const ePublisherEvent type_, const SSubscriptionInfo& subscription_info_, const SDataTypeInformation& data_type_info_);
 
     void FireConnectEvent   (const SSubscriptionInfo& subscription_info_, const SDataTypeInformation& data_type_info_);
-    void FireUpdateEvent    (const SSubscriptionInfo& subscription_info_, const SDataTypeInformation& data_type_info_);
     void FireDisconnectEvent(const SSubscriptionInfo& subscription_info_, const SDataTypeInformation& data_type_info_);
 
     size_t GetConnectionCount();
@@ -168,7 +167,7 @@ namespace eCAL
     EventCallbackMapT                      m_event_callback_map;
 
     std::mutex                             m_event_id_callback_mutex;
-    PubEventCallbackT                    m_event_id_callback;
+    PubEventCallbackT                      m_event_id_callback;
 
     long long                              m_id = 0;
     long long                              m_clock = 0;

--- a/ecal/core/src/pubsub/ecal_subscriber_impl.h
+++ b/ecal/core/src/pubsub/ecal_subscriber_impl.h
@@ -126,12 +126,12 @@ namespace eCAL
     void FireEvent(const eSubscriberEvent type_, const SPublicationInfo& publication_info_, const SDataTypeInformation& data_type_info_);
 
     void FireConnectEvent   (const SPublicationInfo& publication_info_, const SDataTypeInformation& data_type_info_);
-    void FireUpdateEvent    (const SPublicationInfo& publication_info_, const SDataTypeInformation& data_type_info_);
     void FireDisconnectEvent(const SPublicationInfo& publication_info_, const SDataTypeInformation& data_type_info_);
-    
+    void FireDroppedEvent   (const SPublicationInfo& publication_info_, const SDataTypeInformation& data_type_info_);
+
     size_t GetConnectionCount();
 
-    bool CheckMessageClock(const Registration::EntityIdT& tid_, long long current_clock_);
+    bool CheckMessageClock(const SPublicationInfo& publication_info_, long long current_clock_);
 
     int32_t GetFrequency();
 

--- a/lang/c/core/src/ecal_publisher_cimpl.cpp
+++ b/lang/c/core/src/ecal_publisher_cimpl.cpp
@@ -39,8 +39,7 @@ namespace
     case eCAL::ePublisherEvent::connected:              return pub_event_connected;
     case eCAL::ePublisherEvent::disconnected:           return pub_event_disconnected;
     case eCAL::ePublisherEvent::dropped:                return pub_event_dropped;
-    case eCAL::ePublisherEvent::update_connection:      return pub_event_update_connection;
-    default:                                                      return pub_event_none;
+    default:                                            return pub_event_none;
     }
   }
 
@@ -50,7 +49,6 @@ namespace
     case pub_event_connected:              return eCAL::ePublisherEvent::connected;
     case pub_event_disconnected:           return eCAL::ePublisherEvent::disconnected;
     case pub_event_dropped:                return eCAL::ePublisherEvent::dropped;
-    case pub_event_update_connection:      return eCAL::ePublisherEvent::update_connection;
     default:                               return eCAL::ePublisherEvent::none;
     }
   }

--- a/lang/c/core/src/ecal_subscriber_cimpl.cpp
+++ b/lang/c/core/src/ecal_subscriber_cimpl.cpp
@@ -39,9 +39,7 @@ namespace
     case eCAL::eSubscriberEvent::connected:              return sub_event_connected;
     case eCAL::eSubscriberEvent::disconnected:           return sub_event_disconnected;
     case eCAL::eSubscriberEvent::dropped:                return sub_event_dropped;
-    case eCAL::eSubscriberEvent::corrupted:              return sub_event_corrupted;
-    case eCAL::eSubscriberEvent::update_connection:      return sub_event_update_connection;
-    default:            return sub_event_none;
+    default:                                             return sub_event_none;
     }
   }
 
@@ -51,8 +49,6 @@ namespace
     case sub_event_connected:              return eCAL::eSubscriberEvent::connected;
     case sub_event_disconnected:           return eCAL::eSubscriberEvent::disconnected;
     case sub_event_dropped:                return eCAL::eSubscriberEvent::dropped;
-    case sub_event_corrupted:              return eCAL::eSubscriberEvent::corrupted;
-    case sub_event_update_connection:      return eCAL::eSubscriberEvent::update_connection;
     default:                               return eCAL::eSubscriberEvent::none;
     }
   }

--- a/lang/c/tests/core_test/src/core_test.cpp
+++ b/lang/c/tests/core_test/src/core_test.cpp
@@ -20,6 +20,7 @@
 #include <ecal/cimpl/ecal_core_cimpl.h>
 #include <ecal/cimpl/ecal_process_cimpl.h>
 #include <ecal/ecal_defs.h>
+#include <ecal/ecal_os.h>
 
 #include <cstring>
 

--- a/lang/python/core/src/ecal_clang.cpp
+++ b/lang/python/core/src/ecal_clang.cpp
@@ -80,8 +80,7 @@ namespace
     case eCAL::ePublisherEvent::connected:              return pub_event_connected;
     case eCAL::ePublisherEvent::disconnected:           return pub_event_disconnected;
     case eCAL::ePublisherEvent::dropped:                return pub_event_dropped;
-    case eCAL::ePublisherEvent::update_connection:      return pub_event_update_connection;
-    default:                                                      return pub_event_none;
+    default:                                            return pub_event_none;
     }
   }
 
@@ -91,7 +90,6 @@ namespace
     case pub_event_connected:              return eCAL::ePublisherEvent::connected;
     case pub_event_disconnected:           return eCAL::ePublisherEvent::disconnected;
     case pub_event_dropped:                return eCAL::ePublisherEvent::dropped;
-    case pub_event_update_connection:      return eCAL::ePublisherEvent::update_connection;
     default:                               return eCAL::ePublisherEvent::none;
     }
   }
@@ -102,9 +100,7 @@ namespace
     case eCAL::eSubscriberEvent::connected:              return sub_event_connected;
     case eCAL::eSubscriberEvent::disconnected:           return sub_event_disconnected;
     case eCAL::eSubscriberEvent::dropped:                return sub_event_dropped;
-    case eCAL::eSubscriberEvent::corrupted:              return sub_event_corrupted;
-    case eCAL::eSubscriberEvent::update_connection:      return sub_event_update_connection;
-    default:            return sub_event_none;
+    default:                                             return sub_event_none;
     }
   }
 
@@ -114,8 +110,6 @@ namespace
     case sub_event_connected:              return eCAL::eSubscriberEvent::connected;
     case sub_event_disconnected:           return eCAL::eSubscriberEvent::disconnected;
     case sub_event_dropped:                return eCAL::eSubscriberEvent::dropped;
-    case sub_event_corrupted:              return eCAL::eSubscriberEvent::corrupted;
-    case sub_event_update_connection:      return eCAL::eSubscriberEvent::update_connection;
     default:                               return eCAL::eSubscriberEvent::none;
     }
   }

--- a/serialization/protobuf/samples/pubsub/person_events_rec/src/person_events_rec.cpp
+++ b/serialization/protobuf/samples/pubsub/person_events_rec/src/person_events_rec.cpp
@@ -35,19 +35,9 @@ void OnEvent(const char* topic_name_, const struct eCAL::v5::SSubEventCallbackDa
   case eCAL::eSubscriberEvent::disconnected:
     std::cout << "event            : " << "disconnected" << std::endl;
     break;
+  // not implemented yet
   case eCAL::eSubscriberEvent::dropped:
     std::cout << "event            : " << "dropped (" << data_->clock << " messages)" << std::endl;
-    break;
-  // not implemented yet
-  case eCAL::eSubscriberEvent::corrupted:
-    std::cout << "event            : " << "corrupted" << std::endl;
-    break;
-  case eCAL::eSubscriberEvent::update_connection:
-    std::cout << "event            : " << "update_connection" << std::endl;
-    std::cout << "  topic_id       : " << data_->tid << std::endl;
-    std::cout << "  topic_encoding : " << data_->tdatatype.encoding << std::endl;
-    std::cout << "  topic_type     : " << data_->tdatatype.name << std::endl;
-    //std::cout << "  topic_desc : " << data_->tdesc << std::endl;
     break;
   default:
     std::cout << "event            : " << "unknown" << std::endl;
@@ -72,8 +62,6 @@ int main()
   sub.AddEventCallback(eCAL::eSubscriberEvent::connected,         evt_callback);
   sub.AddEventCallback(eCAL::eSubscriberEvent::disconnected,      evt_callback);
   sub.AddEventCallback(eCAL::eSubscriberEvent::dropped,           evt_callback);
-  sub.AddEventCallback(eCAL::eSubscriberEvent::corrupted,         evt_callback);
-  sub.AddEventCallback(eCAL::eSubscriberEvent::update_connection, evt_callback);
 
   // start application and wait for events
   std::cout << "Please start 'person_snd_events sample." << std::endl << std::endl;

--- a/serialization/protobuf/samples/pubsub/person_events_snd/src/person_events_snd.cpp
+++ b/serialization/protobuf/samples/pubsub/person_events_snd/src/person_events_snd.cpp
@@ -39,15 +39,8 @@ void OnEvent(const char* topic_name_, const struct eCAL::v5::SPubEventCallbackDa
   case eCAL::ePublisherEvent::dropped:
     std::cout << "event            : " << "dropped" << std::endl;
     break;
-  case eCAL::ePublisherEvent::update_connection:
-    std::cout << "event            : " << "update_connection" << std::endl;
-    std::cout << "  topic_id       : " << data_->tid << std::endl;
-    std::cout << "  topic_encoding : " << data_->tdatatype.encoding << std::endl;
-    std::cout << "  topic_type     : " << data_->tdatatype.name << std::endl;
-    //std::cout << "  topic_desc : " << data_->tdesc << std::endl;
-    break;
   default:
-    std::cout << "event        : " << "unknown" << std::endl;
+    std::cout << "event            : " << "unknown" << std::endl;
     break;
   }
   std::cout << std::endl;
@@ -66,9 +59,8 @@ int main()
 
   // add event callback function (_1 = topic_name, _2 = event data struct)
   auto evt_callback = std::bind(OnEvent, std::placeholders::_1, std::placeholders::_2);
-  pub.AddEventCallback(eCAL::ePublisherEvent::connected,         evt_callback);
-  pub.AddEventCallback(eCAL::ePublisherEvent::disconnected,      evt_callback);
-  pub.AddEventCallback(eCAL::ePublisherEvent::update_connection, evt_callback);
+  pub.AddEventCallback(eCAL::ePublisherEvent::connected,    evt_callback);
+  pub.AddEventCallback(eCAL::ePublisherEvent::disconnected, evt_callback);
 
   // generate a class instance of Person
   pb::People::Person person;


### PR DESCRIPTION
### Description

- Removed `corrupted` and `update_connection` events from `eSubscriberEvent` and `ePublisherEvent` enums.
- Removed `clock` field from `SPubEventCallbackData` and `SSubEventCallbackData` structs.
- Added `FireDroppedEvent` function to `CSubscriberImpl`.
