### PR TITLE
[cmake] Remove old helper functions

### DIFF
--- a/cmake/helper_functions/ecal_add_functions.cmake
+++ b/cmake/helper_functions/ecal_add_functions.cmake
@@ -116,34 +116,6 @@ function(ecal_add_time_plugin TARGET_NAME)
   )
 endfunction()
 
-# this appends the 64 / 32 suffix (required for the eCAL Core libraries)
-function(ecal_add_ecal_shared_library TARGET_NAME)
-  add_library(${TARGET_NAME} SHARED ${ARGN})
-  set_target_properties(${TARGET_NAME} PROPERTIES
-    VERSION ${eCAL_VERSION_STRING}
-    SOVERSION ${eCAL_VERSION_MAJOR}
-    OUTPUT_NAME ecal_${TARGET_NAME})
-endfunction()
-
-# this appends the 64 / 32 suffix (required for the eCAL Core libraries)
-function(ecal_add_ecal_static_library TARGET_NAME)
-  add_library(${TARGET_NAME} STATIC ${ARGN})
-  set_target_properties(${TARGET_NAME} PROPERTIES
-    VERSION ${eCAL_VERSION_STRING}
-    SOVERSION ${eCAL_VERSION_MAJOR}
-    OUTPUT_NAME ecal_${TARGET_NAME}
-    POSITION_INDEPENDENT_CODE ON)
-endfunction()
-
-# this appends the 64 / 32 suffix (required for the eCAL Core libraries)
-function(ecal_add_ecal_library TARGET_NAME)
-  if(BUILD_SHARED_LIBS)
-    ecal_add_ecal_shared_library(${TARGET_NAME} ${ARGN})
-  else()
-    ecal_add_ecal_static_library(${TARGET_NAME} ${ARGN})
-  endif()
-endfunction()
-
 function(ecal_add_shared_library TARGET_NAME)
   add_library(${TARGET_NAME} SHARED ${ARGN})
   set_target_properties(${TARGET_NAME} PROPERTIES
@@ -154,11 +126,12 @@ endfunction()
 
 function(ecal_add_static_library TARGET_NAME)
   add_library(${TARGET_NAME} STATIC ${ARGN})
-  set_property(TARGET ${TARGET_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
   set_target_properties(${TARGET_NAME} PROPERTIES 
     VERSION ${eCAL_VERSION_STRING}
     SOVERSION ${eCAL_VERSION_MAJOR}
-    OUTPUT_NAME ecal_${TARGET_NAME})
+    OUTPUT_NAME ecal_${TARGET_NAME}
+    POSITION_INDEPENDENT_CODE ON
+  )
 endfunction()
 
 function(ecal_add_interface_library TARGET_NAME)

--- a/cmake/helper_functions/ecal_install_functions.cmake
+++ b/cmake/helper_functions/ecal_install_functions.cmake
@@ -21,42 +21,6 @@
 #  Each target will have to install it by themselves (e.g. install(DIRECTORY ...))
 ######################
 
-# this appends the 64 / 32 suffix (required for the eCAL Core libraries)
-function(ecal_install_ecal_library TARGET_NAME)
-  if(BUILD_SHARED_LIBS)
-    ecal_install_ecal_shared_library(${TARGET_NAME})
-  else()
-    ecal_install_ecal_static_library(${TARGET_NAME})
-  endif()
-endfunction()
-
-# this appends the 64 / 32 suffix (required for the eCAL Core libraries)
-function(ecal_install_ecal_static_library TARGET_NAME)
-
-  install(TARGETS ${TARGET_NAME}
-  # IMPORTANT: Add the library to the "export-set"
-    EXPORT eCALCoreTargets
-    ARCHIVE       DESTINATION "${eCAL_install_archive_dir}" COMPONENT sdk
-    LIBRARY       DESTINATION "${eCAL_install_lib_dir}"     COMPONENT sdk
-  )
-  ecal_install_pdbs(TARGET ${TARGET_NAME} DESTINATION "${eCAL_install_archive_dir}" COMPONENT runtime)      
-endfunction()
-
-# installing shared libraries is a li
-# this appends the 64 / 32 suffix (required for the eCAL Core libraries)
-function(ecal_install_ecal_shared_library TARGET_NAME)
-
-# Windows, RUNTIME -> .dll, ARCHIVE -> .lib, Unix: LIBRARY -> .so
-  install(TARGETS ${TARGET_NAME}
-  # IMPORTANT: Add the library to the "export-set"
-    EXPORT eCALCoreTargets
-    RUNTIME       DESTINATION "${eCAL_install_bin_dir}"         COMPONENT runtime
-    LIBRARY       DESTINATION "${eCAL_install_lib_dir}"         COMPONENT sdk
-    ARCHIVE       DESTINATION "${eCAL_install_archive_dyn_dir}" COMPONENT sdk
-  )
-  ecal_install_pdbs(TARGET ${TARGET_NAME} DESTINATION "${eCAL_install_bin_dir}" COMPONENT runtime)      
-endfunction()
-
 function(ecal_install_library TARGET_NAME)
   if(BUILD_SHARED_LIBS)
     ecal_install_shared_library(${TARGET_NAME})

--- a/ecal/core/CMakeLists.txt
+++ b/ecal/core/CMakeLists.txt
@@ -674,7 +674,7 @@ target_link_libraries(${PROJECT_NAME}
 
 set_property(TARGET ${PROJECT_NAME}   PROPERTY FOLDER core)
 
-ecal_install_ecal_shared_library(${PROJECT_NAME})
+ecal_install_shared_library(${PROJECT_NAME})
 
 install(DIRECTORY
    "include/" DESTINATION "${INSTALL_INCLUDE_DIR}" COMPONENT sdk

--- a/ecal/core/CMakeLists.txt
+++ b/ecal/core/CMakeLists.txt
@@ -552,7 +552,7 @@ set(ecal_sources
     ${ecal_header_msg}
 )
 
-ecal_add_ecal_shared_library(${PROJECT_NAME}
+ecal_add_shared_library(${PROJECT_NAME}
     ${ecal_sources}
     ${CMAKE_CURRENT_BINARY_DIR}/include/ecal/ecal_defs.h
 )

--- a/lang/c/core/CMakeLists.txt
+++ b/lang/c/core/CMakeLists.txt
@@ -112,7 +112,7 @@ set_target_properties(${PROJECT_NAME}
 
 set_property(TARGET ${PROJECT_NAME} PROPERTY FOLDER lang/c)
 
-ecal_install_ecal_shared_library(${PROJECT_NAME})
+ecal_install_shared_library(${PROJECT_NAME})
 
 install(DIRECTORY
    "include/" DESTINATION "${INSTALL_INCLUDE_DIR}" COMPONENT sdk

--- a/lang/c/core/CMakeLists.txt
+++ b/lang/c/core/CMakeLists.txt
@@ -80,7 +80,7 @@ set(ecal_c_sources
     ${ecal_header_cimpl}
 )
 
-ecal_add_ecal_shared_library(${PROJECT_NAME}
+ecal_add_shared_library(${PROJECT_NAME}
     ${ecal_c_sources}
 )
 


### PR DESCRIPTION
### Description
<!-- What does your PR change? -->
Removes the old redundant `ecal_add_ecal_*` and `ecal_install_ecal_*` CMake functions

### Related issues
<!-- Type "Fixes #123" to automatically close that issue, when this PR is merged -->
- Closes #549 

### Cherry-pick to
<!-- Leave empty, if you don't know. For master-only changes use "none"
- _none_
- 5.11 (old stable)
- 5.12 (current stable)
-->
