### PR TITLE
[cmake] add missing enable_testing call.

### DIFF
--- a/lang/c/CMakeLists.txt
+++ b/lang/c/CMakeLists.txt
@@ -29,5 +29,6 @@ add_subdirectory(samples)
 endif()
 
 if (ECAL_C_BUILD_TESTS)
+enable_testing()
 add_subdirectory(tests)
 endif ()


### PR DESCRIPTION
### Description
Make sure C tests are executed in github actions.