### PR TITLE
[Process] Unit name handling

### DIFF
--- a/ecal/core/include/ecal/ecal_core.h
+++ b/ecal/core/include/ecal/ecal_core.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,16 +100,6 @@ namespace eCAL
    * @return True if eCAL component is initialized.
   **/
   ECAL_API bool IsInitialized(unsigned int component_);
-
-
-  /**
-   * @brief  Set/change the unit name of current module.
-   *
-   * @param unit_name_  Defines the name of the eCAL unit. 
-   *
-   * @return True if succeeded.
-  **/
-  ECAL_API bool SetUnitName(const std::string& unit_name_);
 
   /**
    * @brief Return the eCAL process state.

--- a/ecal/core/src/ecal.cpp
+++ b/ecal/core/src/ecal.cpp
@@ -151,21 +151,6 @@ namespace eCAL
   }
 
   /**
-   * @brief  Set/change the unit name of current module.
-   *
-   * @param unit_name_  Defines the name of the eCAL unit. 
-   *
-   * @return True if succeeded.
-  **/
-  bool SetUnitName(const std::string& unit_name_)
-  {
-    if (unit_name_.empty())
-      return false;
-    g_unit_name = unit_name_;
-    return true;
-  }
-
-  /**
    * @brief Finalize eCAL API.
    *
    * @return True if succeeded.

--- a/ecal/core/src/ecal_global_accessors.cpp
+++ b/ecal/core/src/ecal_global_accessors.cpp
@@ -59,33 +59,30 @@ namespace eCAL
 
   void SetGlobalUnitName(const char *unit_name_)
   {
-    // There is a function already "SetUnitName" which sets the g_unit_name just as string.
-    // Used in global API. It does not have the following logic -> should that be added/removed/combined?
-    // For previous consistency this function is added here for the time being.
     if(unit_name_ != nullptr) g_unit_name = unit_name_;
-      if (g_unit_name.empty())
-      {
-        g_unit_name = Process::GetProcessName();
+    if (g_unit_name.empty())
+    {
+      g_unit_name = Process::GetProcessName();
 #ifdef ECAL_OS_WINDOWS
-        size_t p = g_unit_name.rfind('\\');
-        if (p != std::string::npos)
-        {
-          g_unit_name = g_unit_name.substr(p+1);
-        }
-        p = g_unit_name.rfind('.');
-        if (p != std::string::npos)
-        {
-          g_unit_name = g_unit_name.substr(0, p);
-        }
+      size_t p = g_unit_name.rfind('\\');
+      if (p != std::string::npos)
+      {
+        g_unit_name = g_unit_name.substr(p+1);
+      }
+      p = g_unit_name.rfind('.');
+      if (p != std::string::npos)
+      {
+        g_unit_name = g_unit_name.substr(0, p);
+      }
 #endif
 #ifdef ECAL_OS_LINUX
-        const size_t p = g_unit_name.rfind('/');
-        if (p != std::string::npos)
-        {
+      const size_t p = g_unit_name.rfind('/');
+      if (p != std::string::npos)
+      {
           g_unit_name = g_unit_name.substr(p + 1);
-        }
-#endif
       }
+#endif
+    }
   }
 
   CGlobals* g_globals()

--- a/ecal/core/src/ecal_global_accessors.cpp
+++ b/ecal/core/src/ecal_global_accessors.cpp
@@ -26,6 +26,7 @@
 #include "ecal_global_accessors.h"
 #include "ecal_def.h"
 #include "ecal_globals.h"
+#include "ecal_utils/filesystem.h"
 
 #include <atomic>
 #include <string>
@@ -60,28 +61,10 @@ namespace eCAL
   void SetGlobalUnitName(const char *unit_name_)
   {
     if(unit_name_ != nullptr) g_unit_name = unit_name_;
+    
     if (g_unit_name.empty())
     {
-      g_unit_name = Process::GetProcessName();
-#ifdef ECAL_OS_WINDOWS
-      size_t p = g_unit_name.rfind('\\');
-      if (p != std::string::npos)
-      {
-        g_unit_name = g_unit_name.substr(p+1);
-      }
-      p = g_unit_name.rfind('.');
-      if (p != std::string::npos)
-      {
-        g_unit_name = g_unit_name.substr(0, p);
-      }
-#endif
-#ifdef ECAL_OS_LINUX
-      const size_t p = g_unit_name.rfind('/');
-      if (p != std::string::npos)
-      {
-          g_unit_name = g_unit_name.substr(p + 1);
-      }
-#endif
+      g_unit_name = EcalUtils::Filesystem::BaseName(Process::GetProcessName());
     }
   }
 

--- a/ecal/tests/cpp/core_test/CMakeLists.txt
+++ b/ecal/tests/cpp/core_test/CMakeLists.txt
@@ -1,6 +1,6 @@
 # ========================= eCAL LICENSE =================================
 #
-# Copyright (C) 2016 - 2019 Continental Corporation
+# Copyright (C) 2016 - 2025 Continental Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,7 +31,8 @@ target_include_directories(${PROJECT_NAME} PRIVATE $<TARGET_PROPERTY:eCAL::core,
 
 target_link_libraries(${PROJECT_NAME}
   PRIVATE 
-    eCAL::core 
+    eCAL::core
+    eCAL::ecal-utils
     Threads::Threads)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)

--- a/ecal/tests/cpp/core_test/src/core_test.cpp
+++ b/ecal/tests/cpp/core_test/src/core_test.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -120,14 +120,6 @@ TEST(core_cpp_core, SetGetUnitName)
   // if we call eCAL_Initialize with empty unit name, eCAL will use the process name as unit name
   std::string process_name = extractProcessName(eCAL::Process::GetProcessName());
   EXPECT_STREQ(process_name.c_str(), eCAL::Process::GetUnitName().c_str());
-
-  // set unit name (should change the name to 'unit name')
-  EXPECT_EQ(true, eCAL::SetUnitName("unit name"));
-  EXPECT_STREQ("unit name", eCAL::Process::GetUnitName().c_str());
-
-  // set empty unit name (should not change the unit name)
-  EXPECT_EQ(false, eCAL::SetUnitName(""));
-  EXPECT_STREQ("unit name", eCAL::Process::GetUnitName().c_str());
 
   // finalize eCAL API we expect return value 0 because it will be finalized
   EXPECT_EQ(true, eCAL::Finalize());

--- a/ecal/tests/cpp/core_test/src/core_test.cpp
+++ b/ecal/tests/cpp/core_test/src/core_test.cpp
@@ -22,6 +22,8 @@
 #include <ecal/ecal_process.h>
 #include <ecal/ecal_defs.h>
 
+#include <ecal_utils/filesystem.h>
+
 #include <gtest/gtest.h>
 #include <string>
 
@@ -82,34 +84,7 @@ TEST(core_cpp_core, MultipleInitializeFinalize)
   }
 }
 
-namespace
-{
-  std::string extractProcessName(const std::string& full_path_)
-  {
-    // initialize process name with full path
-    std::string processName = full_path_;
-
-    // extract the substring after the last separator
-    size_t lastSeparatorPos = full_path_.find_last_of("\\/");
-    if (lastSeparatorPos != std::string::npos)
-    {
-      processName = full_path_.substr(lastSeparatorPos + 1);
-    }
-
-#ifdef ECAL_OS_WINDOWS
-    // remove the file extension if found
-    size_t lastDotPos = processName.find_last_of('.');
-    if (lastDotPos != std::string::npos)
-    {
-      processName = processName.substr(0, lastDotPos);
-    }
-#endif // ECAL_OS_WINDOWS
-
-    return processName;
-  }
-}
-
-TEST(core_cpp_core, SetGetUnitName)
+TEST(core_cpp_core, GetUnitName)
 {
   // initialize eCAL API with empty unit name (eCAL will use process name as unit name)
   EXPECT_EQ(true, eCAL::Initialize(""));
@@ -118,7 +93,7 @@ TEST(core_cpp_core, SetGetUnitName)
   EXPECT_EQ(true, eCAL::IsInitialized());
 
   // if we call eCAL_Initialize with empty unit name, eCAL will use the process name as unit name
-  std::string process_name = extractProcessName(eCAL::Process::GetProcessName());
+  std::string process_name = EcalUtils::Filesystem::BaseName(eCAL::Process::GetProcessName());
   EXPECT_STREQ(process_name.c_str(), eCAL::Process::GetUnitName().c_str());
 
   // finalize eCAL API we expect return value 0 because it will be finalized

--- a/lang/c/core/include/ecal/cimpl/ecal_core_cimpl.h
+++ b/lang/c/core/include/ecal/cimpl/ecal_core_cimpl.h
@@ -72,15 +72,6 @@ extern "C"
   ECALC_API int eCAL_Initialize(const char *unit_name_, unsigned int components_);
 
   /**
-   * @brief  Set/change the unit name of current module.
-   *
-   * @param unit_name_  Defines the name of the eCAL unit. 
-   *
-   * @return  Zero if succeeded.
-  **/
-  ECALC_API int eCAL_SetUnitName(const char *unit_name_);
-
-  /**
    * @brief Finalize eCAL API.
    *
    * @return Zero if succeeded.

--- a/lang/c/core/src/ecal_core_cimpl.cpp
+++ b/lang/c/core/src/ecal_core_cimpl.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,12 +46,6 @@ extern "C"
   {
     const std::string unit_name = (unit_name_ != nullptr) ? std::string(unit_name_) : std::string("");
     return static_cast<int>(!eCAL::Initialize(unit_name, components_));
-  }
-
-  ECALC_API int eCAL_SetUnitName(const char* unit_name_)
-  {
-    const std::string unit_name = (unit_name_ != nullptr) ? std::string(unit_name_) : std::string("");
-    return static_cast<int>(!eCAL::SetUnitName(unit_name));
   }
 
   ECALC_API int eCAL_Finalize()

--- a/lang/c/tests/core_test/CMakeLists.txt
+++ b/lang/c/tests/core_test/CMakeLists.txt
@@ -1,6 +1,6 @@
 # ========================= eCAL LICENSE =================================
 #
-# Copyright (C) 2016 - 2019 Continental Corporation
+# Copyright (C) 2016 - 2025 Continental Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE $<TARGET_PROPERTY:eCAL::core,
 target_link_libraries(${PROJECT_NAME}
   PRIVATE 
     eCAL::core_c
+    eCAL::ecal-utils
     Threads::Threads)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)

--- a/lang/c/tests/core_test/src/core_test.cpp
+++ b/lang/c/tests/core_test/src/core_test.cpp
@@ -22,6 +22,8 @@
 #include <ecal/ecal_defs.h>
 #include <ecal/ecal_os.h>
 
+#include <ecal_utils/filesystem.h>
+
 #include <cstring>
 
 #include <gtest/gtest.h>
@@ -83,33 +85,6 @@ TEST(core_c_core, MultipleInitializeFinalize)
   }
 }
 
-namespace
-{
-  std::string extractProcessName(const std::string& full_path_)
-  {
-    // initialize process name with full path
-    std::string processName = full_path_;
-
-    // extract the substring after the last separator
-    size_t lastSeparatorPos = full_path_.find_last_of("\\/");
-    if (lastSeparatorPos != std::string::npos)
-    {
-      processName = full_path_.substr(lastSeparatorPos + 1);
-    }
-
-#ifdef ECAL_OS_WINDOWS
-    // remove the file extension if found
-    size_t lastDotPos = processName.find_last_of('.');
-    if (lastDotPos != std::string::npos)
-    {
-      processName = processName.substr(0, lastDotPos);
-    }
-#endif // ECAL_OS_WINDOWS
-
-    return processName;
-  }
-}
-
 TEST(core_c_core, GetUnitName)
 {
   // initialize eCAL API with empty unit name (eCAL will use process name as unit name)
@@ -121,7 +96,7 @@ TEST(core_c_core, GetUnitName)
   // if we call eCAL_Initialize with empty unit name, eCAL will use the process name as unit name
   char process_name[1024] = { 0 };
   eCAL_Process_GetProcessName(process_name, sizeof(process_name));
-  std::string process_name_s = extractProcessName(process_name);
+  std::string process_name_s = EcalUtils::Filesystem::BaseName(process_name);
   char unit_name[1024] = { 0 };
   eCAL_Process_GetUnitName(unit_name, sizeof(unit_name));
   EXPECT_STREQ(process_name_s.c_str(), unit_name);

--- a/lang/c/tests/core_test/src/core_test.cpp
+++ b/lang/c/tests/core_test/src/core_test.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,7 +110,7 @@ namespace
   }
 }
 
-TEST(core_c_core, SetGetUnitName)
+TEST(core_c_core, GetUnitName)
 {
   // initialize eCAL API with empty unit name (eCAL will use process name as unit name)
   EXPECT_EQ(0, eCAL_Initialize("", 0));
@@ -125,24 +125,6 @@ TEST(core_c_core, SetGetUnitName)
   char unit_name[1024] = { 0 };
   eCAL_Process_GetUnitName(unit_name, sizeof(unit_name));
   EXPECT_STREQ(process_name_s.c_str(), unit_name);
-
-  // set unit name (should change the name to 'unit name')
-  EXPECT_EQ(0, eCAL_SetUnitName("unit name"));
-  memset(unit_name, 0, sizeof(unit_name));
-  eCAL_Process_GetUnitName(unit_name, sizeof(unit_name));
-  EXPECT_STREQ("unit name", unit_name);
-
-  // set nullptr unit name (should not change the unit name)
-  EXPECT_EQ(1, eCAL_SetUnitName(nullptr));
-  memset(unit_name, 0, sizeof(unit_name));
-  eCAL_Process_GetUnitName(unit_name, sizeof(unit_name));
-  EXPECT_STREQ("unit name", unit_name);
-
-  // set empty unit name (should not change the unit name)
-  EXPECT_EQ(1, eCAL_SetUnitName(""));
-  memset(unit_name, 0, sizeof(unit_name));
-  eCAL_Process_GetUnitName(unit_name, sizeof(unit_name));
-  EXPECT_STREQ("unit name", unit_name);
 
   // finalize eCAL API we expect return value 0 because it will be finalized
   EXPECT_EQ(0, eCAL_Finalize());

--- a/lang/python/core/ecal/core/core.py
+++ b/lang/python/core/ecal/core/core.py
@@ -1,6 +1,6 @@
 # ========================= eCAL LICENSE =================================
 #
-# Copyright (C) 2016 - 2024 Continental Corporation
+# Copyright (C) 2016 - 2025 Continental Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -68,15 +68,6 @@ def getversion_components():
   """ get ecal version as major, minor, patch tuple
   """
   return _ecal.getversion_components()
-
-
-def set_unit_name(unit_name):
-  """ set/change the unit name of the current module
-  
-  :param unit_name: Name of the eCAL unit
-  :type unit_name: string
-  """
-  return _ecal.set_unit_name(unit_name)
 
 
 def getdate():

--- a/lang/python/core/src/ecal_clang.cpp
+++ b/lang/python/core/src/ecal_clang.cpp
@@ -172,14 +172,6 @@ int ecal_is_initialized()
 }
 
 /****************************************/
-/*      ecal_set_unit_name              */
-/****************************************/
-int ecal_set_unit_name(const char* unit_name_)
-{
-  return static_cast<int>(eCAL::SetUnitName(unit_name_));
-}
-
-/****************************************/
 /*      ecal_set_process_state          */
 /****************************************/
 void ecal_set_process_state(const int severity_, const int level_, const char* info_)

--- a/lang/python/core/src/ecal_clang.h
+++ b/lang/python/core/src/ecal_clang.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,15 +78,6 @@ int ecal_finalize();
  * @return 1 if eCAL is initialized.
 **/
 int ecal_is_initialized();
-
-/**
- * @brief  Set/change the unit name of current module.
- *
- * @param unit_name_  Defines the name of the eCAL unit.
- *
- * @return Zero if succeeded.
-**/
-int ecal_set_unit_name(const char *unit_name_);
 
 /**
  * @brief  Set process state info.

--- a/lang/python/core/src/ecal_wrap.cxx
+++ b/lang/python/core/src/ecal_wrap.cxx
@@ -117,19 +117,6 @@ PyObject* is_initialized(PyObject* /*self*/, PyObject* /*args*/)
 }
 
 /****************************************/
-/*      set_unit_name                   */
-/****************************************/
-PyObject* set_unit_name(PyObject* /*self*/, PyObject* args)
-{
-  char* unit_name = nullptr;
-
-  if (!PyArg_ParseTuple(args, "s", &unit_name))
-    return nullptr;
-
-  return(Py_BuildValue("i", ecal_set_unit_name(unit_name)));
-}
-
-/****************************************/
 /*      getversion                      */
 /****************************************/
 PyObject* getversion(PyObject* /*self*/, PyObject* /*args*/)
@@ -1290,7 +1277,6 @@ static PyMethodDef _ecal_methods[] =
   {"initialize",                    initialize,                    METH_VARARGS,  "initialize(unit_name)"},
   {"finalize",                      finalize,                      METH_NOARGS,   "finalize()"},
   {"is_initialized",                is_initialized,                METH_NOARGS,   "is_initialized()"},
-  {"set_unit_name",                 set_unit_name,                 METH_VARARGS,  "set_unit_name(unit_name)"},
 
   {"getversion",                    getversion,                    METH_NOARGS,   "getversion()"},
   {"getversion_components",         getversion_components,         METH_NOARGS,   "getversion_components()"},


### PR DESCRIPTION
### Description
Removed SetUnitName from API in C++, C and Python.
Changed UnitName generation in globals to use EcalUtils function.