### PR TITLE
[core] linux warning fixes

### DIFF
--- a/ecal/core/CMakeLists.txt
+++ b/ecal/core/CMakeLists.txt
@@ -65,17 +65,22 @@ endif()
 # config
 ######################################
 set(ecal_config_src
-    src/config/default_configuration.cpp        
+    src/config/default_configuration.cpp
+    src/config/default_configuration.h
     src/config/ecal_config.cpp
     src/config/configuration.cpp
     src/config/ecal_path_processing.cpp
+    src/config/ecal_path_processing.h
     src/types/ecal_custom_data_types.cpp
 )
 if (ECAL_CORE_CONFIGURATION)
   list(APPEND ecal_config_src
       src/config/configuration_to_yaml.cpp
+      src/config/configuration_to_yaml.h
       src/config/configuration_reader.cpp
+      src/config/configuration_reader.h
       src/config/configuration_writer.cpp
+      src/config/configuration_writer.h
   )
 endif()
 ######################################
@@ -183,7 +188,9 @@ endif()
 set(ecal_logging_src
     src/logging/ecal_log.cpp
     src/logging/ecal_log_provider.cpp
+    src/logging/ecal_log_provider.h
     src/logging/ecal_log_receiver.cpp
+    src/logging/ecal_log_receiver.h
 )
 
 ######################################
@@ -433,6 +440,7 @@ endif()
 ######################################
 set(ecal_cmn_src
     src/ecal.cpp
+    src/ecal_config_internal.h
     src/ecal_def.h
     src/ecal_descgate.cpp
     src/ecal_descgate.h
@@ -458,18 +466,55 @@ endif()
 ######################################
 set (ecal_builder_src
     src/config/builder/logging_attribute_builder.cpp
+    src/config/builder/logging_attribute_builder.h
     src/config/builder/registration_attribute_builder.cpp
+    src/config/builder/registration_attribute_builder.h
+
+    src/logging/config/attributes/ecal_log_provider_attributes.h
+    src/logging/config/attributes/ecal_log_receiver_attributes.h
     src/logging/config/builder/udp_attribute_builder.cpp
+    src/logging/config/builder/udp_attribute_builder.h
+
     src/pubsub/config/builder/reader_attribute_builder.cpp
+    src/pubsub/config/builder/reader_attribute_builder.h
     src/pubsub/config/builder/writer_attribute_builder.cpp
+    src/pubsub/config/builder/writer_attribute_builder.h
+
+    src/readwrite/config/attributes/reader_attributes.h
+    src/readwrite/config/attributes/writer_attributes.h
     src/readwrite/config/builder/shm_attribute_builder.cpp
+    src/readwrite/config/builder/shm_attribute_builder.h
     src/readwrite/config/builder/tcp_attribute_builder.cpp
+    src/readwrite/config/builder/tcp_attribute_builder.h
     src/readwrite/config/builder/udp_attribute_builder.cpp
+    src/readwrite/config/builder/udp_attribute_builder.h
+
+    src/readwrite/shm/config/attributes/reader_shm_attributes.h
+    src/readwrite/shm/config/attributes/writer_shm_attributes.h
+
+    src/readwrite/tcp/config/attributes/data_reader_tcp_attributes.h
+    src/readwrite/tcp/config/attributes/data_writer_tcp_attributes.h
+    src/readwrite/tcp/config/attributes/tcp_reader_layer_attributes.h
     src/readwrite/tcp/config/builder/data_reader_tcp_attribute_builder.cpp
+    src/readwrite/tcp/config/builder/data_reader_tcp_attribute_builder.h
+
+    src/readwrite/udp/config/attributes/reader_udp_attributes.h
+    src/readwrite/udp/config/attributes/writer_udp_attributes.h
     src/readwrite/udp/config/builder/udp_attribute_builder.cpp
-    src/registration/config/builder/udp_shm_attribute_builder.cpp
+    src/readwrite/udp/config/builder/udp_attribute_builder.h
+
+    src/registration/config/attributes/registration_attributes.h
+    src/registration/config/attributes/sample_applier_attributes.h
     src/registration/config/builder/sample_applier_attribute_builder.cpp
+    src/registration/config/builder/sample_applier_attribute_builder.h
+    src/registration/config/builder/udp_shm_attribute_builder.cpp
+    src/registration/config/builder/udp_shm_attribute_builder.h
+
+    src/registration/shm/config/attributes/registration_shm_attributes.h
+    src/registration/udp/config/attributes/registration_receiver_udp_attributes.h
+    src/registration/udp/config/attributes/registration_sender_udp_attributes.h
     src/registration/udp/config/builder/udp_attribute_builder.cpp
+    src/registration/udp/config/builder/udp_attribute_builder.h
 )
 
 ######################################

--- a/ecal/core/src/logging/ecal_log_provider.cpp
+++ b/ecal/core/src/logging/ecal_log_provider.cpp
@@ -46,13 +46,14 @@ namespace
 }
 #endif
 
-#if 0 // TODO: Can we remove this?
 #ifdef ECAL_OS_LINUX
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <ctime>
 
-namespace{
+namespace
+{
+#if 0 // TODO: Can we remove this?
   bool isDirectory(const std::string& path_)
   {
     if (path_.empty()) return false;
@@ -63,6 +64,7 @@ namespace{
 
     return false;
   }
+#endif
 
   std::string get_time_str()
   {
@@ -78,7 +80,6 @@ namespace{
     return(std::string(fmt));
   }
 }
-#endif
 #endif
 
 namespace

--- a/ecal/core/src/logging/ecal_log_provider.cpp
+++ b/ecal/core/src/logging/ecal_log_provider.cpp
@@ -46,6 +46,7 @@ namespace
 }
 #endif
 
+#if 0 // TODO: Can we remove this?
 #ifdef ECAL_OS_LINUX
 #include <sys/stat.h>
 #include <sys/time.h>
@@ -77,6 +78,7 @@ namespace{
     return(std::string(fmt));
   }
 }
+#endif
 #endif
 
 namespace
@@ -149,9 +151,9 @@ namespace eCAL
   namespace Logging
   {
     CLogProvider::CLogProvider(const SProviderAttributes& attr_)
-    : m_attributes(attr_)
-    , m_created(false)
+    : m_created(false)
     , m_logfile(nullptr)
+    , m_attributes(attr_)
     {
     }
 

--- a/ecal/core/src/logging/ecal_log_provider.cpp
+++ b/ecal/core/src/logging/ecal_log_provider.cpp
@@ -53,19 +53,6 @@ namespace
 
 namespace
 {
-#if 0 // TODO: Can we remove this?
-  bool isDirectory(const std::string& path_)
-  {
-    if (path_.empty()) return false;
-
-    struct stat st;
-    if (stat(path_.c_str(), &st) == 0)
-      return S_ISDIR(st.st_mode);
-
-    return false;
-  }
-#endif
-
   std::string get_time_str()
   {
     char            fmt[64];

--- a/ecal/core/src/logging/ecal_log_receiver.cpp
+++ b/ecal/core/src/logging/ecal_log_receiver.cpp
@@ -37,8 +37,8 @@ namespace eCAL
   namespace Logging
   {
     CLogReceiver::CLogReceiver(const SReceiverAttributes& attr_)
-    : m_attributes(attr_)
-    , m_created(false)
+    : m_created(false)
+    , m_attributes(attr_)
     {
     }
 

--- a/ecal/core/src/pubsub/ecal_subscriber_impl.cpp
+++ b/ecal/core/src/pubsub/ecal_subscriber_impl.cpp
@@ -70,11 +70,11 @@ namespace eCAL
   CSubscriberImpl::CSubscriberImpl(const SDataTypeInformation& topic_info_, const eCAL::eCALReader::SAttributes& attr_) :
                  m_topic_info(topic_info_),
                  m_topic_size(0),
-                 m_attributes(attr_),
                  m_receive_time(0),
                  m_clock(0),
                  m_frequency_calculator(3.0f),
-                 m_created(false)
+                 m_created(false),
+                 m_attributes(attr_)
   {
 #ifndef NDEBUG
     // log it

--- a/ecal/core/src/pubsub/ecal_subscriber_impl.h
+++ b/ecal/core/src/pubsub/ecal_subscriber_impl.h
@@ -158,7 +158,7 @@ namespace eCAL
     long long                                 m_read_time = 0;
 
     std::mutex                                m_receive_callback_mutex;
-    ReceiveCallbackT                        m_receive_callback;
+    ReceiveCallbackT                          m_receive_callback;
     std::atomic<int>                          m_receive_time;
 
     std::deque<size_t>                        m_sample_hash_queue;
@@ -168,7 +168,7 @@ namespace eCAL
     EventCallbackMapT                         m_event_callback_map;
 
     std::mutex                                m_event_id_callback_mutex;
-    SubEventCallbackT                       m_event_id_callback;
+    SubEventCallbackT                         m_event_id_callback;
 
     std::atomic<long long>                    m_clock;
 

--- a/ecal/core/src/service/ecal_service_server_impl.cpp
+++ b/ecal/core/src/service/ecal_service_server_impl.cpp
@@ -50,7 +50,7 @@ namespace eCAL
 
   // Constructor
   CServiceServerImpl::CServiceServerImpl(const std::string& service_name_, const ServerEventCallbackT& event_callback_)
-    : m_created(false), m_service_name(service_name_), m_event_callback(event_callback_)
+    : m_service_name(service_name_), m_created(false), m_event_callback(event_callback_)
   {
 #ifndef NDEBUG
     Logging::Log(Logging::log_level_debug2, "CServiceServerImpl::CServiceServerImpl: Initializing service server for: " + m_service_name);

--- a/ecal/core/src/service/ecal_service_server_impl.h
+++ b/ecal/core/src/service/ecal_service_server_impl.h
@@ -118,7 +118,7 @@ namespace eCAL
 
     // Event callback and synchronization
     std::mutex                             m_event_callback_mutex;
-    ServerEventCallbackT                 m_event_callback;
+    ServerEventCallbackT                   m_event_callback;
 
     // Server interface
     std::shared_ptr<eCAL::service::Server> m_tcp_server;


### PR DESCRIPTION
### Description

#### Integrated and reordered all config/builder/attributes header in CMakeList.txt

#### Fixed some minor warnings for linux platform:

- File: ecal_log_provider.cpp
    - Type: Member initialization order (-Wreorder)
    - Details: `m_attributes` is initialized after `m_created`.

- File: ecal_log_provider.cpp
    - Type: Unused function (-Wunused-function)
    - Details: The function `isDirectory` is defined but not used.
 
- File: ecal_log_receiver.cpp
    - Type: Member initialization order (-Wreorder)
    - Details: `m_attributes` is initialized after `m_created`.
  
- File: ecal_subscriber_impl.cpp
    - Type: Member initialization order (-Wreorder)
    - Details: `m_attributes` is initialized after `m_receive_time`.

- File: ecal_service_server_impl.cpp
    - Type: Member initialization order (-Wreorder)
    - Details: `m_created` is initialized after `m_service_name`.
