### PR TITLE
[core] move SServiceResponse (old API) to v5/ecal_callback.h

### DIFF
--- a/app/rec/rec_server_cli/src/commands/command.cpp
+++ b/app/rec/rec_server_cli/src/commands/command.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2020 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ namespace eCAL
       {
         remote_ecalsys_service->SetHostName(hostname);
 
-        eCAL::ServiceResponseVecT service_response_vec;
+        eCAL::v5::ServiceResponseVecT service_response_vec;
         constexpr int timeout_ms = 1000;
 
         if (remote_ecalsys_service->Call(method_name, request.SerializeAsString(), timeout_ms, &service_response_vec))

--- a/app/rec/rec_server_core/src/recorder/remote_recorder.cpp
+++ b/app/rec/rec_server_core/src/recorder/remote_recorder.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -669,7 +669,7 @@ namespace eCAL
     {
       // The target (i.e. the hostname) has already been set in the Constructor.
 
-      eCAL::ServiceResponseVecT service_response_vec;
+      eCAL::v5::ServiceResponseVecT service_response_vec;
       constexpr int timeout_ms = 1000;
       if (recorder_service_.Call(method_name, request.SerializeAsString(), timeout_ms, &service_response_vec))
       {

--- a/app/rec/rec_tests/rec_rpc_tests/src/external_ecal_rec.cpp
+++ b/app/rec/rec_tests/rec_rpc_tests/src/external_ecal_rec.cpp
@@ -120,7 +120,7 @@ eCAL::rec::Error ExternalEcalRecInstance::GetConfigViaRpc(eCAL::rec_server::RecS
 eCAL::rec::Error ExternalEcalRecInstance::GetConfigViaRpc(eCAL::pb::rec_server::RecServerConfig& config_pb_output)
 {
   eCAL::pb::rec_server::GenericRequest request;
-  eCAL::ServiceResponseVecT            service_response_vec;
+  eCAL::v5::ServiceResponseVecT            service_response_vec;
 
   constexpr int timeout_ms = 1000;
 
@@ -143,7 +143,7 @@ eCAL::rec::Error ExternalEcalRecInstance::SetConfigViaRpc(const eCAL::rec_server
 
 eCAL::rec::Error ExternalEcalRecInstance::SetConfigViaRpc(const eCAL::pb::rec_server::RecServerConfig& config_pb)
 {
-  eCAL::ServiceResponseVecT service_response_vec;
+  eCAL::v5::ServiceResponseVecT service_response_vec;
 
   constexpr int timeout_ms = 1000;
 

--- a/app/sys/sys_cli/src/commands/command.cpp
+++ b/app/sys/sys_cli/src/commands/command.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2020 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ namespace eCAL
       {
         remote_ecalsys_service->SetHostName(hostname);
 
-        eCAL::ServiceResponseVecT service_response_vec;
+        eCAL::v5::ServiceResponseVecT service_response_vec;
         constexpr int timeout_ms = 1000;
 
         if (remote_ecalsys_service->Call(method_name, request.SerializeAsString(), timeout_ms, &service_response_vec))

--- a/app/sys/sys_core/src/connection/remote_connection.cpp
+++ b/app/sys/sys_core/src/connection/remote_connection.cpp
@@ -124,7 +124,7 @@ namespace eCAL
     {
       std::lock_guard<decltype(connection_mutex_)> connection_lock(connection_mutex_);
 
-      eCAL::ServiceResponseVecT service_response_vec;
+      eCAL::v5::ServiceResponseVecT service_response_vec;
       constexpr int timeout_ms = 1000;
 
       if (sys_client_service_.Call(method_name, request.SerializeAsString(), timeout_ms, &service_response_vec))

--- a/ecal/core/include/ecal/service/types.h
+++ b/ecal/core/include/ecal/service/types.h
@@ -159,27 +159,6 @@ namespace eCAL
   };
 
   /**
-   * @brief Service response struct containing the (responding) server informations and the response itself. (deprecated)
-  **/
-  struct SServiceResponse
-  {
-    SServiceResponse()
-    {
-      ret_state  = 0;
-      call_state = eCallState::none;
-    };
-    std::string  host_name;      //!< service host name
-    std::string  service_name;   //!< name of the service
-    std::string  service_id;     //!< id of the service
-    std::string  method_name;    //!< name of the service method
-    std::string  error_msg;      //!< human readable error message
-    int          ret_state;      //!< return state of the called service method
-    eCallState   call_state;     //!< call state (see eCallState)
-    std::string  response;       //!< service response
-  };
-  using ServiceResponseVecT = std::vector<SServiceResponse>; //!< vector of multiple service responses (deprecated)
-
-  /**
    * @brief Service response struct containing the (responding) server informations and the response itself.
   **/
   struct SServiceIDResponse
@@ -211,13 +190,6 @@ namespace eCAL
    * @param response_   The response returned from the method call.
   **/
   using MethodInfoCallbackT = std::function<int(const SMethodInfo& method_info_, const std::string& request_, std::string& response_)>;
-
-  /**
-   * @brief Service response callback function type (low level client interface). (deprecated)
-   *
-   * @param service_response_  Service response struct containing the (responding) server informations and the response itself.
-  **/
-  using ResponseCallbackT = std::function<void(const struct SServiceResponse& service_response_)>;
 
   /**
    * @brief Service response callback function type (low level client interface).

--- a/ecal/core/include/ecal/v5/ecal_callback.h
+++ b/ecal/core/include/ecal/v5/ecal_callback.h
@@ -106,6 +106,35 @@ namespace eCAL
       unsigned int   version = 0;   //!< client version
     };
 
+
+    /**
+     * @brief Service response struct containing the (responding) server informations and the response itself. (deprecated)
+    **/
+    struct SServiceResponse
+    {
+      SServiceResponse()
+      {
+        ret_state = 0;
+        call_state = eCallState::none;
+      };
+      std::string  host_name;      //!< service host name
+      std::string  service_name;   //!< name of the service
+      std::string  service_id;     //!< id of the service
+      std::string  method_name;    //!< name of the service method
+      std::string  error_msg;      //!< human readable error message
+      int          ret_state;      //!< return state of the called service method
+      eCallState   call_state;     //!< call state (see eCallState)
+      std::string  response;       //!< service response
+    };
+    using ServiceResponseVecT = std::vector<SServiceResponse>; //!< vector of multiple service responses (deprecated)
+
+    /**
+     * @brief Service response callback function type (low level client interface). (deprecated)
+     *
+     * @param service_response_  Service response struct containing the (responding) server informations and the response itself.
+    **/
+    using ResponseCallbackT = std::function<void(const struct v5::SServiceResponse& service_response_)>;
+
     /**
      * @brief eCAL server event callback struct.
     **/

--- a/ecal/core/src/v5/service/ecal_service_client_impl.cpp
+++ b/ecal/core/src/v5/service/ecal_service_client_impl.cpp
@@ -27,9 +27,9 @@
 
 namespace
 {
-  eCAL::SServiceResponse ConvertToServiceResponse(const eCAL::SServiceIDResponse& service_id_response)
+  eCAL::v5::SServiceResponse ConvertToServiceResponse(const eCAL::SServiceIDResponse& service_id_response)
   {
-    eCAL::SServiceResponse service_response;
+    eCAL::v5::SServiceResponse service_response;
 
     // service/method id
     service_response.host_name    = service_id_response.service_method_id.service_id.host_name;
@@ -191,7 +191,7 @@ namespace eCAL
             Logging::Log(Logging::log_level_debug2, "v5::CServiceClientImpl: Response received for method call.");
             
             // Convert SServiceResponse to SServiceIDResponse
-            const SServiceResponse service_response = ConvertToServiceResponse(service_response_);
+            const v5::SServiceResponse service_response = ConvertToServiceResponse(service_response_);
 
             // Call the stored response callback
             m_response_callback(service_response);

--- a/ecal/samples/cpp/orchestration/orchestrator/src/orchestrator.cpp
+++ b/ecal/samples/cpp/orchestration/orchestrator/src/orchestrator.cpp
@@ -37,7 +37,7 @@ int main()
 
   // prepare service request and response vector
   orchestrator::request     srv_request;
-  eCAL::ServiceResponseVecT srv_response_vec;
+  eCAL::v5::ServiceResponseVecT srv_response_vec;
 
   // call components 1 and 2
   uint64_t cycle = 0;

--- a/ecal/samples/cpp/services/minimal_client/src/minimal_client.cpp
+++ b/ecal/samples/cpp/services/minimal_client/src/minimal_client.cpp
@@ -62,7 +62,6 @@ int main()
 
   while(eCAL::Ok())
   {
-    eCAL::SServiceResponse service_info;
     std::string method_name("echo");
     std::string request("Hello");
 
@@ -75,18 +74,20 @@ int main()
       const auto service_response = client_instance.CallWithResponse(method_name, request, -1);
       if (std::get<0>(service_response))
       {
+        auto& response_content = std::get<1>(service_response);
         std::cout << std::endl << "Method 'echo' called with message : " << request << std::endl;
-        switch (service_info.call_state)
+        auto& server_host_name = response_content.service_method_id.service_id.host_name;
+        switch (response_content.call_state)
         {
           // service successful executed
         case eCAL::eCallState::executed:
         {
-          std::cout << "Received response : " << service_response.second.response << " from service id " << client_instance.GetClientID() << " from host " << service_info.host_name << std::endl;
+          std::cout << "Received response : " << response_content.response << " from service id " << client_instance.GetClientID() << " from host " << server_host_name << std::endl;
         }
         break;
         // service execution failed
         case eCAL::eCallState::failed:
-          std::cout << "Received error : " << service_info.error_msg << " from service id " << client_instance.GetClientID() << " from host " << service_info.host_name << std::endl;
+          std::cout << "Received error : " << response_content.error_msg << " from service id " << client_instance.GetClientID() << " from host " << server_host_name << std::endl;
           break;
         default:
           break;

--- a/ecal/tests/cpp/clientserver_v5_test/src/clientserver_test.cpp
+++ b/ecal/tests/cpp/clientserver_v5_test/src/clientserver_test.cpp
@@ -70,7 +70,7 @@ namespace
 #endif
 
 #if DO_LOGGING
-  void PrintResponse(const struct eCAL::SServiceResponse& service_response_)
+  void PrintResponse(const struct eCAL::v5::SServiceResponse& service_response_)
   {
     std::cout << "------ RESPONSE ------" << std::endl;
     std::cout << "Executed on host name : " << service_response_.host_name << std::endl;
@@ -96,7 +96,7 @@ namespace
     std::cout << std::endl;
   }
 #else
-  void PrintResponse(const struct eCAL::SServiceResponse& /*service_response_*/)
+  void PrintResponse(const struct eCAL::v5::SServiceResponse& /*service_response_*/)
   {
   }
 #endif
@@ -283,7 +283,7 @@ TEST(core_cpp_clientserver_v5, ClientServerBaseCallback)
 
   // response callback function
   std::atomic<int> responses_executed(0);
-  auto response_callback = [&](const struct eCAL::SServiceResponse& service_response_)
+  auto response_callback = [&](const struct eCAL::v5::SServiceResponse& service_response_)
   {
     PrintResponse(service_response_);
     responses_executed++;
@@ -392,7 +392,7 @@ TEST(core_cpp_clientserver_v5, ClientServerBaseCallbackTimeout)
 
   // response callback function
   std::atomic<int> responses_executed(0);
-  auto response_callback = [&](const struct eCAL::SServiceResponse& service_response_)
+  auto response_callback = [&](const struct eCAL::v5::SServiceResponse& service_response_)
                             {
                               PrintResponse(service_response_);
                               responses_executed++;
@@ -543,7 +543,7 @@ TEST(core_cpp_clientserver_v5, ClientServerBaseAsyncCallback)
 
   // response callback function
   std::atomic<int> responses_executed(0);
-  auto response_callback = [&](const struct eCAL::SServiceResponse& service_response_)
+  auto response_callback = [&](const struct eCAL::v5::SServiceResponse& service_response_)
   {
     PrintResponse(service_response_);
     responses_executed++;
@@ -619,7 +619,7 @@ TEST(core_cpp_clientserver_v5, ClientServerBaseAsync)
 
   // response callback function
   atomic_signalable<int> num_client_response_callbacks_finished(0);
-  auto client_response_callback = [&](const struct eCAL::SServiceResponse& service_response_)
+  auto client_response_callback = [&](const struct eCAL::v5::SServiceResponse& service_response_)
                                   {
                                     PrintResponse(service_response_);
                                     num_client_response_callbacks_finished++;
@@ -740,7 +740,7 @@ TEST(core_cpp_clientserver_v5, ClientServerBaseBlocking)
   // call service
   std::atomic<int> methods_called(0);
   std::atomic<int> responses_executed(0);
-  eCAL::ServiceResponseVecT service_response_vec;
+  eCAL::v5::ServiceResponseVecT service_response_vec;
   for (auto i = 0; i < calls; ++i)
   {
     // call methods
@@ -826,14 +826,14 @@ TEST(core_cpp_clientserver_v5, NestedRPCCall)
   std::atomic<int> methods_called(0);
   std::atomic<int> responses_executed(0);
   bool success(true);
-  auto response_callback1 = [&](const struct eCAL::SServiceResponse& service_response_)
+  auto response_callback1 = [&](const struct eCAL::v5::SServiceResponse& service_response_)
   {
     PrintResponse(service_response_);
     success &= client2.Call("foo::method2", "my request for method 2");
     methods_called++;
     responses_executed++;
   };
-  auto response_callback2 = [&](const struct eCAL::SServiceResponse& service_response_)
+  auto response_callback2 = [&](const struct eCAL::v5::SServiceResponse& service_response_)
   {
     PrintResponse(service_response_);
     responses_executed++;

--- a/lang/c/core/src/ecal_client_cimpl.cpp
+++ b/lang/c/core/src/ecal_client_cimpl.cpp
@@ -72,7 +72,7 @@ namespace
 
 
   std::recursive_mutex g_response_callback_mtx; // NOLINT(*-avoid-non-const-global-variables)
-  void g_response_callback(const struct eCAL::SServiceResponse& service_response_, const ResponseCallbackCT callback_, void* par_)
+  void g_response_callback(const struct eCAL::v5::SServiceResponse& service_response_, const ResponseCallbackCT callback_, void* par_)
   {
     const std::lock_guard<std::recursive_mutex> lock(g_response_callback_mtx);
     struct SServiceResponseC service_response {};
@@ -137,7 +137,7 @@ extern "C"
   {
     if (handle_ == nullptr) return(0);
     auto* client = static_cast<eCAL::v5::CServiceClient*>(handle_);
-    eCAL::ServiceResponseVecT service_response_vec;
+    eCAL::v5::ServiceResponseVecT service_response_vec;
     if (client->Call(method_name_, std::string(request_, static_cast<size_t>(request_len_)), timeout_, &service_response_vec))
     {
       if (!service_response_vec.empty())

--- a/lang/csharp/Continental.eCAL.Core/ecal_clr.cpp
+++ b/lang/csharp/Continental.eCAL.Core/ecal_clr.cpp
@@ -461,13 +461,13 @@ ServiceClient::~ServiceClient()
 List<ServiceClient::ServiceClientCallbackData^>^ ServiceClient::Call(System::String^ method_name_, array<Byte>^ request, const int rcv_timeout_)
 {
     if (m_client == nullptr) return(nullptr);
-    ::eCAL::ServiceResponseVecT responseVecT;
+    ::eCAL::v5::ServiceResponseVecT responseVecT;
 
     if (m_client->Call(StringToStlString(method_name_), ByteArrayToStlString(request), rcv_timeout_, &responseVecT))
     {
         List<ServiceClientCallbackData^>^ rcv_Datas = gcnew List<ServiceClientCallbackData^>();
 
-        for each (::eCAL::SServiceResponse response in responseVecT)
+        for each (::eCAL::v5::SServiceResponse response in responseVecT)
         {
             ServiceClientCallbackData^ rcv_data = gcnew ServiceClientCallbackData;
             rcv_data->call_state = static_cast<CallState>(response.call_state);

--- a/lang/python/core/src/ecal_wrap.cxx
+++ b/lang/python/core/src/ecal_wrap.cxx
@@ -764,7 +764,7 @@ PyObject* client_call_method(PyObject* /*self*/, PyObject* args)   // (client_ha
 /****************************************/
 /*      client_add_response_callback    */
 /****************************************/
-static void c_client_callback(const struct eCAL::SServiceResponse& service_response_, ECAL_HANDLE handle_)
+static void c_client_callback(const struct eCAL::v5::SServiceResponse& service_response_, ECAL_HANDLE handle_)
 {
 #if ECAL_PY_INIT_THREADS_NEEDED
   if (!g_pygil_init)

--- a/samples/cpp/services/ecalplayer_client/src/ecalplayer_client.cpp
+++ b/samples/cpp/services/ecalplayer_client/src/ecalplayer_client.cpp
@@ -34,7 +34,7 @@
 #include <thread>
 
 // callback for player service response
-void OnPlayerResponse(const struct eCAL::SServiceResponse& service_response_)
+void OnPlayerResponse(const struct eCAL::v5::SServiceResponse& service_response_)
 {
   switch (service_response_.call_state)
   {

--- a/samples/cpp/services/ecalplayer_gui_client/src/ecalplayer_gui_client.cpp
+++ b/samples/cpp/services/ecalplayer_gui_client/src/ecalplayer_gui_client.cpp
@@ -31,7 +31,7 @@ EcalplayGuiClient::EcalplayGuiClient(QWidget *parent)
   eCAL::Initialize("ecalplayer gui client");
 
   // create player service client
-  player_service_.AddResponseCallback([this](const struct eCAL::SServiceResponse& service_response) {this->onPlayerResponse(service_response); });
+  player_service_.AddResponseCallback([this](const struct eCAL::v5::SServiceResponse& service_response) {this->onPlayerResponse(service_response); });
 
   connect(ui_.get_config_request_button, &QPushButton::clicked,                 this,                   &EcalplayGuiClient::getConfigRequest);
   connect(ui_.set_config_request_button, &QPushButton::clicked,                 this,                   &EcalplayGuiClient::setConfigRequest);
@@ -196,7 +196,7 @@ void EcalplayGuiClient::commandRequest()
 //// Response                                                               ////
 ////////////////////////////////////////////////////////////////////////////////
 
-void EcalplayGuiClient::onPlayerResponse(const struct eCAL::SServiceResponse& service_response_)
+void EcalplayGuiClient::onPlayerResponse(const struct eCAL::v5::SServiceResponse& service_response_)
 {
   QString response_string;
   QTextStream response_stream(&response_string);

--- a/samples/cpp/services/ecalplayer_gui_client/src/ecalplayer_gui_client.h
+++ b/samples/cpp/services/ecalplayer_gui_client/src/ecalplayer_gui_client.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ signals:
   void setResponseSignal(QString response);
 
 private:
-  void onPlayerResponse(const struct eCAL::SServiceResponse& service_response_);
+  void onPlayerResponse(const struct eCAL::v5::SServiceResponse& service_response_);
 
 private:
   Ui::EcalplayGuiServiceMainWindow ui_;

--- a/samples/cpp/services/ecalsys_client/src/ecalsys_client.cpp
+++ b/samples/cpp/services/ecalsys_client/src/ecalsys_client.cpp
@@ -34,7 +34,7 @@
 #include <iostream>
 
 // callback for sys service response
-void OnSysResponse(const struct eCAL::SServiceResponse& service_response_)
+void OnSysResponse(const struct eCAL::v5::SServiceResponse& service_response_)
 {
   switch (service_response_.call_state)
   {

--- a/samples/cpp/services/rec_client_service_cli/src/ecalrecorder_client.cpp
+++ b/samples/cpp/services/rec_client_service_cli/src/ecalrecorder_client.cpp
@@ -34,7 +34,7 @@
 #include <iostream>
 
 // callback for recorder service response
-void OnRecorderResponse(const struct eCAL::SServiceResponse& service_response_)
+void OnRecorderResponse(const struct eCAL::v5::SServiceResponse& service_response_)
 {
   switch (service_response_.call_state)
   {

--- a/samples/cpp/services/rec_client_service_gui/src/EcalrecGuiClient.cpp
+++ b/samples/cpp/services/rec_client_service_gui/src/EcalrecGuiClient.cpp
@@ -31,7 +31,7 @@ EcalrecGuiClient::EcalrecGuiClient(QWidget *parent)
   eCAL::Initialize("RecClientServiceGui");
 
   // create player service client
-  recorder_service_.AddResponseCallback([this](const struct eCAL::SServiceResponse& service_response) {this->onRecorderResponse(service_response); });
+  recorder_service_.AddResponseCallback([this](const struct eCAL::v5::SServiceResponse& service_response) {this->onRecorderResponse(service_response); });
 
   connect(ui_.hostname_lineedit, &QLineEdit::editingFinished, this, [this]() {recorder_service_.SetHostName(ui_.hostname_lineedit->text().toStdString()); });
 
@@ -218,7 +218,7 @@ void EcalrecGuiClient::getStateRequest()
 //// Response                                                               ////
 ////////////////////////////////////////////////////////////////////////////////
 
-void EcalrecGuiClient::onRecorderResponse(const struct eCAL::SServiceResponse& service_response_)
+void EcalrecGuiClient::onRecorderResponse(const struct eCAL::v5::SServiceResponse& service_response_)
 {
   QString response_string;
   QTextStream response_stream(&response_string);

--- a/samples/cpp/services/rec_client_service_gui/src/EcalrecGuiClient.h
+++ b/samples/cpp/services/rec_client_service_gui/src/EcalrecGuiClient.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ signals:
   void setResponseSignal(QString response);
 
 private:
-  void onRecorderResponse(const struct eCAL::SServiceResponse& service_response_);
+  void onRecorderResponse(const struct eCAL::v5::SServiceResponse& service_response_);
 
 
 

--- a/samples/cpp/services/rec_server_service_gui/src/rec_server_service_gui.cpp
+++ b/samples/cpp/services/rec_server_service_gui/src/rec_server_service_gui.cpp
@@ -32,7 +32,7 @@ RecServerServiceGui::RecServerServiceGui(QWidget *parent)
   eCAL::Initialize("RecServerServiceGui");
 
   // create player service client
-  recorder_service_.AddResponseCallback([this](const struct eCAL::SServiceResponse& service_response) {this->onRecorderResponse(service_response); });
+  recorder_service_.AddResponseCallback([this](const struct eCAL::v5::SServiceResponse& service_response) {this->onRecorderResponse(service_response); });
 
   connect(ui_.hostname_lineedit, &QLineEdit::editingFinished, this, [this]() {recorder_service_.SetHostName(ui_.hostname_lineedit->text().toStdString()); });
 
@@ -230,7 +230,7 @@ void RecServerServiceGui::addComment()
 //// Response                                                               ////
 ////////////////////////////////////////////////////////////////////////////////
 
-void RecServerServiceGui::onRecorderResponse(const struct eCAL::SServiceResponse& service_response_)
+void RecServerServiceGui::onRecorderResponse(const struct eCAL::v5::SServiceResponse& service_response_)
 {
   QString     response_string;
   QTextStream response_stream(&response_string);

--- a/samples/cpp/services/rec_server_service_gui/src/rec_server_service_gui.h
+++ b/samples/cpp/services/rec_server_service_gui/src/rec_server_service_gui.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ signals:
   void setResponseSignal(QString response);
 
 private:
-  void onRecorderResponse(const struct eCAL::SServiceResponse& service_response_);
+  void onRecorderResponse(const struct eCAL::v5::SServiceResponse& service_response_);
 
 
 

--- a/serialization/protobuf/protobuf/include/ecal/msg/protobuf/client.h
+++ b/serialization/protobuf/protobuf/include/ecal/msg/protobuf/client.h
@@ -112,7 +112,7 @@ namespace eCAL
        *
        * @return  True if successful.
       **/
-      bool Call(const std::string& method_name_, const google::protobuf::Message& request_, const int timeout_, ServiceResponseVecT* service_response_vec_)
+      bool Call(const std::string& method_name_, const google::protobuf::Message& request_, const int timeout_, v5::ServiceResponseVecT* service_response_vec_)
       {
         return Call(method_name_, request_.SerializeAsString(), timeout_, service_response_vec_);
       }

--- a/serialization/protobuf/samples/services/math_client/src/math_client.cpp
+++ b/serialization/protobuf/samples/services/math_client/src/math_client.cpp
@@ -62,7 +62,7 @@ void OnClientState(const eCAL::v5::SClientEventCallbackData* data_)
 }
 
 // callback for math service response
-void OnMathResponse(const struct eCAL::SServiceResponse& service_response_)
+void OnMathResponse(const struct eCAL::v5::SServiceResponse& service_response_)
 {
   switch(service_response_.call_state)
   {

--- a/serialization/protobuf/samples/services/ping_client/src/ping_client.cpp
+++ b/serialization/protobuf/samples/services/ping_client/src/ping_client.cpp
@@ -50,7 +50,7 @@ int main()
       // Ping service (blocking call)
       //////////////////////////////////////
       PingRequest               ping_request;
-      eCAL::ServiceResponseVecT service_response_vec;
+      eCAL::v5::ServiceResponseVecT service_response_vec;
       ping_request.set_message("PING");
       if (ping_client.Call("Ping", ping_request, -1, &service_response_vec))
       {

--- a/serialization/protobuf/tests/clientserver_proto_test/src/clientserver_test_proto.cpp
+++ b/serialization/protobuf/tests/clientserver_proto_test/src/clientserver_test_proto.cpp
@@ -82,7 +82,7 @@ TEST(core_cpp_clientserver_proto, ProtoCallback)
 
   // response callback function
   double math_response(0.0);
-  auto response_callback = [&](const struct eCAL::SServiceResponse& service_response_)
+  auto response_callback = [&](const struct eCAL::v5::SServiceResponse& service_response_)
   {
     math_response = 0.0;
     switch (service_response_.call_state)
@@ -173,7 +173,7 @@ TEST(core_cpp_clientserver_proto, ProtoBlocking)
   eCAL::Process::SleepMS(2000);
 
   // test ping service
-  eCAL::ServiceResponseVecT service_response_vec;
+  eCAL::v5::ServiceResponseVecT service_response_vec;
   PingRequest ping_request;
   ping_request.set_message("PING");
   ping_client.Call("Ping", ping_request, -1, &service_response_vec);


### PR DESCRIPTION
### Description
Move deprecated type used for v5 Services to v5/ecal_callback.h

Fix minimal_client sample as it used incorrect values.