### PR TITLE
Harmonize Server API

### DIFF
--- a/ecal/core/include/ecal/registration.h
+++ b/ecal/core/include/ecal/registration.h
@@ -130,28 +130,28 @@ namespace eCAL
      *
      * @return Set of service id's.
     **/
-    ECAL_API std::set<SServiceMethodId> GetServerIDs();
+    ECAL_API std::set<SServiceId> GetServerIDs();
 
     /**
-     * @brief Get service method information with quality for a specific server.
+     * @brief Get service method information for a specific server.
      *
      * @return True if information could be queried.
     **/
-    ECAL_API bool GetServerInfo(const SServiceMethodId& id_, SServiceMethodInformation& service_method_info_);
+    ECAL_API bool GetServerInfo(const SServiceId& id_, ServiceMethodInfoSetT& service_method_info_);
 
     /**
      * @brief Get complete snapshot of all known clients.
      *
      * @return Set of service id's.
     **/
-    ECAL_API std::set<SServiceMethodId> GetClientIDs();
+    ECAL_API std::set<SServiceId> GetClientIDs();
 
     /**
-     * @brief Get service method information with quality for a specific client.
+     * @brief Get service method information for a specific client.
      *
      * @return True if information could be queried.
     **/
-    ECAL_API bool GetClientInfo(const SServiceMethodId& id_, SServiceMethodInformation& service_method_info_);
+    ECAL_API bool GetClientInfo(const SServiceId& id_, ServiceMethodInfoSetT& service_method_info_);
 
     /**
      * @brief Get all topic names.

--- a/ecal/core/include/ecal/registration.h
+++ b/ecal/core/include/ecal/registration.h
@@ -161,14 +161,14 @@ namespace eCAL
     ECAL_API void GetTopicNames(std::set<std::string>& topic_names_);
 
     /**
-     * @brief Get all service/method names.
+     * @brief Get the pairs of service name / method name of all eCAL Servers.
      *
      * @param service_method_names_ Set to store the service/method names (Set { (ServiceName, MethodName) }).
     **/
-    ECAL_API void GetServiceMethodNames(std::set<SServiceMethod>& service_method_names_);
+    ECAL_API void GetServerMethodNames(std::set<SServiceMethod>& server_method_names_);
 
     /**
-     * @brief Get all client/method names.
+     * @brief Get the pairs of service name / method name of all eCAL Clients.
      *
      * @param client_method_names_ Set to store the client/method names (Set { (ClientName, MethodName) }).
     **/

--- a/ecal/core/include/ecal/service/client.h
+++ b/ecal/core/include/ecal/service/client.h
@@ -55,7 +55,7 @@ namespace eCAL
        * @param event_callback_          The client event callback funtion.
       **/
       ECAL_API_EXPORTED_MEMBER
-        CServiceClient(const std::string& service_name_, const ServiceMethodInformationMapT method_information_map_ = ServiceMethodInformationMapT(), const ClientEventCallbackT event_callback_ = ClientEventCallbackT());
+        CServiceClient(const std::string& service_name_, const ServiceMethodInfoSetT method_information_map_ = ServiceMethodInfoSetT(), const ClientEventCallbackT event_callback_ = ClientEventCallbackT());
 
       /**
        * @brief Destructor.

--- a/ecal/core/include/ecal/service/client.h
+++ b/ecal/core/include/ecal/service/client.h
@@ -51,11 +51,11 @@ namespace eCAL
        * @brief Constructor.
        *
        * @param service_name_            Unique service name.
-       * @param method_information_map_  Map of method names and corresponding datatype information.
+       * @param method_information_set_  Set of method names and corresponding datatype information.
        * @param event_callback_          The client event callback funtion.
       **/
       ECAL_API_EXPORTED_MEMBER
-        CServiceClient(const std::string& service_name_, const ServiceMethodInfoSetT method_information_map_ = ServiceMethodInfoSetT(), const ClientEventCallbackT event_callback_ = ClientEventCallbackT());
+        CServiceClient(const std::string& service_name_, const ServiceMethodInfoSetT& method_information_set_ = ServiceMethodInfoSetT(), const ClientEventCallbackT event_callback_ = ClientEventCallbackT());
 
       /**
        * @brief Destructor.

--- a/ecal/core/include/ecal/service/server.h
+++ b/ecal/core/include/ecal/service/server.h
@@ -92,7 +92,7 @@ namespace eCAL
        * @return  True if succeeded, false if not.
       **/
       ECAL_API_EXPORTED_MEMBER
-        bool SetMethodCallback(const std::string& method_, const SServiceMethodInformation& method_info_, const MethodInfoCallbackT& callback_);
+        bool SetMethodCallback(const SMethodInfo& method_info_, const MethodInfoCallbackT& callback_);
 
       /**
        * @brief Remove method callback.

--- a/ecal/core/include/ecal/service/server.h
+++ b/ecal/core/include/ecal/service/server.h
@@ -92,7 +92,7 @@ namespace eCAL
        * @return  True if succeeded, false if not.
       **/
       ECAL_API_EXPORTED_MEMBER
-        bool SetMethodCallback(const SMethodInfo& method_info_, const MethodInfoCallbackT& callback_);
+        bool SetMethodCallback(const SServiceMethodInformation& method_info_, const MethodInfoCallbackT& callback_);
 
       /**
        * @brief Remove method callback.

--- a/ecal/core/include/ecal/service/types.h
+++ b/ecal/core/include/ecal/service/types.h
@@ -126,46 +126,19 @@ namespace eCAL
   **/
   struct SMethodInfo
   {
-    std::string              method_name; //!< The name of the method.
-    SDataTypeInformation     req_type;    //!< The type of the method request.
-    SDataTypeInformation     resp_type;   //!< The type of the method response.
+    std::string              method_name;     //!< The name of the method.
+    SDataTypeInformation     request_type;    //!< The type of the method request.
+    SDataTypeInformation     response_type;   //!< The type of the method response.
 
     bool operator==(const SMethodInfo& other) const
     {
-      return method_name == other.method_name && req_type == other.req_type && resp_type == other.resp_type;
+      return method_name == other.method_name && request_type == other.request_type && response_type == other.response_type;
     }
 
     bool operator<(const SMethodInfo& other) const
     {
-      return std::tie(method_name, method_name, resp_type) < std::tie(other.method_name, other.method_name, other.resp_type);
+      return std::tie(method_name, method_name, response_type) < std::tie(other.method_name, other.method_name, other.response_type);
     }
-  };
-
-  /**
-   * @brief Optional compile time information associated with a given service method
-   *        (necessary for reflection / runtime type checking)
-  **/
-  struct SServiceMethodInformation
-  {
-    SDataTypeInformation request_type;   //!< Data type description of the request
-    SDataTypeInformation response_type;  //!< Data type description of the response
-
-    //!< @cond
-    bool operator==(const SServiceMethodInformation& other) const
-    {
-      return request_type == other.request_type && response_type == other.response_type;
-    }
-
-    bool operator!=(const SServiceMethodInformation& other) const
-    {
-      return !(*this == other);
-    }
-
-    bool operator<(const SServiceMethodInformation& rhs) const
-    {
-      return std::tie(request_type, response_type) < std::tie(rhs.request_type, rhs.response_type);
-    }
-    //!< @endcond
   };
 
   /**

--- a/ecal/core/include/ecal/service/types.h
+++ b/ecal/core/include/ecal/service/types.h
@@ -124,18 +124,18 @@ namespace eCAL
   /**
    * @brief Service method information struct containing the request and response type information.
   **/
-  struct SMethodInfo
+  struct SServiceMethodInformation
   {
     std::string              method_name;     //!< The name of the method.
     SDataTypeInformation     request_type;    //!< The type of the method request.
     SDataTypeInformation     response_type;   //!< The type of the method response.
 
-    bool operator==(const SMethodInfo& other) const
+    bool operator==(const SServiceMethodInformation& other) const
     {
       return method_name == other.method_name && request_type == other.request_type && response_type == other.response_type;
     }
 
-    bool operator<(const SMethodInfo& other) const
+    bool operator<(const SServiceMethodInformation& other) const
     {
       return std::tie(method_name, method_name, response_type) < std::tie(other.method_name, other.method_name, other.response_type);
     }
@@ -161,7 +161,7 @@ namespace eCAL
    * @param request_    The request.
    * @param response_   The response returned from the method call.
   **/
-  using MethodInfoCallbackT = std::function<int(const SMethodInfo& method_info_, const std::string& request_, std::string& response_)>;
+  using MethodInfoCallbackT = std::function<int(const SServiceMethodInformation& method_info_, const std::string& request_, std::string& response_)>;
 
   /**
    * @brief Service response callback function type (low level client interface).
@@ -174,7 +174,7 @@ namespace eCAL
   /**
    * @brief Map of <method name, method information (like request type, reponse type)>.
   **/
-  using ServiceMethodInfoSetT = std::set<SMethodInfo>;
+  using ServiceMethodInfoSetT = std::set<SServiceMethodInformation>;
   
   ECAL_CORE_NAMESPACE_V6
   {

--- a/ecal/core/include/ecal/service/types.h
+++ b/ecal/core/include/ecal/service/types.h
@@ -30,7 +30,7 @@
 #include <functional>
 #include <string>
 #include <vector>
-#include <map>
+#include <set>
 
 namespace eCAL
 {
@@ -129,6 +129,16 @@ namespace eCAL
     std::string              method_name; //!< The name of the method.
     SDataTypeInformation     req_type;    //!< The type of the method request.
     SDataTypeInformation     resp_type;   //!< The type of the method response.
+
+    bool operator==(const SMethodInfo& other) const
+    {
+      return method_name == other.method_name && req_type == other.req_type && resp_type == other.resp_type;
+    }
+
+    bool operator<(const SMethodInfo& other) const
+    {
+      return std::tie(method_name, method_name, resp_type) < std::tie(other.method_name, other.method_name, other.resp_type);
+    }
   };
 
   /**
@@ -191,7 +201,7 @@ namespace eCAL
   /**
    * @brief Map of <method name, method information (like request type, reponse type)>.
   **/
-  using ServiceMethodInformationMapT = std::map<std::string, SServiceMethodInformation>;
+  using ServiceMethodInfoSetT = std::set<SMethodInfo>;
   
   ECAL_CORE_NAMESPACE_V6
   {

--- a/ecal/core/include/ecal/v5/ecal_client.h
+++ b/ecal/core/include/ecal/v5/ecal_client.h
@@ -67,7 +67,7 @@ namespace eCAL
        * @param method_information_map_  Map of method names and corresponding datatype information.
       **/
       ECAL_API_EXPORTED_MEMBER
-        explicit CServiceClient(const std::string& service_name_, const ServiceMethodInformationMapT& method_information_map_);
+        explicit CServiceClient(const std::string& service_name_, const ServiceMethodInfoSetT& method_information_map_);
 
       /**
        * @brief Destructor.
@@ -104,7 +104,7 @@ namespace eCAL
        * @return  True if successful.
       **/
       ECAL_API_EXPORTED_MEMBER
-        bool Create(const std::string& service_name_, const ServiceMethodInformationMapT& method_information_map_);
+        bool Create(const std::string& service_name_, const ServiceMethodInfoSetT& method_information_map_);
 
       /**
        * @brief Destroys this object.

--- a/ecal/core/src/ecal_descgate.cpp
+++ b/ecal/core/src/ecal_descgate.cpp
@@ -65,7 +65,7 @@ namespace
     {
       const eCAL::SDataTypeInformation request_datatype = GetDataTypeInformation(method.req_datatype, method.req_type, method.req_desc);
       const eCAL::SDataTypeInformation response_datatype = GetDataTypeInformation(method.resp_datatype, method.resp_type, method.resp_desc);
-      methods.insert(eCAL::SMethodInfo{method.mname, request_datatype, response_datatype });
+      methods.insert(eCAL::SServiceMethodInformation{method.mname, request_datatype, response_datatype });
     }
     return methods;
   }

--- a/ecal/core/src/ecal_descgate.cpp
+++ b/ecal/core/src/ecal_descgate.cpp
@@ -305,10 +305,10 @@ namespace eCAL
       RemServiceDescription(m_service_info_map, sample_.identifier, sample_.service);
       break;
     case bct_reg_client:
-      ApplyServiceDescription(m_service_info_map, sample_.identifier, sample_.client);
+      ApplyServiceDescription(m_client_info_map, sample_.identifier, sample_.client);
       break;
     case bct_unreg_client:
-      RemServiceDescription(m_service_info_map, sample_.identifier, sample_.client);
+      RemServiceDescription(m_client_info_map, sample_.identifier, sample_.client);
       break;
     case bct_reg_publisher:
       ApplyTopicDescription(m_publisher_info_map, m_publisher_callback_map, sample_.identifier, sample_.topic.tname, sample_.topic.tdatatype);

--- a/ecal/core/src/ecal_descgate.cpp
+++ b/ecal/core/src/ecal_descgate.cpp
@@ -27,10 +27,134 @@
 
 namespace
 {
+  // TODO: this is not very performant
+  // a) this should be done when the information is first retrieved
+  // b) we always copy the info around, which is problematic for performance
+  eCAL::SDataTypeInformation GetDataTypeInformation(const eCAL::SDataTypeInformation& datatype_info_, const std::string& legacy_type_, const std::string& legacy_desc_)
+  {
+    eCAL::SDataTypeInformation datatype_info;
+
+    // if the new datatype_info field is set, use it
+    if (!datatype_info_.name.empty())
+    {
+      datatype_info = datatype_info_;
+    }
+    // otherwise use the old type and desc fields
+    else
+    {
+      datatype_info.name = legacy_type_;
+      datatype_info.descriptor = legacy_desc_;
+    }
+
+    return datatype_info;
+  }
+
   eCAL::Registration::SEntityId ConvertToEntityId(const eCAL::Registration::SampleIdentifier& sample_identifier)
   {
     eCAL::Registration::SEntityId id{ sample_identifier.entity_id, sample_identifier.process_id, sample_identifier.host_name};
     return id;
+  }
+
+  // we could also think about an update function here
+  // e.g. we don't always copy everything, but only write if things have changed. At least this would be beneficial for performance.
+  template<typename Service>
+  eCAL::ServiceMethodInfoSetT Convert(const Service& service_)
+  {
+    eCAL::ServiceMethodInfoSetT methods;
+    for (const auto& method : service_.methods)
+    {
+      const eCAL::SDataTypeInformation request_datatype = GetDataTypeInformation(method.req_datatype, method.req_type, method.req_desc);
+      const eCAL::SDataTypeInformation response_datatype = GetDataTypeInformation(method.resp_datatype, method.resp_type, method.resp_desc);
+      methods.insert(eCAL::SMethodInfo{method.mname, request_datatype, response_datatype });
+    }
+    return methods;
+  }
+
+  void ApplyTopicDescription(eCAL::CDescGate::STopicIdInfoMap& topic_info_map_,
+    const eCAL::CDescGate::STopicEventCallbackMap& topic_callback_map_,
+    const eCAL::Registration::SampleIdentifier& topic_id_,
+    const std::string& topic_name_,
+    const eCAL::SDataTypeInformation& topic_info_)
+  {
+    const auto topic_info_key = eCAL::Registration::STopicId{ ConvertToEntityId(topic_id_), topic_name_ };
+
+    // update topic info
+    bool new_topic_info(false);
+    {
+      const std::unique_lock<std::mutex> lock(topic_info_map_.mtx);
+      eCAL::CDescGate::TopicIdInfoMap::iterator topic_info_quality_iter = topic_info_map_.map.find(topic_info_key);
+      new_topic_info = topic_info_quality_iter == topic_info_map_.map.end();
+
+      if (new_topic_info)
+      {
+        std::tie(topic_info_quality_iter, std::ignore) = topic_info_map_.map.emplace(topic_info_key, eCAL::SDataTypeInformation{});
+      }
+
+      topic_info_quality_iter->second = topic_info_;
+    }
+
+    // notify publisher / subscriber registration callbacks about new entity
+    if (new_topic_info)
+    {
+      const std::unique_lock<std::mutex> lock(topic_callback_map_.mtx);
+      for (const auto& callback_iter : topic_callback_map_.map)
+      {
+        if (callback_iter.second)
+        {
+          callback_iter.second(topic_info_key, eCAL::Registration::RegistrationEventType::new_entity);
+        }
+      }
+    }
+  }
+
+  void RemTopicDescription(eCAL::CDescGate::STopicIdInfoMap& topic_info_map_,
+    const eCAL::CDescGate::STopicEventCallbackMap& topic_callback_map_,
+    const eCAL::Registration::SampleIdentifier& topic_id_,
+    const std::string& topic_name_)
+  {
+    const auto topic_info_key = eCAL::Registration::STopicId{ ConvertToEntityId(topic_id_), topic_name_ };
+
+    // delete topic info
+    bool deleted_topic_info(false);
+    {
+      const std::unique_lock<std::mutex> lock(topic_info_map_.mtx);
+      deleted_topic_info = topic_info_map_.map.erase(topic_info_key) > 0;
+    }
+
+    // notify publisher / subscriber registration callbacks about deleted entity
+    if (deleted_topic_info)
+    {
+      const std::unique_lock<std::mutex> lock(topic_callback_map_.mtx);
+      for (const auto& callback_iter : topic_callback_map_.map)
+      {
+        if (callback_iter.second)
+        {
+          callback_iter.second(topic_info_key, eCAL::Registration::RegistrationEventType::deleted_entity);
+        }
+      }
+    }
+  }
+
+  template<typename Service>
+  void ApplyServiceDescription(eCAL::CDescGate::SServiceIdInfoMap& service_method_info_map_,
+    const eCAL::Registration::SampleIdentifier& service_id_,
+    const Service& service_)
+  {
+    const auto service_method_info_key = eCAL::Registration::SServiceId{ ConvertToEntityId(service_id_), service_.sname };
+
+    const std::lock_guard<std::mutex> lock(service_method_info_map_.mtx);
+    service_method_info_map_.id_map[service_method_info_key] = Convert(service_);
+  }
+
+  template<typename Service>
+  void RemServiceDescription(eCAL::CDescGate::SServiceIdInfoMap& service_method_info_map_,
+    const eCAL::Registration::SampleIdentifier& service_id_,
+    const Service& service_)
+  {
+    const auto service_method_info_key = eCAL::Registration::SServiceId{ ConvertToEntityId(service_id_),  service_.sname };
+
+    const std::lock_guard<std::mutex> lock(service_method_info_map_.mtx);
+    service_method_info_map_.id_map.erase(service_method_info_key);
   }
 }
 
@@ -91,22 +215,22 @@ namespace eCAL
     m_subscriber_callback_map.map.erase(token_);
   }
 
-  std::set<Registration::SServiceMethodId> CDescGate::GetServerIDs() const
+  std::set<Registration::SServiceId> CDescGate::GetServerIDs() const
   {
-    return GetServerIDs(m_service_info_map);
+    return GetServiceIDs(m_service_info_map);
   }
 
-  bool CDescGate::GetServerInfo(const Registration::SServiceMethodId& id_, SServiceMethodInformation& service_info_) const
+  bool CDescGate::GetServerInfo(const Registration::SServiceId& id_, ServiceMethodInfoSetT& service_info_) const
   {
     return GetService(id_, m_service_info_map, service_info_);
   }
 
-  std::set<Registration::SServiceMethodId> CDescGate::GetClientIDs() const
+  std::set<Registration::SServiceId> CDescGate::GetClientIDs() const
   {
-    return GetServerIDs(m_client_info_map);
+    return GetServiceIDs(m_client_info_map);
   }
 
-  bool CDescGate::GetClientInfo(const Registration::SServiceMethodId& id_, SServiceMethodInformation& service_info_) const
+  bool CDescGate::GetClientInfo(const Registration::SServiceId& id_, ServiceMethodInfoSetT& service_info_) const
   {
     return GetService(id_, m_client_info_map, service_info_);
   }
@@ -138,9 +262,9 @@ namespace eCAL
     }
   }
 
-  std::set<Registration::SServiceMethodId> CDescGate::GetServerIDs(const SServiceIdInfoMap& service_method_info_map_)
+  std::set<Registration::SServiceId> CDescGate::GetServiceIDs(const SServiceIdInfoMap& service_method_info_map_)
   {
-    std::set<Registration::SServiceMethodId> service_id_set;
+    std::set<Registration::SServiceId> service_id_set;
 
     const std::lock_guard<std::mutex> lock(service_method_info_map_.mtx);
     for (const auto& service_method_info_map_it : service_method_info_map_.id_map)
@@ -150,7 +274,7 @@ namespace eCAL
     return service_id_set;
   }
 
-  bool CDescGate::GetService(const Registration::SServiceMethodId& id_, const SServiceIdInfoMap& service_method_info_map_, SServiceMethodInformation& service_method_info_)
+  bool CDescGate::GetService(const Registration::SServiceId& id_, const SServiceIdInfoMap& service_method_info_map_, ServiceMethodInfoSetT& service_method_info_)
   {
     const std::lock_guard<std::mutex> lock(service_method_info_map_.mtx);
     auto iter = service_method_info_map_.id_map.find(id_);
@@ -175,30 +299,16 @@ namespace eCAL
     case bct_unreg_process:
       break;
     case bct_reg_service:
-    {
-      for (const auto& method : sample_.service.methods)
-      {
-        const SDataTypeInformation request_datatype  = GetDataTypeInformation(method.req_datatype, method.req_type, method.req_desc);
-        const SDataTypeInformation response_datatype = GetDataTypeInformation(method.resp_datatype, method.resp_type, method.resp_desc);
-
-        ApplyServiceDescription(m_service_info_map, sample_.identifier, sample_.service.sname, method.mname, request_datatype, response_datatype);
-      }
-    }
-    break;
+      ApplyServiceDescription(m_service_info_map, sample_.identifier, sample_.service);
+      break;
     case bct_unreg_service:
-      RemServiceDescription(m_service_info_map, sample_.identifier, sample_.service.sname);
+      RemServiceDescription(m_service_info_map, sample_.identifier, sample_.service);
       break;
     case bct_reg_client:
-      for (const auto& method : sample_.client.methods)
-      {
-        const SDataTypeInformation request_datatype  = GetDataTypeInformation(method.req_datatype, method.req_type, method.req_desc);
-        const SDataTypeInformation response_datatype = GetDataTypeInformation(method.resp_datatype, method.resp_type, method.resp_desc);
-
-        ApplyServiceDescription(m_client_info_map, sample_.identifier, sample_.client.sname, method.mname, request_datatype, response_datatype);
-     }
+      ApplyServiceDescription(m_service_info_map, sample_.identifier, sample_.client);
       break;
     case bct_unreg_client:
-      RemServiceDescription(m_client_info_map, sample_.identifier, sample_.client.sname);
+      RemServiceDescription(m_service_info_map, sample_.identifier, sample_.client);
       break;
     case bct_reg_publisher:
       ApplyTopicDescription(m_publisher_info_map, m_publisher_callback_map, sample_.identifier, sample_.topic.tname, sample_.topic.tdatatype);
@@ -218,131 +328,6 @@ namespace eCAL
     }
     break;
     }
-  }
-
-  void CDescGate::ApplyTopicDescription(STopicIdInfoMap& topic_info_map_,
-                                        const STopicEventCallbackMap& topic_callback_map_,
-                                        const Registration::SampleIdentifier& topic_id_,
-                                        const std::string& topic_name_,
-                                        const SDataTypeInformation& topic_info_)
-  {
-    const auto topic_info_key = Registration::STopicId{ ConvertToEntityId(topic_id_), topic_name_ };
-
-    // update topic info
-    bool new_topic_info(false);
-    {
-      const std::unique_lock<std::mutex> lock(topic_info_map_.mtx);
-      TopicIdInfoMap::iterator topic_info_quality_iter = topic_info_map_.map.find(topic_info_key);
-      new_topic_info = topic_info_quality_iter == topic_info_map_.map.end();
-
-      if (new_topic_info)
-      {
-        std::tie(topic_info_quality_iter, std::ignore) = topic_info_map_.map.emplace(topic_info_key, SDataTypeInformation{});
-      }
-
-      topic_info_quality_iter->second = topic_info_;
-    }
-
-    // notify publisher / subscriber registration callbacks about new entity
-    if(new_topic_info)
-    {
-      const std::unique_lock<std::mutex> lock(topic_callback_map_.mtx);
-      for (const auto& callback_iter : topic_callback_map_.map)
-      {
-        if (callback_iter.second)
-        {
-          callback_iter.second(topic_info_key, Registration::RegistrationEventType::new_entity);
-        }
-      }
-    }
-  }
-
-  void CDescGate::RemTopicDescription(STopicIdInfoMap& topic_info_map_,
-                                      const STopicEventCallbackMap& topic_callback_map_,
-                                      const Registration::SampleIdentifier& topic_id_,
-                                      const std::string& topic_name_)
-  {
-    const auto topic_info_key = Registration::STopicId{ ConvertToEntityId(topic_id_), topic_name_ };
-
-    // delete topic info
-    bool deleted_topic_info(false);
-    {
-      const std::unique_lock<std::mutex> lock(topic_info_map_.mtx);
-      deleted_topic_info = topic_info_map_.map.erase(topic_info_key) > 0;
-    }
-
-    // notify publisher / subscriber registration callbacks about deleted entity
-    if (deleted_topic_info)
-    {
-      const std::unique_lock<std::mutex> lock(topic_callback_map_.mtx);
-      for (const auto& callback_iter : topic_callback_map_.map)
-      {
-        if (callback_iter.second)
-        {
-          callback_iter.second(topic_info_key, Registration::RegistrationEventType::deleted_entity);
-        }
-      }
-    }
-  }
-
-  void CDescGate::ApplyServiceDescription(SServiceIdInfoMap& service_method_info_map_,
-                                          const Registration::SampleIdentifier& service_id_,
-                                          const std::string& service_name_,
-                                          const std::string& method_name_,
-                                          const SDataTypeInformation& request_type_information_,
-                                          const SDataTypeInformation& response_type_information_)
-  {
-    const auto service_method_info_key = Registration::SServiceMethodId{ ConvertToEntityId(service_id_), service_name_, method_name_};
-
-    SServiceMethodInformation service_info;
-    service_info.request_type  = request_type_information_;
-    service_info.response_type = response_type_information_;
-
-    const std::lock_guard<std::mutex> lock(service_method_info_map_.mtx);
-    service_method_info_map_.id_map[service_method_info_key] = service_info;
-  }
-
-  void CDescGate::RemServiceDescription(SServiceIdInfoMap& service_method_info_map_,
-                                        const Registration::SampleIdentifier& service_id_,
-                                        const std::string& service_name_)
-  {
-    std::list<Registration::SServiceMethodId> service_method_info_keys_to_remove;
-
-    const std::lock_guard<std::mutex> lock(service_method_info_map_.mtx);
-
-    for (auto&& service_it : service_method_info_map_.id_map)
-    {
-      const auto service_method_info_key = service_it.first;
-      if ((service_method_info_key.service_name == service_name_)
-        && (service_method_info_key.service_id == ConvertToEntityId(service_id_)))
-      {
-        service_method_info_keys_to_remove.push_back(service_method_info_key);
-      }
-    }
-
-    for (const auto& service_method_info_key : service_method_info_keys_to_remove)
-    {
-      service_method_info_map_.id_map.erase(service_method_info_key);
-    }
-  }
-
-  SDataTypeInformation CDescGate::GetDataTypeInformation(const SDataTypeInformation& datatype_info_, const std::string& legacy_type_, const std::string& legacy_desc_)
-  {
-    SDataTypeInformation datatype_info;
-
-    // if the new datatype_info field is set, use it
-    if (!datatype_info_.name.empty())
-    {
-      datatype_info = datatype_info_;
-    }
-    // otherwise use the old type and desc fields
-    else
-    {
-      datatype_info.name       = legacy_type_;
-      datatype_info.descriptor = legacy_desc_;
-    }
-
-    return datatype_info;
   }
 
   Registration::CallbackToken CDescGate::CreateToken()

--- a/ecal/core/src/ecal_descgate.h
+++ b/ecal/core/src/ecal_descgate.h
@@ -61,12 +61,12 @@ namespace eCAL
     void RemSubscriberEventCallback(Registration::CallbackToken token_);
 
     // get service information
-    std::set<Registration::SServiceMethodId> GetServerIDs() const;
-    bool GetServerInfo(const Registration::SServiceMethodId& id_, SServiceMethodInformation& service_info_) const;
+    std::set<Registration::SServiceId> GetServerIDs() const;
+    bool GetServerInfo(const Registration::SServiceId& id_, ServiceMethodInfoSetT& service_info_) const;
 
     // get client information
-    std::set<Registration::SServiceMethodId> GetClientIDs() const;
-    bool GetClientInfo(const Registration::SServiceMethodId& id_, SServiceMethodInformation& service_info_) const;
+    std::set<Registration::SServiceId> GetClientIDs() const;
+    bool GetClientInfo(const Registration::SServiceId& id_, ServiceMethodInfoSetT& service_info_) const;
 
     // delete copy constructor and copy assignment operator
     CDescGate(const CDescGate&) = delete;
@@ -76,7 +76,6 @@ namespace eCAL
     CDescGate(CDescGate&&) = delete;
     CDescGate& operator=(CDescGate&&) = delete;
 
-  protected:
     using TopicIdInfoMap  = std::map<Registration::STopicId, SDataTypeInformation>;
     struct STopicIdInfoMap
     {
@@ -91,42 +90,21 @@ namespace eCAL
       TopicEventCallbackMap map;
     };
 
-    using ServiceIdInfoMap = std::map<Registration::SServiceMethodId, SServiceMethodInformation>;
+    using ServiceIdInfoMap = std::map<Registration::SServiceId, ServiceMethodInfoSetT>;
     struct SServiceIdInfoMap
     {
       mutable std::mutex  mtx;
       ServiceIdInfoMap id_map;
     };
 
+  protected:
+
     static std::set<Registration::STopicId>   GetTopicIDs(const STopicIdInfoMap& topic_info_map_);
     static bool                               GetTopic   (const Registration::STopicId& id_, const STopicIdInfoMap& topic_info_map_, SDataTypeInformation& topic_info_);
 
-    static std::set<Registration::SServiceMethodId> GetServerIDs(const SServiceIdInfoMap& service_method_info_map_);
-    static bool                                     GetService   (const Registration::SServiceMethodId& id_, const SServiceIdInfoMap& service_method_info_map_, SServiceMethodInformation& service_method_info_);
+    static std::set<Registration::SServiceId> GetServiceIDs(const SServiceIdInfoMap& service_method_info_map_);
+    static bool                               GetService   (const Registration::SServiceId& id_, const SServiceIdInfoMap& service_method_info_map_, ServiceMethodInfoSetT& service_method_info_);
 
-    static void ApplyTopicDescription(STopicIdInfoMap& topic_info_map_,
-                                      const STopicEventCallbackMap& topic_callback_map_, 
-                                      const Registration::SampleIdentifier& topic_id_,
-                                      const std::string& topic_name_,
-                                      const SDataTypeInformation& topic_info_);
-
-    static void RemTopicDescription(STopicIdInfoMap& topic_info_map_,
-                                    const STopicEventCallbackMap& topic_callback_map_,
-                                    const Registration::SampleIdentifier& topic_id_,
-                                    const std::string& topic_name_);
-
-    static void ApplyServiceDescription(SServiceIdInfoMap& service_method_info_map_,
-                                        const Registration::SampleIdentifier& service_id_,
-                                        const std::string& service_name_,
-                                        const std::string& method_name_,
-                                        const SDataTypeInformation& request_type_information_,
-                                        const SDataTypeInformation& response_type_information_);
-
-    static void RemServiceDescription(SServiceIdInfoMap& service_method_info_map_,
-                                      const Registration::SampleIdentifier& service_id_,
-                                      const std::string& service_name_);
-
-    static SDataTypeInformation GetDataTypeInformation(const SDataTypeInformation& datatype_info_, const std::string& legacy_type_, const std::string& legacy_desc_);
     Registration::CallbackToken CreateToken();
       
     // internal quality topic info publisher/subscriber maps

--- a/ecal/core/src/registration/ecal_registration.cpp
+++ b/ecal/core/src/registration/ecal_registration.cpp
@@ -123,19 +123,19 @@ namespace eCAL
       }
     }
     
-    void GetServiceMethodNames(std::set<SServiceMethod>& service_method_names_)
+    void GetServerMethodNames(std::set<SServiceMethod>& server_method_names_)
     {
-      service_method_names_.clear();
+      server_method_names_.clear();
 
-      // get clients id set and insert names into the client_method_names set
-      const std::set<SServiceId> client_id_set = GetServerIDs();
-      for (const auto& client_id : client_id_set)
+      // get servers id set and insert names into the server_method_names_ set
+      const std::set<SServiceId> server_id_set = GetServerIDs();
+      for (const auto& server_id : server_id_set)
       {
         eCAL::ServiceMethodInfoSetT methods;
-        (void)GetServerInfo(client_id, methods);
+        (void)GetServerInfo(server_id, methods);
         for (const auto& method : methods)
         {
-          service_method_names_.insert({ client_id.service_name, method.method_name });
+          server_method_names_.insert({ server_id.service_name, method.method_name });
         }
       }
     }

--- a/ecal/core/src/registration/ecal_registration.cpp
+++ b/ecal/core/src/registration/ecal_registration.cpp
@@ -82,25 +82,25 @@ namespace eCAL
       return g_descgate()->RemSubscriberEventCallback(token_);
     }
 
-    std::set<SServiceMethodId> GetServerIDs()
+    std::set<SServiceId> GetServerIDs()
     {
-      if (g_descgate() == nullptr) return std::set<SServiceMethodId>();
+      if (g_descgate() == nullptr) return std::set<SServiceId>();
       return g_descgate()->GetServerIDs();
     }
 
-    bool GetServerInfo(const SServiceMethodId& id_, SServiceMethodInformation& service_info_)
+    bool GetServerInfo(const SServiceId& id_, ServiceMethodInfoSetT& service_info_)
     {
       if (g_descgate() == nullptr) return false;
       return g_descgate()->GetServerInfo(id_, service_info_);
     }
 
-    std::set<SServiceMethodId> GetClientIDs()
+    std::set<SServiceId> GetClientIDs()
     {
-      if (g_descgate() == nullptr) return std::set<SServiceMethodId>();
+      if (g_descgate() == nullptr) return std::set<SServiceId>();
       return g_descgate()->GetClientIDs();
     }
 
-    bool GetClientInfo(const SServiceMethodId& id_, SServiceMethodInformation& service_info_)
+    bool GetClientInfo(const SServiceId& id_, ServiceMethodInfoSetT& service_info_)
     {
       if (g_descgate() == nullptr) return false;
       return g_descgate()->GetClientInfo(id_, service_info_);
@@ -122,16 +122,20 @@ namespace eCAL
         topic_names_.insert(sub_id.topic_name);
       }
     }
-
+    
     void GetServiceMethodNames(std::set<SServiceMethod>& service_method_names_)
     {
       service_method_names_.clear();
 
-      // get services id set and insert names into the service_method_names set
-      const std::set<SServiceMethodId> service_id_set = GetServerIDs();
-      for (const auto& service_id : service_id_set)
+      // get clients id set and insert names into the client_method_names set
+      const std::set<SServiceId> client_id_set = GetClientIDs();
+      for (const auto& client_id : client_id_set)
       {
-        service_method_names_.insert({ service_id.service_name, service_id.method_name });
+        eCAL::ServiceMethodInfoSetT methods;
+        for (const auto& method : methods)
+        {
+          service_method_names_.insert({ client_id.service_name, method.method_name });
+        }
       }
     }
 
@@ -140,11 +144,16 @@ namespace eCAL
       client_method_names_.clear();
 
       // get clients id set and insert names into the client_method_names set
-      const std::set<SServiceMethodId> client_id_set = GetClientIDs();
+      const std::set<SServiceId> client_id_set = GetClientIDs();
       for (const auto& client_id : client_id_set)
       {
-        client_method_names_.insert({ client_id.service_name, client_id.method_name });
+        eCAL::ServiceMethodInfoSetT methods;
+        for (const auto& method : methods)
+        {
+          client_method_names_.insert({ client_id.service_name, method.method_name });
+        }
       }
     }
+    
   }
 }

--- a/ecal/core/src/registration/ecal_registration.cpp
+++ b/ecal/core/src/registration/ecal_registration.cpp
@@ -128,10 +128,11 @@ namespace eCAL
       service_method_names_.clear();
 
       // get clients id set and insert names into the client_method_names set
-      const std::set<SServiceId> client_id_set = GetClientIDs();
+      const std::set<SServiceId> client_id_set = GetServerIDs();
       for (const auto& client_id : client_id_set)
       {
         eCAL::ServiceMethodInfoSetT methods;
+        (void)GetServerInfo(client_id, methods);
         for (const auto& method : methods)
         {
           service_method_names_.insert({ client_id.service_name, method.method_name });
@@ -148,6 +149,7 @@ namespace eCAL
       for (const auto& client_id : client_id_set)
       {
         eCAL::ServiceMethodInfoSetT methods;
+        (void)GetClientInfo(client_id, methods);
         for (const auto& method : methods)
         {
           client_method_names_.insert({ client_id.service_name, method.method_name });

--- a/ecal/core/src/serialization/ecal_struct_sample_common.h
+++ b/ecal/core/src/serialization/ecal_struct_sample_common.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,12 +33,12 @@ namespace eCAL
     bct_reg_publisher    = 2,
     bct_reg_subscriber   = 3,
     bct_reg_process      = 4,
-    bct_reg_service      = 5,
+    bct_reg_service      = 5,  // TODO: should be named server!
     bct_reg_client       = 6,
     bct_unreg_publisher  = 12,
     bct_unreg_subscriber = 13,
     bct_unreg_process    = 14,
-    bct_unreg_service    = 15,
+    bct_unreg_service    = 15, // TODO: should be named server!
     bct_unreg_client     = 16
   };
 

--- a/ecal/core/src/serialization/ecal_struct_service.h
+++ b/ecal/core/src/serialization/ecal_struct_service.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -154,6 +154,7 @@ namespace eCAL
     };
 
     // Service
+    // TODO: this naming is wrong, it should be Server!!!
     struct Service
     {
       int32_t                         rclock = 0;       // Registration clock

--- a/ecal/core/src/service/ecal_service_client.cpp
+++ b/ecal/core/src/service/ecal_service_client.cpp
@@ -34,7 +34,7 @@ namespace eCAL
 {
   ECAL_CORE_NAMESPACE_V6
   {
-  CServiceClient::CServiceClient(const std::string & service_name_, const ServiceMethodInformationMapT method_information_map_, const ClientEventCallbackT event_callback_)
+  CServiceClient::CServiceClient(const std::string & service_name_, const ServiceMethodInfoSetT method_information_map_, const ClientEventCallbackT event_callback_)
   {
     // create client implementation
     m_service_client_impl = CServiceClientImpl::CreateInstance(service_name_, method_information_map_, event_callback_);

--- a/ecal/core/src/service/ecal_service_client.cpp
+++ b/ecal/core/src/service/ecal_service_client.cpp
@@ -34,10 +34,10 @@ namespace eCAL
 {
   ECAL_CORE_NAMESPACE_V6
   {
-  CServiceClient::CServiceClient(const std::string & service_name_, const ServiceMethodInfoSetT method_information_map_, const ClientEventCallbackT event_callback_)
+  CServiceClient::CServiceClient(const std::string & service_name_, const ServiceMethodInfoSetT& method_information_set_, const ClientEventCallbackT event_callback_)
   {
     // create client implementation
-    m_service_client_impl = CServiceClientImpl::CreateInstance(service_name_, method_information_map_, event_callback_);
+    m_service_client_impl = CServiceClientImpl::CreateInstance(service_name_, method_information_set_, event_callback_);
 
     // register client
     if (g_clientgate() != nullptr) g_clientgate()->Register(service_name_, m_service_client_impl);

--- a/ecal/core/src/service/ecal_service_client_impl.cpp
+++ b/ecal/core/src/service/ecal_service_client_impl.cpp
@@ -375,14 +375,14 @@ namespace eCAL
       method.mname = method_name;
 
       // old type and descriptor fields
-      method.req_type = method_information.req_type.name;
-      method.req_desc = method_information.req_type.descriptor;
-      method.resp_type = method_information.resp_type.name;
-      method.resp_desc = method_information.resp_type.descriptor;
+      method.req_type = method_information.request_type.name;
+      method.req_desc = method_information.request_type.descriptor;
+      method.resp_type = method_information.response_type.name;
+      method.resp_desc = method_information.response_type.descriptor;
 
       // new type and descriptor fields
-      method.req_datatype = method_information.req_type;
-      method.resp_datatype = method_information.resp_type;
+      method.req_datatype = method_information.request_type;
+      method.resp_datatype = method_information.response_type;
 
       {
         const auto& call_count_iter = m_method_call_count_map.find(method_name);

--- a/ecal/core/src/service/ecal_service_client_impl.h
+++ b/ecal/core/src/service/ecal_service_client_impl.h
@@ -49,11 +49,11 @@ namespace eCAL
     public:
       // Factory method to create an instance of the client implementation
       static std::shared_ptr<CServiceClientImpl> CreateInstance(
-        const std::string& service_name_, const ServiceMethodInformationMapT& method_information_map_, const ClientEventCallbackT& event_callback_);
+        const std::string& service_name_, const ServiceMethodInfoSetT& method_information_map_, const ClientEventCallbackT& event_callback_);
 
     private:
       // Private constructor to enforce creation through factory method
-      CServiceClientImpl(const std::string& service_name_, const ServiceMethodInformationMapT& method_information_map_, const ClientEventCallbackT& event_callback_);
+      CServiceClientImpl(const std::string& service_name_, const ServiceMethodInfoSetT& method_information_map_, const ClientEventCallbackT& event_callback_);
 
     public:
       ~CServiceClientImpl();
@@ -158,8 +158,8 @@ namespace eCAL
       ClientSessionsMapT           m_client_session_map;
 
       // Method information map (tracks method attributes like data type and description)
-      std::mutex                   m_method_information_map_mutex;
-      ServiceMethodInformationMapT m_method_information_map;
+      std::mutex                   m_method_information_set_mutex;
+      ServiceMethodInfoSetT        m_method_information_set;
 
       // Method call count map (tracks number of calls for each method)
       using MethodCallCountMapT = std::map<std::string, uint64_t>;

--- a/ecal/core/src/service/ecal_service_server.cpp
+++ b/ecal/core/src/service/ecal_service_server.cpp
@@ -64,10 +64,10 @@ namespace eCAL
     return *this;
   }
 
-  bool CServiceServer::SetMethodCallback(const std::string & method_, const SServiceMethodInformation & method_info_, const MethodInfoCallbackT & callback_)
+  bool CServiceServer::SetMethodCallback(const SMethodInfo& method_info_, const MethodInfoCallbackT & callback_)
   {
     if (m_service_server_impl == nullptr) return false;
-    return m_service_server_impl->SetMethodCallback(method_, method_info_, callback_);
+    return m_service_server_impl->SetMethodCallback(method_info_, callback_);
   }
 
   bool CServiceServer::RemoveMethodCallback(const std::string & method_)

--- a/ecal/core/src/service/ecal_service_server.cpp
+++ b/ecal/core/src/service/ecal_service_server.cpp
@@ -64,7 +64,7 @@ namespace eCAL
     return *this;
   }
 
-  bool CServiceServer::SetMethodCallback(const SMethodInfo& method_info_, const MethodInfoCallbackT & callback_)
+  bool CServiceServer::SetMethodCallback(const SServiceMethodInformation& method_info_, const MethodInfoCallbackT & callback_)
   {
     if (m_service_server_impl == nullptr) return false;
     return m_service_server_impl->SetMethodCallback(method_info_, callback_);

--- a/ecal/core/src/service/ecal_service_server_impl.cpp
+++ b/ecal/core/src/service/ecal_service_server_impl.cpp
@@ -68,7 +68,7 @@ namespace eCAL
     Stop();
   }
 
-  bool CServiceServerImpl::SetMethodCallback(const SMethodInfo& method_info_, const MethodInfoCallbackT & callback_)
+  bool CServiceServerImpl::SetMethodCallback(const SServiceMethodInformation& method_info_, const MethodInfoCallbackT & callback_)
   {
     const auto& method_ = method_info_.method_name;
 
@@ -477,7 +477,7 @@ namespace eCAL
     // execute method (outside lock guard)
     const std::string& request_s = request.request;
     std::string response_s;
-    const SMethodInfo method_info{
+    const SServiceMethodInformation method_info{
       method.method.mname,
       method.method.req_datatype,
       method.method.resp_datatype

--- a/ecal/core/src/service/ecal_service_server_impl.cpp
+++ b/ecal/core/src/service/ecal_service_server_impl.cpp
@@ -68,8 +68,10 @@ namespace eCAL
     Stop();
   }
 
-  bool CServiceServerImpl::SetMethodCallback(const std::string & method_, const SServiceMethodInformation & method_info_, const MethodInfoCallbackT & callback_)
+  bool CServiceServerImpl::SetMethodCallback(const SMethodInfo& method_info_, const MethodInfoCallbackT & callback_)
   {
+    const auto& method_ = method_info_.method_name;
+
 #ifndef NDEBUG
     Logging::Log(Logging::log_level_debug1, "CServiceServerImpl::SetMethodCallback: Adding method callback for method: " + method_);
 #endif

--- a/ecal/core/src/service/ecal_service_server_impl.h
+++ b/ecal/core/src/service/ecal_service_server_impl.h
@@ -59,7 +59,7 @@ namespace eCAL
     public:
       ~CServiceServerImpl();
 
-      bool SetMethodCallback(const std::string& method_, const SServiceMethodInformation& method_info_, const MethodInfoCallbackT& callback_);
+      bool SetMethodCallback(const SMethodInfo& method_info_, const MethodInfoCallbackT& callback_);
       bool RemoveMethodCallback(const std::string& method_);
 
       // Check connection state of a specific service

--- a/ecal/core/src/service/ecal_service_server_impl.h
+++ b/ecal/core/src/service/ecal_service_server_impl.h
@@ -59,7 +59,7 @@ namespace eCAL
     public:
       ~CServiceServerImpl();
 
-      bool SetMethodCallback(const SMethodInfo& method_info_, const MethodInfoCallbackT& callback_);
+      bool SetMethodCallback(const SServiceMethodInformation& method_info_, const MethodInfoCallbackT& callback_);
       bool RemoveMethodCallback(const std::string& method_);
 
       // Check connection state of a specific service

--- a/ecal/core/src/v5/service/ecal_service_client.cpp
+++ b/ecal/core/src/v5/service/ecal_service_client.cpp
@@ -44,7 +44,7 @@ namespace eCAL
       Create(service_name_);
     }
 
-    CServiceClient::CServiceClient(const std::string& service_name_, const ServiceMethodInformationMapT& method_information_map_)
+    CServiceClient::CServiceClient(const std::string& service_name_, const ServiceMethodInfoSetT& method_information_map_)
       : m_service_client_impl(nullptr)
     {
       Create(service_name_, method_information_map_);
@@ -57,10 +57,10 @@ namespace eCAL
 
     bool CServiceClient::Create(const std::string& service_name_)
     {
-      return Create(service_name_, ServiceMethodInformationMapT());
+      return Create(service_name_, ServiceMethodInfoSetT());
     }
 
-    bool CServiceClient::Create(const std::string& service_name_, const ServiceMethodInformationMapT& method_information_map_)
+    bool CServiceClient::Create(const std::string& service_name_, const ServiceMethodInfoSetT& method_information_map_)
     {
       if (m_service_client_impl != nullptr) return false;
       m_service_client_impl = std::make_shared<CServiceClientImpl>(service_name_, method_information_map_);

--- a/ecal/core/src/v5/service/ecal_service_client_impl.cpp
+++ b/ecal/core/src/v5/service/ecal_service_client_impl.cpp
@@ -66,7 +66,7 @@ namespace eCAL
       Create(service_name_);
     }
 
-    CServiceClientImpl::CServiceClientImpl(const std::string& service_name_, const ServiceMethodInformationMapT& method_information_map_)
+    CServiceClientImpl::CServiceClientImpl(const std::string& service_name_, const ServiceMethodInfoSetT& method_information_map_)
       : m_service_client_impl(nullptr)
     {
       Logging::Log(Logging::log_level_debug2, "v5::CServiceClientImpl: Initializing service client with name: " + service_name_);
@@ -81,10 +81,10 @@ namespace eCAL
 
     bool CServiceClientImpl::Create(const std::string& service_name_)
     {
-      return Create(service_name_, ServiceMethodInformationMapT());
+      return Create(service_name_, ServiceMethodInfoSetT());
     }
 
-    bool CServiceClientImpl::Create(const std::string& service_name_, const ServiceMethodInformationMapT& method_information_map_)
+    bool CServiceClientImpl::Create(const std::string& service_name_, const ServiceMethodInfoSetT& method_information_map_)
     {
       if (m_service_client_impl != nullptr)
       {

--- a/ecal/core/src/v5/service/ecal_service_client_impl.h
+++ b/ecal/core/src/v5/service/ecal_service_client_impl.h
@@ -51,7 +51,7 @@ namespace eCAL
       explicit CServiceClientImpl(const std::string& service_name_);
 
       // Constructor for creating a service client instance with a service name and method information map.
-      explicit CServiceClientImpl(const std::string& service_name_, const ServiceMethodInformationMapT& method_information_map_);
+      explicit CServiceClientImpl(const std::string& service_name_, const ServiceMethodInfoSetT& method_information_map_);
 
       // Destructor to clean up resources.
       virtual ~CServiceClientImpl();
@@ -60,7 +60,7 @@ namespace eCAL
       bool Create(const std::string& service_name_);
 
       // Creates a service client with a specific service name and method information map.
-      bool Create(const std::string& service_name_, const ServiceMethodInformationMapT& method_information_map_);
+      bool Create(const std::string& service_name_, const ServiceMethodInfoSetT& method_information_map_);
 
       // Destroys the service client instance and releases resources.
       bool Destroy();

--- a/ecal/core/src/v5/service/ecal_service_server_impl.cpp
+++ b/ecal/core/src/v5/service/ecal_service_server_impl.cpp
@@ -105,13 +105,14 @@ namespace eCAL
         return false;
       }
 
-      SServiceMethodInformation method_info;
+      SMethodInfo method_info;
+      method_info.method_name          = method_;
       method_info.request_type.name        = req_type_;
       method_info.request_type.descriptor  = req_desc_;
       method_info.response_type.name       = resp_type_;
       method_info.response_type.descriptor = resp_desc_;
 
-      return m_service_server_impl->SetMethodCallback(method_, method_info, nullptr);
+      return m_service_server_impl->SetMethodCallback(method_info, nullptr);
     }
 
     bool CServiceServerImpl::AddMethodCallback(const std::string& method_, const std::string& req_type_, const std::string& resp_type_, const MethodCallbackT& callback_)
@@ -124,7 +125,8 @@ namespace eCAL
         return false;
       }
 
-      SServiceMethodInformation method_info;
+      SMethodInfo method_info;
+      method_info.method_name    = method_;
       method_info.request_type.name  = req_type_;
       method_info.response_type.name = resp_type_;
 
@@ -134,10 +136,10 @@ namespace eCAL
           const std::string& request,
           std::string&       response) -> int
         {
-          return callback_(method_info.method_name, method_info.req_type.name, method_info.resp_type.name, request, response);
+          return callback_(method_info.method_name, method_info.request_type.name, method_info.response_type.name, request, response);
         };
 
-      return m_service_server_impl->SetMethodCallback(method_, method_info, callback);
+      return m_service_server_impl->SetMethodCallback(method_info, callback);
     }
 
     bool CServiceServerImpl::RemMethodCallback(const std::string& method_)

--- a/ecal/core/src/v5/service/ecal_service_server_impl.cpp
+++ b/ecal/core/src/v5/service/ecal_service_server_impl.cpp
@@ -105,7 +105,7 @@ namespace eCAL
         return false;
       }
 
-      SMethodInfo method_info;
+      SServiceMethodInformation method_info;
       method_info.method_name          = method_;
       method_info.request_type.name        = req_type_;
       method_info.request_type.descriptor  = req_desc_;
@@ -125,14 +125,14 @@ namespace eCAL
         return false;
       }
 
-      SMethodInfo method_info;
+      SServiceMethodInformation method_info;
       method_info.method_name    = method_;
       method_info.request_type.name  = req_type_;
       method_info.response_type.name = resp_type_;
 
       const MethodInfoCallbackT callback =
         [req_type_, resp_type_, callback_](
-          const SMethodInfo& method_info,
+          const SServiceMethodInformation& method_info,
           const std::string& request,
           std::string&       response) -> int
         {

--- a/ecal/core/src/v5/service/ecal_service_server_impl.h
+++ b/ecal/core/src/v5/service/ecal_service_server_impl.h
@@ -29,6 +29,7 @@
 #include <ecal/service/server.h>
 #include <ecal/v5/ecal_callback.h>
 
+#include <map>
 #include <mutex>
 #include <string>
 

--- a/ecal/samples/cpp/monitoring/monitoring_get_services/src/monitoring_get_services.cpp
+++ b/ecal/samples/cpp/monitoring/monitoring_get_services/src/monitoring_get_services.cpp
@@ -36,33 +36,33 @@ int main()
   // monitor for ever
   while(eCAL::Ok())
   {
-    // GetServices
+    // GetServers
     {
-      std::set<eCAL::Registration::SServiceId> service_method_id_set;
+      std::set<eCAL::Registration::SServiceId> server_method_id_set;
 
       start_time = std::chrono::steady_clock::now();
       for (run = 0; run < runs; ++run)
       {
-        service_method_id_set = eCAL::Registration::GetServerIDs();
+        server_method_id_set = eCAL::Registration::GetServerIDs();
       }
 
-      auto num_services = service_method_id_set.size();
+      auto num_services = server_method_id_set.size();
       auto diff_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time);
       std::cout << "GetServices      : " << static_cast<double>(diff_time.count()) / runs << " ms" << " (" << num_services << " services)" << std::endl;
       std::cout << std::endl;
     }
 
-    // GetServiceMethodNames
+    // GetServerMethodNames
     {
-      std::set<eCAL::Registration::SServiceMethod> service_method_names;
+      std::set<eCAL::Registration::SServiceMethod> server_method_names;
 
       start_time = std::chrono::steady_clock::now();
       for (run = 0; run < runs; ++run)
       {
-        eCAL::Registration::GetServiceMethodNames(service_method_names);
+        eCAL::Registration::GetServerMethodNames(server_method_names);
       }
 
-      auto num_services = service_method_names.size();
+      auto num_services = server_method_names.size();
       auto diff_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time);
       std::cout << "GetServicesNames : " << static_cast<double>(diff_time.count()) / runs << " ms" << " (" << num_services << " services)" << std::endl;
       std::cout << std::endl;

--- a/ecal/samples/cpp/monitoring/monitoring_get_services/src/monitoring_get_services.cpp
+++ b/ecal/samples/cpp/monitoring/monitoring_get_services/src/monitoring_get_services.cpp
@@ -38,9 +38,7 @@ int main()
   {
     // GetServices
     {
-      std::set<eCAL::Registration::SServiceMethodId> service_method_id_set;
-
-      std::map<eCAL::Registration::SServiceMethod, eCAL::SServiceMethodInformation> service_info_map;
+      std::set<eCAL::Registration::SServiceId> service_method_id_set;
 
       start_time = std::chrono::steady_clock::now();
       for (run = 0; run < runs; ++run)

--- a/ecal/samples/cpp/services/latency_server/src/latency_server.cpp
+++ b/ecal/samples/cpp/services/latency_server/src/latency_server.cpp
@@ -22,7 +22,7 @@
 #include <chrono>
 #include <thread>
 
-int OnHello(const eCAL::SMethodInfo& /*method_info_*/, const std::string& /*request_*/, std::string& /*response_*/)
+int OnHello(const eCAL::SServiceMethodInformation& /*method_info_*/, const std::string& /*request_*/, std::string& /*response_*/)
 {
   return 0;
 }

--- a/ecal/samples/cpp/services/latency_server/src/latency_server.cpp
+++ b/ecal/samples/cpp/services/latency_server/src/latency_server.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ int main()
   eCAL::CServiceServer latency_service("latency");
 
   // add hello method callback
-  latency_service.SetMethodCallback("hello", eCAL::SServiceMethodInformation(), OnHello);
+  latency_service.SetMethodCallback({ "hello", {}, {} }, OnHello);
 
   // idle main thread
   while (eCAL::Ok()) std::this_thread::sleep_for(std::chrono::milliseconds(100));

--- a/ecal/samples/cpp/services/minimal_client/src/minimal_client.cpp
+++ b/ecal/samples/cpp/services/minimal_client/src/minimal_client.cpp
@@ -30,7 +30,7 @@ int main()
   eCAL::Initialize("minimal client");
 
   // create minimal service client
-  const eCAL::CServiceClient minimal_client("service1", { {"echo", eCAL::SServiceMethodInformation()} });
+  const eCAL::CServiceClient minimal_client("service1", { {"echo", {}, {} } });
 
   // callback for service response
   auto service_response_callback = [](const eCAL::Registration::SEntityId& entity_id_, const eCAL::SServiceIDResponse& service_response_) {

--- a/ecal/samples/cpp/services/minimal_server/src/minimal_server.cpp
+++ b/ecal/samples/cpp/services/minimal_server/src/minimal_server.cpp
@@ -24,7 +24,7 @@
 #include <thread>
 
 // method callback
-int OnMethodCallback(const eCAL::SMethodInfo& method_info_, const std::string& request_, std::string& response_)
+int OnMethodCallback(const eCAL::SServiceMethodInformation& method_info_, const std::string& request_, std::string& response_)
 {
   std::cout << "Method called : " << method_info_.method_name << std::endl;
   std::cout << "Request       : " << request_ << std::endl << std::endl;

--- a/ecal/samples/cpp/services/minimal_server/src/minimal_server.cpp
+++ b/ecal/samples/cpp/services/minimal_server/src/minimal_server.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ int main()
   eCAL::CServiceServer minimal_server("service1");
 
   // add method callback
-  minimal_server.SetMethodCallback("echo", eCAL::SServiceMethodInformation(), OnMethodCallback);
+  minimal_server.SetMethodCallback({ "echo", {}, {} }, OnMethodCallback);
 
   // idle
   while(eCAL::Ok())

--- a/ecal/tests/cpp/clientserver_test/src/clientserver_test.cpp
+++ b/ecal/tests/cpp/clientserver_test/src/clientserver_test.cpp
@@ -138,7 +138,7 @@ TEST(core_cpp_clientserver, ClientConnectEvent)
     };
 
   // create client
-  eCAL::CServiceClient client("service", eCAL::ServiceMethodInformationMapT(), event_callback);
+  eCAL::CServiceClient client("service", eCAL::ServiceMethodInfoSetT(), event_callback);
 
   // check events
   eCAL::Process::SleepMS(CMN_REGISTRATION_REFRESH_MS);
@@ -399,7 +399,7 @@ TEST(core_cpp_clientserver, ClientServerBaseCallbackTimeout)
   ClientVecT client_vec;
   for (auto s = 0; s < num_clients; ++s)
   {
-    client_vec.push_back(std::make_shared<eCAL::CServiceClient>("service", eCAL::ServiceMethodInformationMapT(), event_callback));
+    client_vec.push_back(std::make_shared<eCAL::CServiceClient>("service", eCAL::ServiceMethodInfoSetT(), event_callback));
   }
 
   // response callback function

--- a/ecal/tests/cpp/clientserver_test/src/clientserver_test.cpp
+++ b/ecal/tests/cpp/clientserver_test/src/clientserver_test.cpp
@@ -56,7 +56,7 @@ namespace
   typedef std::vector<std::shared_ptr<eCAL::CServiceClient>> ClientVecT;
 
 #if DO_LOGGING
-  void PrintRequest(const eCAL::SMethodInfo& method_info_, const std::string& request_)
+  void PrintRequest(const eCAL::SServiceMethodInformation& method_info_, const std::string& request_)
   {
     std::cout << "------ REQUEST -------" << std::endl;
     std::cout << "Method name                    : " << method_info_.method_name        << std::endl;
@@ -68,7 +68,7 @@ namespace
     std::cout << std::endl;
   }
 #else
-  void PrintRequest(const eCAL::SMethodInfo& /*method_info_*/, const std::string& /*request_*/)
+  void PrintRequest(const eCAL::SServiceMethodInformation& /*method_info_*/, const std::string& /*request_*/)
   {
   }
 #endif
@@ -259,7 +259,7 @@ TEST(core_cpp_clientserver, ClientServerBaseCallback)
   // method callback function
   std::atomic<int> methods_executed(0);
   std::atomic<int> method_process_time(0);
-  auto method_callback = [&](const eCAL::SMethodInfo& method_info_, const std::string& request_, std::string& response_) -> int
+  auto method_callback = [&](const eCAL::SServiceMethodInformation& method_info_, const std::string& request_, std::string& response_) -> int
     {
       eCAL::Process::SleepMS(method_process_time);
       PrintRequest(method_info_, request_);
@@ -271,8 +271,8 @@ TEST(core_cpp_clientserver, ClientServerBaseCallback)
   // add method callbacks
   for (const auto& service : service_vec)
   {
-    eCAL::SMethodInfo method1_info{"foo::method1", {"foo::req_type1", "", ""}, {"foo::resp_type1", "", ""}};
-    eCAL::SMethodInfo method2_info{"foo::method2", {"foo::req_type2", "", ""}, {"foo::resp_type2", "", ""} };
+    eCAL::SServiceMethodInformation method1_info{"foo::method1", {"foo::req_type1", "", ""}, {"foo::resp_type1", "", ""}};
+    eCAL::SServiceMethodInformation method2_info{"foo::method2", {"foo::req_type2", "", ""}, {"foo::resp_type2", "", ""} };
     service->SetMethodCallback(method1_info, method_callback);
     service->SetMethodCallback(method2_info, method_callback);
   }
@@ -364,7 +364,7 @@ TEST(core_cpp_clientserver, ClientServerBaseCallbackTimeout)
   // method callback function
   std::atomic<int> methods_executed(0);
   std::atomic<int> method_process_time(0);
-  auto method_callback = [&](const eCAL::SMethodInfo& method_info_, const std::string& request_, std::string& response_) -> int
+  auto method_callback = [&](const eCAL::SServiceMethodInformation& method_info_, const std::string& request_, std::string& response_) -> int
     {
       eCAL::Process::SleepMS(method_process_time);
       PrintRequest(method_info_, request_);
@@ -376,8 +376,8 @@ TEST(core_cpp_clientserver, ClientServerBaseCallbackTimeout)
   // add method callbacks
   for (const auto& service : service_vec)
   {
-    eCAL::SMethodInfo method1_info{ "foo::method1", {"foo::req_type1", "", ""}, {"foo::resp_type1", "", ""} };
-    eCAL::SMethodInfo method2_info{ "foo::method2", {"foo::req_type2", "", ""}, {"foo::resp_type2", "", ""} };
+    eCAL::SServiceMethodInformation method1_info{ "foo::method1", {"foo::req_type1", "", ""}, {"foo::resp_type1", "", ""} };
+    eCAL::SServiceMethodInformation method2_info{ "foo::method2", {"foo::req_type2", "", ""}, {"foo::resp_type2", "", ""} };
     service->SetMethodCallback(method1_info, method_callback);
     service->SetMethodCallback(method2_info, method_callback);
   }
@@ -520,7 +520,7 @@ TEST(core_cpp_clientserver, ClientServerBaseAsyncCallback)
 
   // method callback function
   std::atomic<int> methods_executed(0);
-  auto method_callback = [&](const eCAL::SMethodInfo& method_info_, const std::string& request_, std::string& response_) -> int
+  auto method_callback = [&](const eCAL::SServiceMethodInformation& method_info_, const std::string& request_, std::string& response_) -> int
     {
       PrintRequest(method_info_, request_);
       response_ = "I answered on " + request_;
@@ -529,8 +529,8 @@ TEST(core_cpp_clientserver, ClientServerBaseAsyncCallback)
     };
 
   // add callback for client request
-  eCAL::SMethodInfo method1_info{ "foo::method1", {"foo::req_type1", "", ""}, {"foo::resp_type1", "", ""} };
-  eCAL::SMethodInfo method2_info{ "foo::method2", {"foo::req_type2", "", ""}, {"foo::resp_type2", "", ""} };
+  eCAL::SServiceMethodInformation method1_info{ "foo::method1", {"foo::req_type1", "", ""}, {"foo::resp_type1", "", ""} };
+  eCAL::SServiceMethodInformation method2_info{ "foo::method2", {"foo::req_type2", "", ""}, {"foo::resp_type2", "", ""} };
   server.SetMethodCallback(method1_info, method_callback);
   server.SetMethodCallback(method2_info, method_callback);
 
@@ -594,7 +594,7 @@ TEST(core_cpp_clientserver, ClientServerBaseAsync)
   atomic_signalable<int> num_service_callbacks_finished(0);
   int service_callback_time_ms(0);
 
-  auto method_callback = [&](const eCAL::SMethodInfo& method_info_, const std::string& request_, std::string& response_) -> int
+  auto method_callback = [&](const eCAL::SServiceMethodInformation& method_info_, const std::string& request_, std::string& response_) -> int
     {
       eCAL::Process::SleepMS(service_callback_time_ms);
       PrintRequest(method_info_, request_);
@@ -604,8 +604,8 @@ TEST(core_cpp_clientserver, ClientServerBaseAsync)
     };
 
   // add callback for client request
-  eCAL::SMethodInfo method1_info{ "foo::method1", {"foo::req_type1", "", ""}, {"foo::resp_type1", "", ""} };
-  eCAL::SMethodInfo method2_info{ "foo::method2", {"foo::req_type2", "", ""}, {"foo::resp_type2", "", ""} };
+  eCAL::SServiceMethodInformation method1_info{ "foo::method1", {"foo::req_type1", "", ""}, {"foo::resp_type1", "", ""} };
+  eCAL::SServiceMethodInformation method2_info{ "foo::method2", {"foo::req_type2", "", ""}, {"foo::resp_type2", "", ""} };
   server.SetMethodCallback(method1_info, method_callback);
   server.SetMethodCallback(method2_info, method_callback);
 
@@ -704,7 +704,7 @@ TEST(core_cpp_clientserver, ClientServerBaseBlocking)
 
   // method callback function
   std::atomic<int> methods_executed(0);
-  auto method_callback = [&](const eCAL::SMethodInfo& method_info_, const std::string& request_, std::string& response_) -> int
+  auto method_callback = [&](const eCAL::SServiceMethodInformation& method_info_, const std::string& request_, std::string& response_) -> int
     {
       PrintRequest(method_info_, request_);
       response_ = "I answer on " + request_;
@@ -715,8 +715,8 @@ TEST(core_cpp_clientserver, ClientServerBaseBlocking)
   // add method callback
   for (const auto& service : service_vec)
   {
-    eCAL::SMethodInfo method1_info{ "foo::method1", {"foo::req_type1", "", ""}, {"foo::resp_type1", "", ""} };
-    eCAL::SMethodInfo method2_info{ "foo::method2", {"foo::req_type2", "", ""}, {"foo::resp_type2", "", ""} };
+    eCAL::SServiceMethodInformation method1_info{ "foo::method1", {"foo::req_type1", "", ""}, {"foo::resp_type1", "", ""} };
+    eCAL::SServiceMethodInformation method2_info{ "foo::method2", {"foo::req_type2", "", ""}, {"foo::resp_type2", "", ""} };
     service->SetMethodCallback(method1_info, method_callback);
     service->SetMethodCallback(method2_info, method_callback);
   }
@@ -801,7 +801,7 @@ TEST(core_cpp_clientserver, NestedRPCCall)
 
   // request callback function
   std::atomic<int> methods_executed(0);
-  auto method_callback = [&](const eCAL::SMethodInfo& method_info_, const std::string& request_, std::string& response_) -> int
+  auto method_callback = [&](const eCAL::SServiceMethodInformation& method_info_, const std::string& request_, std::string& response_) -> int
     {
       PrintRequest(method_info_, request_);
       response_ = "I answer on " + request_;
@@ -810,8 +810,8 @@ TEST(core_cpp_clientserver, NestedRPCCall)
     };
 
   // add callback for client request
-  eCAL::SMethodInfo method1_info{ "foo::method1", {"foo::req_type1", "", ""}, {"foo::resp_type1", "", ""} };
-  eCAL::SMethodInfo method2_info{ "foo::method2", {"foo::req_type2", "", ""}, {"foo::resp_type2", "", ""} };
+  eCAL::SServiceMethodInformation method1_info{ "foo::method1", {"foo::req_type1", "", ""}, {"foo::resp_type1", "", ""} };
+  eCAL::SServiceMethodInformation method2_info{ "foo::method2", {"foo::req_type2", "", ""}, {"foo::resp_type2", "", ""} };
   server.SetMethodCallback(method1_info, method_callback);
   server.SetMethodCallback(method2_info, method_callback);
 

--- a/ecal/tests/cpp/clientserver_test/src/clientserver_test.cpp
+++ b/ecal/tests/cpp/clientserver_test/src/clientserver_test.cpp
@@ -60,10 +60,10 @@ namespace
   {
     std::cout << "------ REQUEST -------" << std::endl;
     std::cout << "Method name                    : " << method_info_.method_name        << std::endl;
-    std::cout << "Method request  type name      : " << method_info_.req_type.name      << std::endl;
-    std::cout << "Method request  type encoding  : " << method_info_.req_type.encoding  << std::endl;
-    std::cout << "Method response type name      : " << method_info_.resp_type.name     << std::endl;
-    std::cout << "Method response type encoding  : " << method_info_.resp_type.encoding << std::endl;
+    std::cout << "Method request  type name      : " << method_info_.request_type.name      << std::endl;
+    std::cout << "Method request  type encoding  : " << method_info_.request_type.encoding  << std::endl;
+    std::cout << "Method response type name      : " << method_info_.response_type.name     << std::endl;
+    std::cout << "Method response type encoding  : " << method_info_.response_type.encoding << std::endl;
     std::cout << "Method request                 : " << request_                        << std::endl;
     std::cout << std::endl;
   }
@@ -271,10 +271,10 @@ TEST(core_cpp_clientserver, ClientServerBaseCallback)
   // add method callbacks
   for (const auto& service : service_vec)
   {
-    eCAL::SServiceMethodInformation method1_info{ {"foo::req_type1", "", ""}, {"foo::resp_type1", "", ""}};
-    eCAL::SServiceMethodInformation method2_info{ {"foo::req_type2", "", ""}, {"foo::resp_type2", "", ""} };
-    service->SetMethodCallback("foo::method1", method1_info, method_callback);
-    service->SetMethodCallback("foo::method2", method2_info, method_callback);
+    eCAL::SMethodInfo method1_info{"foo::method1", {"foo::req_type1", "", ""}, {"foo::resp_type1", "", ""}};
+    eCAL::SMethodInfo method2_info{"foo::method2", {"foo::req_type2", "", ""}, {"foo::resp_type2", "", ""} };
+    service->SetMethodCallback(method1_info, method_callback);
+    service->SetMethodCallback(method2_info, method_callback);
   }
 
   // create service clients
@@ -376,10 +376,10 @@ TEST(core_cpp_clientserver, ClientServerBaseCallbackTimeout)
   // add method callbacks
   for (const auto& service : service_vec)
   {
-    eCAL::SServiceMethodInformation method1_info{ {"foo::req_type1", "", ""}, {"foo::resp_type1", "", ""} };
-    eCAL::SServiceMethodInformation method2_info{ {"foo::req_type2", "", ""}, {"foo::resp_type2", "", ""} };
-    service->SetMethodCallback("foo::method1", method1_info, method_callback);
-    service->SetMethodCallback("foo::method2", method2_info, method_callback);
+    eCAL::SMethodInfo method1_info{ "foo::method1", {"foo::req_type1", "", ""}, {"foo::resp_type1", "", ""} };
+    eCAL::SMethodInfo method2_info{ "foo::method2", {"foo::req_type2", "", ""}, {"foo::resp_type2", "", ""} };
+    service->SetMethodCallback(method1_info, method_callback);
+    service->SetMethodCallback(method2_info, method_callback);
   }
 
   // event callback for timeout event
@@ -529,10 +529,10 @@ TEST(core_cpp_clientserver, ClientServerBaseAsyncCallback)
     };
 
   // add callback for client request
-  eCAL::SServiceMethodInformation method1_info{ {"foo::req_type1", "", ""}, {"foo::resp_type1", "", ""} };
-  eCAL::SServiceMethodInformation method2_info{ {"foo::req_type2", "", ""}, {"foo::resp_type2", "", ""} };
-  server.SetMethodCallback("foo::method1", method1_info, method_callback);
-  server.SetMethodCallback("foo::method2", method2_info, method_callback);
+  eCAL::SMethodInfo method1_info{ "foo::method1", {"foo::req_type1", "", ""}, {"foo::resp_type1", "", ""} };
+  eCAL::SMethodInfo method2_info{ "foo::method2", {"foo::req_type2", "", ""}, {"foo::resp_type2", "", ""} };
+  server.SetMethodCallback(method1_info, method_callback);
+  server.SetMethodCallback(method2_info, method_callback);
 
   // create service client
   eCAL::CServiceClient client("service");
@@ -604,10 +604,10 @@ TEST(core_cpp_clientserver, ClientServerBaseAsync)
     };
 
   // add callback for client request
-  eCAL::SServiceMethodInformation method1_info{ {"foo::req_type1", "", ""}, {"foo::resp_type1", "", ""} };
-  eCAL::SServiceMethodInformation method2_info{ {"foo::req_type2", "", ""}, {"foo::resp_type2", "", ""} };
-  server.SetMethodCallback("foo::method1", method1_info, method_callback);
-  server.SetMethodCallback("foo::method2", method2_info, method_callback);
+  eCAL::SMethodInfo method1_info{ "foo::method1", {"foo::req_type1", "", ""}, {"foo::resp_type1", "", ""} };
+  eCAL::SMethodInfo method2_info{ "foo::method2", {"foo::req_type2", "", ""}, {"foo::resp_type2", "", ""} };
+  server.SetMethodCallback(method1_info, method_callback);
+  server.SetMethodCallback(method2_info, method_callback);
 
   // create service client
   eCAL::CServiceClient client("service");
@@ -715,10 +715,10 @@ TEST(core_cpp_clientserver, ClientServerBaseBlocking)
   // add method callback
   for (const auto& service : service_vec)
   {
-    eCAL::SServiceMethodInformation method1_info{ {"foo::req_type1", "", ""}, {"foo::resp_type1", "", ""} };
-    eCAL::SServiceMethodInformation method2_info{ {"foo::req_type2", "", ""}, {"foo::resp_type2", "", ""} };
-    service->SetMethodCallback("foo::method1", method1_info, method_callback);
-    service->SetMethodCallback("foo::method2", method2_info, method_callback);
+    eCAL::SMethodInfo method1_info{ "foo::method1", {"foo::req_type1", "", ""}, {"foo::resp_type1", "", ""} };
+    eCAL::SMethodInfo method2_info{ "foo::method2", {"foo::req_type2", "", ""}, {"foo::resp_type2", "", ""} };
+    service->SetMethodCallback(method1_info, method_callback);
+    service->SetMethodCallback(method2_info, method_callback);
   }
 
   // create service clients
@@ -810,10 +810,10 @@ TEST(core_cpp_clientserver, NestedRPCCall)
     };
 
   // add callback for client request
-  eCAL::SServiceMethodInformation method1_info{ {"foo::req_type1", "", ""}, {"foo::resp_type1", "", ""} };
-  eCAL::SServiceMethodInformation method2_info{ {"foo::req_type2", "", ""}, {"foo::resp_type2", "", ""} };
-  server.SetMethodCallback("foo::method1", method1_info, method_callback);
-  server.SetMethodCallback("foo::method2", method2_info, method_callback);
+  eCAL::SMethodInfo method1_info{ "foo::method1", {"foo::req_type1", "", ""}, {"foo::resp_type1", "", ""} };
+  eCAL::SMethodInfo method2_info{ "foo::method2", {"foo::req_type2", "", ""}, {"foo::resp_type2", "", ""} };
+  server.SetMethodCallback(method1_info, method_callback);
+  server.SetMethodCallback(method2_info, method_callback);
 
   // create service client
   eCAL::CServiceClient client1("service");

--- a/ecal/tests/cpp/registration_test_public/src/registration_getclients.cpp
+++ b/ecal/tests/cpp/registration_test_public/src/registration_getclients.cpp
@@ -59,7 +59,7 @@ TEST_P(ClientsTestFixture, ClientExpiration)
   // create simple client and let it expire
   {
     // create client
-    eCAL::SMethodInfo service_method_info;
+    eCAL::SServiceMethodInformation service_method_info;
     service_method_info.method_name              = "foo::method";
     service_method_info.request_type.name        = "foo::req_type";
     service_method_info.request_type.descriptor  = "foo::req_desc";
@@ -112,7 +112,7 @@ TEST_P(ClientsTestFixture, GetClientIDs)
   // create simple client
   {
     // create client
-    eCAL::SMethodInfo service_method_info;
+    eCAL::SServiceMethodInformation service_method_info;
     service_method_info.method_name          = "foo::method";
     service_method_info.request_type.name        = "foo::req_type";
     service_method_info.request_type.descriptor  = "foo::req_desc";

--- a/ecal/tests/cpp/registration_test_public/src/registration_getclients.cpp
+++ b/ecal/tests/cpp/registration_test_public/src/registration_getclients.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,12 +59,12 @@ TEST_P(ClientsTestFixture, ClientExpiration)
   // create simple client and let it expire
   {
     // create client
-    eCAL::SServiceMethodInformation service_method_info;
-    service_method_info.request_type.name        = "foo::req_type";
-    service_method_info.request_type.descriptor  = "foo::req_desc";
-    service_method_info.response_type.name       = "foo::resp_type";
-    service_method_info.response_type.descriptor = "foo::resp_desc";
-    const eCAL::CServiceClient client("foo::service", { {"foo::method", service_method_info} });
+    eCAL::SMethodInfo service_method_info;
+    service_method_info.req_type.name        = "foo::req_type";
+    service_method_info.req_type.descriptor  = "foo::req_desc";
+    service_method_info.resp_type.name       = "foo::resp_type";
+    service_method_info.resp_type.descriptor = "foo::resp_desc";
+    const eCAL::CServiceClient client("foo::service", { service_method_info });
 
     // let's register
     eCAL::Process::SleepMS(2 * CMN_REGISTRATION_REFRESH_MS);
@@ -111,12 +111,13 @@ TEST_P(ClientsTestFixture, GetClientIDs)
   // create simple client
   {
     // create client
-    eCAL::SServiceMethodInformation service_method_info;
-    service_method_info.request_type.name        = "foo::req_type";
-    service_method_info.request_type.descriptor  = "foo::req_desc";
-    service_method_info.response_type.name       = "foo::resp_type";
-    service_method_info.response_type.descriptor = "foo::resp_desc";
-    const eCAL::CServiceClient client("foo::service", { {"foo::method", service_method_info} });
+    eCAL::SMethodInfo service_method_info;
+    service_method_info.method_name          = "foo::method";
+    service_method_info.req_type.name        = "foo::req_type";
+    service_method_info.req_type.descriptor  = "foo::req_desc";
+    service_method_info.resp_type.name       = "foo::resp_type";
+    service_method_info.resp_type.descriptor = "foo::resp_desc";
+    const eCAL::CServiceClient client("foo::service", { service_method_info });
 
     // let's register
     eCAL::Process::SleepMS(2 * CMN_REGISTRATION_REFRESH_MS);

--- a/ecal/tests/cpp/registration_test_public/src/registration_getclients.cpp
+++ b/ecal/tests/cpp/registration_test_public/src/registration_getclients.cpp
@@ -54,16 +54,16 @@ protected:
 };
 TEST_P(ClientsTestFixture, ClientExpiration)
 {
-  std::set<eCAL::Registration::SServiceMethodId> id_set;
+  std::set<eCAL::Registration::SServiceId> id_set;
 
   // create simple client and let it expire
   {
     // create client
     eCAL::SMethodInfo service_method_info;
-    service_method_info.req_type.name        = "foo::req_type";
-    service_method_info.req_type.descriptor  = "foo::req_desc";
-    service_method_info.resp_type.name       = "foo::resp_type";
-    service_method_info.resp_type.descriptor = "foo::resp_desc";
+    service_method_info.request_type.name        = "foo::req_type";
+    service_method_info.request_type.descriptor  = "foo::req_desc";
+    service_method_info.response_type.name       = "foo::resp_type";
+    service_method_info.response_type.descriptor = "foo::resp_desc";
     const eCAL::CServiceClient client("foo::service", { service_method_info });
 
     // let's register
@@ -113,10 +113,10 @@ TEST_P(ClientsTestFixture, GetClientIDs)
     // create client
     eCAL::SMethodInfo service_method_info;
     service_method_info.method_name          = "foo::method";
-    service_method_info.req_type.name        = "foo::req_type";
-    service_method_info.req_type.descriptor  = "foo::req_desc";
-    service_method_info.resp_type.name       = "foo::resp_type";
-    service_method_info.resp_type.descriptor = "foo::resp_desc";
+    service_method_info.request_type.name        = "foo::req_type";
+    service_method_info.request_type.descriptor  = "foo::req_desc";
+    service_method_info.response_type.name       = "foo::resp_type";
+    service_method_info.response_type.descriptor = "foo::resp_desc";
     const eCAL::CServiceClient client("foo::service", { service_method_info });
 
     // let's register
@@ -127,11 +127,11 @@ TEST_P(ClientsTestFixture, GetClientIDs)
     EXPECT_EQ(1, id_set.size());
     if (id_set.size() > 0)
     {
-      eCAL::SServiceMethodInformation info;
+      eCAL::ServiceMethodInfoSetT info;
       EXPECT_TRUE(eCAL::Registration::GetClientInfo(*id_set.begin(), info));
 
       // check service/method names
-      EXPECT_EQ(service_method_info, info);
+      EXPECT_TRUE(info.find(service_method_info) != info.end());
     }
   }
 }

--- a/ecal/tests/cpp/registration_test_public/src/registration_getclients.cpp
+++ b/ecal/tests/cpp/registration_test_public/src/registration_getclients.cpp
@@ -60,6 +60,7 @@ TEST_P(ClientsTestFixture, ClientExpiration)
   {
     // create client
     eCAL::SMethodInfo service_method_info;
+    service_method_info.method_name              = "foo::method";
     service_method_info.request_type.name        = "foo::req_type";
     service_method_info.request_type.descriptor  = "foo::req_desc";
     service_method_info.response_type.name       = "foo::resp_type";

--- a/ecal/tests/cpp/registration_test_public/src/registration_getservices.cpp
+++ b/ecal/tests/cpp/registration_test_public/src/registration_getservices.cpp
@@ -74,7 +74,7 @@ TEST_P(ServicesTestFixture, ServiceExpiration)
 
     // check service/method names
     std::set<eCAL::Registration::SServiceMethod> service_method_names;
-    eCAL::Registration::GetServiceMethodNames(service_method_names);
+    eCAL::Registration::GetServerMethodNames(service_method_names);
     EXPECT_EQ(service_method_names.size(), 1);
     for (const auto& name : service_method_names)
     {

--- a/ecal/tests/cpp/registration_test_public/src/registration_getservices.cpp
+++ b/ecal/tests/cpp/registration_test_public/src/registration_getservices.cpp
@@ -55,13 +55,13 @@ protected:
 
 TEST_P(ServicesTestFixture, ServiceExpiration)
 {
-  std::set<eCAL::Registration::SServiceMethodId> id_set;
+  std::set<eCAL::Registration::SServiceId> id_set;
 
   // create simple service and let it expire
   {
     // create service
     eCAL::CServiceServer service("foo::service");
-    service.SetMethodCallback("foo::method", { { "foo::req_type", "foo::req_desc" }, { "foo::resp_type", "foo::resp_desc" } }, eCAL::MethodInfoCallbackT());
+    service.SetMethodCallback({ "foo::method",  { "foo::req_type", "foo::req_desc" }, { "foo::resp_type", "foo::resp_desc" } }, eCAL::MethodInfoCallbackT());
 
     // let's register
     eCAL::Process::SleepMS(2 * CMN_REGISTRATION_REFRESH_MS);
@@ -111,12 +111,13 @@ TEST_P(ServicesTestFixture, GetServiceIDs)
     eCAL::CServiceServer service("foo::service");
 
     // add method
-    eCAL::SServiceMethodInformation service_method_info;
+    eCAL::SMethodInfo service_method_info;
+    service_method_info.method_name = "method";
     service_method_info.request_type.name        = "foo::req_type";
     service_method_info.request_type.descriptor  = "foo::req_desc";
     service_method_info.response_type.name       = "foo::resp_type";
     service_method_info.response_type.descriptor = "foo::resp_desc";
-    service.SetMethodCallback("method", service_method_info, eCAL::MethodInfoCallbackT());
+    service.SetMethodCallback(service_method_info, eCAL::MethodInfoCallbackT());
 
     // let's register
     eCAL::Process::SleepMS(2 * CMN_REGISTRATION_REFRESH_MS);
@@ -126,11 +127,11 @@ TEST_P(ServicesTestFixture, GetServiceIDs)
     EXPECT_EQ(1, id_set.size());
     if (id_set.size() > 0)
     {
-      eCAL::SServiceMethodInformation info;
-      EXPECT_TRUE(eCAL::Registration::GetServerInfo(*id_set.begin(), info));
+      eCAL::ServiceMethodInfoSetT methods;
+      EXPECT_TRUE(eCAL::Registration::GetServerInfo(*id_set.begin(), methods));
 
       // check service/method names
-      EXPECT_EQ(service_method_info, info);
+      EXPECT_TRUE(methods.find(service_method_info) != methods.end());
     }
   }
 }

--- a/ecal/tests/cpp/registration_test_public/src/registration_getservices.cpp
+++ b/ecal/tests/cpp/registration_test_public/src/registration_getservices.cpp
@@ -111,7 +111,7 @@ TEST_P(ServicesTestFixture, GetServiceIDs)
     eCAL::CServiceServer service("foo::service");
 
     // add method
-    eCAL::SMethodInfo service_method_info;
+    eCAL::SServiceMethodInformation service_method_info;
     service_method_info.method_name = "method";
     service_method_info.request_type.name        = "foo::req_type";
     service_method_info.request_type.descriptor  = "foo::req_desc";

--- a/serialization/protobuf/protobuf/include/ecal/msg/protobuf/client.h
+++ b/serialization/protobuf/protobuf/include/ecal/msg/protobuf/client.h
@@ -162,7 +162,7 @@ namespace eCAL
           dyn_decoder.GetServiceMessageDescFromType(service_descriptor, request_type_name, request_type_descriptor, error_s);
           dyn_decoder.GetServiceMessageDescFromType(service_descriptor, response_type_name, response_type_descriptor, error_s);
 
-          method_information_map.emplace(SMethodInfo{ method_name,
+          method_information_map.emplace(SServiceMethodInformation{ method_name,
             SDataTypeInformation{request_type_name, "proto", request_type_descriptor},
             SDataTypeInformation{response_type_name, "proto", response_type_descriptor}
             }

--- a/serialization/protobuf/protobuf/include/ecal/msg/protobuf/client.h
+++ b/serialization/protobuf/protobuf/include/ecal/msg/protobuf/client.h
@@ -134,7 +134,7 @@ namespace eCAL
       using eCAL::v5::CServiceClient::Call;
       using eCAL::v5::CServiceClient::CallAsync;
     private:
-      ServiceMethodInformationMapT CreateMethodInformationMap()
+      ServiceMethodInfoSetT CreateMethodInformationMap()
       {
         // As google::protobuf::Service::GetDescriptor() is defined in a protected class scope
         // we need to inherit public from T in order to make the method accessible in our code.
@@ -143,7 +143,7 @@ namespace eCAL
         const google::protobuf::ServiceDescriptor* service_descriptor = service->GetDescriptor();
 
         std::string error_s;
-        ServiceMethodInformationMapT method_information_map;
+        ServiceMethodInfoSetT method_information_map;
         CProtoDynDecoder dyn_decoder;
         for (int i = 0; i < service_descriptor->method_count(); ++i)
         {
@@ -162,12 +162,11 @@ namespace eCAL
           dyn_decoder.GetServiceMessageDescFromType(service_descriptor, request_type_name, request_type_descriptor, error_s);
           dyn_decoder.GetServiceMessageDescFromType(service_descriptor, response_type_name, response_type_descriptor, error_s);
 
-
-          method_information_map[method_name] = SServiceMethodInformation({
-            {request_type_name, "proto", request_type_descriptor} ,
-            {response_type_name, "proto", response_type_descriptor}
-            });
-
+          method_information_map.emplace(SMethodInfo{ method_name,
+            SDataTypeInformation{request_type_name, "proto", request_type_descriptor},
+            SDataTypeInformation{response_type_name, "proto", response_type_descriptor}
+            }
+          );
         }
 
         return method_information_map;

--- a/serialization/protobuf/samples/services/ping_client_dyn/src/ping_client_dyn.cpp
+++ b/serialization/protobuf/samples/services/ping_client_dyn/src/ping_client_dyn.cpp
@@ -55,16 +55,23 @@ int main()
   bool service_info_found(false);
   for (const auto& service_id : service_ids)
   {
-    if ((service_id.service_name == service_name) && (service_id.method_name == method_name))
+    if (service_id.service_name == service_name)
     {
-      eCAL::SServiceMethodInformation service_method_info;
-      eCAL::Registration::GetServerInfo(service_id, service_method_info);
-      req_type  = service_method_info.request_type.name;
-      req_desc  = service_method_info.request_type.descriptor;
-      resp_type = service_method_info.response_type.name;
-      resp_desc = service_method_info.response_type.descriptor;
-      service_info_found = true;
-      break;
+      eCAL::ServiceMethodInfoSetT methods;
+      eCAL::Registration::GetServerInfo(service_id, methods);
+
+      for (const auto& method : methods)
+      {
+        if (method.method_name == method_name)
+        {
+          req_type = method.request_type.name;
+          req_desc = method.request_type.descriptor;
+          resp_type = method.response_type.name;
+          resp_desc = method.response_type.descriptor;
+          service_info_found = true;
+          break;
+        }
+      }
     }
   }
   if (!service_info_found)


### PR DESCRIPTION
### Description
We want to further harmonize the Server API.

`SServiceId` is used as a Type to qualify either a Client or a Server. This is returned from the Registration functions, to see which server / clients are available.
About each server / client, the user can then retrieve information about the available service methods, including their meta information. (`ServiceMethodInfoSetT`)

