### PR TITLE
[core] Fixed topic resubscription via shared memory

### DIFF
--- a/ecal/core/src/readwrite/shm/ecal_writer_shm.cpp
+++ b/ecal/core/src/readwrite/shm/ecal_writer_shm.cpp
@@ -110,7 +110,7 @@ namespace eCAL
     if (host_name_ != m_attributes.host_name) return;
 
     // remove topic id from the id set for the given process id
-    bool memfile_has_subscriptions(true);
+    // bool memfile_has_subscriptions(true);
     {
       const std::lock_guard<std::mutex> lock(m_process_id_topic_id_set_map_sync);
       auto process_it = m_process_id_topic_id_set_map.find(process_id_);
@@ -127,22 +127,26 @@ namespace eCAL
           // we can remove the empty topic id set
           m_process_id_topic_id_set_map.erase(process_it);
           // and set the subscription state to false for later processing
-          memfile_has_subscriptions = false;
+          //memfile_has_subscriptions = false;
         }
       }
     }
-
-    // memory file is still connected to at least one topic id of this process id
-    // no need to Disconnect process id
-    if (memfile_has_subscriptions) return;
-
-    for (auto& memory_file : m_memory_file_vec)
-    {
-      memory_file->Disconnect(std::to_string(process_id_));
-#ifndef NDEBUG
-      Logging::Log(Logging::log_level_debug1, std::string("CDataWriterSHM::RemoveSubscription - Memory FileName: ") + memory_file->GetName() + " to ProcessId " + std::to_string(process_id_));
-#endif
-    }
+// TODO: Disconnect events immediately if there is no longer an existing subscription.
+//       Unfortunately the below Disconnect()-method leads to incongruous event handles on
+//       unix operating systems in case of a subscriber tries to reconnected to same publisher
+//       again.
+//
+//    // memory file is still connected to at least one topic id of this process id
+//    // no need to Disconnect process id
+//    if (memfile_has_subscriptions) return;
+//
+//    for (auto& memory_file : m_memory_file_vec)
+//    {
+//      memory_file->Disconnect(std::to_string(process_id_));
+//#ifndef NDEBUG
+//      Logging::Log(Logging::log_level_debug1, std::string("CDataWriterSHM::RemoveSubscription - Memory FileName: ") + memory_file->GetName() + " to ProcessId " + std::to_string(process_id_));
+//#endif
+//    }
   }
 
   Registration::ConnectionPar CDataWriterSHM::GetConnectionParameter()


### PR DESCRIPTION
Due to newly created event handles when resubscribing an existing topic, it is no longer possible to receive data via shared memory of the same process and topic on unix operating systems. This commit fixes the problem temporarily until an even more elegant solution is implemented.