### PR TITLE
[core] remove multiple structs from Registration namespace. (IDs for pubsub / services).

### DIFF
--- a/app/mon/mon_plugins/raw_data_reflection/src/plugin_widget.cpp
+++ b/app/mon/mon_plugins/raw_data_reflection/src/plugin_widget.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ PluginWidget::PluginWidget(const QString& topic_name, const QString&, QWidget* p
   ui_.content_layout->addWidget(frame);
 
   // Connect the eCAL Subscriber
-  subscriber_.SetReceiveCallback([this](const eCAL::Registration::STopicId& /*topic_id*/,
+  subscriber_.SetReceiveCallback([this](const eCAL::STopicId& /*topic_id*/,
     const eCAL::SDataTypeInformation& /*data_type_info*/,
     const eCAL::SReceiveCallbackData& callback_data)
     {
@@ -134,7 +134,7 @@ void PluginWidget::onUpdate()
 void PluginWidget::onResume()
 {
   // (Re)Connect the eCAL Subscriber
-  subscriber_.SetReceiveCallback([this](const eCAL::Registration::STopicId& /*topic_id*/,
+  subscriber_.SetReceiveCallback([this](const eCAL::STopicId& /*topic_id*/,
     const eCAL::SDataTypeInformation& /*data_type_info*/,
     const eCAL::SReceiveCallbackData& callback_data)
     {

--- a/app/rec/rec_client_core/src/ecal_rec_impl.cpp
+++ b/app/rec/rec_client_core/src/ecal_rec_impl.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -695,7 +695,7 @@ namespace eCAL
       return subscribed_topics;
     }
 
-    void EcalRecImpl::EcalMessageReceived(const eCAL::Registration::STopicId& topic_id_, const eCAL::SReceiveCallbackData& data_)
+    void EcalRecImpl::EcalMessageReceived(const eCAL::STopicId& topic_id_, const eCAL::SReceiveCallbackData& data_)
     {
       auto ecal_receive_time   = eCAL::Time::ecal_clock::now();
       auto system_receive_time = std::chrono::steady_clock::now();

--- a/app/rec/rec_client_core/src/ecal_rec_impl.h
+++ b/app/rec/rec_client_core/src/ecal_rec_impl.h
@@ -114,7 +114,7 @@ namespace eCAL
 
       std::set<std::string> GetSubscribedTopics() const;
 
-      void EcalMessageReceived(const eCAL::Registration::STopicId& topic_id_, const eCAL::SReceiveCallbackData& data_);
+      void EcalMessageReceived(const eCAL::STopicId& topic_id_, const eCAL::SReceiveCallbackData& data_);
 
       //////////////////////////////////////
       //// API for external threads     ////

--- a/ecal/core/include/ecal/msg/dynamic.h
+++ b/ecal/core/include/ecal/msg/dynamic.h
@@ -148,7 +148,7 @@ namespace eCAL
      * @param clock_     Message writer clock.
      * @param id_        Message id.
      **/
-    using MsgReceiveCallbackT = std::function<void(const Registration::STopicId& topic_id_, const T& msg_, long long time_, long long clock_, long long id_)>;
+    using MsgReceiveCallbackT = std::function<void(const STopicId& topic_id_, const T& msg_, long long time_, long long clock_, long long id_)>;
 
     /**
      * @brief  Add receive callback for incoming messages.
@@ -221,7 +221,7 @@ namespace eCAL
     }
 
   private:
-    void ReceiveCallback(const Registration::STopicId& topic_id_, const SDataTypeInformation& topic_info_, const struct SReceiveCallbackData& data_)
+    void ReceiveCallback(const STopicId& topic_id_, const SDataTypeInformation& topic_info_, const struct SReceiveCallbackData& data_)
     {
       MsgReceiveCallbackT fn_callback = nullptr;
       {

--- a/ecal/core/include/ecal/pubsub/publisher.h
+++ b/ecal/core/include/ecal/pubsub/publisher.h
@@ -156,7 +156,7 @@ namespace eCAL
        * @return  The topic id.
       **/
       ECAL_API_EXPORTED_MEMBER
-        Registration::STopicId GetTopicId() const;
+        STopicId GetTopicId() const;
 
       /**
        * @brief Gets description of the connected topic.

--- a/ecal/core/include/ecal/pubsub/subscriber.h
+++ b/ecal/core/include/ecal/pubsub/subscriber.h
@@ -135,7 +135,7 @@ namespace eCAL
        * @return  The topic id.
       **/
       ECAL_API_EXPORTED_MEMBER
-        Registration::STopicId GetTopicId() const;
+        STopicId GetTopicId() const;
 
       /**
        * @brief Retrieve the topic information.

--- a/ecal/core/include/ecal/pubsub/types.h
+++ b/ecal/core/include/ecal/pubsub/types.h
@@ -33,9 +33,7 @@
 
 namespace eCAL
 {
-  namespace Registration
-  {
-    struct STopicId
+  struct STopicId
     {
       SEntityId    topic_id;
       std::string  topic_name;
@@ -51,13 +49,12 @@ namespace eCAL
       }
     };
 
-    inline std::ostream& operator<<(std::ostream& os, const STopicId& id)
+  inline std::ostream& operator<<(std::ostream& os, const STopicId& id)
     {
       os << "STopicId(topic_id: " << id.topic_id
         << ", topic_name: " << id.topic_name << ")";
       return os;
     }
-  }
   
   /**
    * @brief eCAL subscriber receive callback struct.
@@ -123,7 +120,7 @@ namespace eCAL
      * @param data_type_info_  Topic data type information (encoding, type, descriptor).
      * @param data_            Data struct containing payload, timestamp and publication clock.
     **/
-    using ReceiveCallbackT = std::function<void(const Registration::STopicId& topic_id_, const SDataTypeInformation& data_type_info_, const SReceiveCallbackData& data_)>;
+    using ReceiveCallbackT = std::function<void(const STopicId& topic_id_, const SDataTypeInformation& data_type_info_, const SReceiveCallbackData& data_)>;
 
     /**
      * @brief eCAL publisher event callback struct.
@@ -141,7 +138,7 @@ namespace eCAL
      * @param topic_id_  The topic id struct of the received message.
      * @param data_      Event callback data structure with the event specific information.
     **/
-    using PubEventCallbackT = std::function<void(const Registration::STopicId& topic_id_, const SPubEventCallbackData& data_)>;
+    using PubEventCallbackT = std::function<void(const STopicId& topic_id_, const SPubEventCallbackData& data_)>;
 
     /**
      * @brief eCAL subscriber event callback struct.
@@ -159,7 +156,7 @@ namespace eCAL
      * @param topic_id_  The topic id struct of the received message.
      * @param data_      Event callback data structure with the event specific information.
     **/
-    using SubEventCallbackT = std::function<void(const Registration::STopicId& topic_id_, const SSubEventCallbackData& data_)>;
+    using SubEventCallbackT = std::function<void(const STopicId& topic_id_, const SSubEventCallbackData& data_)>;
   }
 }
 

--- a/ecal/core/include/ecal/service/client.h
+++ b/ecal/core/include/ecal/service/client.h
@@ -145,7 +145,7 @@ namespace eCAL
        * @return  The service id.
       **/
       ECAL_API_EXPORTED_MEMBER
-        Registration::SServiceId GetServiceId() const;
+        SServiceId GetServiceId() const;
 
       /**
        * @brief Check connection to at least one service.

--- a/ecal/core/include/ecal/service/client_instance.h
+++ b/ecal/core/include/ecal/service/client_instance.h
@@ -45,7 +45,7 @@ namespace eCAL
   public:
     // Constructor
     ECAL_API_EXPORTED_MEMBER
-      CClientInstance(const Registration::SEntityId& entity_id_, const std::shared_ptr<v6::CServiceClientImpl>& service_client_id_impl_);
+      CClientInstance(const SEntityId& entity_id_, const std::shared_ptr<v6::CServiceClientImpl>& service_client_id_impl_);
 
     // Defaulted destructor
     ~CClientInstance() = default;
@@ -109,10 +109,10 @@ namespace eCAL
      * @return  The client entity id.
     **/
     ECAL_API_EXPORTED_MEMBER
-      Registration::SEntityId GetClientID() const;
+      SEntityId GetClientID() const;
 
   private:
-    Registration::SEntityId                             m_entity_id;
+    SEntityId                             m_entity_id;
     const std::shared_ptr<eCAL::v6::CServiceClientImpl> m_service_client_impl;
   };
 }

--- a/ecal/core/include/ecal/service/server.h
+++ b/ecal/core/include/ecal/service/server.h
@@ -118,7 +118,7 @@ namespace eCAL
        * @return  The service id.
       **/
       ECAL_API_EXPORTED_MEMBER
-        Registration::SServiceId GetServiceId() const;
+        SServiceId GetServiceId() const;
 
       /**
        * @brief Check connection state.

--- a/ecal/core/include/ecal/service/types.h
+++ b/ecal/core/include/ecal/service/types.h
@@ -84,45 +84,46 @@ namespace eCAL
     }
   }
 
-  namespace Registration
+  /**
+   * @brief Unique ID with which to identify a service (client or server)
+   *        It can be queried from the client or the server, and it can be obtained from the registration layer.
+  **/
+  struct SServiceId
   {
+    SEntityId    service_id;
+    std::string  service_name;
 
-    struct SServiceId
+    bool operator==(const SServiceId& other) const
     {
-      SEntityId    service_id;
-      std::string  service_name;
+      return service_id == other.service_id && service_name == other.service_name;
+    }
 
-      bool operator==(const SServiceId& other) const
-      {
-        return service_id == other.service_id && service_name == other.service_name;
-      }
-
-      bool operator<(const SServiceId& other) const
-      {
-        return std::tie(service_id, service_name) < std::tie(other.service_id, other.service_name);
-      }
-    };
-
-    struct SServiceMethodId
+    bool operator<(const SServiceId& other) const
     {
-      SEntityId    service_id;
-      std::string  service_name;
-      std::string  method_name;
+      return std::tie(service_id, service_name) < std::tie(other.service_id, other.service_name);
+    }
+  };
 
-      bool operator==(const SServiceMethodId& other) const
-      {
-        return service_id == other.service_id && service_name == other.service_name && method_name == other.method_name;
-      }
+  struct SServiceMethodId
+  {
+    SEntityId    service_id;
+    std::string  service_name;
+    std::string  method_name;
 
-      bool operator<(const SServiceMethodId& other) const
-      {
-        return std::tie(service_id, service_name, method_name) < std::tie(other.service_id, other.service_name, other.method_name);
-      }
-    };
-  }
+    bool operator==(const SServiceMethodId& other) const
+    {
+      return service_id == other.service_id && service_name == other.service_name && method_name == other.method_name;
+    }
+
+    bool operator<(const SServiceMethodId& other) const
+    {
+      return std::tie(service_id, service_name, method_name) < std::tie(other.service_id, other.service_name, other.method_name);
+    }
+  };
 
   /**
-   * @brief Service method information struct containing the request and response type information.
+   * @brief Service method information struct containing the method name, the request and response type information.
+   *        This type is used when creating services (servers or clients), or when querying information about them from the registration layer.
   **/
   struct SServiceMethodInformation
   {
@@ -146,7 +147,7 @@ namespace eCAL
   **/
   struct SServiceIDResponse
   {
-    Registration::SServiceMethodId service_method_id;            //!< service method information (service id (entity id, process id, host name), service name, method name)
+    SServiceMethodId service_method_id;            //!< service method information (service id (entity id, process id, host name), service name, method name)
     std::string                    error_msg;                    //!< human readable error message
     int                            ret_state  = 0;               //!< return state of the called service method
     eCallState                     call_state = eCallState::none; //!< call state (see eCallState)
@@ -169,7 +170,7 @@ namespace eCAL
    * @param entity_id_         Unique service id (entity id, process id, host name, service name, method name)
    * @param service_response_  Service response struct containing the (responding) server informations and the response itself.
   **/
-  using ResponseIDCallbackT = std::function<void (const Registration::SEntityId& entity_id_, const struct SServiceIDResponse& service_response_)>;
+  using ResponseIDCallbackT = std::function<void (const SEntityId& entity_id_, const struct SServiceIDResponse& service_response_)>;
 
   /**
    * @brief Map of <method name, method information (like request type, reponse type)>.
@@ -193,7 +194,7 @@ namespace eCAL
      * @param service_id_  The service id struct of the connection that triggered the event.
      * @param data_        Event callback data structure with the event specific information.
     **/
-    using ClientEventCallbackT = std::function<void(const Registration::SServiceId& service_id_, const SClientEventCallbackData& data_)>;
+    using ClientEventCallbackT = std::function<void(const SServiceId& service_id_, const SClientEventCallbackData& data_)>;
 
     /**
      * @brief eCAL server event callback struct.
@@ -210,7 +211,7 @@ namespace eCAL
      * @param service_id_  The service id struct of the connection that triggered the event.
      * @param data_        Event callback data structure with the event specific information.
     **/
-    using ServerEventCallbackT = std::function<void(const Registration::SServiceId& service_id_, const struct SServerEventCallbackData& data_)>;
+    using ServerEventCallbackT = std::function<void(const SServiceId& service_id_, const struct SServerEventCallbackData& data_)>;
   }
     
 }

--- a/ecal/core/include/ecal/types.h
+++ b/ecal/core/include/ecal/types.h
@@ -75,33 +75,30 @@ namespace eCAL
     //!< @endcond
   };
 
-  namespace Registration
+  using EntityIdT = uint64_t;
+
+  struct SEntityId
   {
-    using EntityIdT = uint64_t;
+    EntityIdT    entity_id  = 0;    // unique id within that process (it should already be unique within the whole system)
+    int32_t      process_id = 0;    // process id which produced the sample
+    std::string  host_name;         // host which produced the sample
 
-    struct SEntityId
-    {
-      EntityIdT    entity_id  = 0;    // unique id within that process (it should already be unique within the whole system)
-      int32_t      process_id = 0;    // process id which produced the sample
-      std::string  host_name;         // host which produced the sample
-
-      bool operator==(const SEntityId& other) const {
-        return entity_id == other.entity_id;
-      }
-
-      bool operator<(const SEntityId& other) const
-      {
-        return entity_id < other.entity_id;
-      }
-    };
-
-    // Overload the << operator for SEntityId
-    inline std::ostream& operator<<(std::ostream& os, const SEntityId& id)
-    {
-      os << "SEntityId(entity_id: " << id.entity_id
-        << ", process_id: " << id.process_id
-        << ", host_name: " << id.host_name << ")";
-      return os;
+    bool operator==(const SEntityId& other) const {
+      return entity_id == other.entity_id;
     }
+
+    bool operator<(const SEntityId& other) const
+    {
+      return entity_id < other.entity_id;
+    }
+  };
+
+  // Overload the << operator for SEntityId
+  inline std::ostream& operator<<(std::ostream& os, const SEntityId& id)
+  {
+    os << "SEntityId(entity_id: " << id.entity_id
+      << ", process_id: " << id.process_id
+      << ", host_name: " << id.host_name << ")";
+    return os;
   }
 }

--- a/ecal/core/include/ecal/types/monitoring.h
+++ b/ecal/core/include/ecal/types/monitoring.h
@@ -77,7 +77,7 @@ namespace eCAL
       int32_t                             pid{0};               //!< process id
       std::string                         pname;                //!< process name
       std::string                         uname;                //!< unit name
-      Registration::EntityIdT             tid{0};               //!< topic id
+      EntityIdT             tid{0};               //!< topic id
       std::string                         tname;                //!< topic name
       std::string                         direction;            //!< direction (publisher, subscriber)
       SDataTypeInformation                tdatatype;            //!< topic datatype information (name, encoding, descriptor)
@@ -151,7 +151,7 @@ namespace eCAL
       int32_t                  pid{0};                          //<! process id
 
       std::string              sname;                           //<! service name
-      Registration::EntityIdT  sid{0};                          //<! service id
+      EntityIdT  sid{0};                          //<! service id
 
       uint32_t                 version{0};                      //<! service protocol version
       uint32_t                 tcp_port_v0{0};                  //<! the tcp port protocol version 0 used for that service
@@ -169,7 +169,7 @@ namespace eCAL
       int32_t                  pid{0};                          //<! process id
 
       std::string              sname;                           //<! service name
-      Registration::EntityIdT  sid{0};                          //<! service id
+      EntityIdT  sid{0};                          //<! service id
 
       std::vector<SMethodMon>  methods;                         //<! list of methods
 

--- a/ecal/core/include/ecal/v5/ecal_callback.h
+++ b/ecal/core/include/ecal/v5/ecal_callback.h
@@ -71,7 +71,7 @@ namespace eCAL
       std::string             pname;            //!< process name
       std::string             uname;            //!< process unit name
       std::string             sname;            //!< service name
-      Registration::EntityIdT sid = 0;  //!< service id
+      EntityIdT sid = 0;  //!< service id
       int                     pid = 0;  //!< process id
 
       // internal protocol specifics

--- a/ecal/core/include/ecal/v5/ecal_publisher.h
+++ b/ecal/core/include/ecal/v5/ecal_publisher.h
@@ -296,7 +296,7 @@ namespace eCAL
        * @return  The topic id.
       **/
       ECAL_API_EXPORTED_MEMBER
-        Registration::STopicId GetId() const;
+        STopicId GetId() const;
 
       /**
        * @brief Gets description of the connected topic.

--- a/ecal/core/include/ecal/v5/ecal_subscriber.h
+++ b/ecal/core/include/ecal/v5/ecal_subscriber.h
@@ -265,7 +265,7 @@ namespace eCAL
        * @return  The topic id.
       **/
       ECAL_API_EXPORTED_MEMBER
-        Registration::STopicId GetId() const;
+        STopicId GetId() const;
 
       /**
        * @brief Gets description of the connected topic.

--- a/ecal/core/src/ecal_descgate.cpp
+++ b/ecal/core/src/ecal_descgate.cpp
@@ -49,9 +49,9 @@ namespace
     return datatype_info;
   }
 
-  eCAL::Registration::SEntityId ConvertToEntityId(const eCAL::Registration::SampleIdentifier& sample_identifier)
+  eCAL::SEntityId ConvertToEntityId(const eCAL::Registration::SampleIdentifier& sample_identifier)
   {
-    eCAL::Registration::SEntityId id{ sample_identifier.entity_id, sample_identifier.process_id, sample_identifier.host_name};
+    eCAL::SEntityId id{ sample_identifier.entity_id, sample_identifier.process_id, sample_identifier.host_name};
     return id;
   }
 
@@ -76,7 +76,7 @@ namespace
     const std::string& topic_name_,
     const eCAL::SDataTypeInformation& topic_info_)
   {
-    const auto topic_info_key = eCAL::Registration::STopicId{ ConvertToEntityId(topic_id_), topic_name_ };
+    const auto topic_info_key = eCAL::STopicId{ ConvertToEntityId(topic_id_), topic_name_ };
 
     // update topic info
     bool new_topic_info(false);
@@ -112,7 +112,7 @@ namespace
     const eCAL::Registration::SampleIdentifier& topic_id_,
     const std::string& topic_name_)
   {
-    const auto topic_info_key = eCAL::Registration::STopicId{ ConvertToEntityId(topic_id_), topic_name_ };
+    const auto topic_info_key = eCAL::STopicId{ ConvertToEntityId(topic_id_), topic_name_ };
 
     // delete topic info
     bool deleted_topic_info(false);
@@ -140,7 +140,7 @@ namespace
     const eCAL::Registration::SampleIdentifier& service_id_,
     const Service& service_)
   {
-    const auto service_method_info_key = eCAL::Registration::SServiceId{ ConvertToEntityId(service_id_), service_.sname };
+    const auto service_method_info_key = eCAL::SServiceId{ ConvertToEntityId(service_id_), service_.sname };
 
     const std::lock_guard<std::mutex> lock(service_method_info_map_.mtx);
     service_method_info_map_.id_map[service_method_info_key] = Convert(service_);
@@ -151,7 +151,7 @@ namespace
     const eCAL::Registration::SampleIdentifier& service_id_,
     const Service& service_)
   {
-    const auto service_method_info_key = eCAL::Registration::SServiceId{ ConvertToEntityId(service_id_),  service_.sname };
+    const auto service_method_info_key = eCAL::SServiceId{ ConvertToEntityId(service_id_),  service_.sname };
 
     const std::lock_guard<std::mutex> lock(service_method_info_map_.mtx);
     service_method_info_map_.id_map.erase(service_method_info_key);
@@ -163,12 +163,12 @@ namespace eCAL
   CDescGate::CDescGate() = default;
   CDescGate::~CDescGate() = default;
 
-  std::set<Registration::STopicId> CDescGate::GetPublisherIDs() const
+  std::set<STopicId> CDescGate::GetPublisherIDs() const
   {
     return GetTopicIDs(m_publisher_info_map);
   }
 
-  bool CDescGate::GetPublisherInfo(const Registration::STopicId& id_, SDataTypeInformation& topic_info_) const
+  bool CDescGate::GetPublisherInfo(const STopicId& id_, SDataTypeInformation& topic_info_) const
   {
     return GetTopic(id_, m_publisher_info_map, topic_info_);
   }
@@ -189,12 +189,12 @@ namespace eCAL
     m_publisher_callback_map.map.erase(token_);
   }
 
-  std::set<Registration::STopicId> CDescGate::GetSubscriberIDs() const
+  std::set<STopicId> CDescGate::GetSubscriberIDs() const
   {
     return GetTopicIDs(m_subscriber_info_map);
   }
 
-  bool CDescGate::GetSubscriberInfo(const Registration::STopicId& id_, SDataTypeInformation& topic_info_) const
+  bool CDescGate::GetSubscriberInfo(const STopicId& id_, SDataTypeInformation& topic_info_) const
   {
     return GetTopic(id_, m_subscriber_info_map, topic_info_);
   }
@@ -215,29 +215,29 @@ namespace eCAL
     m_subscriber_callback_map.map.erase(token_);
   }
 
-  std::set<Registration::SServiceId> CDescGate::GetServerIDs() const
+  std::set<SServiceId> CDescGate::GetServerIDs() const
   {
     return GetServiceIDs(m_service_info_map);
   }
 
-  bool CDescGate::GetServerInfo(const Registration::SServiceId& id_, ServiceMethodInfoSetT& service_info_) const
+  bool CDescGate::GetServerInfo(const SServiceId& id_, ServiceMethodInfoSetT& service_info_) const
   {
     return GetService(id_, m_service_info_map, service_info_);
   }
 
-  std::set<Registration::SServiceId> CDescGate::GetClientIDs() const
+  std::set<SServiceId> CDescGate::GetClientIDs() const
   {
     return GetServiceIDs(m_client_info_map);
   }
 
-  bool CDescGate::GetClientInfo(const Registration::SServiceId& id_, ServiceMethodInfoSetT& service_info_) const
+  bool CDescGate::GetClientInfo(const SServiceId& id_, ServiceMethodInfoSetT& service_info_) const
   {
     return GetService(id_, m_client_info_map, service_info_);
   }
 
-  std::set<Registration::STopicId> CDescGate::GetTopicIDs(const STopicIdInfoMap& topic_info_map_)
+  std::set<STopicId> CDescGate::GetTopicIDs(const STopicIdInfoMap& topic_info_map_)
   {
-    std::set<Registration::STopicId> topic_id_set;
+    std::set<STopicId> topic_id_set;
 
     const std::lock_guard<std::mutex> lock(topic_info_map_.mtx);
     for (const auto& topic_map_it : topic_info_map_.map)
@@ -247,7 +247,7 @@ namespace eCAL
     return topic_id_set;
   }
 
-  bool CDescGate::GetTopic(const Registration::STopicId& id_, const STopicIdInfoMap& topic_info_map_, SDataTypeInformation& topic_info_)
+  bool CDescGate::GetTopic(const STopicId& id_, const STopicIdInfoMap& topic_info_map_, SDataTypeInformation& topic_info_)
   {
     const std::lock_guard<std::mutex> lock(topic_info_map_.mtx);
     auto iter = topic_info_map_.map.find(id_);
@@ -262,9 +262,9 @@ namespace eCAL
     }
   }
 
-  std::set<Registration::SServiceId> CDescGate::GetServiceIDs(const SServiceIdInfoMap& service_method_info_map_)
+  std::set<SServiceId> CDescGate::GetServiceIDs(const SServiceIdInfoMap& service_method_info_map_)
   {
-    std::set<Registration::SServiceId> service_id_set;
+    std::set<SServiceId> service_id_set;
 
     const std::lock_guard<std::mutex> lock(service_method_info_map_.mtx);
     for (const auto& service_method_info_map_it : service_method_info_map_.id_map)
@@ -274,7 +274,7 @@ namespace eCAL
     return service_id_set;
   }
 
-  bool CDescGate::GetService(const Registration::SServiceId& id_, const SServiceIdInfoMap& service_method_info_map_, ServiceMethodInfoSetT& service_method_info_)
+  bool CDescGate::GetService(const SServiceId& id_, const SServiceIdInfoMap& service_method_info_map_, ServiceMethodInfoSetT& service_method_info_)
   {
     const std::lock_guard<std::mutex> lock(service_method_info_map_.mtx);
     auto iter = service_method_info_map_.id_map.find(id_);

--- a/ecal/core/src/ecal_descgate.h
+++ b/ecal/core/src/ecal_descgate.h
@@ -49,24 +49,24 @@ namespace eCAL
     void ApplySample(const Registration::Sample& sample_, eTLayerType layer_);
 
     // get publisher information
-    std::set<Registration::STopicId> GetPublisherIDs() const;
-    bool GetPublisherInfo(const Registration::STopicId& id_, SDataTypeInformation& topic_info_) const;
+    std::set<STopicId> GetPublisherIDs() const;
+    bool GetPublisherInfo(const STopicId& id_, SDataTypeInformation& topic_info_) const;
     Registration::CallbackToken AddPublisherEventCallback(const Registration::TopicEventCallbackT& callback_);
     void RemPublisherEventCallback(Registration::CallbackToken token_);
 
     // get subscriber information
-    std::set<Registration::STopicId> GetSubscriberIDs() const;
-    bool GetSubscriberInfo(const Registration::STopicId& id_, SDataTypeInformation& topic_info_) const;
+    std::set<STopicId> GetSubscriberIDs() const;
+    bool GetSubscriberInfo(const STopicId& id_, SDataTypeInformation& topic_info_) const;
     Registration::CallbackToken AddSubscriberEventCallback(const Registration::TopicEventCallbackT& callback_);
     void RemSubscriberEventCallback(Registration::CallbackToken token_);
 
     // get service information
-    std::set<Registration::SServiceId> GetServerIDs() const;
-    bool GetServerInfo(const Registration::SServiceId& id_, ServiceMethodInfoSetT& service_info_) const;
+    std::set<SServiceId> GetServerIDs() const;
+    bool GetServerInfo(const SServiceId& id_, ServiceMethodInfoSetT& service_info_) const;
 
     // get client information
-    std::set<Registration::SServiceId> GetClientIDs() const;
-    bool GetClientInfo(const Registration::SServiceId& id_, ServiceMethodInfoSetT& service_info_) const;
+    std::set<SServiceId> GetClientIDs() const;
+    bool GetClientInfo(const SServiceId& id_, ServiceMethodInfoSetT& service_info_) const;
 
     // delete copy constructor and copy assignment operator
     CDescGate(const CDescGate&) = delete;
@@ -76,7 +76,7 @@ namespace eCAL
     CDescGate(CDescGate&&) = delete;
     CDescGate& operator=(CDescGate&&) = delete;
 
-    using TopicIdInfoMap  = std::map<Registration::STopicId, SDataTypeInformation>;
+    using TopicIdInfoMap  = std::map<STopicId, SDataTypeInformation>;
     struct STopicIdInfoMap
     {
       mutable std::mutex mtx;
@@ -90,7 +90,7 @@ namespace eCAL
       TopicEventCallbackMap map;
     };
 
-    using ServiceIdInfoMap = std::map<Registration::SServiceId, ServiceMethodInfoSetT>;
+    using ServiceIdInfoMap = std::map<SServiceId, ServiceMethodInfoSetT>;
     struct SServiceIdInfoMap
     {
       mutable std::mutex  mtx;
@@ -99,11 +99,11 @@ namespace eCAL
 
   protected:
 
-    static std::set<Registration::STopicId>   GetTopicIDs(const STopicIdInfoMap& topic_info_map_);
-    static bool                               GetTopic   (const Registration::STopicId& id_, const STopicIdInfoMap& topic_info_map_, SDataTypeInformation& topic_info_);
+    static std::set<STopicId>   GetTopicIDs(const STopicIdInfoMap& topic_info_map_);
+    static bool                               GetTopic   (const STopicId& id_, const STopicIdInfoMap& topic_info_map_, SDataTypeInformation& topic_info_);
 
-    static std::set<Registration::SServiceId> GetServiceIDs(const SServiceIdInfoMap& service_method_info_map_);
-    static bool                               GetService   (const Registration::SServiceId& id_, const SServiceIdInfoMap& service_method_info_map_, ServiceMethodInfoSetT& service_method_info_);
+    static std::set<SServiceId> GetServiceIDs(const SServiceIdInfoMap& service_method_info_map_);
+    static bool                               GetService   (const SServiceId& id_, const SServiceIdInfoMap& service_method_info_map_, ServiceMethodInfoSetT& service_method_info_);
 
     Registration::CallbackToken CreateToken();
       

--- a/ecal/core/src/monitoring/ecal_monitoring_impl.h
+++ b/ecal/core/src/monitoring/ecal_monitoring_impl.h
@@ -73,7 +73,7 @@ namespace eCAL
     bool RegisterTopic(const Registration::Sample& sample_, enum ePubSub pubsub_type_);
     bool UnregisterTopic(const Registration::Sample& sample_, enum ePubSub pubsub_type_);
 
-    using TopicMonMapT = std::map<Registration::EntityIdT, Monitoring::STopicMon>;
+    using TopicMonMapT = std::map<EntityIdT, Monitoring::STopicMon>;
     struct STopicMonMap
     {
       explicit STopicMonMap() :
@@ -84,7 +84,7 @@ namespace eCAL
       std::unique_ptr<TopicMonMapT>  map;
     };
 
-    using ProcessMonMapT = std::map<Registration::EntityIdT, Monitoring::SProcessMon>;
+    using ProcessMonMapT = std::map<EntityIdT, Monitoring::SProcessMon>;
     struct SProcessMonMap
     {
       explicit SProcessMonMap() :
@@ -95,7 +95,7 @@ namespace eCAL
       std::unique_ptr<ProcessMonMapT>  map;
     };
 
-    using ServerMonMapT = std::map<Registration::EntityIdT, Monitoring::SServerMon>;
+    using ServerMonMapT = std::map<EntityIdT, Monitoring::SServerMon>;
     struct SServerMonMap
     {
       explicit SServerMonMap() :
@@ -106,7 +106,7 @@ namespace eCAL
       std::unique_ptr<ServerMonMapT>  map;
     };
 
-    using ClientMonMapT = std::map<Registration::EntityIdT, Monitoring::SClientMon>;
+    using ClientMonMapT = std::map<EntityIdT, Monitoring::SClientMon>;
     struct SClientMonMap
     {
       explicit SClientMonMap() :

--- a/ecal/core/src/pubsub/ecal_publisher.cpp
+++ b/ecal/core/src/pubsub/ecal_publisher.cpp
@@ -123,9 +123,9 @@ namespace eCAL
       return(m_publisher_impl->GetTopicName());
     }
   
-    Registration::STopicId CPublisher::GetTopicId() const
+    STopicId CPublisher::GetTopicId() const
     {
-      if (m_publisher_impl == nullptr) return Registration::STopicId();
+      if (m_publisher_impl == nullptr) return STopicId();
       return(m_publisher_impl->GetTopicId());
     }
   

--- a/ecal/core/src/pubsub/ecal_publisher_impl.cpp
+++ b/ecal/core/src/pubsub/ecal_publisher_impl.cpp
@@ -52,8 +52,8 @@
 
 struct SSndHash
 {
-  SSndHash(const eCAL::Registration::EntityIdT& t, long long c) : topic_id(t), snd_clock(c) {}
-  eCAL::Registration::EntityIdT topic_id;
+  SSndHash(const eCAL::EntityIdT& t, long long c) : topic_id(t), snd_clock(c) {}
+  eCAL::EntityIdT topic_id;
   long long                     snd_clock;
 };
 
@@ -64,7 +64,7 @@ namespace std
   public:
     size_t operator()(const SSndHash& h) const
     {
-      const size_t h1 = std::hash<eCAL::Registration::EntityIdT>()(h.topic_id);
+      const size_t h1 = std::hash<eCAL::EntityIdT>()(h.topic_id);
       const size_t h2 = std::hash<long long>()(h.snd_clock);
       return h1 ^ (h2 << 1);
     }
@@ -733,7 +733,7 @@ namespace eCAL
       data.event_time          = eCAL::Time::GetMicroSeconds();
       data.subscriber_datatype = data_type_info_;
 
-      Registration::STopicId topic_id;
+      STopicId topic_id;
       topic_id.topic_id.entity_id  = subscription_info_.entity_id;
       topic_id.topic_id.process_id = subscription_info_.process_id;
       topic_id.topic_id.host_name  = subscription_info_.host_name;

--- a/ecal/core/src/pubsub/ecal_publisher_impl.h
+++ b/ecal/core/src/pubsub/ecal_publisher_impl.h
@@ -103,9 +103,9 @@ namespace eCAL
     bool IsSubscribed() const;
     size_t GetSubscriberCount() const;
 
-    Registration::STopicId GetTopicId() const
+    STopicId GetTopicId() const
     {
-      Registration::STopicId id;
+      STopicId id;
       id.topic_name          = m_attributes.topic_name;
       id.topic_id.entity_id  = m_topic_id;
       id.topic_id.host_name  = m_attributes.host_name;
@@ -142,7 +142,7 @@ namespace eCAL
     
     int32_t GetFrequency();
 
-    Registration::EntityIdT                m_topic_id;
+    EntityIdT                m_topic_id;
     SDataTypeInformation                   m_topic_info;
     std::map<std::string, std::string>     m_attr;
     size_t                                 m_topic_size = 0;

--- a/ecal/core/src/pubsub/ecal_subscriber.cpp
+++ b/ecal/core/src/pubsub/ecal_subscriber.cpp
@@ -96,7 +96,7 @@ namespace eCAL
       return m_subscriber_impl->GetTopicName();
     }
   
-    Registration::STopicId CSubscriber::GetTopicId() const
+    STopicId CSubscriber::GetTopicId() const
     {
       if (m_subscriber_impl == nullptr) return{};
       return m_subscriber_impl->GetId();

--- a/ecal/core/src/pubsub/ecal_subscriber_impl.cpp
+++ b/ecal/core/src/pubsub/ecal_subscriber_impl.cpp
@@ -537,7 +537,7 @@ namespace eCAL
         cb_data.time  = time_;
         cb_data.clock = clock_;
 
-        Registration::STopicId topic_id;
+        STopicId topic_id;
         topic_id.topic_name          = topic_info_.tname;
         topic_id.topic_id.host_name  = topic_info_.hname;
         topic_id.topic_id.entity_id  = topic_info_.tid;
@@ -787,7 +787,7 @@ namespace eCAL
       data.event_time         = eCAL::Time::GetMicroSeconds();
       data.publisher_datatype = data_type_info_;
 
-      Registration::STopicId topic_id;
+      STopicId topic_id;
       topic_id.topic_id.entity_id  = publication_info_.entity_id;
       topic_id.topic_id.process_id = publication_info_.process_id;
       topic_id.topic_id.host_name  = publication_info_.host_name;

--- a/ecal/core/src/pubsub/ecal_subscriber_impl.h
+++ b/ecal/core/src/pubsub/ecal_subscriber_impl.h
@@ -96,9 +96,9 @@ namespace eCAL
     bool IsPublished() const;
     size_t GetPublisherCount() const;
 
-    Registration::STopicId GetId() const
+    STopicId GetId() const
     {
-      Registration::STopicId id;
+      STopicId id;
       id.topic_name          = m_attributes.topic_name;
       id.topic_id.entity_id  = m_topic_id;
       id.topic_id.host_name  = m_attributes.host_name;
@@ -134,7 +134,7 @@ namespace eCAL
 
     int32_t GetFrequency();
 
-    Registration::EntityIdT                   m_topic_id;
+    EntityIdT                   m_topic_id;
     SDataTypeInformation                      m_topic_info;
     std::map<std::string, std::string>        m_attr;
     std::atomic<size_t>                       m_topic_size;
@@ -176,7 +176,7 @@ namespace eCAL
 
     std::set<long long>                       m_id_set;
 
-    using WriterCounterMapT = std::unordered_map<Registration::EntityIdT, long long>;
+    using WriterCounterMapT = std::unordered_map<EntityIdT, long long>;
     WriterCounterMapT                         m_writer_counter_map;
     long long                                 m_message_drops = 0;
 

--- a/ecal/core/src/readwrite/ecal_reader_layer.h
+++ b/ecal/core/src/readwrite/ecal_reader_layer.h
@@ -37,7 +37,7 @@ namespace eCAL
     std::string                 host_name;
     int32_t                     process_id = 0;
     std::string                 topic_name;
-    Registration::EntityIdT     topic_id = 0;
+    EntityIdT     topic_id = 0;
     Registration::ConnectionPar parameter;
   };
 
@@ -55,10 +55,10 @@ namespace eCAL
     virtual void Initialize(const U& attr_) = 0;
 
     // activate / create a specific subscription
-    virtual void AddSubscription(const std::string& host_name_, const std::string& topic_name_, const Registration::EntityIdT& topic_id_) = 0;
+    virtual void AddSubscription(const std::string& host_name_, const std::string& topic_name_, const EntityIdT& topic_id_) = 0;
 
     // deactivate / destroy a specific subscription
-    virtual void RemSubscription(const std::string& host_name_, const std::string& topic_name_, const Registration::EntityIdT& topic_id_) = 0;
+    virtual void RemSubscription(const std::string& host_name_, const std::string& topic_name_, const EntityIdT& topic_id_) = 0;
 
     // connection parameter from writer side
     virtual void SetConnectionParameter(SReaderLayerPar& par_) = 0;

--- a/ecal/core/src/readwrite/ecal_writer_base.h
+++ b/ecal/core/src/readwrite/ecal_writer_base.h
@@ -42,8 +42,8 @@ namespace eCAL
 
     virtual SWriterInfo GetInfo() = 0;
 
-    virtual void ApplySubscription(const std::string& /*host_name_*/, const int32_t /*process_id_*/, const Registration::EntityIdT& /*topic_id_*/, const std::string& /*conn_par_*/) {};
-    virtual void RemoveSubscription(const std::string& /*host_name_*/, const int32_t /*process_id_*/, const Registration::EntityIdT& /*topic_id_*/) {};
+    virtual void ApplySubscription(const std::string& /*host_name_*/, const int32_t /*process_id_*/, const EntityIdT& /*topic_id_*/, const std::string& /*conn_par_*/) {};
+    virtual void RemoveSubscription(const std::string& /*host_name_*/, const int32_t /*process_id_*/, const EntityIdT& /*topic_id_*/) {};
 
     virtual Registration::ConnectionPar GetConnectionParameter() { return {}; };
 

--- a/ecal/core/src/readwrite/shm/ecal_reader_shm.h
+++ b/ecal/core/src/readwrite/shm/ecal_reader_shm.h
@@ -44,8 +44,8 @@ namespace eCAL
     ~CSHMReaderLayer() override = default;
 
     void Initialize(const eCAL::eCALReader::SHM::SAttributes& attr_) override;
-    void AddSubscription(const std::string& /*host_name_*/, const std::string& /*topic_name_*/, const Registration::EntityIdT& /*topic_id_*/) override {}
-    void RemSubscription(const std::string& /*host_name_*/, const std::string& /*topic_name_*/, const Registration::EntityIdT& /*topic_id_*/) override {}
+    void AddSubscription(const std::string& /*host_name_*/, const std::string& /*topic_name_*/, const EntityIdT& /*topic_id_*/) override {}
+    void RemSubscription(const std::string& /*host_name_*/, const std::string& /*topic_name_*/, const EntityIdT& /*topic_id_*/) override {}
 
     void SetConnectionParameter(SReaderLayerPar& par_) override;
 

--- a/ecal/core/src/readwrite/shm/ecal_writer_shm.cpp
+++ b/ecal/core/src/readwrite/shm/ecal_writer_shm.cpp
@@ -83,7 +83,7 @@ namespace eCAL
     return sent;
   }
 
-  void CDataWriterSHM::ApplySubscription(const std::string& host_name_, const int32_t process_id_, const Registration::EntityIdT& topic_id_, const std::string& /*conn_par_*/)
+  void CDataWriterSHM::ApplySubscription(const std::string& host_name_, const int32_t process_id_, const EntityIdT& topic_id_, const std::string& /*conn_par_*/)
   {
     // we accept local connections only
     if (host_name_ != m_attributes.host_name) return;
@@ -104,7 +104,7 @@ namespace eCAL
     }
   }
 
-  void CDataWriterSHM::RemoveSubscription(const std::string& host_name_, const int32_t process_id_, const Registration::EntityIdT& topic_id_)
+  void CDataWriterSHM::RemoveSubscription(const std::string& host_name_, const int32_t process_id_, const EntityIdT& topic_id_)
   {
     // we accept local disconnections only
     if (host_name_ != m_attributes.host_name) return;

--- a/ecal/core/src/readwrite/shm/ecal_writer_shm.h
+++ b/ecal/core/src/readwrite/shm/ecal_writer_shm.h
@@ -49,8 +49,8 @@ namespace eCAL
 
     bool Write(CPayloadWriter& payload_, const SWriterAttr& attr_) override;
 
-    void ApplySubscription(const std::string& host_name_, int32_t process_id_, const Registration::EntityIdT& topic_id_, const std::string& conn_par_) override;
-    void RemoveSubscription(const std::string& host_name_, int32_t process_id_, const Registration::EntityIdT& topic_id_) override;
+    void ApplySubscription(const std::string& host_name_, int32_t process_id_, const EntityIdT& topic_id_, const std::string& conn_par_) override;
+    void RemoveSubscription(const std::string& host_name_, int32_t process_id_, const EntityIdT& topic_id_) override;
 
     Registration::ConnectionPar GetConnectionParameter() override;
 
@@ -63,7 +63,7 @@ namespace eCAL
     std::vector<std::shared_ptr<CSyncMemoryFile>> m_memory_file_vec;
     static const std::string                      m_memfile_base_name;
 
-    using ProcessIDTopicIDSetT = std::map<int32_t, std::set<Registration::EntityIdT>>;
+    using ProcessIDTopicIDSetT = std::map<int32_t, std::set<EntityIdT>>;
     std::mutex                                    m_process_id_topic_id_set_map_sync;
     ProcessIDTopicIDSetT                          m_process_id_topic_id_set_map;
   };

--- a/ecal/core/src/readwrite/tcp/ecal_reader_tcp.cpp
+++ b/ecal/core/src/readwrite/tcp/ecal_reader_tcp.cpp
@@ -140,7 +140,7 @@ namespace eCAL
     m_executor = std::make_shared<tcp_pubsub::Executor>(m_attributes.thread_pool_size, tcp_pubsub_logger);
   }
 
-  void CTCPReaderLayer::AddSubscription(const std::string& /*host_name_*/, const std::string& topic_name_, const Registration::EntityIdT& /*topic_id_*/)
+  void CTCPReaderLayer::AddSubscription(const std::string& /*host_name_*/, const std::string& topic_name_, const EntityIdT& /*topic_id_*/)
   {
     const std::string& map_key(topic_name_);
 
@@ -153,7 +153,7 @@ namespace eCAL
     m_datareadertcp_map.insert(std::pair<std::string, std::shared_ptr<CDataReaderTCP>>(map_key, reader));
   }
 
-  void CTCPReaderLayer::RemSubscription(const std::string& /*host_name_*/, const std::string& topic_name_, const Registration::EntityIdT& /*topic_id_*/)
+  void CTCPReaderLayer::RemSubscription(const std::string& /*host_name_*/, const std::string& topic_name_, const EntityIdT& /*topic_id_*/)
   {
     const std::string& map_key(topic_name_);
 

--- a/ecal/core/src/readwrite/tcp/ecal_reader_tcp.h
+++ b/ecal/core/src/readwrite/tcp/ecal_reader_tcp.h
@@ -71,8 +71,8 @@ namespace eCAL
 
     void Initialize(const eCAL::eCALReader::TCPLayer::SAttributes& attr_) override;
 
-    void AddSubscription(const std::string& host_name_, const std::string& topic_name_, const Registration::EntityIdT& topic_id_) override;
-    void RemSubscription(const std::string& host_name_, const std::string& topic_name_, const Registration::EntityIdT& topic_id_) override;
+    void AddSubscription(const std::string& host_name_, const std::string& topic_name_, const EntityIdT& topic_id_) override;
+    void RemSubscription(const std::string& host_name_, const std::string& topic_name_, const EntityIdT& topic_id_) override;
 
     void SetConnectionParameter(SReaderLayerPar& /*par_*/) override;
 

--- a/ecal/core/src/readwrite/udp/ecal_reader_udp.cpp
+++ b/ecal/core/src/readwrite/udp/ecal_reader_udp.cpp
@@ -50,7 +50,7 @@ namespace eCAL
      m_attributes = attr_;
   }
 
-  void CUDPReaderLayer::AddSubscription(const std::string& /*host_name_*/, const std::string& topic_name_, const Registration::EntityIdT& /*topic_id_*/)
+  void CUDPReaderLayer::AddSubscription(const std::string& /*host_name_*/, const std::string& topic_name_, const EntityIdT& /*topic_id_*/)
   {
     if (!m_started)
     {      
@@ -77,7 +77,7 @@ namespace eCAL
     m_topic_name_mcast_map[mcast_address]++;
   }
 
-  void CUDPReaderLayer::RemSubscription(const std::string& /*host_name_*/, const std::string& topic_name_, const Registration::EntityIdT& /*topic_id_*/)
+  void CUDPReaderLayer::RemSubscription(const std::string& /*host_name_*/, const std::string& topic_name_, const EntityIdT& /*topic_id_*/)
   {
     // we use udp broadcast in local mode
     if (m_attributes.broadcast) return;

--- a/ecal/core/src/readwrite/udp/ecal_reader_udp.h
+++ b/ecal/core/src/readwrite/udp/ecal_reader_udp.h
@@ -45,8 +45,8 @@ namespace eCAL
 
     void Initialize(const eCAL::eCALReader::UDP::SAttributes& attr_) override;
 
-    void AddSubscription(const std::string& /*host_name_*/, const std::string& topic_name_, const Registration::EntityIdT& /*topic_id_*/) override;
-    void RemSubscription(const std::string& /*host_name_*/, const std::string& topic_name_, const Registration::EntityIdT& /*topic_id_*/) override;
+    void AddSubscription(const std::string& /*host_name_*/, const std::string& topic_name_, const EntityIdT& /*topic_id_*/) override;
+    void RemSubscription(const std::string& /*host_name_*/, const std::string& topic_name_, const EntityIdT& /*topic_id_*/) override;
 
     void SetConnectionParameter(SReaderLayerPar& /*par_*/) override {}
 

--- a/ecal/core/src/service/ecal_clientgate.cpp
+++ b/ecal/core/src/service/ecal_clientgate.cpp
@@ -114,7 +114,7 @@ namespace eCAL
       auto res = m_service_client_map.equal_range(service.sname);
       for (ServiceNameClientIDImplMapT::const_iterator iter = res.first; iter != res.second; ++iter)
       {
-        Registration::SEntityId service_entity;
+        SEntityId service_entity;
         service_entity.entity_id  = service.sid;
         service_entity.process_id = service.pid;
         service_entity.host_name  = service.hname;

--- a/ecal/core/src/service/ecal_service_client.cpp
+++ b/ecal/core/src/service/ecal_service_client.cpp
@@ -187,9 +187,9 @@ namespace eCAL
     return m_service_client_impl->GetServiceName();
   }
 
-  Registration::SServiceId CServiceClient::GetServiceId() const
+  SServiceId CServiceClient::GetServiceId() const
   {
-    if (m_service_client_impl == nullptr) return Registration::SServiceId();
+    if (m_service_client_impl == nullptr) return SServiceId();
     return m_service_client_impl->GetServiceId();
   }
 

--- a/ecal/core/src/service/ecal_service_client_impl.cpp
+++ b/ecal/core/src/service/ecal_service_client_impl.cpp
@@ -47,7 +47,7 @@ namespace
     return request_shared_ptr;
   }
 
-  eCAL::SServiceIDResponse CreateErrorResponse(const eCAL::Registration::SEntityId& entity_id_, const std::string& service_name_, const std::string& method_name_, const std::string& error_message_)
+  eCAL::SServiceIDResponse CreateErrorResponse(const eCAL::SEntityId& entity_id_, const std::string& service_name_, const std::string& method_name_, const std::string& error_message_)
   {
     eCAL::SServiceIDResponse error_response;
     // service/method id
@@ -62,7 +62,7 @@ namespace
     return error_response;
   }
 
-  void ResponseError(const eCAL::Registration::SEntityId& entity_id_, const std::string& service_name_, const std::string& method_name_,
+  void ResponseError(const eCAL::SEntityId& entity_id_, const std::string& service_name_, const std::string& method_name_,
     const std::string& error_message_, const eCAL::ResponseIDCallbackT& response_callback_)
   {
     eCAL::Logging::Log(eCAL::Logging::log_level_error, "CServiceClientImpl: Response error for service: " + service_name_ + ", method: " + method_name_ + ", error: " + error_message_);
@@ -148,9 +148,9 @@ namespace eCAL
   }
 
   // Retrieve service IDs of all matching services
-  std::vector<Registration::SEntityId> CServiceClientImpl::GetServiceIDs()
+  std::vector<SEntityId> CServiceClientImpl::GetServiceIDs()
   {
-    std::vector<Registration::SEntityId> entity_vector;
+    std::vector<SEntityId> entity_vector;
 
     // lock client map
     const std::lock_guard<std::mutex> lock(m_client_session_map_mutex);
@@ -165,7 +165,7 @@ namespace eCAL
 
   // Calls a service method synchronously, blocking until a response is received or timeout occurs
   std::pair<bool, SServiceIDResponse> CServiceClientImpl::CallWithCallback(
-      const Registration::SEntityId & entity_id_, const std::string & method_name_,
+      const SEntityId & entity_id_, const std::string & method_name_,
       const std::string & request_, int timeout_ms_, const ResponseIDCallbackT & response_callback_)
   {
 #ifndef NDEBUG
@@ -190,7 +190,7 @@ namespace eCAL
     // Handle timeout event
     if (!response.first && response.second.call_state == eCallState::timeouted)
     {
-      Registration::SServiceId service_id;
+      SServiceId service_id;
       service_id.service_name = m_service_name;
       service_id.service_id = entity_id_;
       NotifyEventCallback(service_id, eClientEvent::timeout);
@@ -203,7 +203,7 @@ namespace eCAL
   }
 
   // Asynchronous call to a service with a specified timeout
-  bool CServiceClientImpl::CallWithCallbackAsync(const Registration::SEntityId & entity_id_, const std::string & method_name_, const std::string & request_, const ResponseIDCallbackT & response_callback_)
+  bool CServiceClientImpl::CallWithCallbackAsync(const SEntityId & entity_id_, const std::string & method_name_, const std::string & request_, const ResponseIDCallbackT & response_callback_)
   {
 #ifndef NDEBUG
     eCAL::Logging::Log(eCAL::Logging::log_level_debug2, "CServiceClientImpl::CallWithCallbackAsync: Performing asynchronous call for service: " + m_service_name + ", method: " + method_name_);
@@ -277,7 +277,7 @@ namespace eCAL
   }
 
   // Check if a specific service is connected
-  bool CServiceClientImpl::IsConnected(const Registration::SEntityId & entity_id_)
+  bool CServiceClientImpl::IsConnected(const SEntityId & entity_id_)
   {
     const std::lock_guard<std::mutex> lock(m_client_session_map_mutex);
     auto iter = m_client_session_map.find(entity_id_);
@@ -288,7 +288,7 @@ namespace eCAL
     return state;
   }
 
-  void CServiceClientImpl::RegisterService(const Registration::SEntityId & entity_id_, const v5::SServiceAttr & service_)
+  void CServiceClientImpl::RegisterService(const SEntityId & entity_id_, const v5::SServiceAttr & service_)
   {
     const std::lock_guard<std::mutex> lock(m_client_session_map_mutex);
 
@@ -333,9 +333,9 @@ namespace eCAL
     return GetRegistrationSample();
   }
 
-  Registration::SServiceId CServiceClientImpl::GetServiceId() const
+  SServiceId CServiceClientImpl::GetServiceId() const
   {
-    Registration::SServiceId service_id;
+    SServiceId service_id;
 
     service_id.service_id.entity_id = m_client_id;
     service_id.service_id.process_id = Process::GetProcessID();
@@ -416,7 +416,7 @@ namespace eCAL
   }
 
   // Attempts to retrieve a client session for a given entity ID
-  bool CServiceClientImpl::GetClientByEntity(const Registration::SEntityId & entity_id_, SClient & client_)
+  bool CServiceClientImpl::GetClientByEntity(const SEntityId & entity_id_, SClient & client_)
   {
     const std::lock_guard<std::mutex> lock(m_client_session_map_mutex);
     auto iter = m_client_session_map.find(entity_id_);
@@ -429,7 +429,7 @@ namespace eCAL
 
   // Blocking call to a service with a specified timeout
   std::pair<bool, SServiceIDResponse> CServiceClientImpl::CallMethodWithTimeout(
-    const Registration::SEntityId & entity_id_, SClient & client_, const std::string & method_name_,
+    const SEntityId & entity_id_, SClient & client_, const std::string & method_name_,
     const std::string & request_, std::chrono::nanoseconds timeout_)
   {
     if (method_name_.empty())
@@ -481,12 +481,12 @@ namespace eCAL
       auto& client_data = it->second;
       auto state = client_data.client_session->get_state();
 
-      Registration::SEntityId entity_id;
+      SEntityId entity_id;
       entity_id.entity_id = client_data.service_attr.sid;
       entity_id.process_id = client_data.service_attr.pid;
       entity_id.host_name = client_data.service_attr.hname;
 
-      Registration::SServiceId service_id;
+      SServiceId service_id;
       service_id.service_name = m_service_name;
       service_id.service_id = entity_id;
 
@@ -516,7 +516,7 @@ namespace eCAL
   }
 
 
-  void CServiceClientImpl::NotifyEventCallback(const Registration::SServiceId & service_id_, eClientEvent event_type_)
+  void CServiceClientImpl::NotifyEventCallback(const SServiceId & service_id_, eClientEvent event_type_)
   {
 #ifndef NDEBUG
     Logging::Log(Logging::log_level_debug1, "CServiceClientImpl::NotifyEventCallback: Notifying event callback for: " + m_service_name + " Event Type: " + to_string(event_type_));

--- a/ecal/core/src/service/ecal_service_client_impl.h
+++ b/ecal/core/src/service/ecal_service_client_impl.h
@@ -59,30 +59,30 @@ namespace eCAL
       ~CServiceClientImpl();
 
       // Retrieve service IDs of all matching services
-      std::vector<Registration::SEntityId> GetServiceIDs();
+      std::vector<SEntityId> GetServiceIDs();
 
       // Blocking call to a specific service; returns response as pair<bool, SServiceIDResponse>
       // if a callback is provided call the callback as well
       std::pair<bool, SServiceIDResponse> CallWithCallback(
-        const Registration::SEntityId& entity_id_, const std::string& method_name_,
+        const SEntityId& entity_id_, const std::string& method_name_,
         const std::string& request_, int timeout_ms_, const ResponseIDCallbackT& response_callback_ = nullptr);
 
       // Asynchronous call to a specific service using callback
       bool CallWithCallbackAsync(
-        const Registration::SEntityId& entity_id_, const std::string& method_name_,
+        const SEntityId& entity_id_, const std::string& method_name_,
         const std::string& request_, const ResponseIDCallbackT& response_callback_);
 
       // Check connection state of a specific service
-      bool IsConnected(const Registration::SEntityId& entity_id_);
+      bool IsConnected(const SEntityId& entity_id_);
 
       // Called by the registration receiver to process a service registration
-      void RegisterService(const Registration::SEntityId& entity_id_, const v5::SServiceAttr& service_);
+      void RegisterService(const SEntityId& entity_id_, const v5::SServiceAttr& service_);
 
       // Called by the registration provider to get a registration sample
       Registration::Sample GetRegistration();
 
       // Retrieves the service id
-      Registration::SServiceId GetServiceId() const;
+      SServiceId GetServiceId() const;
 
       // Retrieves the service name
       std::string GetServiceName() const;
@@ -107,10 +107,10 @@ namespace eCAL
       };
 
       // Get client for specific entity id
-      bool GetClientByEntity(const Registration::SEntityId& entity_id_, SClient& client_);
+      bool GetClientByEntity(const SEntityId& entity_id_, SClient& client_);
 
       // Blocking call to a specific service method with timeout
-      std::pair<bool, SServiceIDResponse> CallMethodWithTimeout(const Registration::SEntityId& entity_id_, SClient& client_,
+      std::pair<bool, SServiceIDResponse> CallMethodWithTimeout(const SEntityId& entity_id_, SClient& client_,
         const std::string& method_name_, const std::string& request_, std::chrono::nanoseconds timeout_);
 
       // Update the connection states for client sessions
@@ -120,7 +120,7 @@ namespace eCAL
       void IncrementMethodCallCount(const std::string& method_name_);
 
       // Notify specific event callback
-      void NotifyEventCallback(const Registration::SServiceId& service_id_, eClientEvent event_type_);
+      void NotifyEventCallback(const SServiceId& service_id_, eClientEvent event_type_);
 
       // SResponseData struct for handling response callbacks
       struct SResponseData
@@ -150,10 +150,10 @@ namespace eCAL
 
       // Service attributes
       std::string                  m_service_name;
-      Registration::EntityIdT      m_client_id;
+      EntityIdT      m_client_id;
 
       // Client session map and synchronization
-      using ClientSessionsMapT = std::map<Registration::SEntityId, SClient>;
+      using ClientSessionsMapT = std::map<SEntityId, SClient>;
       std::mutex                   m_client_session_map_mutex;
       ClientSessionsMapT           m_client_session_map;
 

--- a/ecal/core/src/service/ecal_service_client_instance.cpp
+++ b/ecal/core/src/service/ecal_service_client_instance.cpp
@@ -26,7 +26,7 @@
 
 namespace eCAL
 {
-  CClientInstance::CClientInstance(const Registration::SEntityId& entity_id_, const std::shared_ptr<v6::CServiceClientImpl>& service_client_id_impl_)
+  CClientInstance::CClientInstance(const SEntityId& entity_id_, const std::shared_ptr<v6::CServiceClientImpl>& service_client_id_impl_)
     : m_entity_id(entity_id_), m_service_client_impl(service_client_id_impl_)
   {
     assert(m_service_client_impl && "service_client_id_impl_ must not be null");
@@ -53,7 +53,7 @@ namespace eCAL
     return m_service_client_impl->IsConnected(m_entity_id);
   }
 
-  Registration::SEntityId CClientInstance::GetClientID() const
+  SEntityId CClientInstance::GetClientID() const
   {
     return m_entity_id;
   }

--- a/ecal/core/src/service/ecal_service_server.cpp
+++ b/ecal/core/src/service/ecal_service_server.cpp
@@ -82,9 +82,9 @@ namespace eCAL
     return m_service_server_impl->GetServiceName();
   }
 
-  Registration::SServiceId CServiceServer::GetServiceId() const
+  SServiceId CServiceServer::GetServiceId() const
   {
-    if (m_service_server_impl == nullptr) return Registration::SServiceId();
+    if (m_service_server_impl == nullptr) return SServiceId();
     return m_service_server_impl->GetServiceId();
   }
 

--- a/ecal/core/src/service/ecal_service_server_impl.cpp
+++ b/ecal/core/src/service/ecal_service_server_impl.cpp
@@ -219,9 +219,9 @@ namespace eCAL
     return GetRegistrationSample();
   }
 
-  Registration::SServiceId CServiceServerImpl::GetServiceId() const
+  SServiceId CServiceServerImpl::GetServiceId() const
   {
-    Registration::SServiceId service_id;
+    SServiceId service_id;
 
     service_id.service_id.entity_id = m_service_id;
     service_id.service_id.process_id = Process::GetProcessID();
@@ -265,7 +265,7 @@ namespace eCAL
       {
         if (auto me = weak_me.lock())
         {
-          Registration::SServiceId service_id;
+          SServiceId service_id;
           service_id.service_name = me->m_service_name;
           service_id.service_id.entity_id = me->m_service_id;
           // TODO: Also fill process ID and hostname?
@@ -498,7 +498,7 @@ namespace eCAL
     return 0;
   }
 
-  void CServiceServerImpl::NotifyEventCallback(const Registration::SServiceId & service_id_, eServerEvent event_type_, const std::string& /*message_*/)
+  void CServiceServerImpl::NotifyEventCallback(const SServiceId & service_id_, eServerEvent event_type_, const std::string& /*message_*/)
   {
 #ifndef NDEBUG
     Logging::Log(Logging::log_level_debug1, "CServiceServerImpl::NotifyEventCallback: Notifying event callback for: " + m_service_name + " Event Type: " + to_string(event_type_));

--- a/ecal/core/src/service/ecal_service_server_impl.h
+++ b/ecal/core/src/service/ecal_service_server_impl.h
@@ -72,7 +72,7 @@ namespace eCAL
       Registration::Sample GetRegistration();
 
       // Retrieves the service id
-      Registration::SServiceId GetServiceId() const;
+      SServiceId GetServiceId() const;
 
       // Retrieves the service name
       std::string GetServiceName() const;
@@ -94,14 +94,14 @@ namespace eCAL
 
       // Request and event callback methods
       int RequestCallback(const std::string& request_pb_, std::string& response_pb_);
-      void NotifyEventCallback(const Registration::SServiceId& service_id_, eServerEvent event_type_, const std::string& message_);
+      void NotifyEventCallback(const SServiceId& service_id_, eServerEvent event_type_, const std::string& message_);
 
       // Server version (incremented for protocol or functionality changes)
       static constexpr int                   m_server_version = 1;
 
       // Server attributes
       std::string                            m_service_name;
-      Registration::EntityIdT                m_service_id;
+      EntityIdT                m_service_id;
 
       // Server connection state and synchronization
       mutable std::mutex                     m_connected_mutex; // mutex protecting m_connected (modified by the event callbacks in another thread)

--- a/ecal/core/src/v5/pubsub/ecal_publisher.cpp
+++ b/ecal/core/src/v5/pubsub/ecal_publisher.cpp
@@ -219,7 +219,7 @@ namespace eCAL
       return(m_publisher_impl->GetTopicName());
     }
 
-    Registration::STopicId CPublisher::GetId() const
+    STopicId CPublisher::GetId() const
     {
       if (m_publisher_impl == nullptr) return{};
       return(m_publisher_impl->GetTopicId());

--- a/ecal/core/src/v5/pubsub/ecal_subscriber.cpp
+++ b/ecal/core/src/v5/pubsub/ecal_subscriber.cpp
@@ -150,7 +150,7 @@ namespace eCAL
 
     bool CSubscriber::AddReceiveCallback(ReceiveCallbackT callback_)
     {
-      auto v6_callback = [callback_](const Registration::STopicId& topic_id_, const SDataTypeInformation&, const eCAL::SReceiveCallbackData& data_)
+      auto v6_callback = [callback_](const STopicId& topic_id_, const SDataTypeInformation&, const eCAL::SReceiveCallbackData& data_)
         {
           callback_(topic_id_.topic_name.c_str(), &data_);
         };
@@ -201,7 +201,7 @@ namespace eCAL
       return(m_subscriber_impl->GetTopicName());
     }
 
-    Registration::STopicId CSubscriber::GetId() const
+    STopicId CSubscriber::GetId() const
     {
       if (m_subscriber_impl == nullptr) return{};
       return(m_subscriber_impl->GetId());

--- a/ecal/core/src/v5/service/ecal_service_client_impl.cpp
+++ b/ecal/core/src/v5/service/ecal_service_client_impl.cpp
@@ -95,7 +95,7 @@ namespace eCAL
       Logging::Log(Logging::log_level_debug1, "v5::CServiceClientImpl: Creating service client with name: " + service_name_);
 
       // Define the event callback to pass to CServiceClient
-      v6::ClientEventCallbackT event_callback = [this](const Registration::SServiceId& service_id_, const v6::SClientEventCallbackData& data_)
+      v6::ClientEventCallbackT event_callback = [this](const SServiceId& service_id_, const v6::SClientEventCallbackData& data_)
         {
           Logging::Log(Logging::log_level_debug2, "v5::CServiceClientImpl: Event callback triggered for event type: " + to_string(data_.type));
 
@@ -184,7 +184,7 @@ namespace eCAL
       Logging::Log(Logging::log_level_debug1, "v5::CServiceClientImpl: Making a synchronous call to method: " + method_name_);
 
       // Wrap the response callback to filter by host name if necessary
-      const ResponseIDCallbackT callback = [this](const Registration::SEntityId& /*entity_id_*/, const struct SServiceIDResponse& service_response_)
+      const ResponseIDCallbackT callback = [this](const SEntityId& /*entity_id_*/, const struct SServiceIDResponse& service_response_)
         {
           if (m_host_name.empty() || service_response_.service_method_id.service_id.host_name == m_host_name)
           {
@@ -263,7 +263,7 @@ namespace eCAL
       Logging::Log(Logging::log_level_debug1, "v5::CServiceClientImpl: Making an asynchronous call to method: " + method_name_);
 
       // Wrap the response callback to filter by host name if necessary
-      const ResponseIDCallbackT callback = [this](const Registration::SEntityId& /*entity_id_*/, const struct SServiceIDResponse& service_response_)
+      const ResponseIDCallbackT callback = [this](const SEntityId& /*entity_id_*/, const struct SServiceIDResponse& service_response_)
         {
           if (m_host_name.empty() || service_response_.service_method_id.service_id.host_name == m_host_name)
           {

--- a/ecal/core/src/v5/service/ecal_service_server_impl.cpp
+++ b/ecal/core/src/v5/service/ecal_service_server_impl.cpp
@@ -57,7 +57,7 @@ namespace eCAL
       }
 
       // Define the event callback to pass to CServiceClient
-      v6::ServerEventCallbackT event_callback = [this](const Registration::SServiceId& service_id_, const v6::SServerEventCallbackData& data_)
+      v6::ServerEventCallbackT event_callback = [this](const SServiceId& service_id_, const v6::SServerEventCallbackData& data_)
         {
           Logging::Log(Logging::log_level_debug2, "v5::CServiceServerImpl: Event callback triggered for event type: " + to_string(data_.type));
 

--- a/ecal/samples/cpp/benchmarks/many_connections_rec/src/many_connections_rec.cpp
+++ b/ecal/samples/cpp/benchmarks/many_connections_rec/src/many_connections_rec.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ public:
       std::ostringstream tname;
       tname << std::setw(5) << std::setfill('0') << i;
       subscribers.emplace_back("Topic" + tname.str(), eCAL::SDataTypeInformation{ ttype, "", tdesc });
-      auto on_receive = [this](const eCAL::Registration::STopicId&, const eCAL::SDataTypeInformation&, const eCAL::SReceiveCallbackData&)
+      auto on_receive = [this](const eCAL::STopicId&, const eCAL::SDataTypeInformation&, const eCAL::SReceiveCallbackData&)
       {
         Receive();
       };

--- a/ecal/samples/cpp/benchmarks/massive_pub_sub/src/massive_pub_sub.cpp
+++ b/ecal/samples/cpp/benchmarks/massive_pub_sub/src/massive_pub_sub.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,10 +68,10 @@ int main()
   // publisher registration event callback
   size_t created_publisher_num(0);
   size_t deleted_publisher_num(0);
-  std::set<eCAL::Registration::STopicId> created_publisher_ids;
-  std::set<eCAL::Registration::STopicId> deleted_publisher_ids;
+  std::set<eCAL::STopicId> created_publisher_ids;
+  std::set<eCAL::STopicId> deleted_publisher_ids;
   eCAL::Registration::AddPublisherEventCallback(
-    [&](const eCAL::Registration::STopicId& id_, eCAL::Registration::RegistrationEventType event_type_)
+    [&](const eCAL::STopicId& id_, eCAL::Registration::RegistrationEventType event_type_)
     {
       switch (event_type_)
       {
@@ -200,7 +200,7 @@ int main()
   }
 
   // check creation events
-  const std::set<eCAL::Registration::STopicId> publisher_ids = eCAL::Registration::GetPublisherIDs();
+  const std::set<eCAL::STopicId> publisher_ids = eCAL::Registration::GetPublisherIDs();
   std::cout << "Number of publisher creation events   " << created_publisher_num << std::endl;
   std::cout << "Size   of publisher creation id set   " << created_publisher_ids.size() << std::endl;
   //std::cout << "Publisher creation id sets are equal  " << (publisher_ids == created_publisher_ids) << std::endl;

--- a/ecal/samples/cpp/benchmarks/multiple_rec/src/multiple_rec.cpp
+++ b/ecal/samples/cpp/benchmarks/multiple_rec/src/multiple_rec.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ int              g_overalll_read = 0;
 std::chrono::steady_clock::time_point start_time(std::chrono::nanoseconds(0));
 
 // global subscriber callback
-void OnReceive(const eCAL::Registration::STopicId& topic_id_)
+void OnReceive(const eCAL::STopicId& topic_id_)
 {
   // statistics
   {

--- a/ecal/samples/cpp/benchmarks/performance_rec/src/performance_rec.cpp
+++ b/ecal/samples/cpp/benchmarks/performance_rec/src/performance_rec.cpp
@@ -62,7 +62,7 @@ int main()
   long long bytes(0);
 
   // add callback
-    auto on_receive = [&](const eCAL::Registration::STopicId& topic_id_, const eCAL::SReceiveCallbackData & data_) {
+    auto on_receive = [&](const eCAL::STopicId& topic_id_, const eCAL::SReceiveCallbackData & data_) {
     auto size = data_.size;
 
     msgs++;

--- a/ecal/samples/cpp/benchmarks/perftool/src/subscriber.cpp
+++ b/ecal/samples/cpp/benchmarks/perftool/src/subscriber.cpp
@@ -54,7 +54,7 @@ Subscriber::Subscriber(const std::string&                   topic_name
   if (!quiet)
     statistics_thread_ = std::make_unique<std::thread>([this](){ this->statisticsLoop(); });
 
-  ecal_sub.SetReceiveCallback([this](const eCAL::Registration::STopicId& /*topic_id_*/, const eCAL::SDataTypeInformation& /*data_type_info_*/, const eCAL::SReceiveCallbackData& data_) { callback(data_); });
+  ecal_sub.SetReceiveCallback([this](const eCAL::STopicId& /*topic_id_*/, const eCAL::SDataTypeInformation& /*data_type_info_*/, const eCAL::SReceiveCallbackData& data_) { callback(data_); });
 }
 
 // Destructor

--- a/ecal/samples/cpp/monitoring/monitoring_get_services/src/monitoring_get_services.cpp
+++ b/ecal/samples/cpp/monitoring/monitoring_get_services/src/monitoring_get_services.cpp
@@ -38,7 +38,7 @@ int main()
   {
     // GetServers
     {
-      std::set<eCAL::Registration::SServiceId> server_method_id_set;
+      std::set<eCAL::SServiceId> server_method_id_set;
 
       start_time = std::chrono::steady_clock::now();
       for (run = 0; run < runs; ++run)

--- a/ecal/samples/cpp/monitoring/monitoring_get_topics/src/monitoring_get_topics.cpp
+++ b/ecal/samples/cpp/monitoring/monitoring_get_topics/src/monitoring_get_topics.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,8 +38,8 @@ int main()
   {
     // GetTopics
     {
-      std::set<eCAL::Registration::STopicId> topic_id_pub_set;
-      std::set<eCAL::Registration::STopicId> topic_id_sub_set;
+      std::set<eCAL::STopicId> topic_id_pub_set;
+      std::set<eCAL::STopicId> topic_id_sub_set;
 
       start_time = std::chrono::steady_clock::now();
       for (run = 0; run < runs; ++run)

--- a/ecal/samples/cpp/pubsub/binary/binary_rec/src/binary_rec.cpp
+++ b/ecal/samples/cpp/pubsub/binary/binary_rec/src/binary_rec.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@
 #include <thread>
 
 // subscriber callback function
-void OnReceive(const eCAL::Registration::STopicId& /*topic_id_*/, const eCAL::SDataTypeInformation& /*data_type_info_*/, const eCAL::SReceiveCallbackData& data_)
+void OnReceive(const eCAL::STopicId& /*topic_id_*/, const eCAL::SDataTypeInformation& /*data_type_info_*/, const eCAL::SReceiveCallbackData& data_)
 {
   if (data_.size < 1) return;
 

--- a/ecal/samples/cpp/pubsub/binary/binary_zero_copy_rec/src/binary_zero_copy_rec.cpp
+++ b/ecal/samples/cpp/pubsub/binary/binary_zero_copy_rec/src/binary_zero_copy_rec.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ std::ostream& operator<<(std::ostream& os, const SSimpleStruct& s)
 }
 
 // subscriber callback function
-void OnReceive(const eCAL::Registration::STopicId& /*topic_id_*/, const eCAL::SDataTypeInformation& /*data_type_info_*/, const eCAL::SReceiveCallbackData& data_)
+void OnReceive(const eCAL::STopicId& /*topic_id_*/, const eCAL::SDataTypeInformation& /*data_type_info_*/, const eCAL::SReceiveCallbackData& data_)
 {
   if (data_.size < 1) return;
 

--- a/ecal/samples/cpp/services/minimal_client/src/minimal_client.cpp
+++ b/ecal/samples/cpp/services/minimal_client/src/minimal_client.cpp
@@ -33,7 +33,7 @@ int main()
   const eCAL::CServiceClient minimal_client("service1", { {"echo", {}, {} } });
 
   // callback for service response
-  auto service_response_callback = [](const eCAL::Registration::SEntityId& entity_id_, const eCAL::SServiceIDResponse& service_response_) {
+  auto service_response_callback = [](const eCAL::SEntityId& entity_id_, const eCAL::SServiceIDResponse& service_response_) {
     switch (service_response_.call_state)
     {
       // service successful executed

--- a/ecal/tests/cpp/clientserver_test/src/clientserver_test.cpp
+++ b/ecal/tests/cpp/clientserver_test/src/clientserver_test.cpp
@@ -116,7 +116,7 @@ TEST(core_cpp_clientserver, ClientConnectEvent)
   // client event callback for connect events
   atomic_signalable<int> event_connected_fired   (0);
   atomic_signalable<int> event_disconnected_fired(0);
-  auto event_callback = [&](const eCAL::Registration::SServiceId& /*service_id_*/, const struct eCAL::SClientEventCallbackData& data_)
+  auto event_callback = [&](const eCAL::SServiceId& /*service_id_*/, const struct eCAL::SClientEventCallbackData& data_)
     {
       switch (data_.type)
       {
@@ -181,7 +181,7 @@ TEST(core_cpp_clientserver, ServerConnectEvent)
   // server event callback for connect events
   atomic_signalable<int> event_connected_fired   (0);
   atomic_signalable<int> event_disconnected_fired(0);
-  auto event_callback = [&](const eCAL::Registration::SServiceId& /*service_id_*/, const struct eCAL::SServerEventCallbackData& data_) -> void
+  auto event_callback = [&](const eCAL::SServiceId& /*service_id_*/, const struct eCAL::SServerEventCallbackData& data_) -> void
     {
       switch (data_.type)
       {
@@ -286,7 +286,7 @@ TEST(core_cpp_clientserver, ClientServerBaseCallback)
 
   // response callback function
   std::atomic<int> responses_executed(0);
-  auto response_callback = [&](const eCAL::Registration::SEntityId& /*entity_id_*/, const struct eCAL::SServiceIDResponse& service_response_)
+  auto response_callback = [&](const eCAL::SEntityId& /*entity_id_*/, const struct eCAL::SServiceIDResponse& service_response_)
     {
       PrintResponse(service_response_);
       responses_executed++;
@@ -384,7 +384,7 @@ TEST(core_cpp_clientserver, ClientServerBaseCallbackTimeout)
 
   // event callback for timeout event
   std::atomic<int> timeout_fired(0);
-  auto event_callback = [&](const eCAL::Registration::SServiceId& /*service_id_*/, const struct eCAL::SClientEventCallbackData& data_) -> void
+  auto event_callback = [&](const eCAL::SServiceId& /*service_id_*/, const struct eCAL::SClientEventCallbackData& data_) -> void
     {
       if (data_.type == eCAL::eClientEvent::timeout)
       {
@@ -404,7 +404,7 @@ TEST(core_cpp_clientserver, ClientServerBaseCallbackTimeout)
 
   // response callback function
   std::atomic<int> responses_executed(0);
-  auto response_callback = [&](const eCAL::Registration::SEntityId& /*entity_id_*/, const struct eCAL::SServiceIDResponse& service_response_)
+  auto response_callback = [&](const eCAL::SEntityId& /*entity_id_*/, const struct eCAL::SServiceIDResponse& service_response_)
     {
       PrintResponse(service_response_);
       responses_executed++;
@@ -539,7 +539,7 @@ TEST(core_cpp_clientserver, ClientServerBaseAsyncCallback)
 
   // response callback function
   std::atomic<int> responses_executed(0);
-  auto response_callback = [&](const eCAL::Registration::SEntityId& /*entity_id_*/, const struct eCAL::SServiceIDResponse& service_response_)
+  auto response_callback = [&](const eCAL::SEntityId& /*entity_id_*/, const struct eCAL::SServiceIDResponse& service_response_)
     {
       PrintResponse(service_response_);
       responses_executed++;
@@ -614,7 +614,7 @@ TEST(core_cpp_clientserver, ClientServerBaseAsync)
 
   // response callback function
   atomic_signalable<int> num_client_response_callbacks_finished(0);
-  auto response_callback = [&](const eCAL::Registration::SEntityId& /*entity_id_*/, const struct eCAL::SServiceIDResponse& service_response_)
+  auto response_callback = [&](const eCAL::SEntityId& /*entity_id_*/, const struct eCAL::SServiceIDResponse& service_response_)
     {
       PrintResponse(service_response_);
       num_client_response_callbacks_finished++;
@@ -823,12 +823,12 @@ TEST(core_cpp_clientserver, NestedRPCCall)
   std::atomic<int> methods_called(0);
   std::atomic<int> responses_executed(0);
   bool success(true);
-  auto response_callback2 = [&](const eCAL::Registration::SEntityId& /*entity_id_*/, const struct eCAL::SServiceIDResponse& service_response_)
+  auto response_callback2 = [&](const eCAL::SEntityId& /*entity_id_*/, const struct eCAL::SServiceIDResponse& service_response_)
     {
       PrintResponse(service_response_);
       responses_executed++;
     };
-  auto response_callback1 = [&](const eCAL::Registration::SEntityId& /*entity_id_*/, const struct eCAL::SServiceIDResponse& service_response_)
+  auto response_callback1 = [&](const eCAL::SEntityId& /*entity_id_*/, const struct eCAL::SServiceIDResponse& service_response_)
     {
       PrintResponse(service_response_);
       success &= client2.CallWithCallback("foo::method2", "my request for method 2", -1, response_callback2);

--- a/ecal/tests/cpp/pubsub_test/src/pubsub_acknowledge.cpp
+++ b/ecal/tests/cpp/pubsub_test/src/pubsub_acknowledge.cpp
@@ -61,7 +61,7 @@ TEST(core_cpp_pubsub, TimeoutAcknowledgment)
   // create publisher
   eCAL::CPublisher pub("topic", {}, pub_config);
   auto sub1 = std::make_shared< eCAL::CSubscriber>("topic");
-  auto sleeper_variable_time = [](const eCAL::Registration::STopicId& topic_id_, const eCAL::SDataTypeInformation&  /*data_type_info_*/, const eCAL::SReceiveCallbackData& data_)
+  auto sleeper_variable_time = [](const eCAL::STopicId& topic_id_, const eCAL::SDataTypeInformation&  /*data_type_info_*/, const eCAL::SReceiveCallbackData& data_)
                                 {
                                   std::string const sleep_time((const char*)data_.buf, data_.size);
                                   int const sleep = std::stoi(sleep_time);

--- a/ecal/tests/cpp/pubsub_test/src/pubsub_callback_topicid.cpp
+++ b/ecal/tests/cpp/pubsub_test/src/pubsub_callback_topicid.cpp
@@ -117,11 +117,11 @@ TEST_P(TestFixture, OnePubSub)
   eCAL::CPublisher  publisher ("foo", datatype_info);
   eCAL::CSubscriber subscriber("foo", datatype_info);
 
-  eCAL::Registration::STopicId callback_topic_id;
+  eCAL::STopicId callback_topic_id;
   eCAL::SDataTypeInformation   callback_datatype_info;
   int                          callback_count{ 0 };
 
-  subscriber.SetReceiveCallback([&callback_topic_id, &callback_datatype_info, &callback_count](const eCAL::Registration::STopicId& topic_id_, const eCAL::SDataTypeInformation& datatype_info_, const eCAL::SReceiveCallbackData&)
+  subscriber.SetReceiveCallback([&callback_topic_id, &callback_datatype_info, &callback_count](const eCAL::STopicId& topic_id_, const eCAL::SDataTypeInformation& datatype_info_, const eCAL::SReceiveCallbackData&)
     {
       ++callback_count;
       callback_topic_id = topic_id_;
@@ -157,11 +157,11 @@ TEST_P(TestFixture, MultiplePubSub)
   }
   eCAL::CSubscriber subscriber("foo");
 
-  eCAL::Registration::STopicId callback_topic_id;
+  eCAL::STopicId callback_topic_id;
   eCAL::SDataTypeInformation   callback_datatype_info;
   int                          callback_count{ 0 };
 
-  subscriber.SetReceiveCallback([&callback_topic_id, &callback_datatype_info, &callback_count](const eCAL::Registration::STopicId& topic_id_, const eCAL::SDataTypeInformation& datatype_info_, const eCAL::SReceiveCallbackData&)
+  subscriber.SetReceiveCallback([&callback_topic_id, &callback_datatype_info, &callback_count](const eCAL::STopicId& topic_id_, const eCAL::SDataTypeInformation& datatype_info_, const eCAL::SReceiveCallbackData&)
     {
       ++callback_count;
       callback_topic_id = topic_id_;

--- a/ecal/tests/cpp/pubsub_test/src/pubsub_connection_test.cpp
+++ b/ecal/tests/cpp/pubsub_test/src/pubsub_connection_test.cpp
@@ -73,7 +73,7 @@ TEST(core_cpp_pubsub, TestSubscriberIsPublishedTiming)
     eCAL::CSubscriber sub("blob");
     const auto max_sub_count(10);
     auto sub_count(0);
-    auto receive_lambda = [&max_sub_count, &sub_count, &publisher_seen_at_subscription_start, &first_received_sample, &sub](const eCAL::Registration::STopicId& /*topic_id_*/, const eCAL::SDataTypeInformation& /*data_type_info_*/, const eCAL::SReceiveCallbackData& data_) {
+    auto receive_lambda = [&max_sub_count, &sub_count, &publisher_seen_at_subscription_start, &first_received_sample, &sub](const eCAL::STopicId& /*topic_id_*/, const eCAL::SDataTypeInformation& /*data_type_info_*/, const eCAL::SReceiveCallbackData& data_) {
       if (sub_count == 0)
       {
         publisher_seen_at_subscription_start = sub.GetPublisherCount() > 0;
@@ -172,7 +172,7 @@ TEST(core_cpp_pubsub, TestPublisherIsSubscribedTiming)
     eCAL::CSubscriber sub("blob");
     const auto max_sub_count(10);
     auto sub_count(0);
-    auto receive_lambda = [&max_sub_count, &sub_count, &publisher_seen_at_subscription_start, &first_received_sample, &sub](const eCAL::Registration::STopicId& /*topic_id_*/, const eCAL::SDataTypeInformation& /*data_type_info_*/, const eCAL::SReceiveCallbackData& data_) {
+    auto receive_lambda = [&max_sub_count, &sub_count, &publisher_seen_at_subscription_start, &first_received_sample, &sub](const eCAL::STopicId& /*topic_id_*/, const eCAL::SDataTypeInformation& /*data_type_info_*/, const eCAL::SReceiveCallbackData& data_) {
       if (sub_count == 0)
       {
         publisher_seen_at_subscription_start = sub.GetPublisherCount() > 0;
@@ -253,7 +253,7 @@ TEST(core_cpp_pubsub, TestChainedPublisherSubscriberCallback)
 
   // Subscriber1 with callback that triggers Publisher2
   eCAL::CSubscriber sub1("topic1");
-  auto subscriber1_callback = [&pub2](const eCAL::Registration::STopicId& /*topic_id_*/, const eCAL::SDataTypeInformation& /*data_type_info_*/, const eCAL::SReceiveCallbackData& data_) {
+  auto subscriber1_callback = [&pub2](const eCAL::STopicId& /*topic_id_*/, const eCAL::SDataTypeInformation& /*data_type_info_*/, const eCAL::SReceiveCallbackData& data_) {
     // On receiving data from Publisher1, Publisher2 sends the same data
     const std::string received_data(static_cast<const char*>(data_.buf), data_.size);
     pub2.Send(received_data);
@@ -262,7 +262,7 @@ TEST(core_cpp_pubsub, TestChainedPublisherSubscriberCallback)
 
   // Subscriber2 that receives data from Publisher2
   eCAL::CSubscriber sub2("topic2");
-  auto subscriber2_callback = [&subscriber2_received_count](const eCAL::Registration::STopicId& /*topic_id_*/, const eCAL::SDataTypeInformation& /*data_type_info_*/, const eCAL::SReceiveCallbackData& /*data_*/) {
+  auto subscriber2_callback = [&subscriber2_received_count](const eCAL::STopicId& /*topic_id_*/, const eCAL::SDataTypeInformation& /*data_type_info_*/, const eCAL::SReceiveCallbackData& /*data_*/) {
     // Count each received message from Publisher2
     subscriber2_received_count++;
     //std::cout << "Subscriber2 Receiving " << std::string(static_cast<const char*>(data_.buf), data_.size) << std::endl;

--- a/ecal/tests/cpp/pubsub_test/src/pubsub_multibuffer.cpp
+++ b/ecal/tests/cpp/pubsub_test/src/pubsub_multibuffer.cpp
@@ -98,7 +98,7 @@ std::vector<char> multibuffer_pub_sub_test(int buffer_count, bool zero_copy, int
   std::vector<char>   received_content;
 
   // add callback
-  auto lambda = [&](const eCAL::Registration::STopicId& /*topic_id_*/, const eCAL::SDataTypeInformation& /*data_type_info_*/, const eCAL::SReceiveCallbackData& data_) {
+  auto lambda = [&](const eCAL::STopicId& /*topic_id_*/, const eCAL::SDataTypeInformation& /*data_type_info_*/, const eCAL::SReceiveCallbackData& data_) {
     received_bytes += data_.size;
     ++received_count;
     for (auto i = 0; i < bytes_to_read; ++i)

--- a/ecal/tests/cpp/pubsub_test/src/pubsub_test.cpp
+++ b/ecal/tests/cpp/pubsub_test/src/pubsub_test.cpp
@@ -395,7 +395,7 @@ TEST(core_cpp_pubsub /*unused*/, DISABLED_DestroyInCallback /*unused*/)
   eCAL::CSubscriber sub_destroy("destroy");
   std::atomic<bool> destroyed(false);
 
-  auto destroy_lambda = [&sub_foo, &destroyed](const eCAL::Registration::STopicId& /*topic_id_*/, const eCAL::SDataTypeInformation& /*data_type_info_*/, const eCAL::SReceiveCallbackData& /*data_*/) {
+  auto destroy_lambda = [&sub_foo, &destroyed](const eCAL::STopicId& /*topic_id_*/, const eCAL::SDataTypeInformation& /*data_type_info_*/, const eCAL::SReceiveCallbackData& /*data_*/) {
     std::cout << "Receive destroy command" << std::endl;
     //sub_foo.Destroy();
     destroyed = true;
@@ -403,7 +403,7 @@ TEST(core_cpp_pubsub /*unused*/, DISABLED_DestroyInCallback /*unused*/)
   };
   sub_destroy.SetReceiveCallback(destroy_lambda);
 
-  auto receive_lambda = [](const eCAL::Registration::STopicId& /*topic_id_*/, const eCAL::SDataTypeInformation& /*data_type_info_*/, const eCAL::SReceiveCallbackData& /*data_*/) {
+  auto receive_lambda = [](const eCAL::STopicId& /*topic_id_*/, const eCAL::SDataTypeInformation& /*data_type_info_*/, const eCAL::SReceiveCallbackData& /*data_*/) {
     std::cout << "Hello" << std::endl;
   };
   sub_foo.SetReceiveCallback(receive_lambda);
@@ -467,7 +467,7 @@ TEST(core_cpp_pubsub, SubscriberReconnection)
     size_t callback_received_count(0);
 
     eCAL::CSubscriber sub_foo("foo");
-    auto receive_lambda = [&callback_received_count](const eCAL::Registration::STopicId& /*topic_id_*/, const eCAL::SDataTypeInformation& /*data_type_info_*/, const eCAL::SReceiveCallbackData& /*data_*/) {
+    auto receive_lambda = [&callback_received_count](const eCAL::STopicId& /*topic_id_*/, const eCAL::SDataTypeInformation& /*data_type_info_*/, const eCAL::SReceiveCallbackData& /*data_*/) {
       std::cout << "Receiving in scope 1" << std::endl;
       callback_received_count++;
     };
@@ -484,7 +484,7 @@ TEST(core_cpp_pubsub, SubscriberReconnection)
     size_t callback_received_count(0);
 
     eCAL::CSubscriber sub_foo("foo");
-    auto receive_lambda = [&callback_received_count](const eCAL::Registration::STopicId& /*topic_id_*/, const eCAL::SDataTypeInformation& /*data_type_info_*/, const eCAL::SReceiveCallbackData& /*data_*/) {
+    auto receive_lambda = [&callback_received_count](const eCAL::STopicId& /*topic_id_*/, const eCAL::SDataTypeInformation& /*data_type_info_*/, const eCAL::SReceiveCallbackData& /*data_*/) {
       std::cout << "Receiving in scope 2" << std::endl;
       callback_received_count++;
     };

--- a/ecal/tests/cpp/pubsub_test/src/pubsub_test_shm.cpp
+++ b/ecal/tests/cpp/pubsub_test/src/pubsub_test_shm.cpp
@@ -127,7 +127,7 @@ TEST(core_cpp_pubsub, MultipleSendsSHM)
   eCAL::CPublisher pub("A", {}, pub_config);
 
   // add callback
-  auto save_data = [&last_received_msg, &last_received_timestamp](const eCAL::Registration::STopicId& /*topic_id_*/, const eCAL::SDataTypeInformation& /*data_type_info_*/, const eCAL::SReceiveCallbackData& data_)
+  auto save_data = [&last_received_msg, &last_received_timestamp](const eCAL::STopicId& /*topic_id_*/, const eCAL::SDataTypeInformation& /*data_type_info_*/, const eCAL::SReceiveCallbackData& data_)
   {
     last_received_msg = std::string{ (const char*)data_.buf, (size_t)data_.size};
     last_received_timestamp = data_.time;

--- a/ecal/tests/cpp/pubsub_test/src/pubsub_test_udp.cpp
+++ b/ecal/tests/cpp/pubsub_test/src/pubsub_test_udp.cpp
@@ -114,7 +114,7 @@ TEST(core_cpp_pubsub, MultipleSendsUDP)
   eCAL::CPublisher pub("A", {}, pub_config);
 
   // add callback
-  auto save_data = [&last_received_msg, &last_received_timestamp](const eCAL::Registration::STopicId& /*topic_id_*/, const eCAL::SDataTypeInformation& /*data_type_info_*/, const eCAL::SReceiveCallbackData& data_)
+  auto save_data = [&last_received_msg, &last_received_timestamp](const eCAL::STopicId& /*topic_id_*/, const eCAL::SDataTypeInformation& /*data_type_info_*/, const eCAL::SReceiveCallbackData& data_)
   {
     last_received_msg = std::string{ (const char*)data_.buf, (size_t)data_.size };
     last_received_timestamp = data_.time;

--- a/ecal/tests/cpp/pubsub_v5_test/src/pubsub_callback_topicid.cpp
+++ b/ecal/tests/cpp/pubsub_v5_test/src/pubsub_callback_topicid.cpp
@@ -117,11 +117,11 @@ TEST_P(TestFixture, OnePubSub)
   eCAL::v5::CPublisher  publisher ("foo", datatype_info);
   eCAL::v5::CSubscriber subscriber("foo", datatype_info);
 
-  eCAL::Registration::STopicId callback_topic_id;
+  eCAL::STopicId callback_topic_id;
   eCAL::SDataTypeInformation   callback_datatype_info;
   int                          callback_count{ 0 };
 
-  subscriber.AddReceiveCallback([&callback_topic_id, &callback_datatype_info, &callback_count](const eCAL::Registration::STopicId& topic_id_, const eCAL::SDataTypeInformation& datatype_info_, const eCAL::SReceiveCallbackData&)
+  subscriber.AddReceiveCallback([&callback_topic_id, &callback_datatype_info, &callback_count](const eCAL::STopicId& topic_id_, const eCAL::SDataTypeInformation& datatype_info_, const eCAL::SReceiveCallbackData&)
     {
       ++callback_count;
       callback_topic_id = topic_id_;
@@ -157,11 +157,11 @@ TEST_P(TestFixture, MultiplePubSub)
   }
   eCAL::v5::CSubscriber subscriber("foo");
 
-  eCAL::Registration::STopicId callback_topic_id;
+  eCAL::STopicId callback_topic_id;
   eCAL::SDataTypeInformation   callback_datatype_info;
   int                          callback_count{ 0 };
 
-  subscriber.AddReceiveCallback([&callback_topic_id, &callback_datatype_info, &callback_count](const eCAL::Registration::STopicId& topic_id_, const eCAL::SDataTypeInformation& datatype_info_, const eCAL::SReceiveCallbackData&)
+  subscriber.AddReceiveCallback([&callback_topic_id, &callback_datatype_info, &callback_count](const eCAL::STopicId& topic_id_, const eCAL::SDataTypeInformation& datatype_info_, const eCAL::SReceiveCallbackData&)
     {
       ++callback_count;
       callback_topic_id = topic_id_;

--- a/ecal/tests/cpp/registration_test_public/src/registration_getclients.cpp
+++ b/ecal/tests/cpp/registration_test_public/src/registration_getclients.cpp
@@ -54,7 +54,7 @@ protected:
 };
 TEST_P(ClientsTestFixture, ClientExpiration)
 {
-  std::set<eCAL::Registration::SServiceId> id_set;
+  std::set<eCAL::SServiceId> id_set;
 
   // create simple client and let it expire
   {

--- a/ecal/tests/cpp/registration_test_public/src/registration_getpublisherids.cpp
+++ b/ecal/tests/cpp/registration_test_public/src/registration_getpublisherids.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,12 +95,12 @@ TEST_P(TestFixture, PublisherEventCallbackIsTriggered)
 {
   std::atomic<size_t> created_publisher_num(0);
   std::atomic<size_t> deleted_publisher_num(0);
-  std::set<eCAL::Registration::STopicId> created_publisher_ids;
-  std::set<eCAL::Registration::STopicId> deleted_publisher_ids;
+  std::set<eCAL::STopicId> created_publisher_ids;
+  std::set<eCAL::STopicId> deleted_publisher_ids;
 
   // register the callback
   auto callback_token = eCAL::Registration::AddPublisherEventCallback(
-    [&](const eCAL::Registration::STopicId& id, eCAL::Registration::RegistrationEventType event_type)
+    [&](const eCAL::STopicId& id, eCAL::Registration::RegistrationEventType event_type)
     {
       if (event_type == eCAL::Registration::RegistrationEventType::new_entity)
       {

--- a/ecal/tests/cpp/registration_test_public/src/registration_getservices.cpp
+++ b/ecal/tests/cpp/registration_test_public/src/registration_getservices.cpp
@@ -55,7 +55,7 @@ protected:
 
 TEST_P(ServicesTestFixture, ServiceExpiration)
 {
-  std::set<eCAL::Registration::SServiceId> id_set;
+  std::set<eCAL::SServiceId> id_set;
 
   // create simple service and let it expire
   {

--- a/ecal/tests/cpp/registration_test_public/src/registration_getsubscriberids.cpp
+++ b/ecal/tests/cpp/registration_test_public/src/registration_getsubscriberids.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,12 +95,12 @@ TEST_P(TestFixture, SubscriberEventCallbackIsTriggered)
 {
   std::atomic<size_t> created_subscriber_num(0);
   std::atomic<size_t> deleted_subscriber_num(0);
-  std::set<eCAL::Registration::STopicId> created_subscriber_ids;
-  std::set<eCAL::Registration::STopicId> deleted_subscriber_ids;
+  std::set<eCAL::STopicId> created_subscriber_ids;
+  std::set<eCAL::STopicId> deleted_subscriber_ids;
 
   // register the callback
   auto callback_token = eCAL::Registration::AddSubscriberEventCallback(
-    [&](const eCAL::Registration::STopicId& id, eCAL::Registration::RegistrationEventType event_type)
+    [&](const eCAL::STopicId& id, eCAL::Registration::RegistrationEventType event_type)
     {
       if (event_type == eCAL::Registration::RegistrationEventType::new_entity)
       {

--- a/ecal/tests/cpp/registration_test_public/src/registration_gettopics.cpp
+++ b/ecal/tests/cpp/registration_test_public/src/registration_gettopics.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,8 +39,8 @@ TEST(core_cpp_registration_public, GetTopics)
   // initialize eCAL API
   eCAL::Initialize("core_cpp_registration_public");
 
-  std::set<eCAL::Registration::STopicId> topic_id_pub_set;
-  std::set<eCAL::Registration::STopicId> topic_id_sub_set;
+  std::set<eCAL::STopicId> topic_id_pub_set;
+  std::set<eCAL::STopicId> topic_id_sub_set;
 
   // create and check a few pub/sub entities
   {
@@ -167,7 +167,7 @@ TEST(core_cpp_registration_public, GetTopicsParallel)
     size_t max_number_publishers_seen = 0;
 
     std::set<std::string> tmp_topic_names;
-    std::set<eCAL::Registration::STopicId> tmp_topic_ids;
+    std::set<eCAL::STopicId> tmp_topic_ids;
 
     do {
       eCAL::Registration::GetTopicNames(tmp_topic_names);

--- a/samples/cpp/services/player_stepper/src/ecal_stepper.cpp
+++ b/samples/cpp/services/player_stepper/src/ecal_stepper.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ std::string pauseName;   // receiving on this channel should pause playback
 std::string triggerName; // receiving on this channel should start playback
 bool received = false;
 
-void callback(const eCAL::Registration::STopicId& topic_id_)
+void callback(const eCAL::STopicId& topic_id_)
 {
     std::string topicName = topic_id_.topic_name;
     if (topicName == triggerName || topicName == pauseName)

--- a/serialization/capnproto/samples/pubsub/addressbook_rec_dynamic/src/addressbook_rec_dynamic.cpp
+++ b/serialization/capnproto/samples/pubsub/addressbook_rec_dynamic/src/addressbook_rec_dynamic.cpp
@@ -115,7 +115,7 @@ int main(int argc, char** argv)
   // create a subscriber (topic name "addressbook")
   eCAL::capnproto::CDynamicSubscriber sub("addressbook");
 
-  auto lambda = [](const eCAL::Registration::STopicId& /*topic_id_*/, const capnp::DynamicValue::Reader& msg_, long long /*time_*/, long long /*clock_*/, long long /*id_*/) -> void {
+  auto lambda = [](const eCAL::STopicId& /*topic_id_*/, const capnp::DynamicValue::Reader& msg_, long long /*time_*/, long long /*clock_*/, long long /*id_*/) -> void {
     dynamicPrintValue(msg_);
   };
   sub.AddReceiveCallback(lambda);

--- a/serialization/protobuf/samples/pubsub/proto_dyn_json_rec/src/proto_dyn_json_rec.cpp
+++ b/serialization/protobuf/samples/pubsub/proto_dyn_json_rec/src/proto_dyn_json_rec.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@
 
 const std::string MESSAGE_NAME("person");
 
-void ProtoMsgCallback(const eCAL::Registration::STopicId& topic_id_, const std::string& msg_)
+void ProtoMsgCallback(const eCAL::STopicId& topic_id_, const std::string& msg_)
 {
   std::cout << topic_id_.topic_name << " : " << msg_ << std::endl;
   std::cout << std::endl;

--- a/serialization/protobuf/samples/pubsub/proto_dyn_rec/src/proto_dyn_rec.cpp
+++ b/serialization/protobuf/samples/pubsub/proto_dyn_rec/src/proto_dyn_rec.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -270,7 +270,7 @@ void ProcProtoMsg(const google::protobuf::Message& msg_, const std::string& pref
   }
 }
 
-void ProtoMsgCallback(const eCAL::Registration::STopicId& topic_id_, const std::shared_ptr<google::protobuf::Message>& msg_)
+void ProtoMsgCallback(const eCAL::STopicId& topic_id_, const std::shared_ptr<google::protobuf::Message>& msg_)
 {
   ProcProtoMsg(*msg_, topic_id_.topic_name);
   std::cout << std::endl;


### PR DESCRIPTION
A few structs (STopicId, SEntityId, SServiceId, ) are moved from `eCAL::Registration` namespace to only `eCAL` namespace.