### PR TITLE
[cmake] Optional C bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,8 @@ option(BUILD_APPS                              "Build the eCAL applications"    
 option(BUILD_APP_REC_ADDON_SDK                 "Build eCAL rec addon SDK"                               ${BUILD_APPS})
 option(BUILD_SAMPLES                           "Build the eCAL samples"                                            ON)
 option(BUILD_TIME                              "Build the eCAL time interfaces"                                    ON)
+option(BUILD_C_BINDING                         "Build eCAL C binding"                                              ON)
+mark_as_advanced(FORCE BUILD_C_BINDING)
 option(BUILD_PY_BINDING                        "Build eCAL python binding"                                        OFF)
 option(BUILD_CSHARP_BINDING                    "Build eCAL C# binding"                                            OFF)
 option(BUILD_ECAL_TESTS                        "Build the eCAL google tests"                                      OFF)
@@ -331,9 +333,11 @@ if(BUILD_CSHARP_BINDING AND WIN32)
   add_subdirectory(lang/csharp)
 endif()
 
-set(ECAL_C_BUILD_SAMPLES     ${BUILD_SAMPLES})
-set(ECAL_C_BUILD_TESTS    ${BUILD_ECAL_TESTS})
-add_subdirectory(lang/c)
+if(BUILD_C_BINDING)
+  set(ECAL_C_BUILD_SAMPLES     ${BUILD_SAMPLES})
+  set(ECAL_C_BUILD_TESTS    ${BUILD_ECAL_TESTS})
+  add_subdirectory(lang/c)
+endif()
 
 # --------------------------------------------------------
 # console applications


### PR DESCRIPTION
### Description
<!-- What does your PR change? -->
Adds a CMake option for including the C language bindings.
I know this might be contentious, as I've seen sentiment that you have too many CMake options already (personally, I think its ok and I hope you never look at VTK :laughing).

It feels like the C bindings are considered important, which is why I kept it default-on and marked as advanced to indicate it probably shouldn't be touched.  
The motivation is that, for example, I don't need it for my Go bindings so would like to be to exclude it from the container build (actually I see there's a `core_v5` target now which is a much larger unused resource for me...).

If the marked-as-advanced option is still too much, I ask at least for an undocumented regular variable.

### Related issues
<!-- Type "Fixes #123" to automatically close that issue, when this PR is merged -->
- 

### Cherry-pick to
<!-- Leave empty, if you don't know. For master-only changes use "none"
- _none_
- 5.11 (old stable)
- 5.12 (current stable)
-->
