### PR TITLE
[cmake] Create explicit warnings target

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -194,6 +194,7 @@ jobs:
     # --------------------------------------------------------------------------------------------------
 
   sign-windows-installer:
+    if: github.repository == 'eclipse-ecal/ecal'
     runs-on: windows-2019
     needs: build-windows
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -491,6 +491,7 @@ install(FILES ${eCAL_config} ${eCAL_config_version}
 
 install(FILES
   cmake/helper_functions/ecal_add_functions.cmake
+  cmake/helper_functions/ecal_compiler_warnings.cmake
   cmake/helper_functions/ecal_helper_functions.cmake
   cmake/helper_functions/ecal_install_functions.cmake
   DESTINATION ${${PROJECT_NAME}_install_cmake_dir}/helper_functions

--- a/app/app_pb/CMakeLists.txt
+++ b/app/app_pb/CMakeLists.txt
@@ -68,7 +68,7 @@ target_compile_options(${PROJECT_NAME}
 
 set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
 
-target_link_libraries(${PROJECT_NAME} protobuf::libprotobuf)
+target_link_libraries(${PROJECT_NAME} PUBLIC protobuf::libprotobuf)
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_14) 
 
 ecal_install_library(${PROJECT_NAME})

--- a/app/meas_cutter/CMakeLists.txt
+++ b/app/meas_cutter/CMakeLists.txt
@@ -52,11 +52,13 @@ ecal_add_app_console(${PROJECT_NAME} ${meas_cutter_src})
 target_include_directories(${PROJECT_NAME}
   PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
-target_link_libraries(${PROJECT_NAME}   yaml-cpp::yaml-cpp
-                                        tclap::tclap
-                                        eCAL::ecal-utils
-                                        eCAL::hdf5
-                                        Threads::Threads)
+target_link_libraries(${PROJECT_NAME} PRIVATE
+  yaml-cpp::yaml-cpp
+  tclap::tclap
+  eCAL::ecal-utils
+  eCAL::hdf5
+  Threads::Threads
+)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14) 
 

--- a/app/mon/mon_cli/CMakeLists.txt
+++ b/app/mon/mon_cli/CMakeLists.txt
@@ -41,7 +41,7 @@ target_compile_definitions(${PROJECT_NAME}
 
 create_targets_protobuf()
 
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PRIVATE
   tclap::tclap
   eCAL::protobuf_core
   eCAL::string_core

--- a/app/mon/mon_gui/CMakeLists.txt
+++ b/app/mon/mon_gui/CMakeLists.txt
@@ -195,7 +195,7 @@ ecal_add_app_qt(${PROJECT_NAME}
     ${autogen_ui}
 )
 
-target_link_libraries (${PROJECT_NAME}
+target_link_libraries (${PROJECT_NAME} PRIVATE
     protobuf::libprotobuf
     eCAL::core
     eCAL::core_pb
@@ -209,7 +209,7 @@ target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 
 if(ECAL_NPCAP_SUPPORT)
   add_definitions(-DECAL_NPCAP_SUPPORT)
-  target_link_libraries(${PROJECT_NAME}
+    target_link_libraries(${PROJECT_NAME} PRIVATE
     udpcap::udpcap
   )
 endif(ECAL_NPCAP_SUPPORT)

--- a/app/mon/mon_plugins/capnproto_reflection/CMakeLists.txt
+++ b/app/mon/mon_plugins/capnproto_reflection/CMakeLists.txt
@@ -58,7 +58,7 @@ ecal_add_mon_plugin(${PROJECT_NAME}
   METADATA src/metadata.json
 )
 
-target_link_libraries (${PROJECT_NAME}
+target_link_libraries (${PROJECT_NAME} PRIVATE
   Qt${QT_VERSION_MAJOR}::Core
   Qt${QT_VERSION_MAJOR}::Widgets
   eCAL::capnproto_core

--- a/app/mon/mon_plugins/plugin_template/CMakeLists.txt
+++ b/app/mon/mon_plugins/plugin_template/CMakeLists.txt
@@ -43,7 +43,7 @@ ecal_add_mon_plugin(${PROJECT_NAME}
   METADATA src/metadata.json
 )
 
-target_link_libraries (${PROJECT_NAME}
+target_link_libraries (${PROJECT_NAME} PRIVATE
   Qt${QT_VERSION_MAJOR}::Core
   Qt${QT_VERSION_MAJOR}::Widgets
   eCAL::core

--- a/app/mon/mon_plugins/protobuf_reflection/CMakeLists.txt
+++ b/app/mon/mon_plugins/protobuf_reflection/CMakeLists.txt
@@ -60,7 +60,7 @@ ecal_add_mon_plugin(${PROJECT_NAME}
 )
 
 create_targets_protobuf()
-target_link_libraries (${PROJECT_NAME}
+target_link_libraries (${PROJECT_NAME} PRIVATE
   Qt${QT_VERSION_MAJOR}::Core
   Qt${QT_VERSION_MAJOR}::Widgets
   eCAL::protobuf_core

--- a/app/mon/mon_plugins/raw_data_reflection/CMakeLists.txt
+++ b/app/mon/mon_plugins/raw_data_reflection/CMakeLists.txt
@@ -55,7 +55,7 @@ ecal_add_mon_plugin(${PROJECT_NAME}
 )
 
 create_targets_protobuf()
-target_link_libraries (${PROJECT_NAME}
+target_link_libraries (${PROJECT_NAME} PRIVATE
   Qt${QT_VERSION_MAJOR}::Core
   Qt${QT_VERSION_MAJOR}::Widgets
   eCAL::core

--- a/app/mon/mon_plugins/signals_plotting/CMakeLists.txt
+++ b/app/mon/mon_plugins/signals_plotting/CMakeLists.txt
@@ -72,7 +72,7 @@ ecal_add_mon_plugin(${PROJECT_NAME}
 
 create_targets_protobuf()
 
-target_link_libraries (${PROJECT_NAME}
+target_link_libraries (${PROJECT_NAME} PRIVATE
   Qt${QT_VERSION_MAJOR}::Core
   Qt${QT_VERSION_MAJOR}::Widgets
   eCAL::core

--- a/app/mon/mon_plugins/string_reflection/CMakeLists.txt
+++ b/app/mon/mon_plugins/string_reflection/CMakeLists.txt
@@ -55,7 +55,7 @@ ecal_add_mon_plugin(${PROJECT_NAME}
 )
 
 create_targets_protobuf()
-target_link_libraries (${PROJECT_NAME}
+target_link_libraries (${PROJECT_NAME} PRIVATE
   Qt${QT_VERSION_MAJOR}::Core
   Qt${QT_VERSION_MAJOR}::Widgets
   eCAL::string_core

--- a/app/mon/mon_tui/CMakeLists.txt
+++ b/app/mon/mon_tui/CMakeLists.txt
@@ -115,7 +115,7 @@ target_compile_definitions(${PROJECT_NAME}
 
 create_targets_protobuf()
 
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PRIVATE
   protobuf::libprotobuf
   tclap::tclap
   eCAL::protobuf_core

--- a/app/play/play_cli/CMakeLists.txt
+++ b/app/play/play_cli/CMakeLists.txt
@@ -44,7 +44,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE src)
 target_compile_definitions(${PROJECT_NAME}
   PRIVATE $<$<BOOL:${MSVC}>:PCRE_STATIC;_UNICODE>)
 
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PRIVATE
     termcolor::termcolor
     tclap::tclap
     eCAL::play_core

--- a/app/play/play_gui/CMakeLists.txt
+++ b/app/play/play_gui/CMakeLists.txt
@@ -139,7 +139,7 @@ ecal_add_app_qt(${PROJECT_NAME}
 )
 
 create_targets_protobuf()
-target_link_libraries (${PROJECT_NAME}
+target_link_libraries (${PROJECT_NAME} PRIVATE
     tclap::tclap
     CustomTclap
     eCAL::play_core

--- a/app/rec/rec_gui/CMakeLists.txt
+++ b/app/rec/rec_gui/CMakeLists.txt
@@ -170,7 +170,7 @@ ecal_add_app_qt(${PROJECT_NAME}
 )
 
 create_targets_protobuf()
-target_link_libraries (${PROJECT_NAME}
+target_link_libraries (${PROJECT_NAME} PRIVATE
     tclap::tclap
     protobuf::libprotobuf
     eCAL::core
@@ -195,7 +195,7 @@ if (WIN32 AND (${QT_VERSION_MAJOR} EQUAL 5))
     # Maybe we can re-enable the functionality with the following external lib:
     # https://github.com/oblivioncth/Qx
     #
-    target_link_libraries (${PROJECT_NAME}
+    target_link_libraries (${PROJECT_NAME} PRIVATE
         Qt${QT_VERSION_MAJOR}::WinExtras
     )
 endif()

--- a/app/rec/rec_server_cli/CMakeLists.txt
+++ b/app/rec/rec_server_cli/CMakeLists.txt
@@ -83,7 +83,7 @@ target_compile_definitions(${PROJECT_NAME}
 
 create_targets_protobuf()
 
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PRIVATE
   tclap::tclap
   termcolor::termcolor
   eCAL::rec_server_core

--- a/app/sys/sys_cli/CMakeLists.txt
+++ b/app/sys/sys_cli/CMakeLists.txt
@@ -70,7 +70,7 @@ target_compile_definitions(${PROJECT_NAME}
 
 create_targets_protobuf()
 
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PRIVATE
   tclap::tclap
   termcolor::termcolor
   eCAL::sys_core

--- a/app/sys/sys_client_cli/CMakeLists.txt
+++ b/app/sys/sys_client_cli/CMakeLists.txt
@@ -39,7 +39,7 @@ ecal_add_app_console(${PROJECT_NAME} ${source_files} ${win_src})
 
 create_targets_protobuf()
 
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PRIVATE
   spdlog::spdlog
   tclap::tclap
   protobuf::libprotobuf

--- a/app/sys/sys_gui/CMakeLists.txt
+++ b/app/sys/sys_gui/CMakeLists.txt
@@ -174,7 +174,7 @@ ecal_add_app_qt(${PROJECT_NAME}
 
 create_targets_protobuf() 
 
-target_link_libraries (${PROJECT_NAME}
+target_link_libraries (${PROJECT_NAME} PRIVATE
     Qt${QT_VERSION_MAJOR}::Core
     Qt${QT_VERSION_MAJOR}::Widgets
     CustomQt

--- a/app/util/config/CMakeLists.txt
+++ b/app/util/config/CMakeLists.txt
@@ -30,7 +30,7 @@ target_include_directories(${PROJECT_NAME}
 target_compile_definitions(${PROJECT_NAME}
   PRIVATE $<$<BOOL:${MSVC}>:PCRE_STATIC;_UNICODE>)
 
-target_link_libraries(${PROJECT_NAME} eCAL::core)
+target_link_libraries(${PROJECT_NAME} PRIVATE eCAL::core)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 
 ecal_install_app(${PROJECT_NAME})

--- a/app/util/launcher/CMakeLists.txt
+++ b/app/util/launcher/CMakeLists.txt
@@ -82,7 +82,7 @@ ecal_add_app_qt(${PROJECT_NAME}
     ${autogen_ui}
 )
 
-target_link_libraries (${PROJECT_NAME}
+target_link_libraries (${PROJECT_NAME} PRIVATE
     Qt${QT_VERSION_MAJOR}::Core
     Qt${QT_VERSION_MAJOR}::Widgets
     eCAL::apps

--- a/app/util/stop/CMakeLists.txt
+++ b/app/util/stop/CMakeLists.txt
@@ -30,7 +30,7 @@ target_include_directories(${PROJECT_NAME}
 target_compile_definitions(${PROJECT_NAME}
   PRIVATE $<$<BOOL:${MSVC}>:PCRE_STATIC;_UNICODE>)
 
-target_link_libraries(${PROJECT_NAME} eCAL::core)
+target_link_libraries(${PROJECT_NAME} PRIVATE eCAL::core)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 
 ecal_install_app(${PROJECT_NAME})

--- a/cmake/helper_functions/ecal_add_functions.cmake
+++ b/cmake/helper_functions/ecal_add_functions.cmake
@@ -16,6 +16,10 @@
 #
 # ========================= eCAL LICENSE =================================
 
+include_guard(GLOBAL)
+
+include("${CMAKE_CURRENT_LIST_DIR}/ecal_compiler_warnings.cmake")
+
 # This function will set the output names of the target according to eCAL conventions.
 function(ecal_add_app_console TARGET_NAME)
   add_executable(${TARGET_NAME} ${ARGN})
@@ -24,6 +28,7 @@ function(ecal_add_app_console TARGET_NAME)
     VERSION ${eCAL_VERSION_STRING}
     SOVERSION ${eCAL_VERSION_MAJOR}
     OUTPUT_NAME ecal_${TARGET_NAME})
+  ecal_add_compiler_warnings(${TARGET_NAME})
 endfunction()
 
 # This helper function automatically adds a gtest to ecal.
@@ -50,6 +55,7 @@ function(ecal_add_gtest TARGET_NAME)
     VERSION ${eCAL_VERSION_STRING}
     SOVERSION ${eCAL_VERSION_MAJOR}
     OUTPUT_NAME ecal_${TARGET_NAME})
+  ecal_add_compiler_warnings(${TARGET_NAME})
 endfunction()
 
 function(ecal_add_app_gui TARGET_NAME)
@@ -59,6 +65,7 @@ function(ecal_add_app_gui TARGET_NAME)
     VERSION ${eCAL_VERSION_STRING}
     SOVERSION ${eCAL_VERSION_MAJOR}
     OUTPUT_NAME ecal_${TARGET_NAME})
+  ecal_add_compiler_warnings(${TARGET_NAME})
 endfunction()
 
 function(ecal_add_app_qt TARGET_NAME)
@@ -70,6 +77,7 @@ function(ecal_add_app_qt TARGET_NAME)
   if(WIN32)
     set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "/SUBSYSTEM:WINDOWS /ENTRY:mainCRTStartup")
   endif()
+  ecal_add_compiler_warnings(${TARGET_NAME})
 endfunction()
 
 function(ecal_add_mon_plugin TARGET_NAME)
@@ -94,7 +102,7 @@ function(ecal_add_mon_plugin TARGET_NAME)
       $<$<CONFIG:RelWithDebInfo>:QT_NO_DEBUG>
       $<$<CONFIG:MinSizeRel>:QT_NO_DEBUG>
   )
-    
+  ecal_add_compiler_warnings(${TARGET_NAME})
 endfunction()
 
 function(ecal_add_rec_addon TARGET_NAME)
@@ -105,7 +113,7 @@ function(ecal_add_rec_addon TARGET_NAME)
     OUTPUT_NAME ecal_${TARGET_NAME}
     RUNTIME_OUTPUT_DIRECTORY $<IF:$<BOOL:${WIN32}>,${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/$<CONFIG>/ecalrec_addons,${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/ecal/addons/rec>
   )
-    
+  ecal_add_compiler_warnings(${TARGET_NAME})
 endfunction()
 
 function(ecal_add_time_plugin TARGET_NAME)
@@ -114,6 +122,7 @@ function(ecal_add_time_plugin TARGET_NAME)
     VERSION ${eCAL_VERSION_STRING}
     SOVERSION ${eCAL_VERSION_MAJOR}
   )
+  ecal_add_compiler_warnings(${TARGET_NAME})
 endfunction()
 
 function(ecal_add_shared_library TARGET_NAME)
@@ -122,6 +131,7 @@ function(ecal_add_shared_library TARGET_NAME)
     VERSION ${eCAL_VERSION_STRING}
     SOVERSION ${eCAL_VERSION_MAJOR}
     OUTPUT_NAME ecal_${TARGET_NAME})
+  ecal_add_compiler_warnings(${TARGET_NAME})
 endfunction()
 
 function(ecal_add_static_library TARGET_NAME)
@@ -132,6 +142,7 @@ function(ecal_add_static_library TARGET_NAME)
     OUTPUT_NAME ecal_${TARGET_NAME}
     POSITION_INDEPENDENT_CODE ON
   )
+  ecal_add_compiler_warnings(${TARGET_NAME})
 endfunction()
 
 function(ecal_add_interface_library TARGET_NAME)
@@ -152,5 +163,6 @@ function(ecal_add_sample TARGET_NAME)
     VERSION ${eCAL_VERSION_STRING}
     SOVERSION ${eCAL_VERSION_MAJOR}
     OUTPUT_NAME ecal_sample_${TARGET_NAME})
+  ecal_add_compiler_warnings(${TARGET_NAME})
 endfunction()
 

--- a/cmake/helper_functions/ecal_compiler_warnings.cmake
+++ b/cmake/helper_functions/ecal_compiler_warnings.cmake
@@ -1,0 +1,22 @@
+include_guard(GLOBAL)
+
+
+add_library(_ecal_warnings INTERFACE)
+
+set(compiler_flags "")
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
+  message(STATUS "MSVC detected - Adding flags")
+  set(compiler_flags "/MP" "/W4")
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU|Clang")
+  message(STATUS "Setting GNU/Clang flags")
+  set(compiler_flags "-Wall" "-Wextra")
+else()
+  message(WARNING "Unknown compiler, will not set warning flags")
+endif()
+target_compile_options(_ecal_warnings INTERFACE "${compiler_flags}")
+
+unset(compiler_flags)
+
+function(ecal_add_compiler_warnings TARGET_NAME)
+  target_link_libraries("${TARGET_NAME}" PRIVATE $<BUILD_INTERFACE:_ecal_warnings>)
+endfunction()

--- a/cmake/helper_functions/ecal_compiler_warnings.cmake
+++ b/cmake/helper_functions/ecal_compiler_warnings.cmake
@@ -2,20 +2,26 @@ include_guard(GLOBAL)
 
 add_library(_ecal_warnings INTERFACE)
 
-set(compiler_flags "")
+set(cxx_compiler_flags "")
+
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
   message(STATUS "MSVC detected - Adding flags")
-  set(compiler_flags "/MP" "/W4")
+  set(cxx_compiler_flags "/MP" "/W4")
 elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU|Clang")
   message(STATUS "Setting GNU/Clang flags")
-  set(compiler_flags "-Wall" "-Wextra")
+  set(cxx_compiler_flags "-Wall" "-Wextra")
 else()
   message(WARNING "Unknown compiler, will not set warning flags")
 endif()
-target_compile_options(_ecal_warnings INTERFACE "${compiler_flags}")
 
-unset(compiler_flags)
+target_compile_options(_ecal_warnings INTERFACE
+  "$<$<COMPILE_LANGUAGE:C,CXX>:${cxx_compiler_flags}>"
+)
+
+unset(cxx_compiler_flags)
 
 function(ecal_add_compiler_warnings TARGET_NAME)
-  target_link_libraries("${TARGET_NAME}" PRIVATE $<BUILD_INTERFACE:_ecal_warnings>)
+  target_link_libraries("${TARGET_NAME}" PRIVATE
+    "$<BUILD_INTERFACE:_ecal_warnings>"
+  )
 endfunction()

--- a/cmake/helper_functions/ecal_compiler_warnings.cmake
+++ b/cmake/helper_functions/ecal_compiler_warnings.cmake
@@ -1,6 +1,5 @@
 include_guard(GLOBAL)
 
-
 add_library(_ecal_warnings INTERFACE)
 
 set(compiler_flags "")

--- a/contrib/ecaltime/ecaltime_pb/CMakeLists.txt
+++ b/contrib/ecaltime/ecaltime_pb/CMakeLists.txt
@@ -57,7 +57,7 @@ target_compile_options(${PROJECT_NAME}
 
 set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
 
-target_link_libraries(${PROJECT_NAME} protobuf::libprotobuf)
+target_link_libraries(${PROJECT_NAME} PUBLIC protobuf::libprotobuf)
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_14)
 
 ecal_install_library(${PROJECT_NAME})

--- a/contrib/ecaltime/linuxptp/CMakeLists.txt
+++ b/contrib/ecaltime/linuxptp/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 
 ecal_add_time_plugin(${PROJECT_NAME} SHARED ${ecal_time_linuxptp_src} ${ecal_time_linuxptp_header})
 
-target_link_libraries(${PROJECT_NAME} eCAL::core yaml-cpp::yaml-cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE eCAL::core yaml-cpp::yaml-cpp)
 
 target_include_directories(${PROJECT_NAME} 
   PRIVATE

--- a/contrib/ecaltime/localtime/CMakeLists.txt
+++ b/contrib/ecaltime/localtime/CMakeLists.txt
@@ -43,7 +43,7 @@ target_include_directories(${PROJECT_NAME}
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>)
 
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PRIVATE
   Threads::Threads
   $<$<AND:$<BOOL:${UNIX}>,$<NOT:$<BOOL:${APPLE}>>,$<NOT:$<BOOL:${QNXNTO}>>>:rt>
   )

--- a/contrib/mma/CMakeLists.txt
+++ b/contrib/mma/CMakeLists.txt
@@ -80,7 +80,7 @@ target_include_directories(${PROJECT_NAME}
 
 create_targets_protobuf()
 
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PRIVATE
   Threads::Threads
   eCAL::protobuf_core
   eCAL::app_pb

--- a/ecal/core_pb/CMakeLists.txt
+++ b/ecal/core_pb/CMakeLists.txt
@@ -65,7 +65,7 @@ target_compile_options(${PROJECT_NAME}
 
 set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
 
-target_link_libraries(${PROJECT_NAME} protobuf::libprotobuf)
+target_link_libraries(${PROJECT_NAME} PUBLIC protobuf::libprotobuf)
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_14)
 
 ecal_install_library(${PROJECT_NAME})

--- a/ecal/samples/cpp/benchmarks/counter_rec/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/counter_rec/CMakeLists.txt
@@ -30,7 +30,7 @@ set(counter_rec_src
 
 ecal_add_sample(${PROJECT_NAME} ${counter_rec_src})
 
-target_link_libraries(${PROJECT_NAME} eCAL::core)
+target_link_libraries(${PROJECT_NAME} PRIVATE eCAL::core)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 

--- a/ecal/samples/cpp/benchmarks/counter_snd/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/counter_snd/CMakeLists.txt
@@ -30,7 +30,7 @@ set(counter_snd_src
 
 ecal_add_sample(${PROJECT_NAME} ${counter_snd_src})
 
-target_link_libraries(${PROJECT_NAME} eCAL::core)
+target_link_libraries(${PROJECT_NAME} PRIVATE eCAL::core)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 

--- a/ecal/samples/cpp/benchmarks/datarate_rec/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/datarate_rec/CMakeLists.txt
@@ -31,7 +31,7 @@ set(datarate_rec_src
 
 ecal_add_sample(${PROJECT_NAME} ${datarate_rec_src})
 
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PRIVATE
     eCAL::core
     tclap::tclap)
 

--- a/ecal/samples/cpp/benchmarks/datarate_snd/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/datarate_snd/CMakeLists.txt
@@ -31,7 +31,7 @@ set(datarate_snd_src
 
 ecal_add_sample(${PROJECT_NAME} ${datarate_snd_src})
 
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PRIVATE
     eCAL::core
     tclap::tclap)
 

--- a/ecal/samples/cpp/benchmarks/dynsize_snd/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/dynsize_snd/CMakeLists.txt
@@ -30,7 +30,7 @@ set(dynsize_snd_src
 
 ecal_add_sample(${PROJECT_NAME} ${dynsize_snd_src})
 
-target_link_libraries(${PROJECT_NAME} eCAL::core)
+target_link_libraries(${PROJECT_NAME} PRIVATE eCAL::core)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 

--- a/ecal/samples/cpp/benchmarks/latency_rec/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/latency_rec/CMakeLists.txt
@@ -33,7 +33,7 @@ set(latency_rec_src
 
 ecal_add_sample(${PROJECT_NAME} ${latency_rec_src})
 
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PRIVATE
     eCAL::core
     tclap::tclap)
 

--- a/ecal/samples/cpp/benchmarks/latency_snd/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/latency_snd/CMakeLists.txt
@@ -31,7 +31,7 @@ set(latency_snd_src
 
 ecal_add_sample(${PROJECT_NAME} ${latency_snd_src})
 
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PRIVATE
     eCAL::core
     tclap::tclap)
 

--- a/ecal/samples/cpp/benchmarks/many_connections_rec/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/many_connections_rec/CMakeLists.txt
@@ -30,7 +30,7 @@ set(many_connections_rec_src
 
 ecal_add_sample(${PROJECT_NAME} ${many_connections_rec_src})
 
-target_link_libraries(${PROJECT_NAME} eCAL::core)
+target_link_libraries(${PROJECT_NAME} PRIVATE eCAL::core)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 

--- a/ecal/samples/cpp/benchmarks/many_connections_snd/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/many_connections_snd/CMakeLists.txt
@@ -30,7 +30,7 @@ set(many_connections_snd_src
 
 ecal_add_sample(${PROJECT_NAME} ${many_connections_snd_src})
 
-target_link_libraries(${PROJECT_NAME} eCAL::core)
+target_link_libraries(${PROJECT_NAME} PRIVATE eCAL::core)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 

--- a/ecal/samples/cpp/benchmarks/massive_pub_sub/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/massive_pub_sub/CMakeLists.txt
@@ -30,7 +30,7 @@ set(massive_pub_sub_src
 
 ecal_add_sample(${PROJECT_NAME} ${massive_pub_sub_src})
 
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PRIVATE
   eCAL::core
 )
 

--- a/ecal/samples/cpp/benchmarks/multiple_rec/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/multiple_rec/CMakeLists.txt
@@ -30,7 +30,7 @@ set(multiple_rec_src
 
 ecal_add_sample(${PROJECT_NAME} ${multiple_rec_src})
 
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PRIVATE
     eCAL::core
 )
 

--- a/ecal/samples/cpp/benchmarks/multiple_snd/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/multiple_snd/CMakeLists.txt
@@ -30,7 +30,7 @@ set(multiple_snd_src
 
 ecal_add_sample(${PROJECT_NAME} ${multiple_snd_src})
 
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PRIVATE
   eCAL::core
 )
 

--- a/ecal/samples/cpp/benchmarks/performance_rec/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/performance_rec/CMakeLists.txt
@@ -30,7 +30,7 @@ set(performance_rec_src
 
 ecal_add_sample(${PROJECT_NAME} ${performance_rec_src})
 
-target_link_libraries(${PROJECT_NAME} eCAL::core)
+target_link_libraries(${PROJECT_NAME} PRIVATE eCAL::core)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 

--- a/ecal/samples/cpp/benchmarks/performance_snd/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/performance_snd/CMakeLists.txt
@@ -30,7 +30,7 @@ set(performance_snd_src
 
 ecal_add_sample(${PROJECT_NAME} ${performance_snd_src})
 
-target_link_libraries(${PROJECT_NAME} eCAL::core)
+target_link_libraries(${PROJECT_NAME} PRIVATE eCAL::core)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 

--- a/ecal/samples/cpp/benchmarks/perftool/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/perftool/CMakeLists.txt
@@ -37,7 +37,7 @@ set(source_files
 #add_executable(${PROJECT_NAME} ${source_files})
 ecal_add_sample(${PROJECT_NAME} ${source_files})
 
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PRIVATE
   eCAL::core
   Threads::Threads
 )

--- a/ecal/samples/cpp/benchmarks/pubsub_throughput/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/pubsub_throughput/CMakeLists.txt
@@ -30,7 +30,7 @@ set(pubsub_throughput_src
 
 ecal_add_sample(${PROJECT_NAME} ${pubsub_throughput_src})
 
-target_link_libraries(${PROJECT_NAME} eCAL::core)
+target_link_libraries(${PROJECT_NAME} PRIVATE eCAL::core)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 

--- a/ecal/samples/cpp/misc/config/CMakeLists.txt
+++ b/ecal/samples/cpp/misc/config/CMakeLists.txt
@@ -32,7 +32,7 @@ ecal_add_sample(${PROJECT_NAME} ${config_src})
 
 target_include_directories(${PROJECT_NAME} PRIVATE .)
 
-target_link_libraries (${PROJECT_NAME}
+target_link_libraries (${PROJECT_NAME} PRIVATE
     eCAL::core
 )
 

--- a/ecal/samples/cpp/misc/process/CMakeLists.txt
+++ b/ecal/samples/cpp/misc/process/CMakeLists.txt
@@ -32,7 +32,7 @@ ecal_add_sample(${PROJECT_NAME} ${process_src})
 
 target_include_directories(${PROJECT_NAME} PRIVATE .)
 
-target_link_libraries (${PROJECT_NAME}
+target_link_libraries (${PROJECT_NAME} PRIVATE
     eCAL::core
 )
 

--- a/ecal/samples/cpp/misc/time/CMakeLists.txt
+++ b/ecal/samples/cpp/misc/time/CMakeLists.txt
@@ -30,7 +30,7 @@ set(time_src
 
 ecal_add_sample(${PROJECT_NAME} ${time_src})
 
-target_link_libraries(${PROJECT_NAME} eCAL::core)
+target_link_libraries(${PROJECT_NAME} PRIVATE eCAL::core)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 

--- a/ecal/samples/cpp/misc/timer/CMakeLists.txt
+++ b/ecal/samples/cpp/misc/timer/CMakeLists.txt
@@ -30,7 +30,7 @@ set(timer_src
 
 ecal_add_sample(${PROJECT_NAME} ${timer_src})
 
-target_link_libraries(${PROJECT_NAME} eCAL::core)
+target_link_libraries(${PROJECT_NAME} PRIVATE eCAL::core)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 

--- a/ecal/samples/cpp/monitoring/monitoring_get_services/CMakeLists.txt
+++ b/ecal/samples/cpp/monitoring/monitoring_get_services/CMakeLists.txt
@@ -30,7 +30,7 @@ set(monitoring_get_services_src
 
 ecal_add_sample(${PROJECT_NAME} ${monitoring_get_services_src})
 
-target_link_libraries(${PROJECT_NAME} eCAL::core)
+target_link_libraries(${PROJECT_NAME} PRIVATE eCAL::core)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 

--- a/ecal/samples/cpp/monitoring/monitoring_get_topics/CMakeLists.txt
+++ b/ecal/samples/cpp/monitoring/monitoring_get_topics/CMakeLists.txt
@@ -30,7 +30,7 @@ set(monitoring_get_topics_src
 
 ecal_add_sample(${PROJECT_NAME} ${monitoring_get_topics_src})
 
-target_link_libraries(${PROJECT_NAME} eCAL::core)
+target_link_libraries(${PROJECT_NAME} PRIVATE eCAL::core)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 

--- a/ecal/samples/cpp/monitoring/monitoring_performance/CMakeLists.txt
+++ b/ecal/samples/cpp/monitoring/monitoring_performance/CMakeLists.txt
@@ -31,7 +31,7 @@ set(monitoring_performance_src
 
 ecal_add_sample(${PROJECT_NAME} ${monitoring_performance_src})
 
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PRIVATE
     eCAL::core
     eCAL::core_pb
     protobuf::libprotobuf

--- a/ecal/samples/cpp/monitoring/monitoring_rec/CMakeLists.txt
+++ b/ecal/samples/cpp/monitoring/monitoring_rec/CMakeLists.txt
@@ -31,7 +31,7 @@ set(monitoring_rec_src
 
 ecal_add_sample(${PROJECT_NAME} ${monitoring_rec_src})
 
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PRIVATE
     eCAL::core
     eCAL::core_pb
     protobuf::libprotobuf

--- a/ecal/samples/cpp/pubsub/binary/binary_rec/CMakeLists.txt
+++ b/ecal/samples/cpp/pubsub/binary/binary_rec/CMakeLists.txt
@@ -30,7 +30,7 @@ set(binary_rec_src
 
 ecal_add_sample(${PROJECT_NAME} ${binary_rec_src})
 
-target_link_libraries(${PROJECT_NAME} eCAL::core)
+target_link_libraries(${PROJECT_NAME} PRIVATE eCAL::core)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 

--- a/ecal/samples/cpp/pubsub/binary/binary_snd/CMakeLists.txt
+++ b/ecal/samples/cpp/pubsub/binary/binary_snd/CMakeLists.txt
@@ -30,7 +30,7 @@ set(binary_snd_src
 
 ecal_add_sample(${PROJECT_NAME} ${binary_snd_src})
 
-target_link_libraries(${PROJECT_NAME} eCAL::core)
+target_link_libraries(${PROJECT_NAME} PRIVATE eCAL::core)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 

--- a/ecal/samples/cpp/pubsub/binary/binary_zero_copy_rec/CMakeLists.txt
+++ b/ecal/samples/cpp/pubsub/binary/binary_zero_copy_rec/CMakeLists.txt
@@ -31,7 +31,7 @@ find_package(eCAL REQUIRED)
 # add and configure sample project
 ecal_add_sample(${PROJECT_NAME} ${binary_zero_copy_rec_src})
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
-target_link_libraries(${PROJECT_NAME} eCAL::core)
+target_link_libraries(${PROJECT_NAME} PRIVATE eCAL::core)
 
 # install and set properties
 ecal_install_sample(${PROJECT_NAME})

--- a/ecal/samples/cpp/pubsub/binary/binary_zero_copy_snd/CMakeLists.txt
+++ b/ecal/samples/cpp/pubsub/binary/binary_zero_copy_snd/CMakeLists.txt
@@ -31,7 +31,7 @@ find_package(eCAL REQUIRED)
 # add and configure sample project
 ecal_add_sample(${PROJECT_NAME} ${binary_zero_copy_snd_src})
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
-target_link_libraries(${PROJECT_NAME} eCAL::core)
+target_link_libraries(${PROJECT_NAME} PRIVATE eCAL::core)
 
 # install and set properties
 ecal_install_sample(${PROJECT_NAME})

--- a/ecal/samples/cpp/pubsub/binary/ping/CMakeLists.txt
+++ b/ecal/samples/cpp/pubsub/binary/ping/CMakeLists.txt
@@ -30,7 +30,7 @@ set(ping_src
 
 ecal_add_sample(${PROJECT_NAME} ${ping_src})
 
-target_link_libraries(${PROJECT_NAME} eCAL::core)
+target_link_libraries(${PROJECT_NAME} PRIVATE eCAL::core)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 

--- a/ecal/samples/cpp/pubsub/binary/pong/CMakeLists.txt
+++ b/ecal/samples/cpp/pubsub/binary/pong/CMakeLists.txt
@@ -30,7 +30,7 @@ set(pong_src
 
 ecal_add_sample(${PROJECT_NAME} ${pong_src})
 
-target_link_libraries(${PROJECT_NAME} eCAL::core)
+target_link_libraries(${PROJECT_NAME} PRIVATE eCAL::core)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 

--- a/ecal/samples/cpp/services/latency_client/CMakeLists.txt
+++ b/ecal/samples/cpp/services/latency_client/CMakeLists.txt
@@ -30,7 +30,7 @@ set(latency_client_src
 
 ecal_add_sample(${PROJECT_NAME} ${latency_client_src})
 
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PRIVATE
     eCAL::core
 )
 

--- a/ecal/samples/cpp/services/latency_server/CMakeLists.txt
+++ b/ecal/samples/cpp/services/latency_server/CMakeLists.txt
@@ -30,7 +30,7 @@ set(latency_server_src
 
 ecal_add_sample(${PROJECT_NAME} ${latency_server_src})
 
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PRIVATE
     eCAL::core
 )
 

--- a/ecal/samples/cpp/services/minimal_client/CMakeLists.txt
+++ b/ecal/samples/cpp/services/minimal_client/CMakeLists.txt
@@ -30,7 +30,7 @@ set(minimal_client_src
 
 ecal_add_sample(${PROJECT_NAME} ${minimal_client_src})
 
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PRIVATE
     eCAL::core
 )
 

--- a/ecal/samples/cpp/services/minimal_server/CMakeLists.txt
+++ b/ecal/samples/cpp/services/minimal_server/CMakeLists.txt
@@ -30,7 +30,7 @@ set(minimal_server_src
 
 ecal_add_sample(${PROJECT_NAME} ${minimal_server_src})
 
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PRIVATE
     eCAL::core
 )
 

--- a/lang/c/samples/pubsub/string/minimal_rec/CMakeLists.txt
+++ b/lang/c/samples/pubsub/string/minimal_rec/CMakeLists.txt
@@ -34,7 +34,7 @@ ecal_add_sample(${PROJECT_NAME} ${minimal_rec_c_src})
 
 target_include_directories(${PROJECT_NAME} PRIVATE .)
 
-target_link_libraries(${PROJECT_NAME} eCAL::core_c)
+target_link_libraries(${PROJECT_NAME} PRIVATE eCAL::core_c)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 

--- a/lang/c/samples/pubsub/string/minimal_rec_cb/CMakeLists.txt
+++ b/lang/c/samples/pubsub/string/minimal_rec_cb/CMakeLists.txt
@@ -34,7 +34,7 @@ ecal_add_sample(${PROJECT_NAME} ${minimal_rec_cb_c_src})
 
 target_include_directories(${PROJECT_NAME} PRIVATE .)
 
-target_link_libraries(${PROJECT_NAME} eCAL::core_c)
+target_link_libraries(${PROJECT_NAME} PRIVATE eCAL::core_c)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 

--- a/lang/c/samples/pubsub/string/minimal_snd/CMakeLists.txt
+++ b/lang/c/samples/pubsub/string/minimal_snd/CMakeLists.txt
@@ -34,7 +34,7 @@ ecal_add_sample(${PROJECT_NAME} ${minimal_snd_c_src})
 
 target_include_directories(${PROJECT_NAME} PRIVATE .)
 
-target_link_libraries(${PROJECT_NAME} eCAL::core_c)
+target_link_libraries(${PROJECT_NAME} PRIVATE eCAL::core_c)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 

--- a/lang/c/samples/services/minimal_client_c/CMakeLists.txt
+++ b/lang/c/samples/services/minimal_client_c/CMakeLists.txt
@@ -33,7 +33,7 @@ set(minimal_client_c_src
 ecal_add_sample(${PROJECT_NAME} ${minimal_client_c_src})
 target_include_directories(${PROJECT_NAME} PRIVATE .)
 
-target_link_libraries(${PROJECT_NAME} eCAL::core_c)
+target_link_libraries(${PROJECT_NAME} PRIVATE eCAL::core_c)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 

--- a/lang/c/samples/services/minimal_server_c/CMakeLists.txt
+++ b/lang/c/samples/services/minimal_server_c/CMakeLists.txt
@@ -33,7 +33,7 @@ set(minimal_server_c_src
 ecal_add_sample(${PROJECT_NAME} ${minimal_server_c_src})
 target_include_directories(${PROJECT_NAME} PRIVATE .)
 
-target_link_libraries(${PROJECT_NAME} eCAL::core_c)
+target_link_libraries(${PROJECT_NAME} PRIVATE eCAL::core_c)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 

--- a/lang/csharp/Continental.eCAL.Core.Samples/CMakeLists.txt
+++ b/lang/csharp/Continental.eCAL.Core.Samples/CMakeLists.txt
@@ -23,7 +23,7 @@ find_package(eCAL REQUIRED)
 
 macro(ecal_add_csharp_core_sample sample_name)
   ecal_add_sample(${sample_name} ${sample_name}.cs)
-  target_link_libraries(${sample_name} Continental.eCAL.Core)
+  target_link_libraries(${sample_name} PRIVATE Continental.eCAL.Core)
   set_property(TARGET ${sample_name} PROPERTY FOLDER samples/csharp/core)
 endmacro()
 

--- a/lang/csharp/Continental.eCAL.Protobuf.Samples/CMakeLists.txt
+++ b/lang/csharp/Continental.eCAL.Protobuf.Samples/CMakeLists.txt
@@ -23,7 +23,10 @@ find_package(eCAL REQUIRED)
 
 macro(ecal_add_csharp_protobuf_sample sample_name)
   ecal_add_sample(${sample_name} ${sample_name}.cs)
-  target_link_libraries(${sample_name} Continental.eCAL.Protobuf Continental.eCAL.Protobuf.Samples.Datatypes)
+  target_link_libraries(${sample_name} PRIVATE
+    Continental.eCAL.Protobuf
+    Continental.eCAL.Protobuf.Samples.Datatypes
+  )
   set_property(TARGET ${sample_name} PROPERTY FOLDER samples/csharp/protobuf)
   
   set_target_properties(${sample_name} PROPERTIES

--- a/samples/cpp/measurement/benchmark/CMakeLists.txt
+++ b/samples/cpp/measurement/benchmark/CMakeLists.txt
@@ -26,7 +26,7 @@ find_package(eCAL REQUIRED)
 
 ecal_add_sample(${PROJECT_NAME} src/main.cpp)
 
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PRIVATE
   eCAL::hdf5
 )
 

--- a/serialization/string/samples/pubsub/minimal_rec/CMakeLists.txt
+++ b/serialization/string/samples/pubsub/minimal_rec/CMakeLists.txt
@@ -30,7 +30,7 @@ set(minimal_rec_src
 
 ecal_add_sample(${PROJECT_NAME} ${minimal_rec_src})
 
-target_link_libraries(${PROJECT_NAME} eCAL::string_core)
+target_link_libraries(${PROJECT_NAME} PRIVATE eCAL::string_core)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 

--- a/serialization/string/samples/pubsub/minimal_rec_cb/CMakeLists.txt
+++ b/serialization/string/samples/pubsub/minimal_rec_cb/CMakeLists.txt
@@ -30,7 +30,7 @@ set(minimal_rec_cb_src
 
 ecal_add_sample(${PROJECT_NAME} ${minimal_rec_cb_src})
 
-target_link_libraries(${PROJECT_NAME} eCAL::string_core)
+target_link_libraries(${PROJECT_NAME} PRIVATE eCAL::string_core)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 

--- a/serialization/string/samples/pubsub/minimal_snd/CMakeLists.txt
+++ b/serialization/string/samples/pubsub/minimal_snd/CMakeLists.txt
@@ -30,7 +30,7 @@ set(minimal_snd_src
 
 ecal_add_sample(${PROJECT_NAME} ${minimal_snd_src})
 
-target_link_libraries(${PROJECT_NAME} eCAL::string_core)
+target_link_libraries(${PROJECT_NAME} PRIVATE eCAL::string_core)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 


### PR DESCRIPTION
### Description
<!-- What does your PR change? -->
Creates a new target with the compiler warnings for eCAL and links it with everything created with the helper functions.

This is part 1 of a refactoring that will eventually remove workarounds like [`ecal_disable_all_warnings`](https://github.com/DownerCase/ecal/blob/dcd73635dfcaec79634ec009060b19bc77e11f86/cmake/helper_functions/ecal_helper_functions.cmake#L52C7-L52C32) arising from the dependencies inheriting the global [`CMAKE_CXX_FLAGS`](https://github.com/DownerCase/ecal/blob/dcd73635dfcaec79634ec009060b19bc77e11f86/CMakeLists.txt#L43) and similar. At the end the warnings (and other flags) for eCAL code may be changed in one location and be guaranteed that no dependencies will inherit them. Meanwhile `CMAKE_<LANG>_FLAGS` will remain untouched for user customization.

Part 2 will resolve the other libraries/executables that do not make use of the `ecal_add_*` helpers (eg: `measurement_hdf5`).  
If there's a reason to not be allowed to use the helper function(s) in any particular portion of the build tree, please say.

Part 3 will finally remove the warning flag configuration in the root CMakeLists (as everything eCAL will be getting it from the warnings target) and the workarounds present in the submodule build wrappers.

Future changes could look at things like increasing the warning level to catch things earlier or being able to enforce warnings as errors (for eCAL code); I certainly won't make any attempt unless desire is shown.

Detailed changes:
- Disabled the "sign-windows-installer" GitHub action step for windows when the repo is not the official eCAL repo.
  - (This step was causing the Windows workflow to always fail for forks, not helpful)
- Adds a new helper file `ecal_compiler_warnings.cmake`
  - This had to be added to installed CMake files because `ecal_add_functions.cmake` now uses it and is also installed :shrug: 
- Created an internal interface target `_ecal_warnings` to attach eCAL project warnings/flags to
- Had all the `ecal_add_*` helpers link `_ecal_warnings`
- Add `PRIVATE`/`PUBLIC` specifiers to _many many_ `target_link_libraries(...)` calls because you cannot mix signatures with and without access specifiers on a target.
  - Only the `*_pb` library targets got `PUBLIC` visibility, everything else (that didn't have specifiers) were plugins or executables.

### Related issues
<!-- Type "Fixes #123" to automatically close that issue, when this PR is merged -->
- 

### Cherry-pick to
<!-- Leave empty, if you don't know. For master-only changes use "none"
- _none_
- 5.11 (old stable)
- 5.12 (current stable)
-->
