### PR TITLE
[cmake] Attach warnings to remaining targets

### DIFF
--- a/app/app_pb/CMakeLists.txt
+++ b/app/app_pb/CMakeLists.txt
@@ -57,8 +57,6 @@ else()
   ecal_add_shared_library(${PROJECT_NAME} src/app_pb.cpp)
 endif()
 
-add_library(eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
-
 protobuf_target_cpp(${PROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/src INSTALL_FOLDER include ${ProtoFiles})
 
 target_compile_options(${PROJECT_NAME}

--- a/app/apps/CMakeLists.txt
+++ b/app/apps/CMakeLists.txt
@@ -23,7 +23,6 @@ set(ecal_apps_header
 )
 
 ecal_add_interface_library(${PROJECT_NAME} ${ecal_apps_header})
-add_library(eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 target_include_directories(${PROJECT_NAME} INTERFACE 
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 #  $<INSTALL_INTERFACE:include>

--- a/app/mon/mon_plugin_lib/CMakeLists.txt
+++ b/app/mon/mon_plugin_lib/CMakeLists.txt
@@ -36,7 +36,6 @@ set(ecalmonpluginlib_header
 )
 
 ecal_add_library(${PROJECT_NAME} ${ecalmonpluginlib_src} ${ecalmonpluginlib_header})
-add_library(eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME} PUBLIC 
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/app/mon/mon_plugins/monitor_tree_view/CMakeLists.txt
+++ b/app/mon/mon_plugins/monitor_tree_view/CMakeLists.txt
@@ -37,7 +37,7 @@ set(source_files
 
 set(CMAKE_AUTOMOC ON)
 
-add_library(${PROJECT_NAME} ${source_files})
+ecal_add_library(${PROJECT_NAME} ${source_files})
 add_library(eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME} PUBLIC src)

--- a/app/mon/mon_plugins/monitor_tree_view/CMakeLists.txt
+++ b/app/mon/mon_plugins/monitor_tree_view/CMakeLists.txt
@@ -38,11 +38,10 @@ set(source_files
 set(CMAKE_AUTOMOC ON)
 
 ecal_add_library(${PROJECT_NAME} ${source_files})
-add_library(eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME} PUBLIC src)
 
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PUBLIC
   Qt${QT_VERSION_MAJOR}::Core
   Qt${QT_VERSION_MAJOR}::Widgets
   CustomQt

--- a/app/play/play_core/CMakeLists.txt
+++ b/app/play/play_core/CMakeLists.txt
@@ -43,7 +43,7 @@ set(source_files
   src/measurement_container.h
 ) 
 
-add_library(${PROJECT_NAME} ${source_files})
+ecal_add_library(${PROJECT_NAME} ${source_files})
 add_library(eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME} PRIVATE src)

--- a/app/play/play_core/CMakeLists.txt
+++ b/app/play/play_core/CMakeLists.txt
@@ -44,7 +44,6 @@ set(source_files
 ) 
 
 ecal_add_library(${PROJECT_NAME} ${source_files})
-add_library(eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME} PRIVATE src)
 target_include_directories(${PROJECT_NAME} PUBLIC  include)

--- a/app/rec/rec_addon_core/CMakeLists.txt
+++ b/app/rec/rec_addon_core/CMakeLists.txt
@@ -39,7 +39,6 @@ set(source_files
 ) 
 
 ecal_add_library (${PROJECT_NAME} ${source_files})
-add_library (eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME} 
   PRIVATE  

--- a/app/rec/rec_client_core/CMakeLists.txt
+++ b/app/rec/rec_client_core/CMakeLists.txt
@@ -78,7 +78,7 @@ if (HAS_CURL)
         )
 endif()
 
-add_library (${PROJECT_NAME} ${source_files})
+ecal_add_library (${PROJECT_NAME} ${source_files})
 add_library (eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME} PRIVATE src)

--- a/app/rec/rec_client_core/CMakeLists.txt
+++ b/app/rec/rec_client_core/CMakeLists.txt
@@ -79,7 +79,6 @@ if (HAS_CURL)
 endif()
 
 ecal_add_library (${PROJECT_NAME} ${source_files})
-add_library (eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME} PRIVATE src)
 target_include_directories(${PROJECT_NAME} PUBLIC  include)

--- a/app/rec/rec_server_core/CMakeLists.txt
+++ b/app/rec/rec_server_core/CMakeLists.txt
@@ -56,7 +56,7 @@ set(source_files
     src/recorder/remote_recorder.h
 ) 
 
-add_library (${PROJECT_NAME} ${source_files})
+ecal_add_library (${PROJECT_NAME} ${source_files})
 add_library (eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME} PRIVATE src)

--- a/app/rec/rec_server_core/CMakeLists.txt
+++ b/app/rec/rec_server_core/CMakeLists.txt
@@ -57,7 +57,6 @@ set(source_files
 ) 
 
 ecal_add_library (${PROJECT_NAME} ${source_files})
-add_library (eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME} PRIVATE src)
 target_include_directories(${PROJECT_NAME} PUBLIC  include)

--- a/app/sys/sys_cli/CMakeLists.txt
+++ b/app/sys/sys_cli/CMakeLists.txt
@@ -77,6 +77,7 @@ target_link_libraries(${PROJECT_NAME} PRIVATE
   protobuf::libprotobuf
   CustomTclap
   eCAL::core_pb
+  eCAL::protobuf_core
 )
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)

--- a/app/sys/sys_client_core/CMakeLists.txt
+++ b/app/sys/sys_client_core/CMakeLists.txt
@@ -34,7 +34,7 @@ set(source_files
   src/task.cpp
 ) 
 
-add_library (${PROJECT_NAME} ${source_files})
+ecal_add_library (${PROJECT_NAME} ${source_files})
 add_library (eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME} PRIVATE src)

--- a/app/sys/sys_client_core/CMakeLists.txt
+++ b/app/sys/sys_client_core/CMakeLists.txt
@@ -35,7 +35,6 @@ set(source_files
 ) 
 
 ecal_add_library (${PROJECT_NAME} ${source_files})
-add_library (eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME} PRIVATE src)
 target_include_directories(${PROJECT_NAME} PUBLIC  include)

--- a/app/sys/sys_core/CMakeLists.txt
+++ b/app/sys/sys_core/CMakeLists.txt
@@ -75,7 +75,6 @@ set(ecalsyscore_src
 )
 
 ecal_add_library(${PROJECT_NAME} ${ecalsyscore_src})
-add_library(eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME}
   PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
@@ -87,15 +86,18 @@ target_compile_definitions(${PROJECT_NAME}
 create_targets_protobuf()
 
 target_link_libraries(${PROJECT_NAME}
-  Threads::Threads
-  tinyxml2::tinyxml2
+  PUBLIC
+  eCAL::core
   spdlog::spdlog
-  protobuf::libprotobuf
-  eCAL::protobuf_core
+  eCAL::sys_client_core
   eCAL::core_pb
   eCAL::app_pb
+  PRIVATE
+  Threads::Threads
+  tinyxml2::tinyxml2
+  protobuf::libprotobuf
+  eCAL::protobuf_core
   EcalParser
-  eCAL::sys_client_core
 )
 
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_14)

--- a/app/sys/sys_core/CMakeLists.txt
+++ b/app/sys/sys_core/CMakeLists.txt
@@ -74,7 +74,7 @@ set(ecalsyscore_src
   src/task/task_group.cpp
 )
 
-add_library(${PROJECT_NAME} ${ecalsyscore_src})
+ecal_add_library(${PROJECT_NAME} ${ecalsyscore_src})
 add_library(eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME}

--- a/app/sys/sys_gui/CMakeLists.txt
+++ b/app/sys/sys_gui/CMakeLists.txt
@@ -181,6 +181,7 @@ target_link_libraries (${PROJECT_NAME} PRIVATE
     CustomTclap
     tclap::tclap
     eCAL::core
+    eCAL::protobuf_core
     eCAL::sys_core
     protobuf::libprotobuf
     EcalParser

--- a/cmake/helper_functions/ecal_add_functions.cmake
+++ b/cmake/helper_functions/ecal_add_functions.cmake
@@ -127,6 +127,7 @@ endfunction()
 
 function(ecal_add_shared_library TARGET_NAME)
   add_library(${TARGET_NAME} SHARED ${ARGN})
+  add_library(eCAL::${TARGET_NAME} ALIAS ${TARGET_NAME})
   set_target_properties(${TARGET_NAME} PROPERTIES
     VERSION ${eCAL_VERSION_STRING}
     SOVERSION ${eCAL_VERSION_MAJOR}
@@ -136,6 +137,7 @@ endfunction()
 
 function(ecal_add_static_library TARGET_NAME)
   add_library(${TARGET_NAME} STATIC ${ARGN})
+  add_library(eCAL::${TARGET_NAME} ALIAS ${TARGET_NAME})
   set_target_properties(${TARGET_NAME} PROPERTIES 
     VERSION ${eCAL_VERSION_STRING}
     SOVERSION ${eCAL_VERSION_MAJOR}

--- a/cmake/helper_functions/ecal_add_functions.cmake
+++ b/cmake/helper_functions/ecal_add_functions.cmake
@@ -149,6 +149,7 @@ endfunction()
 
 function(ecal_add_interface_library TARGET_NAME)
   add_library(${TARGET_NAME} INTERFACE)
+  add_library(eCAL::${TARGET_NAME} ALIAS ${TARGET_NAME})
 endfunction()
 
 function(ecal_add_library TARGET_NAME)

--- a/contrib/ecalhdf5/CMakeLists.txt
+++ b/contrib/ecalhdf5/CMakeLists.txt
@@ -67,7 +67,6 @@ set(ecalhdf5_header_base
 )
 
 ecal_add_library(${PROJECT_NAME} ${ecalhdf5_src} ${ecalhdf5_header_base})
-add_library(eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME}
   PRIVATE .

--- a/contrib/ecaltime/ecaltime_pb/CMakeLists.txt
+++ b/contrib/ecaltime/ecaltime_pb/CMakeLists.txt
@@ -46,8 +46,6 @@ else()
   ecal_add_shared_library(${PROJECT_NAME} src/ecaltime_pb.cpp)
 endif()
 
-add_library(eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
-
 protobuf_target_cpp(${PROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/src INSTALL_FOLDER include ${ProtoFiles})
 
 target_compile_options(${PROJECT_NAME}

--- a/contrib/measurement/base/CMakeLists.txt
+++ b/contrib/measurement/base/CMakeLists.txt
@@ -22,8 +22,7 @@ set(ecal_message_header
     include/ecal/measurement/base/measurement.h
 )
 
-add_library(${PROJECT_NAME} INTERFACE)
-add_library(eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+ecal_add_interface_library(${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME} INTERFACE 
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/contrib/measurement/hdf5/CMakeLists.txt
+++ b/contrib/measurement/hdf5/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 project(measurement_hdf5)
 
-add_library(${PROJECT_NAME} 
+ecal_add_library(${PROJECT_NAME}
   include/ecal/measurement/hdf5/reader.h
   include/ecal/measurement/hdf5/writer.h
   src/reader.cpp

--- a/contrib/measurement/hdf5/CMakeLists.txt
+++ b/contrib/measurement/hdf5/CMakeLists.txt
@@ -25,8 +25,6 @@ ecal_add_library(${PROJECT_NAME}
   src/writer.cpp
 )
 
-add_library(eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
-
 target_include_directories(${PROJECT_NAME} PUBLIC 
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>

--- a/ecal/core/CMakeLists.txt
+++ b/ecal/core/CMakeLists.txt
@@ -613,8 +613,6 @@ if(UNIX)
   set_source_files_properties(src/util/convert_utf.cpp PROPERTIES COMPILE_FLAGS -Wno-implicit-fallthrough)
 endif()
 
-add_library(eCAL::${TARGET_NAME}   ALIAS ${TARGET_NAME})
-
 target_compile_definitions(${TARGET_NAME}
   PUBLIC
     ASIO_STANDALONE

--- a/ecal/core/cfg/gen/CMakeLists.txt
+++ b/ecal/core/cfg/gen/CMakeLists.txt
@@ -28,6 +28,8 @@ add_executable(${PROJECT_NAME}
   ${ECAL_CORE_PROJECT_ROOT}/core/src/config/ecal_path_processing.cpp
 )
 
+ecal_add_compiler_warnings(${PROJECT_NAME})
+
 # Set the output path for the generated YAML file
 set(YAML_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/${ECAL_YAML})
 

--- a/ecal/core_pb/CMakeLists.txt
+++ b/ecal/core_pb/CMakeLists.txt
@@ -54,8 +54,6 @@ else()
   ecal_add_shared_library(${PROJECT_NAME} src/core_pb.cpp)
 endif()
 
-add_library(eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
-
 protobuf_target_cpp(${PROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/src INSTALL_FOLDER include ${ProtoFiles})
 
 target_compile_options(${PROJECT_NAME}

--- a/ecal/service/CMakeLists.txt
+++ b/ecal/service/CMakeLists.txt
@@ -19,6 +19,28 @@
 cmake_minimum_required(VERSION 3.16)
 project(ecal_service)
 
+# Root CMakeLists sets CMAKE_MODULE_PATH to include the correct path
+# If the module cannot be found warnings basic warnings will be applied instead
+include(helper_functions/ecal_compiler_warnings OPTIONAL RESULT_VARIABLE _ecal_warnings_found)
+if("${_ecal_warnings_found}" STREQUAL "NOTFOUND")
+  message(AUTHOR_WARNING
+    "  helper_functions/ecal_compiler_warnings.cmake not found.\n"
+    "  Add the path to CMAKE_MODULE_PATH to use warnings specified by the main eCAL repo."
+  )
+  add_library(_ecal_service_warnings INTERFACE)
+  set(cxx_compiler_flags "")
+  if("${CMAKE_CXX_COMPILER_ID}" MATCHES "MSVC")
+      set(cxx_compiler_flags "/MP" "/W4")
+  elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU|Clang")
+      set(cxx_compiler_flags "-Wall" "-Wextra")
+  else()
+      message(WARNING "Unknown compiler, will not set warning flags")
+  endif()
+  target_compile_options(_ecal_service_warnings INTERFACE "${cxx_compiler_flags}")
+else()
+  add_library(_ecal_service_warnings ALIAS _ecal_warnings)
+endif()
+
 # Main library
 add_subdirectory(ecal_service)
 

--- a/ecal/service/ecal_service/CMakeLists.txt
+++ b/ecal/service/ecal_service/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.16)
 
 project(ecal_service)
 
@@ -61,6 +61,7 @@ target_link_libraries(${PROJECT_NAME}
         Threads::Threads
         $<$<BOOL:${WIN32}>:ws2_32>
         $<$<BOOL:${WIN32}>:wsock32>
+        _ecal_service_warnings
 
 )
 
@@ -71,12 +72,6 @@ target_compile_definitions(${PROJECT_NAME}
 )
 
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_14)
-
-target_compile_options(${PROJECT_NAME} PRIVATE
-                           $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-                                -Wall -Wextra>
-                           $<$<CXX_COMPILER_ID:MSVC>:
-                                /W4>)
 
 # Add own public include directory
 target_include_directories(${PROJECT_NAME}

--- a/ecal/service/samples/sample_client/CMakeLists.txt
+++ b/ecal/service/samples/sample_client/CMakeLists.txt
@@ -28,7 +28,9 @@ add_executable(${PROJECT_NAME} ${sources})
 
 target_link_libraries(${PROJECT_NAME}
   PRIVATE
-    ecal_service)
+    ecal_service
+    _ecal_service_warnings
+)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 

--- a/ecal/service/samples/sample_server/CMakeLists.txt
+++ b/ecal/service/samples/sample_server/CMakeLists.txt
@@ -28,7 +28,9 @@ add_executable(${PROJECT_NAME} ${sources})
 
 target_link_libraries(${PROJECT_NAME}
   PRIVATE
-    ecal_service)
+    ecal_service
+    _ecal_service_warnings
+)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 

--- a/ecal/service/samples/sample_standalone/CMakeLists.txt
+++ b/ecal/service/samples/sample_standalone/CMakeLists.txt
@@ -28,7 +28,9 @@ add_executable(${PROJECT_NAME} ${sources})
 
 target_link_libraries(${PROJECT_NAME}
   PRIVATE
-    ecal_service)
+    ecal_service
+    _ecal_service_warnings
+)
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 

--- a/lang/c/core/CMakeLists.txt
+++ b/lang/c/core/CMakeLists.txt
@@ -84,8 +84,6 @@ ecal_add_shared_library(${PROJECT_NAME}
     ${ecal_c_sources}
 )
 
-add_library(eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
-
 target_include_directories(${PROJECT_NAME}
   PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/lib/CustomQt/CMakeLists.txt
+++ b/lib/CustomQt/CMakeLists.txt
@@ -75,12 +75,20 @@ target_include_directories(${PROJECT_NAME}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src
   PUBLIC  ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PUBLIC
     Qt${QT_VERSION_MAJOR}::Core
     Qt${QT_VERSION_MAJOR}::Widgets
 )
 
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_14)
+
+if(COMMAND ecal_add_compiler_warnings)
+    ecal_add_compiler_warnings(${PROJECT_NAME})
+else()
+    message(AUTHOR_WARNING
+        "ecal_add_compiler_warnings() not available. Not setting compiler warnings!"
+    )
+endif()
 
 # Create a source tree that mirrors the filesystem
 source_group(TREE "${CMAKE_CURRENT_LIST_DIR}"

--- a/lib/EcalParser/CMakeLists.txt
+++ b/lib/EcalParser/CMakeLists.txt
@@ -42,7 +42,7 @@ set(sources
     src/functions/username.h
 )
 
-add_library (${PROJECT_NAME} 
+add_library (${PROJECT_NAME}
     ${includes}
     ${sources}
 )
@@ -60,6 +60,14 @@ if(WIN32)
 endif()
 
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_14)
+
+if(COMMAND ecal_add_compiler_warnings)
+    ecal_add_compiler_warnings(${PROJECT_NAME})
+else()
+    message(AUTHOR_WARNING
+        "ecal_add_compiler_warnings() not available. Not setting compiler warnings!"
+    )
+endif()
 
 # Create a source tree that mirrors the filesystem
 source_group(TREE "${CMAKE_CURRENT_LIST_DIR}"

--- a/lib/QEcalParser/CMakeLists.txt
+++ b/lib/QEcalParser/CMakeLists.txt
@@ -92,6 +92,14 @@ target_link_libraries(${PROJECT_NAME}
 
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_14)
 
+if(COMMAND ecal_add_compiler_warnings)
+    ecal_add_compiler_warnings(${PROJECT_NAME})
+else()
+    message(AUTHOR_WARNING
+        "ecal_add_compiler_warnings() not available. Not setting compiler warnings!"
+    )
+endif()
+
 if(MSVC)
     # Disable Compiler warning "Conditional expression is constant"
     set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "/wd4127 /wd4714")

--- a/lib/ThreadingUtils/CMakeLists.txt
+++ b/lib/ThreadingUtils/CMakeLists.txt
@@ -44,6 +44,14 @@ target_include_directories(${PROJECT_NAME}
 
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_14)
 
+if(COMMAND ecal_add_compiler_warnings)
+    ecal_add_compiler_warnings(${PROJECT_NAME})
+else()
+    message(AUTHOR_WARNING
+        "ecal_add_compiler_warnings() not available. Not setting compiler warnings!"
+    )
+endif()
+
 # Create a source tree that mirrors the filesystem
 source_group(TREE "${CMAKE_CURRENT_LIST_DIR}"
     FILES

--- a/lib/ecal_utils/CMakeLists.txt
+++ b/lib/ecal_utils/CMakeLists.txt
@@ -43,8 +43,6 @@ ecal_add_static_library(${PROJECT_NAME}
     ${ecal_utils_src}
 )
 
-add_library(eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
-
 target_include_directories(${PROJECT_NAME} PRIVATE src/)
 target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/serialization/capnproto/capnproto/CMakeLists.txt
+++ b/serialization/capnproto/capnproto/CMakeLists.txt
@@ -21,7 +21,8 @@ find_package(CapnProto REQUIRED)
 ##########################
 # Capnproto core communication extension
 ##########################
-ecal_add_interface_library(capnproto_core)
+add_library(capnproto_core INTERFACE)
+add_library(eCAL::capnproto_core ALIAS capnproto_core)
 
 target_link_libraries(capnproto_core 
   INTERFACE 

--- a/serialization/capnproto/capnproto/CMakeLists.txt
+++ b/serialization/capnproto/capnproto/CMakeLists.txt
@@ -21,8 +21,7 @@ find_package(CapnProto REQUIRED)
 ##########################
 # Capnproto core communication extension
 ##########################
-add_library(capnproto_core INTERFACE)
-add_library(eCAL::capnproto_core ALIAS capnproto_core)
+ecal_add_interface_library(capnproto_core)
 
 target_link_libraries(capnproto_core 
   INTERFACE 

--- a/serialization/flatbuffers/flatbuffers/CMakeLists.txt
+++ b/serialization/flatbuffers/flatbuffers/CMakeLists.txt
@@ -21,8 +21,7 @@ find_package(FlatBuffers REQUIRED)
 ##########################
 # FlatBuffers core communication extension
 ##########################
-add_library(flatbuffers_core INTERFACE)
-add_library(eCAL::flatbuffers_core ALIAS flatbuffers_core)
+ecal_add_interface_library(flatbuffers_core)
 
 target_link_libraries(flatbuffers_core 
   INTERFACE 

--- a/serialization/flatbuffers/flatbuffers/CMakeLists.txt
+++ b/serialization/flatbuffers/flatbuffers/CMakeLists.txt
@@ -21,7 +21,8 @@ find_package(FlatBuffers REQUIRED)
 ##########################
 # FlatBuffers core communication extension
 ##########################
-ecal_add_interface_library(flatbuffers_core)
+add_library(flatbuffers_core INTERFACE)
+add_library(eCAL::flatbuffers_core ALIAS flatbuffers_core)
 
 target_link_libraries(flatbuffers_core 
   INTERFACE 

--- a/serialization/protobuf/protobuf/CMakeLists.txt
+++ b/serialization/protobuf/protobuf/CMakeLists.txt
@@ -46,6 +46,8 @@ target_link_libraries(protobuf_base PUBLIC protobuf::libprotobuf)
 
 target_compile_features(protobuf_base PUBLIC cxx_std_14)
 
+ecal_add_compiler_warnings(protobuf_base)
+
 install(
   TARGETS protobuf_base
   EXPORT eCALCoreTargets  
@@ -59,7 +61,8 @@ set_property(TARGET protobuf_base PROPERTY FOLDER core)
 ##########################
 # Protobuf core communication extension
 ##########################
-ecal_add_interface_library(protobuf_core)
+add_library(protobuf_core INTERFACE)
+add_library(eCAL::protobuf_core ALIAS protobuf_core)
 
 target_link_libraries(protobuf_core 
   INTERFACE 

--- a/serialization/protobuf/protobuf/CMakeLists.txt
+++ b/serialization/protobuf/protobuf/CMakeLists.txt
@@ -59,8 +59,7 @@ set_property(TARGET protobuf_base PROPERTY FOLDER core)
 ##########################
 # Protobuf core communication extension
 ##########################
-add_library(protobuf_core INTERFACE)
-add_library(eCAL::protobuf_core ALIAS protobuf_core)
+ecal_add_interface_library(protobuf_core)
 
 target_link_libraries(protobuf_core 
   INTERFACE 

--- a/serialization/protobuf/protobuf/CMakeLists.txt
+++ b/serialization/protobuf/protobuf/CMakeLists.txt
@@ -21,7 +21,6 @@
 ##########################
 find_package(Protobuf REQUIRED)
 ecal_add_library(protobuf_base)
-add_library(eCAL::protobuf_base ALIAS protobuf_base)
 
 target_sources(protobuf_base
   PUBLIC

--- a/serialization/string/string/CMakeLists.txt
+++ b/serialization/string/string/CMakeLists.txt
@@ -23,8 +23,7 @@
 
 # std::string core communication extension
 ##########################
-add_library(string_base INTERFACE)
-add_library(eCAL::string_base ALIAS string_base)
+ecal_add_interface_library(string_base)
 
 target_sources(string_base
   INTERFACE
@@ -48,8 +47,7 @@ install(
 ##########################
 # std::string core communication extension
 ##########################
-add_library(string_core INTERFACE)
-add_library(eCAL::string_core ALIAS string_core)
+ecal_add_interface_library(string_core)
 
 target_link_libraries(string_core 
   INTERFACE 

--- a/serialization/string/string/CMakeLists.txt
+++ b/serialization/string/string/CMakeLists.txt
@@ -23,7 +23,8 @@
 
 # std::string core communication extension
 ##########################
-ecal_add_interface_library(string_base)
+add_library(string_base INTERFACE)
+add_library(eCAL::string_base ALIAS string_base)
 
 target_sources(string_base
   INTERFACE
@@ -47,7 +48,8 @@ install(
 ##########################
 # std::string core communication extension
 ##########################
-ecal_add_interface_library(string_core)
+add_library(string_core INTERFACE)
+add_library(eCAL::string_core ALIAS string_core)
 
 target_link_libraries(string_core 
   INTERFACE 


### PR DESCRIPTION
### Description
<!-- What does your PR change? -->
Follow up from #1948 -- makes sure all (C/C++) eCAL targets have the warnings set on them.

Detailed changes:
- Rolls creation of the `eCAL::*` alias targets into the `ecal_add_*` helpers.
- Fixed up `PUBLIC/PRIVATE` access specifiers on a few targets

I couldn't decide on the best way to handle the goal to make parts of the repo more standalone whilst also having a single source of truth. So ended up with three approaches.

- For `/app` and `/contrib` I used the `ecal_add_*` helpers as they were already being used in places.
- For `/lib` I used `ecal_add_compiler_warnings` if it was available, otherwise issued a warning.
- For `/ecal/service` it appeared effort was made to make it standalone, so I check for if `helper_functions/ecal_compiler_warnings` can be included:
  - Yes: Great, use the `_ecal_warnings` target via a compatibility alias
  - No: Use duplicated logic
  - Either way, warnings are added by linking `_ecal_service_warnings`

Not sure what would be preferred, personally I would use the helpers everywhere and just carry those helper functions into the new split off repo.

### Related issues
<!-- Type "Fixes #123" to automatically close that issue, when this PR is merged -->
- 

### Cherry-pick to
<!-- Leave empty, if you don't know. For master-only changes use "none"
- _none_
- 5.11 (old stable)
- 5.12 (current stable)
-->
