### PR TITLE
[core] split `GetTopicNames` into `GetPublishedTopicNames` and `GetSubscribedTopicNames`.

### DIFF
--- a/ecal/core/include/ecal/registration.h
+++ b/ecal/core/include/ecal/registration.h
@@ -66,7 +66,7 @@ namespace eCAL
      *
      * @return Set of topic id's.
     **/
-    ECAL_API std::set<STopicId> GetPublisherIDs();
+    ECAL_API bool GetPublisherIDs(std::set<STopicId>& topic_ids_);
 
     /**
      * @brief Get data type information with quality for specific publisher.
@@ -98,7 +98,7 @@ namespace eCAL
      *
      * @return Set of topic id's.
     **/
-    ECAL_API std::set<STopicId> GetSubscriberIDs();
+    ECAL_API bool GetSubscriberIDs(std::set<STopicId>& topic_ids_);
 
     /**
      * @brief Get data type information with quality for specific subscriber.
@@ -130,7 +130,7 @@ namespace eCAL
      *
      * @return Set of service id's.
     **/
-    ECAL_API std::set<SServiceId> GetServerIDs();
+    ECAL_API bool GetServerIDs(std::set<SServiceId>& service_ids_);
 
     /**
      * @brief Get service method information for a specific server.
@@ -144,7 +144,7 @@ namespace eCAL
      *
      * @return Set of service id's.
     **/
-    ECAL_API std::set<SServiceId> GetClientIDs();
+    ECAL_API bool GetClientIDs(std::set<SServiceId>& service_ids_);
 
     /**
      * @brief Get service method information for a specific client.
@@ -160,7 +160,7 @@ namespace eCAL
      *
      * @param topic_names_ Set to store the topic names.
     **/
-    ECAL_API void GetPublishedTopicNames(std::set<std::string>& topic_names_);
+    ECAL_API bool GetPublishedTopicNames(std::set<std::string>& topic_names_);
 
     /**
      * @brief Get all names of topics that are being subscribed
@@ -169,21 +169,21 @@ namespace eCAL
      *
      * @param topic_names_ Set to store the topic names.
     **/
-    ECAL_API void GetSubscribedTopicNames(std::set<std::string>& topic_names_);
+    ECAL_API bool GetSubscribedTopicNames(std::set<std::string>& topic_names_);
 
         /**
      * @brief Get the pairs of service name / method name of all eCAL Servers.
      *
      * @param service_method_names_ Set to store the service/method names (Set { (ServiceName, MethodName) }).
     **/
-    ECAL_API void GetServerMethodNames(std::set<SServiceMethod>& server_method_names_);
+    ECAL_API bool GetServerMethodNames(std::set<SServiceMethod>& server_method_names_);
 
     /**
      * @brief Get the pairs of service name / method name of all eCAL Clients.
      *
      * @param client_method_names_ Set to store the client/method names (Set { (ClientName, MethodName) }).
     **/
-    ECAL_API void GetClientMethodNames(std::set<SServiceMethod>& client_method_names_);
+    ECAL_API bool GetClientMethodNames(std::set<SServiceMethod>& client_method_names_);
   }
 }
 

--- a/ecal/core/include/ecal/registration.h
+++ b/ecal/core/include/ecal/registration.h
@@ -154,13 +154,24 @@ namespace eCAL
     ECAL_API bool GetClientInfo(const SServiceId& id_, ServiceMethodInformationSetT& service_method_info_);
 
     /**
-     * @brief Get all topic names.
+     * @brief Get all names of topics that are being published.
+     *        This is a convenience function. 
+     *        It calls GetPublisherIDs() and filters by name
      *
      * @param topic_names_ Set to store the topic names.
     **/
-    ECAL_API void GetTopicNames(std::set<std::string>& topic_names_);
+    ECAL_API void GetPublishedTopicNames(std::set<std::string>& topic_names_);
 
     /**
+     * @brief Get all names of topics that are being subscribed
+     *        This is a convenience function. 
+     *        It calls GetSubscriberIDs() and filters by name
+     *
+     * @param topic_names_ Set to store the topic names.
+    **/
+    ECAL_API void GetSubscribedTopicNames(std::set<std::string>& topic_names_);
+
+        /**
      * @brief Get the pairs of service name / method name of all eCAL Servers.
      *
      * @param service_method_names_ Set to store the service/method names (Set { (ServiceName, MethodName) }).

--- a/ecal/core/src/registration/ecal_registration.cpp
+++ b/ecal/core/src/registration/ecal_registration.cpp
@@ -34,10 +34,11 @@ namespace eCAL
 {
   namespace Registration
   {
-    std::set<STopicId> GetPublisherIDs()
+    bool GetPublisherIDs(std::set<STopicId>& topic_ids_)
     {
-      if (g_descgate() == nullptr) return std::set<STopicId>();
-      return g_descgate()->GetPublisherIDs();
+      if (g_descgate() == nullptr) return false;
+      topic_ids_ = std::move(g_descgate()->GetPublisherIDs());
+      return true;
     }
 
     bool GetPublisherInfo(const STopicId& id_, SDataTypeInformation& topic_info_)
@@ -58,10 +59,11 @@ namespace eCAL
       return g_descgate()->RemPublisherEventCallback(token_);
     }
 
-    std::set<STopicId> GetSubscriberIDs()
+    bool GetSubscriberIDs(std::set<STopicId>& topic_ids_)
     {
-      if (g_descgate() == nullptr) return std::set<STopicId>();
-      return g_descgate()->GetSubscriberIDs();
+      if (g_descgate() == nullptr) return false;
+      topic_ids_ = std::move(g_descgate()->GetSubscriberIDs());
+      return true;
     }
 
     bool GetSubscriberInfo(const STopicId& id_, SDataTypeInformation& topic_info_)
@@ -82,10 +84,11 @@ namespace eCAL
       return g_descgate()->RemSubscriberEventCallback(token_);
     }
 
-    std::set<SServiceId> GetServerIDs()
+    bool GetServerIDs(std::set<SServiceId>& service_ids_)
     {
-      if (g_descgate() == nullptr) return std::set<SServiceId>();
-      return g_descgate()->GetServerIDs();
+      if (g_descgate() == nullptr) return false;
+      service_ids_ = std::move(g_descgate()->GetServerIDs());
+      return true;
     }
 
     bool GetServerInfo(const SServiceId& id_, ServiceMethodInformationSetT& service_info_)
@@ -94,10 +97,11 @@ namespace eCAL
       return g_descgate()->GetServerInfo(id_, service_info_);
     }
 
-    std::set<SServiceId> GetClientIDs()
+    bool GetClientIDs(std::set<SServiceId>& service_ids_)
     {
-      if (g_descgate() == nullptr) return std::set<SServiceId>();
-      return g_descgate()->GetClientIDs();
+       if (g_descgate() == nullptr) return false;
+       service_ids_ = std::move(g_descgate()->GetClientIDs());
+       return true;
     }
 
     bool GetClientInfo(const SServiceId& id_, ServiceMethodInformationSetT& service_info_)
@@ -106,36 +110,41 @@ namespace eCAL
       return g_descgate()->GetClientInfo(id_, service_info_);
     }
 
-    void GetPublishedTopicNames(std::set<std::string>& topic_names_)
+    bool GetPublishedTopicNames(std::set<std::string>& topic_names_)
     {
       topic_names_.clear();
 
       // get publisher id sets and insert names into the topic_names set
-      const std::set<STopicId> pub_id_set = GetPublisherIDs();
+      std::set<STopicId> pub_id_set;
+      bool return_value = GetPublisherIDs(pub_id_set);
       for (const auto& pub_id : pub_id_set)
       {
         topic_names_.insert(pub_id.topic_name);
       }
+      return return_value;
     }
 
-    void GetSubscribedTopicNames(std::set<std::string>& topic_names_)
+    bool GetSubscribedTopicNames(std::set<std::string>& topic_names_)
     {
       topic_names_.clear();
 
       // get subscriber id sets and insert names into the topic_names set
-      const std::set<STopicId> sub_id_set = GetSubscriberIDs();
+      std::set<STopicId> sub_id_set;
+      bool return_value = GetSubscriberIDs(sub_id_set);
       for (const auto& sub_id : sub_id_set)
       {
         topic_names_.insert(sub_id.topic_name);
       }
+      return return_value;
     }
     
-    void GetServerMethodNames(std::set<SServiceMethod>& server_method_names_)
+    bool GetServerMethodNames(std::set<SServiceMethod>& server_method_names_)
     {
       server_method_names_.clear();
 
       // get servers id set and insert names into the server_method_names_ set
-      const std::set<SServiceId> server_id_set = GetServerIDs();
+      std::set<SServiceId> server_id_set;
+      bool return_value   = GetServerIDs(server_id_set);
       for (const auto& server_id : server_id_set)
       {
         eCAL::ServiceMethodInformationSetT methods;
@@ -145,14 +154,16 @@ namespace eCAL
           server_method_names_.insert({ server_id.service_name, method.method_name });
         }
       }
+      return return_value;
     }
 
-    void GetClientMethodNames(std::set<SServiceMethod>& client_method_names_)
+    bool GetClientMethodNames(std::set<SServiceMethod>& client_method_names_)
     {
       client_method_names_.clear();
 
       // get clients id set and insert names into the client_method_names set
-      const std::set<SServiceId> client_id_set = GetClientIDs();
+      std::set<SServiceId> client_id_set;
+      bool return_value = GetClientIDs(client_id_set);
       for (const auto& client_id : client_id_set)
       {
         eCAL::ServiceMethodInformationSetT methods;
@@ -162,6 +173,7 @@ namespace eCAL
           client_method_names_.insert({ client_id.service_name, method.method_name });
         }
       }
+      return return_value;
     }
     
   }

--- a/ecal/core/src/registration/ecal_registration.cpp
+++ b/ecal/core/src/registration/ecal_registration.cpp
@@ -106,16 +106,23 @@ namespace eCAL
       return g_descgate()->GetClientInfo(id_, service_info_);
     }
 
-    void GetTopicNames(std::set<std::string>& topic_names_)
+    void GetPublishedTopicNames(std::set<std::string>& topic_names_)
     {
       topic_names_.clear();
 
-      // get publisher & subscriber id sets and insert names into the topic_names set
+      // get publisher id sets and insert names into the topic_names set
       const std::set<STopicId> pub_id_set = GetPublisherIDs();
       for (const auto& pub_id : pub_id_set)
       {
         topic_names_.insert(pub_id.topic_name);
       }
+    }
+
+    void GetSubscribedTopicNames(std::set<std::string>& topic_names_)
+    {
+      topic_names_.clear();
+
+      // get subscriber id sets and insert names into the topic_names set
       const std::set<STopicId> sub_id_set = GetSubscriberIDs();
       for (const auto& sub_id : sub_id_set)
       {

--- a/ecal/samples/cpp/benchmarks/massive_pub_sub/src/massive_pub_sub.cpp
+++ b/ecal/samples/cpp/benchmarks/massive_pub_sub/src/massive_pub_sub.cpp
@@ -158,8 +158,14 @@ int main()
     size_t num_sub(0);
     while ((num_pub < publisher_number) || (num_sub < subscriber_number))
     {
-      num_pub = eCAL::Registration::GetPublisherIDs().size();
-      num_sub = eCAL::Registration::GetSubscriberIDs().size();
+      std::set<eCAL::STopicId> publisher_ids;
+      std::set<eCAL::STopicId> subscriber_ids;
+
+      eCAL::Registration::GetPublisherIDs(publisher_ids);
+      eCAL::Registration::GetSubscriberIDs(subscriber_ids);
+
+      num_pub = publisher_ids.size();
+      num_sub = subscriber_ids.size();
 
       std::cout << "Registered publisher : " << num_pub << std::endl;
       std::cout << "Registered subscriber: " << num_sub << std::endl;
@@ -183,7 +189,8 @@ int main()
     // start time measurement
     auto start_time = std::chrono::high_resolution_clock::now();
 
-    const auto pub_ids = eCAL::Registration::GetPublisherIDs();
+    std::set<eCAL::STopicId> pub_ids;
+    eCAL::Registration::GetPublisherIDs(pub_ids);
     num_pub = pub_ids.size();
     for (const auto& id : pub_ids)
     {
@@ -200,7 +207,8 @@ int main()
   }
 
   // check creation events
-  const std::set<eCAL::STopicId> publisher_ids = eCAL::Registration::GetPublisherIDs();
+  std::set<eCAL::STopicId> publisher_ids;
+  eCAL::Registration::GetPublisherIDs(publisher_ids);
   std::cout << "Number of publisher creation events   " << created_publisher_num << std::endl;
   std::cout << "Size   of publisher creation id set   " << created_publisher_ids.size() << std::endl;
   //std::cout << "Publisher creation id sets are equal  " << (publisher_ids == created_publisher_ids) << std::endl;

--- a/ecal/samples/cpp/monitoring/monitoring_get_services/src/monitoring_get_services.cpp
+++ b/ecal/samples/cpp/monitoring/monitoring_get_services/src/monitoring_get_services.cpp
@@ -43,7 +43,7 @@ int main()
       start_time = std::chrono::steady_clock::now();
       for (run = 0; run < runs; ++run)
       {
-        server_method_id_set = eCAL::Registration::GetServerIDs();
+        eCAL::Registration::GetServerIDs(server_method_id_set);
       }
 
       auto num_services = server_method_id_set.size();

--- a/ecal/samples/cpp/monitoring/monitoring_get_topics/src/monitoring_get_topics.cpp
+++ b/ecal/samples/cpp/monitoring/monitoring_get_topics/src/monitoring_get_topics.cpp
@@ -48,26 +48,9 @@ int main()
         topic_id_sub_set = eCAL::Registration::GetSubscriberIDs();
       }
 
-      auto num_topics = topic_id_pub_set.size() + topic_id_sub_set.size();
+      auto num_entities = topic_id_pub_set.size() + topic_id_sub_set.size();
       auto diff_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time);
-      std::cout << "GetTopics      : " << static_cast<double>(diff_time.count()) / runs << " ms" << " (" << num_topics << " topics)" << std::endl;
-    }
-    std::this_thread::sleep_for(std::chrono::milliseconds(500));
-
-    // GetTopicNames
-    {
-      std::set<std::string> topic_names;
-
-      start_time = std::chrono::steady_clock::now();
-      for (run = 0; run < runs; ++run)
-      {
-        eCAL::Registration::GetTopicNames(topic_names);
-      }
-
-      auto num_topics = topic_names.size();
-      auto diff_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time);
-      std::cout << "GetTopicsNames : " << static_cast<double>(diff_time.count()) / runs << " ms" << " (" << num_topics << " topics)" << std::endl;
-      std::cout << std::endl;
+      std::cout << "GetTopics      : " << static_cast<double>(diff_time.count()) / runs << " ms" << " (" << num_entities << " entities)" << std::endl;
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
   }

--- a/ecal/samples/cpp/monitoring/monitoring_get_topics/src/monitoring_get_topics.cpp
+++ b/ecal/samples/cpp/monitoring/monitoring_get_topics/src/monitoring_get_topics.cpp
@@ -44,8 +44,8 @@ int main()
       start_time = std::chrono::steady_clock::now();
       for (run = 0; run < runs; ++run)
       {
-        topic_id_pub_set = eCAL::Registration::GetPublisherIDs();
-        topic_id_sub_set = eCAL::Registration::GetSubscriberIDs();
+        eCAL::Registration::GetPublisherIDs(topic_id_pub_set);
+        eCAL::Registration::GetSubscriberIDs(topic_id_pub_set);
       }
 
       auto num_entities = topic_id_pub_set.size() + topic_id_sub_set.size();

--- a/ecal/tests/cpp/registration_test_public/src/registration_getclients.cpp
+++ b/ecal/tests/cpp/registration_test_public/src/registration_getclients.cpp
@@ -55,6 +55,7 @@ protected:
 TEST_P(ClientsTestFixture, ClientExpiration)
 {
   std::set<eCAL::SServiceId> id_set;
+  bool get_client_ids_succeeded = false;
 
   // create simple client and let it expire
   {
@@ -71,7 +72,8 @@ TEST_P(ClientsTestFixture, ClientExpiration)
     eCAL::Process::SleepMS(2 * CMN_REGISTRATION_REFRESH_MS);
 
     // get all clients
-    id_set = eCAL::Registration::GetClientIDs();
+    get_client_ids_succeeded = eCAL::Registration::GetClientIDs(id_set);
+    EXPECT_TRUE(get_client_ids_succeeded) << "GetClientIDs call failed";
 
     // check size
     EXPECT_EQ(id_set.size(), 1);
@@ -90,7 +92,8 @@ TEST_P(ClientsTestFixture, ClientExpiration)
     eCAL::Process::SleepMS(CMN_MONITORING_TIMEOUT_MS);
 
     // get all clients again, client should not be expired
-    id_set = eCAL::Registration::GetClientIDs();
+    get_client_ids_succeeded = eCAL::Registration::GetClientIDs(id_set);
+    EXPECT_TRUE(get_client_ids_succeeded) << "GetClientIDs call failed";
 
     // check size
     EXPECT_EQ(id_set.size(), 1);
@@ -101,7 +104,8 @@ TEST_P(ClientsTestFixture, ClientExpiration)
 
   // get all clients again, all clients 
   // should be removed from the map
-  id_set = eCAL::Registration::GetClientIDs();
+  get_client_ids_succeeded = eCAL::Registration::GetClientIDs(id_set);
+  EXPECT_TRUE(get_client_ids_succeeded) << "GetClientIDs call failed";
 
   // check size
   EXPECT_EQ(id_set.size(), 0);
@@ -124,7 +128,9 @@ TEST_P(ClientsTestFixture, GetClientIDs)
     eCAL::Process::SleepMS(2 * CMN_REGISTRATION_REFRESH_MS);
 
     // get client
-    auto id_set = eCAL::Registration::GetClientIDs();
+    std::set<eCAL::SServiceId> id_set;
+    auto call_successful = eCAL::Registration::GetClientIDs(id_set);
+    EXPECT_TRUE(call_successful);
     EXPECT_EQ(1, id_set.size());
     if (id_set.size() > 0)
     {

--- a/ecal/tests/cpp/registration_test_public/src/registration_getpublisherids.cpp
+++ b/ecal/tests/cpp/registration_test_public/src/registration_getpublisherids.cpp
@@ -75,9 +75,11 @@ TEST_P(TestFixture, GetPublisherIDsReturnsCorrectNumber)
     eCAL::Process::SleepMS(2 * GetParam().configuration.registration.registration_refresh);
 
     // get the list of publisher IDs
-    const auto pub_ids1 = eCAL::Registration::GetPublisherIDs();
+    std::set<eCAL::STopicId> pub_ids1;
+    const auto get_publisher_ids_succeeded = eCAL::Registration::GetPublisherIDs(pub_ids1);
 
     // verify the number of publishers created
+    EXPECT_TRUE(get_publisher_ids_succeeded) << "GetPublisherIDs call failed";
     ASSERT_EQ(pub_ids1.size(), GetParam().publisher_count);
   }
 
@@ -85,9 +87,11 @@ TEST_P(TestFixture, GetPublisherIDsReturnsCorrectNumber)
   eCAL::Process::SleepMS(GetParam().configuration.registration.registration_timeout);
 
   // get the list of publisher IDs
-  const auto pub_ids2 = eCAL::Registration::GetPublisherIDs();
+  std::set<eCAL::STopicId> pub_ids2;
+  const auto get_publisher_ids_succeeded = eCAL::Registration::GetPublisherIDs(pub_ids2);
 
   // all publisher should be timeouted
+  EXPECT_TRUE(get_publisher_ids_succeeded) << "GetPublisherIDs call failed";
   ASSERT_EQ(pub_ids2.size(), 0);
 }
 

--- a/ecal/tests/cpp/registration_test_public/src/registration_getservices.cpp
+++ b/ecal/tests/cpp/registration_test_public/src/registration_getservices.cpp
@@ -56,6 +56,7 @@ protected:
 TEST_P(ServicesTestFixture, ServiceExpiration)
 {
   std::set<eCAL::SServiceId> id_set;
+  bool get_server_ids_succeeded = false;
 
   // create simple service and let it expire
   {
@@ -67,7 +68,8 @@ TEST_P(ServicesTestFixture, ServiceExpiration)
     eCAL::Process::SleepMS(2 * CMN_REGISTRATION_REFRESH_MS);
 
     // get all services
-    id_set = eCAL::Registration::GetServerIDs();
+    get_server_ids_succeeded = eCAL::Registration::GetServerIDs(id_set);
+    EXPECT_TRUE(get_server_ids_succeeded) << "GetServerIDs call failed";
 
     // check size
     EXPECT_EQ(id_set.size(), 1);
@@ -86,7 +88,8 @@ TEST_P(ServicesTestFixture, ServiceExpiration)
     eCAL::Process::SleepMS(CMN_MONITORING_TIMEOUT_MS);
 
     // get all services again, service should not be expired
-    id_set = eCAL::Registration::GetServerIDs();
+    get_server_ids_succeeded = eCAL::Registration::GetServerIDs(id_set);
+    EXPECT_TRUE(get_server_ids_succeeded) << "GetServerIDs call failed";
 
     // check size
     EXPECT_EQ(id_set.size(), 1);
@@ -97,7 +100,8 @@ TEST_P(ServicesTestFixture, ServiceExpiration)
 
   // get all services again, all services
   // should be removed from the map
-  id_set = eCAL::Registration::GetServerIDs();
+  get_server_ids_succeeded = eCAL::Registration::GetServerIDs(id_set);
+  EXPECT_TRUE(get_server_ids_succeeded) << "GetServerIDs call failed";
 
   // check size
   EXPECT_EQ(id_set.size(), 0);
@@ -123,8 +127,10 @@ TEST_P(ServicesTestFixture, GetServiceIDs)
     eCAL::Process::SleepMS(2 * CMN_REGISTRATION_REFRESH_MS);
 
     // get server
-    auto id_set = eCAL::Registration::GetServerIDs();
-    EXPECT_EQ(1, id_set.size());
+    std::set<eCAL::SServiceId> id_set;
+    const auto success = eCAL::Registration::GetServerIDs(id_set);
+    EXPECT_TRUE(success) << "GetServerIDs should be successfully executed";
+    EXPECT_EQ(1, id_set.size()) << "There should be 1 server in the system";
     if (id_set.size() > 0)
     {
       eCAL::ServiceMethodInformationSetT methods;

--- a/ecal/tests/cpp/registration_test_public/src/registration_getsubscriberids.cpp
+++ b/ecal/tests/cpp/registration_test_public/src/registration_getsubscriberids.cpp
@@ -75,9 +75,11 @@ TEST_P(TestFixture, GetSubscriberIDsReturnsCorrectNumber)
     eCAL::Process::SleepMS(2 * GetParam().configuration.registration.registration_refresh);
 
     // get the list of subscriber IDs
-    const auto sub_ids1 = eCAL::Registration::GetSubscriberIDs();
+    std::set<eCAL::STopicId> sub_ids1;
+    const bool call_successful = eCAL::Registration::GetSubscriberIDs(sub_ids1);
 
     // verify the number of subscribers created
+    ASSERT_TRUE(call_successful) << "GetSubscriberIDs returned false";
     ASSERT_EQ(sub_ids1.size(), GetParam().subscriber_count);
   }
 
@@ -85,9 +87,11 @@ TEST_P(TestFixture, GetSubscriberIDsReturnsCorrectNumber)
   eCAL::Process::SleepMS(2 * GetParam().configuration.registration.registration_timeout);
 
   // get the list of subscriber IDs
-  const auto sub_ids2 = eCAL::Registration::GetSubscriberIDs();
+  std::set<eCAL::STopicId> sub_ids2;
+  const bool call_successful = eCAL::Registration::GetSubscriberIDs(sub_ids2);
 
   // all subscriber should be timeouted
+  ASSERT_TRUE(call_successful) << "GetSubscriberIDs returned false";
   ASSERT_EQ(sub_ids2.size(), 0);
 }
 

--- a/ecal/tests/cpp/registration_test_public/src/registration_gettopics.cpp
+++ b/ecal/tests/cpp/registration_test_public/src/registration_gettopics.cpp
@@ -166,14 +166,12 @@ TEST(core_cpp_registration_public, GetTopicsParallel)
     size_t number_publishers_seen = 0;
     size_t max_number_publishers_seen = 0;
 
-    std::set<std::string> tmp_topic_names;
-    std::set<eCAL::STopicId> tmp_topic_ids;
+    std::set<eCAL::STopicId> tmp_publisher_ids;
 
     do {
-      eCAL::Registration::GetTopicNames(tmp_topic_names);
-      tmp_topic_ids = eCAL::Registration::GetPublisherIDs();
+      tmp_publisher_ids = eCAL::Registration::GetPublisherIDs();
 
-      number_publishers_seen = tmp_topic_names.size();
+      number_publishers_seen = tmp_publisher_ids.size();
       max_number_publishers_seen = std::max(max_number_publishers_seen, number_publishers_seen);
       std::this_thread::sleep_for(std::chrono::milliseconds(500));
     } while (!testing_completed);

--- a/ecal/tests/cpp/registration_test_public/src/registration_gettopics.cpp
+++ b/ecal/tests/cpp/registration_test_public/src/registration_gettopics.cpp
@@ -41,6 +41,8 @@ TEST(core_cpp_registration_public, GetTopics)
 
   std::set<eCAL::STopicId> topic_id_pub_set;
   std::set<eCAL::STopicId> topic_id_sub_set;
+  bool get_publisher_ids_succeeded;
+  bool get_subscriber_ids_succeeded;
 
   // create and check a few pub/sub entities
   {
@@ -64,7 +66,8 @@ TEST(core_cpp_registration_public, GetTopics)
     eCAL::Process::SleepMS(2 * CMN_REGISTRATION_REFRESH_MS);
 
     // get all publisher topics and check size
-    topic_id_pub_set = eCAL::Registration::GetPublisherIDs();
+    get_publisher_ids_succeeded = eCAL::Registration::GetPublisherIDs(topic_id_pub_set);
+    EXPECT_TRUE(get_publisher_ids_succeeded) << "GetPublisherIDs call failed";
     EXPECT_EQ(topic_id_pub_set.size(), 3);
 
     // check publisher types and descriptions
@@ -77,7 +80,8 @@ TEST(core_cpp_registration_public, GetTopics)
     }
 
     // get all subscriber topics and check size
-    topic_id_sub_set = eCAL::Registration::GetSubscriberIDs();
+    get_publisher_ids_succeeded = eCAL::Registration::GetSubscriberIDs(topic_id_sub_set);
+    EXPECT_TRUE(get_publisher_ids_succeeded) << "GetSubscriberIDs call failed";
     EXPECT_EQ(topic_id_sub_set.size(), 2);
 
     // check subscriber types and descriptions
@@ -93,11 +97,13 @@ TEST(core_cpp_registration_public, GetTopics)
     eCAL::Process::SleepMS(CMN_MONITORING_TIMEOUT_MS);
 
     // get all publisher topics and check size (should not be expired)
-    topic_id_pub_set = eCAL::Registration::GetPublisherIDs();
+    get_publisher_ids_succeeded = eCAL::Registration::GetPublisherIDs(topic_id_pub_set);
+    EXPECT_TRUE(get_publisher_ids_succeeded) << "GetPublisherIDs call failed";
     EXPECT_EQ(topic_id_pub_set.size(), 3);
 
     // get all subscriber topics and check size (should not be expired)
-    topic_id_sub_set = eCAL::Registration::GetSubscriberIDs();
+    get_subscriber_ids_succeeded = eCAL::Registration::GetSubscriberIDs(topic_id_sub_set);
+    EXPECT_TRUE(get_subscriber_ids_succeeded) << "GetSubscriberIDs call failed";
     EXPECT_EQ(topic_id_sub_set.size(), 2);
 
     // now destroy publisher pub1 and subscriber sub1
@@ -110,11 +116,13 @@ TEST(core_cpp_registration_public, GetTopics)
     eCAL::Process::SleepMS(2 * CMN_REGISTRATION_REFRESH_MS);
 
     // get all publisher topics and check size (pub1 should be expired)
-    topic_id_pub_set = eCAL::Registration::GetPublisherIDs();
+    get_publisher_ids_succeeded = eCAL::Registration::GetPublisherIDs(topic_id_pub_set);
+    EXPECT_TRUE(get_publisher_ids_succeeded) << "GetPublisherIDs call failed";
     EXPECT_EQ(topic_id_pub_set.size(), 2);
 
     // get all subscriber topics and check size (sub1 should be expired)
-    topic_id_sub_set = eCAL::Registration::GetSubscriberIDs();
+    get_subscriber_ids_succeeded = eCAL::Registration::GetSubscriberIDs(topic_id_sub_set);
+    EXPECT_TRUE(get_subscriber_ids_succeeded) << "GetSubscriberIDs call failed";
     EXPECT_EQ(topic_id_sub_set.size(), 1);
   }
 
@@ -122,11 +130,13 @@ TEST(core_cpp_registration_public, GetTopics)
   eCAL::Process::SleepMS(2 * CMN_REGISTRATION_REFRESH_MS);
 
   // get all publisher topics and check size (all publisher should be expired)
-  topic_id_pub_set = eCAL::Registration::GetPublisherIDs();
+  get_publisher_ids_succeeded = eCAL::Registration::GetPublisherIDs(topic_id_pub_set);
+  EXPECT_TRUE(get_publisher_ids_succeeded) << "GetPublisherIDs call failed";
   EXPECT_EQ(topic_id_pub_set.size(), 0);
 
   // get all subscriber topics and check size (all subscriber should be expired)
-  topic_id_sub_set = eCAL::Registration::GetSubscriberIDs();
+  get_subscriber_ids_succeeded = eCAL::Registration::GetSubscriberIDs(topic_id_sub_set);
+  EXPECT_TRUE(get_subscriber_ids_succeeded) << "GetSubscriberIDs call failed";
   EXPECT_EQ(topic_id_sub_set.size(), 0);
 
   // finalize eCAL API
@@ -169,7 +179,8 @@ TEST(core_cpp_registration_public, GetTopicsParallel)
     std::set<eCAL::STopicId> tmp_publisher_ids;
 
     do {
-      tmp_publisher_ids = eCAL::Registration::GetPublisherIDs();
+      std::set<eCAL::STopicId> tmp_publisher_ids;
+      eCAL::Registration::GetPublisherIDs(tmp_publisher_ids);
 
       number_publishers_seen = tmp_publisher_ids.size();
       max_number_publishers_seen = std::max(max_number_publishers_seen, number_publishers_seen);

--- a/lang/python/core/src/ecal_clang.cpp
+++ b/lang/python/core/src/ecal_clang.cpp
@@ -48,8 +48,10 @@ namespace
 
   bool GetTopicDataTypeInformation(const char* topic_name_, eCAL::SDataTypeInformation& topic_info_)
   {
+    std::set<eCAL::STopicId> pub_ids;
+    eCAL::Registration::GetPublisherIDs(pub_ids);
     // try to find topic name in publisher set
-    for (const auto& pub_id : eCAL::Registration::GetPublisherIDs())
+    for (const auto& pub_id : pub_ids)
     {
       if (pub_id.topic_name == topic_name_)
       {
@@ -57,7 +59,8 @@ namespace
       }
     }
     // try to find topic name in subscriber set
-    const auto& sub_ids = eCAL::Registration::GetSubscriberIDs();
+    std::set<eCAL::STopicId> sub_ids;
+    eCAL::Registration::GetSubscriberIDs(sub_ids);
     for (const auto& sub_id : sub_ids)
     {
       if (sub_id.topic_name == topic_name_)

--- a/serialization/protobuf/samples/services/ping_client_dyn/src/ping_client_dyn.cpp
+++ b/serialization/protobuf/samples/services/ping_client_dyn/src/ping_client_dyn.cpp
@@ -51,7 +51,9 @@ int main()
   std::string req_desc;
   std::string resp_type;
   std::string resp_desc;
-  auto service_ids = eCAL::Registration::GetServerIDs();
+
+  std::set<eCAL::SServiceId> service_ids;
+  eCAL::Registration::GetServerIDs(service_ids);
   bool service_info_found(false);
   for (const auto& service_id : service_ids)
   {


### PR DESCRIPTION
Please see if you like the naming.
To be more in line with the functions for service / client, the function was split into two separate functions.