### PR TITLE
[core] removed "abc" as default ecal yaml file path.

### DIFF
--- a/ecal/core/include/ecal/config/configuration.h
+++ b/ecal/core/include/ecal/config/configuration.h
@@ -61,6 +61,6 @@ namespace eCAL
     ECAL_API std::string GetConfigurationFilePath() const;
 
     protected:
-      std::string ecal_yaml_file_path = "abc";
+      std::string ecal_yaml_file_path;
   };
 }


### PR DESCRIPTION
That string was probably added by accident