### PR TITLE
[Topic] Remove remove user defined attributes for topics

### DIFF
--- a/app/mon/mon_tui/src/model/monitor.hpp
+++ b/app/mon/mon_tui/src/model/monitor.hpp
@@ -216,14 +216,6 @@ class MonitorModel
       topic.data_id = t.data_id();
       topic.data_clock = t.data_clock();
       topic.data_frequency = t.data_frequency();
-      for(auto &attr: *t.mutable_attr())
-      {
-        topic.attributes.emplace(
-          std::pair<std::string, std::string>(
-            std::move(attr.first), std::move(attr.second)
-          )
-        );
-      }
     }
 
     for(auto &s: *mon_.mutable_services())

--- a/ecal/core/include/ecal/types/monitoring.h
+++ b/ecal/core/include/ecal/types/monitoring.h
@@ -92,8 +92,6 @@ namespace eCAL
       int64_t                             data_id{0};              //!< data send id (publisher setid)
       int64_t                             data_clock{0};           //!< data clock (send / receive action)
       int32_t                             data_frequency{0};       //!< data frequency (send / receive samples per second) [mHz]
-
-      std::map<std::string, std::string>  attr;                    //!< generic topic description
     };
 
     struct SProcessMon                                             //<! eCAL Process struct

--- a/ecal/core/src/monitoring/ecal_monitoring_impl.cpp
+++ b/ecal/core/src/monitoring/ecal_monitoring_impl.cpp
@@ -189,7 +189,6 @@ namespace eCAL
       std::string topic_datatype_encoding = sample_topic.datatype_information.encoding;
       std::string topic_datatype_name     = sample_topic.datatype_information.name;
       std::string topic_datatype_desc     = sample_topic.datatype_information.descriptor;
-      auto        attr                    = sample_topic.attr;
 
       // try to get topic info
       const auto& topic_map_key  = topic_id;
@@ -210,9 +209,6 @@ namespace eCAL
       TopicInfo.datatype_information.encoding   = std::move(topic_datatype_encoding);
       TopicInfo.datatype_information.name       = std::move(topic_datatype_name);
       TopicInfo.datatype_information.descriptor = std::move(topic_datatype_desc);
-
-      // attributes
-      TopicInfo.attr = std::map<std::string, std::string>{attr.begin(), attr.end()};
 
       // layer
       TopicInfo.transport_layer.clear();

--- a/ecal/core/src/pubsub/ecal_publisher_impl.cpp
+++ b/ecal/core/src/pubsub/ecal_publisher_impl.cpp
@@ -346,26 +346,24 @@ namespace eCAL
     return(true);
   }
 
-  bool CPublisherImpl::SetAttribute(const std::string& attr_name_, const std::string& attr_value_)
+  bool CPublisherImpl::SetAttribute(const std::string& /* attr_name_ */_, const std::string& /* attr_value_ */)
   {
-    m_attr[attr_name_] = attr_value_;
-
 #ifndef NDEBUG
     Logging::Log(Logging::log_level_debug2, m_attributes.topic_name + "::CPublisherImpl::SetAttribute");
 #endif
-
-    return(true);
+    Logging::Log(Logging::log_level_warning, m_attributes.topic_name + "::CPublisherImpl::SetAttribute - Setting publisher attributes no longer has an effect.");
+    
+    return(false);
   }
 
-  bool CPublisherImpl::ClearAttribute(const std::string& attr_name_)
+  bool CPublisherImpl::ClearAttribute(const std::string& /* attr_name_ */)
   {
-    m_attr.erase(attr_name_);
-
 #ifndef NDEBUG
     Logging::Log(Logging::log_level_debug2, m_attributes.topic_name + "::CPublisherImpl::ClearAttribute");
 #endif
+    Logging::Log(Logging::log_level_warning, m_attributes.topic_name + "::CPublisherImpl::ClearAttribute - Clear publisher attributes no longer has an effect.");
 
-    return(true);
+    return(false);
   }
 
   bool CPublisherImpl::SetEventCallback(ePublisherEvent type_, const v5::PubEventCallbackT callback_)
@@ -640,7 +638,6 @@ namespace eCAL
       ecal_reg_sample_tdatatype.name       = m_topic_info.name;
       ecal_reg_sample_tdatatype.descriptor = m_topic_info.descriptor;
     }
-    ecal_reg_sample_topic.attr  = m_attr;
     ecal_reg_sample_topic.topic_size = static_cast<int32_t>(m_topic_size);
 
 #if ECAL_CORE_TRANSPORT_UDP

--- a/ecal/core/src/pubsub/ecal_publisher_impl.h
+++ b/ecal/core/src/pubsub/ecal_publisher_impl.h
@@ -144,7 +144,6 @@ namespace eCAL
 
     EntityIdT                m_topic_id;
     SDataTypeInformation                   m_topic_info;
-    std::map<std::string, std::string>     m_attr;
     size_t                                 m_topic_size = 0;
     eCAL::eCALWriter::SAttributes          m_attributes;
 

--- a/ecal/core/src/pubsub/ecal_subscriber_impl.cpp
+++ b/ecal/core/src/pubsub/ecal_subscriber_impl.cpp
@@ -266,26 +266,26 @@ namespace eCAL
     return true;
   }
 
-  bool CSubscriberImpl::SetAttribute(const std::string& attr_name_, const std::string& attr_value_)
+  bool CSubscriberImpl::SetAttribute(const std::string& /* attr_name_ */, const std::string& /* attr_value_ */)
   {
 #ifndef NDEBUG
     Logging::Log(Logging::log_level_debug2, m_attributes.topic_name + "::CSubscriberImpl::SetAttribute");
 #endif
 
-    m_attr[attr_name_] = attr_value_;
+    Logging::Log(Logging::log_level_warning, m_attributes.topic_name + "::CSubscriberImpl::SetAttribute - Setting subscriber attributes no longer has an effect.");
 
-    return(true);
+    return(false);
   }
 
-  bool CSubscriberImpl::ClearAttribute(const std::string& attr_name_)
+  bool CSubscriberImpl::ClearAttribute(const std::string& /* attr_name_ */)
   {
 #ifndef NDEBUG
     Logging::Log(Logging::log_level_debug2, m_attributes.topic_name + "::CSubscriberImpl::ClearAttribute");
 #endif
 
-    m_attr.erase(attr_name_);
+    Logging::Log(Logging::log_level_warning, m_attributes.topic_name + "::CSubscriberImpl::ClearAttribute - Clear subscriber attributes no longer has an effect.");
 
-    return(true);
+    return(false);
   }
 
   void CSubscriberImpl::SetFilterIDs(const std::set<long long>& filter_ids_)
@@ -640,7 +640,6 @@ namespace eCAL
       ecal_reg_sample_tdatatype.name       = m_topic_info.name;
       ecal_reg_sample_tdatatype.descriptor = m_topic_info.descriptor;
     }
-    ecal_reg_sample_topic.attr  = m_attr;
     ecal_reg_sample_topic.topic_size = static_cast<int32_t>(m_topic_size);
 
 #if ECAL_CORE_TRANSPORT_UDP

--- a/ecal/core/src/pubsub/ecal_subscriber_impl.h
+++ b/ecal/core/src/pubsub/ecal_subscriber_impl.h
@@ -136,7 +136,6 @@ namespace eCAL
 
     EntityIdT                   m_topic_id;
     SDataTypeInformation                      m_topic_info;
-    std::map<std::string, std::string>        m_attr;
     std::atomic<size_t>                       m_topic_size;
 
     struct SConnection

--- a/ecal/core/src/serialization/ecal_serialize_common.cpp
+++ b/ecal/core/src/serialization/ecal_serialize_common.cpp
@@ -179,69 +179,6 @@ namespace eCAL
     }
 
     ///////////////////////////////////////////////
-    // map<string,string>
-    ///////////////////////////////////////////////
-    bool encode_map_field(pb_ostream_t* stream, const pb_field_iter_t* field, void* const* arg)
-    {
-      if (arg == nullptr)  return false;
-      if (*arg == nullptr) return false;
-
-      auto* attr_map = static_cast<std::map<std::string, std::string>*>(*arg);
-      for (const auto& iter : *attr_map)
-      {
-        if (!pb_encode_tag_for_field(stream, field))
-        {
-          return false;
-        }
-
-        eCAL_pb_Topic_AttrEntry pb_attr_map = eCAL_pb_Topic_AttrEntry_init_default;
-        encode_string(pb_attr_map.key, iter.first);
-        encode_string(pb_attr_map.value, iter.second);
-
-        if (!pb_encode_submessage(stream, eCAL_pb_Topic_AttrEntry_fields, &pb_attr_map))
-        {
-          return false;
-        }
-      }
-
-      return true;
-    }
-
-    void encode_map(pb_callback_t& pb_callback, const std::map<std::string, std::string>& str_map)
-    {
-      pb_callback.funcs.encode = &encode_map_field; // NOLINT(*-pro-type-union-access)
-      pb_callback.arg = (void*)(&str_map);
-    }
-
-    bool decode_map_field(pb_istream_t* stream, const pb_field_iter_t* /*field*/, void** arg)
-    {
-      if (arg == nullptr)  return false;
-      if (*arg == nullptr) return false;
-
-      eCAL_pb_Topic_AttrEntry attr_entry = eCAL_pb_Topic_AttrEntry_init_default;
-      std::string key;
-      std::string value;
-      decode_string(attr_entry.key, key);
-      decode_string(attr_entry.value, value);
-
-      if (!pb_decode(stream, eCAL_pb_Topic_AttrEntry_fields, &attr_entry))
-      {
-        return false;
-      }
-
-      auto* tgt_map = static_cast<std::map<std::string, std::string>*>(*arg);
-      (*tgt_map)[key] = value;
-
-      return true;
-    }
-
-    void decode_map(pb_callback_t& pb_callback, std::map<std::string, std::string>& str_map)
-    {
-      pb_callback.funcs.decode = &decode_map_field; // NOLINT(*-pro-type-union-access)
-      pb_callback.arg = &str_map;
-    }
-
-    ///////////////////////////////////////////////
     // list<string>
     ///////////////////////////////////////////////
     bool encode_string_vector_field(pb_ostream_t* stream, const pb_field_iter_t* field, void* const* arg)

--- a/ecal/core/src/serialization/ecal_serialize_monitoring.cpp
+++ b/ecal/core/src/serialization/ecal_serialize_monitoring.cpp
@@ -189,8 +189,6 @@ namespace
     pb_topic_.data_frequency = topic_.data_frequency;
     // transport_layer
     encode_mon_registration_layer(pb_topic_.transport_layer, topic_.transport_layer);
-    // attr
-    eCAL::nanopb::encode_map(pb_topic_.attr, topic_.attr);
   }
 
   bool encode_mon_message_topics_field(pb_ostream_t* stream, const pb_field_iter_t* field, void* const* arg)
@@ -628,8 +626,6 @@ namespace
     eCAL::nanopb::decode_string(pb_topic_.datatype_information.descriptor_information, topic_.datatype_information.descriptor);
     // transport_layer
     decode_mon_registration_layer(pb_topic_.transport_layer, topic_.transport_layer);
-    // attr
-    eCAL::nanopb::decode_map(pb_topic_.attr, topic_.attr);
   }
 
   void AssignValues(const eCAL_pb_Topic& pb_topic_, eCAL::Monitoring::STopicMon& topic_)

--- a/ecal/core/src/serialization/ecal_serialize_sample_registration.cpp
+++ b/ecal/core/src/serialization/ecal_serialize_sample_registration.cpp
@@ -192,8 +192,6 @@ namespace
     pb_topic_.data_frequency = registration_topic_.data_frequency;
     // transport_layer
     eCAL::nanopb::encode_registration_layer(pb_topic_.transport_layer, registration_topic_.transport_layer);
-    // attr
-    eCAL::nanopb::encode_map(pb_topic_.attr, registration_topic_.attr);
   }
 
   /////////////////////////////////////////////////////////////////////////////////
@@ -392,8 +390,6 @@ namespace
     eCAL::nanopb::decode_string(pb_sample_.topic.datatype_information.descriptor_information, registration_.topic.datatype_information.descriptor);
     // transport_layer
     eCAL::nanopb::decode_registration_layer(pb_sample_.topic.transport_layer, registration_.topic.transport_layer);
-    // attr
-    eCAL::nanopb::decode_map(pb_sample_.topic.attr, registration_.topic.attr);
   }
 
   void AssignValues(const eCAL_pb_Sample& pb_sample_, eCAL::Registration::Sample& registration_)

--- a/ecal/core/src/serialization/ecal_struct_sample_registration.h
+++ b/ecal/core/src/serialization/ecal_struct_sample_registration.h
@@ -278,7 +278,6 @@ namespace eCAL
       int64_t                             data_clock = 0;               // data clock (send / receive action)
       int32_t                             data_frequency  = 0;                   // data frequency (send / receive registrations per second) [mHz]
 
-      std::map<std::string, std::string>  attr;                         // generic topic description
 
       bool operator==(const Topic& other) const {
         return registration_clock == other.registration_clock &&
@@ -295,8 +294,7 @@ namespace eCAL
           message_drops == other.message_drops &&
           data_id == other.data_id &&
           data_clock == other.data_clock &&
-          data_frequency == other.data_frequency &&
-          attr == other.attr;
+          data_frequency == other.data_frequency;
       }
 
       void clear()
@@ -319,8 +317,6 @@ namespace eCAL
         data_id = 0;
         data_clock = 0;
         data_frequency = 0;
-
-        attr.clear();
       }
     };
 

--- a/ecal/core/src/serialization/nanopb/ecal/core/pb/topic.npb.c
+++ b/ecal/core/src/serialization/nanopb/ecal/core/pb/topic.npb.c
@@ -6,10 +6,7 @@
 #error Regenerate this file with the current version of nanopb generator.
 #endif
 
-PB_BIND(eCAL_pb_Topic, eCAL_pb_Topic, 2)
-
-
-PB_BIND(eCAL_pb_Topic_AttrEntry, eCAL_pb_Topic_AttrEntry, AUTO)
+PB_BIND(eCAL_pb_Topic, eCAL_pb_Topic, AUTO)
 
 
 

--- a/ecal/core/src/serialization/nanopb/ecal/core/pb/topic.npb.h
+++ b/ecal/core/src/serialization/nanopb/ecal/core/pb/topic.npb.h
@@ -30,7 +30,6 @@ typedef struct _eCAL_pb_Topic { /* Reserved fields in enums are not supported in
     int64_t data_id; /* data send id (publisher setid) */
     int64_t data_clock; /* data clock (send / receive action) */
     int32_t data_frequency; /* data frequency (send / receive samples per second) [mHz] */
-    pb_callback_t attr; /* generic topic description */
     pb_callback_t shm_transport_domain; /* shm_transport_domain */
     /* 9 = topic type + topic encoding (deprecated)
  10 = topic description (protocol descriptor) (deprecated) */
@@ -38,21 +37,14 @@ typedef struct _eCAL_pb_Topic { /* Reserved fields in enums are not supported in
     eCAL_pb_DataTypeInformation datatype_information; /* topic datatype information (encoding & type & description) */
 } eCAL_pb_Topic;
 
-typedef struct _eCAL_pb_Topic_AttrEntry {
-    pb_callback_t key;
-    pb_callback_t value;
-} eCAL_pb_Topic_AttrEntry;
-
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /* Initializer values for message structs */
-#define eCAL_pb_Topic_init_default               {0, {{NULL}, NULL}, 0, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, 0, 0, 0, 0, 0, 0, 0, {{NULL}, NULL}, {{NULL}, NULL}, false, eCAL_pb_DataTypeInformation_init_default}
-#define eCAL_pb_Topic_AttrEntry_init_default     {{{NULL}, NULL}, {{NULL}, NULL}}
-#define eCAL_pb_Topic_init_zero                  {0, {{NULL}, NULL}, 0, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, 0, 0, 0, 0, 0, 0, 0, {{NULL}, NULL}, {{NULL}, NULL}, false, eCAL_pb_DataTypeInformation_init_zero}
-#define eCAL_pb_Topic_AttrEntry_init_zero        {{{NULL}, NULL}, {{NULL}, NULL}}
+#define eCAL_pb_Topic_init_default               {0, {{NULL}, NULL}, 0, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, 0, 0, 0, 0, 0, 0, 0, {{NULL}, NULL}, false, eCAL_pb_DataTypeInformation_init_default}
+#define eCAL_pb_Topic_init_zero                  {0, {{NULL}, NULL}, 0, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, {{NULL}, NULL}, 0, 0, 0, 0, 0, 0, 0, {{NULL}, NULL}, false, eCAL_pb_DataTypeInformation_init_zero}
 
 /* Field tags (for use in manual encoding/decoding) */
 #define eCAL_pb_Topic_registration_clock_tag     1
@@ -71,11 +63,8 @@ extern "C" {
 #define eCAL_pb_Topic_data_id_tag                19
 #define eCAL_pb_Topic_data_clock_tag             20
 #define eCAL_pb_Topic_data_frequency_tag         21
-#define eCAL_pb_Topic_attr_tag                   27
 #define eCAL_pb_Topic_shm_transport_domain_tag   28
 #define eCAL_pb_Topic_datatype_information_tag   30
-#define eCAL_pb_Topic_AttrEntry_key_tag          1
-#define eCAL_pb_Topic_AttrEntry_value_tag        2
 
 /* Struct field encoding specification for nanopb */
 #define eCAL_pb_Topic_FIELDLIST(X, a) \
@@ -95,31 +84,20 @@ X(a, STATIC,   SINGULAR, INT32,    message_drops,    18) \
 X(a, STATIC,   SINGULAR, INT64,    data_id,          19) \
 X(a, STATIC,   SINGULAR, INT64,    data_clock,       20) \
 X(a, STATIC,   SINGULAR, INT32,    data_frequency,   21) \
-X(a, CALLBACK, REPEATED, MESSAGE,  attr,             27) \
 X(a, CALLBACK, SINGULAR, STRING,   shm_transport_domain,  28) \
 X(a, STATIC,   OPTIONAL, MESSAGE,  datatype_information,  30)
 #define eCAL_pb_Topic_CALLBACK pb_default_field_callback
 #define eCAL_pb_Topic_DEFAULT NULL
 #define eCAL_pb_Topic_transport_layer_MSGTYPE eCAL_pb_TransportLayer
-#define eCAL_pb_Topic_attr_MSGTYPE eCAL_pb_Topic_AttrEntry
 #define eCAL_pb_Topic_datatype_information_MSGTYPE eCAL_pb_DataTypeInformation
 
-#define eCAL_pb_Topic_AttrEntry_FIELDLIST(X, a) \
-X(a, CALLBACK, SINGULAR, STRING,   key,               1) \
-X(a, CALLBACK, SINGULAR, STRING,   value,             2)
-#define eCAL_pb_Topic_AttrEntry_CALLBACK pb_default_field_callback
-#define eCAL_pb_Topic_AttrEntry_DEFAULT NULL
-
 extern const pb_msgdesc_t eCAL_pb_Topic_msg;
-extern const pb_msgdesc_t eCAL_pb_Topic_AttrEntry_msg;
 
 /* Defines for backwards compatibility with code written before nanopb-0.4.0 */
 #define eCAL_pb_Topic_fields &eCAL_pb_Topic_msg
-#define eCAL_pb_Topic_AttrEntry_fields &eCAL_pb_Topic_AttrEntry_msg
 
 /* Maximum encoded size of messages (where known) */
 /* eCAL_pb_Topic_size depends on runtime parameters */
-/* eCAL_pb_Topic_AttrEntry_size depends on runtime parameters */
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/ecal/core_pb/src/ecal/core/pb/topic.proto
+++ b/ecal/core_pb/src/ecal/core/pb/topic.proto
@@ -50,8 +50,6 @@ message Topic                                      // eCAL topic
   int32               message_drops         = 18;  // dropped messages
                       
   int64               data_id               = 19;  // data send id (publisher setid)
-  int64               data_clock                = 20;  // data clock (send / receive action)
-  int32               data_frequency                 = 21;  // data frequency (send / receive samples per second) [mHz]
-
-  map<string, string> attr                  = 27;  // generic topic description
+  int64               data_clock            = 20;  // data clock (send / receive action)
+  int32               data_frequency        = 21;  // data frequency (send / receive samples per second) [mHz]
 }

--- a/ecal/core_pb/src/ecal/core/pb/topic.proto
+++ b/ecal/core_pb/src/ecal/core/pb/topic.proto
@@ -52,4 +52,6 @@ message Topic                                      // eCAL topic
   int64               data_id               = 19;  // data send id (publisher setid)
   int64               data_clock            = 20;  // data clock (send / receive action)
   int32               data_frequency        = 21;  // data frequency (send / receive samples per second) [mHz]
+
+  reserved 27;                                     // previously "attr" for generic topic description
 }

--- a/ecal/tests/cpp/serialization_test/src/monitoring_compare.cpp
+++ b/ecal/tests/cpp/serialization_test/src/monitoring_compare.cpp
@@ -84,8 +84,7 @@ namespace eCAL
           monitoring1.publisher[i].message_drops != monitoring2.publisher[i].message_drops ||
           monitoring1.publisher[i].data_id != monitoring2.publisher[i].data_id ||
           monitoring1.publisher[i].data_clock != monitoring2.publisher[i].data_clock ||
-          monitoring1.publisher[i].data_frequency != monitoring2.publisher[i].data_frequency ||
-          monitoring1.publisher[i].attr != monitoring2.publisher[i].attr)
+          monitoring1.publisher[i].data_frequency != monitoring2.publisher[i].data_frequency)
         {
           return false;
         }
@@ -116,8 +115,7 @@ namespace eCAL
           monitoring1.subscriber[i].message_drops != monitoring2.subscriber[i].message_drops ||
           monitoring1.subscriber[i].data_id != monitoring2.subscriber[i].data_id ||
           monitoring1.subscriber[i].data_clock != monitoring2.subscriber[i].data_clock ||
-          monitoring1.subscriber[i].data_frequency != monitoring2.subscriber[i].data_frequency ||
-          monitoring1.subscriber[i].attr != monitoring2.subscriber[i].attr)
+          monitoring1.subscriber[i].data_frequency != monitoring2.subscriber[i].data_frequency)
         {
           return false;
         }


### PR DESCRIPTION
### Description
Remove user defined attributes for topics. This includes also removing any functionality in the publisher/subscriber v5 implementation, where these interface calls still exist. They will now log a warning, that this has no impact anymore.

In v6 this already is phased out.
