### PR TITLE
[ecal_sys] Fix for startup bug when applications are not callable

### DIFF
--- a/app/sys/sys_core/src/connection/remote_connection.cpp
+++ b/app/sys/sys_core/src/connection/remote_connection.cpp
@@ -128,7 +128,14 @@ namespace eCAL
       std::lock_guard<decltype(connection_mutex_)> connection_lock(connection_mutex_);
 
       eCAL::v5::ServiceResponseVecT service_response_vec;
-      constexpr int timeout_ms = 1000;
+      
+      // We changed timeout value, as with the new v6 implementation the behaviour changed.
+      // Now, when there are applications in the list that are not available/cannot be called,
+      // all apps on this host become failed, however if the app was reachable, it was started.
+      // The -1 prevents this from happening, so the call gets recognized for each application
+      // as expected.
+      // Timeout happens in ecal_service_client_impl.cpp in method CallMethodWithTimeout(...).
+      constexpr int timeout_ms = -1;
 
       // After client creation it takes some time for the client to be actually connected.
       // As the call and the creation is too close together, the first call will fail.


### PR DESCRIPTION
### Description
When starting applications in ecal_sys, it happens that if an application is not available on the host, all other applications that are available on the host are shown as "failed". But they are proper started. You can find and close them through the cloud search.

The problem is, that all calls timeout when setting the timeout parameter too low. With this fix, the timeout is set to infinite, so the call will happen, while the calls to the missing application are proper recognized as "failed".

Increasing this timeout to 6-7 seconds also had the wanted effect.

This seems to be a fix for a symptom, not the cause. As this whole handling needs to be changed to the v6 implementation, it might be different then and for right now we will get the wanted behaviour with this fix.
