### PR TITLE
[core] remove function declaration without implementation

### DIFF
--- a/ecal/core/include/ecal/config.h
+++ b/ecal/core/include/ecal/config.h
@@ -95,13 +95,6 @@ namespace eCAL
     /////////////////////////////////////
 
     ECAL_API std::string              GetEcalSysFilterExcludeList          ();
-
-    /////////////////////////////////////
-    // publisher
-    /////////////////////////////////////
-    
-    ECAL_API bool                     IsTopicTypeSharingEnabled            ();
-    ECAL_API bool                     IsTopicDescriptionSharingEnabled     ();
     
     /////////////////////////////////////
     // subscriber


### PR DESCRIPTION
The implementation was removed in a previous PR.

### Description
Sorry, this was a clear oversight on my side, the declaration should have been removed earlier.
