### PR TITLE
fix[cmake]: Remove thirdparty build options from presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -51,14 +51,7 @@
         "ECAL_BUILD_APPS": "OFF",
         "ECAL_BUILD_SAMPLES": "OFF",
         "ECAL_CORE_CONFIGURATION": "OFF",
-        "ECAL_INSTALL_SAMPLE_SOURCES": "OFF",
-        "ECAL_THIRDPARTY_BUILD_FINEFTP": "OFF",
-        "ECAL_THIRDPARTY_BUILD_FTXUI": "OFF",
-        "ECAL_THIRDPARTY_BUILD_SPDLOG": "OFF",
-        "ECAL_THIRDPARTY_BUILD_TERMCOLOR": "OFF",
-        "ECAL_THIRDPARTY_BUILD_TINYXML2": "OFF",
-        "ECAL_THIRDPARTY_BUILD_CURL": "OFF",
-        "ECAL_THIRDPARTY_BUILD_HDF5": "OFF"
+        "ECAL_INSTALL_SAMPLE_SOURCES": "OFF"
       }
     },
     {
@@ -69,8 +62,7 @@
       "cacheVariables": {
         "ECAL_USE_HDF5": "ON",
         "ECAL_BUILD_PY_BINDING": "ON",
-        "BUILD_SHARED": "OFF",
-        "ECAL_THIRDPARTY_BUILD_HDF5": "ON"
+        "BUILD_SHARED": "OFF"
       }
     },
     {
@@ -92,14 +84,7 @@
         "ECAL_USE_CURL": "ON",
         "ECAL_USE_FTXUI": "ON",
         "ECAL_BUILD_APPS": "ON",
-        "ECAL_BUILD_SAMPLES": "ON",
-        "ECAL_THIRDPARTY_BUILD_FINEFTP": "ON",
-        "ECAL_THIRDPARTY_BUILD_FTXUI": "ON",
-        "ECAL_THIRDPARTY_BUILD_SPDLOG": "ON",
-        "ECAL_THIRDPARTY_BUILD_TERMCOLOR": "ON",
-        "ECAL_THIRDPARTY_BUILD_TINYXML2": "ON",
-        "ECAL_THIRDPARTY_BUILD_CURL": null,
-        "ECAL_THIRDPARTY_BUILD_HDF5": null
+        "ECAL_BUILD_SAMPLES": "ON"
       }
     },
     {


### PR DESCRIPTION
### Description
<!-- What does your PR change? -->
Removes all the explicit CMake options to disable building from the submodules. With the submodule dependency provider dependencies are only pulled into the build when needed and are excluded from all anyway. They were only disabling unused dependencies.

This fixes usage of the presets on Windows where curl and hdf5 weren't being set (was relying on logic that got deleted in the transition)

### Related issues
<!-- Type "Fixes #123" to automatically close that issue, when this PR is merged -->
- Me trying to build on Windows with the preset and it not working...

### Cherry-pick to
<!-- Leave empty, if you don't know. For master-only changes use "none"
- _none_
- 5.11 (old stable)
- 5.12 (current stable)
-->
