### PR TITLE
[cmake]: Disable unwanted curl options and put missed targets in correct IDE folder

### DIFF
--- a/thirdparty/curl/build-curl.cmake
+++ b/thirdparty/curl/build-curl.cmake
@@ -5,7 +5,11 @@ if(WIN32)
 endif()
 
 set(BUILD_CURL_EXE OFF CACHE BOOL "Don't build the curl executable" FORCE)
-set(ENABLE_MANUAL  OFF CACHE BOOL "Disable built-in manual" FORCE)
+set(ENABLE_CURL_MANUAL  OFF CACHE BOOL "Disable built-in manual" FORCE)
+set(PICKY_COMPILER  OFF CACHE BOOL "Disable extra compiler options" FORCE)
+set(BUILD_LIBCURL_DOCS  OFF CACHE BOOL "Disable libcurl man pages" FORCE)
+set(BUILD_MISC_DOCS  OFF CACHE BOOL "Disable misc man pages" FORCE)
+set(BUILD_EXAMPLES  OFF CACHE BOOL "Disable curl examples" FORCE)
 
 ecal_disable_all_warnings()
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/curl thirdparty/curl EXCLUDE_FROM_ALL SYSTEM)

--- a/thirdparty/curl/build-curl.cmake
+++ b/thirdparty/curl/build-curl.cmake
@@ -11,6 +11,9 @@ set(BUILD_LIBCURL_DOCS  OFF CACHE BOOL "Disable libcurl man pages" FORCE)
 set(BUILD_MISC_DOCS  OFF CACHE BOOL "Disable misc man pages" FORCE)
 set(BUILD_EXAMPLES  OFF CACHE BOOL "Disable curl examples" FORCE)
 
+# All targets made by curl will go in the correct IDE folder
+set(CMAKE_FOLDER "thirdparty/curl")
+
 ecal_disable_all_warnings()
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/curl thirdparty/curl EXCLUDE_FROM_ALL SYSTEM)
 ecal_restore_warning_level()

--- a/thirdparty/yaml-cpp/build-yaml-cpp.cmake
+++ b/thirdparty/yaml-cpp/build-yaml-cpp.cmake
@@ -5,5 +5,9 @@ set(YAML_MSVC_SHARED_RT ON CACHE BOOL "My option" FORCE)
 set(YAML_BUILD_SHARED_LIBS OFF CACHE BOOL "My option" FORCE)
 set(YAML_CPP_BUILD_TOOLS OFF CACHE BOOL "My option" FORCE)
 set(YAML_CPP_BUILD_CONTRIB OFF CACHE BOOL "My option" FORCE)
+
+# All targets made by yaml-cpp (including the uninstall target) will go in
+# the correct IDE folder
+set(CMAKE_FOLDER "thirdparty/yaml-cpp")
+
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/yaml-cpp thirdparty/yaml-cpp EXCLUDE_FROM_ALL SYSTEM)
-set_property(TARGET yaml-cpp PROPERTY FOLDER thirdparty/yaml-cpp)


### PR DESCRIPTION
### Description
<!-- What does your PR change? -->
Disables many curl targets from being generated and places missed thirdparty targets (just curl and yaml-cpp) into the correct IDE folder. (`CMAKE_FOLDER sets the default value for the `FOLDER` property)

### Related issues
<!-- Type "Fixes #123" to automatically close that issue, when this PR is merged -->
- Visual studio CMake targets list being filled with junk from curl.

### Cherry-pick to
<!-- Leave empty, if you don't know. For master-only changes use "none"
- _none_
- 5.11 (old stable)
- 5.12 (current stable)
-->
