### PR TITLE
[cmake] Remove need for `CMAKE_FIND_PACKAGE_PREFER_CONFIG`

### DIFF
--- a/cmake/eCALConfig.cmake.in
+++ b/cmake/eCALConfig.cmake.in
@@ -30,7 +30,13 @@ set(eCAL_VERSION_STRING @eCAL_VERSION_STRING@)
 set(CMAKE_MAP_IMPORTED_CONFIG_MINSIZEREL Release "")
 set(CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO Release "")
 
-find_package(Protobuf REQUIRED)
+# Try and find protobuf in Config mode first
+# (Primarily for Windows where we provide protobuf as part of eCAL)
+find_package(Protobuf CONFIG)
+if(NOT Protobuf_FOUND)
+  # Search for Protobuf using Module mode (with no Config mode fallback)
+  find_package(Protobuf MODULE REQUIRED)
+endif()
 
 include("@PACKAGE_eCAL_install_cmake_dir@/helper_functions/ecal_add_functions.cmake")
 include("@PACKAGE_eCAL_install_cmake_dir@/helper_functions/ecal_helper_functions.cmake")

--- a/conanfile.py
+++ b/conanfile.py
@@ -46,7 +46,6 @@ class eCALConan(ConanFile):
         tc.variables["ECAL_THIRDPARTY_BUILD_HDF5"] = "OFF"
         tc.variables["ECAL_THIRDPARTY_BUILD_TINYXML2"] = "OFF"
         tc.variables["ECAL_BUILD_DOCS"] = "ON"
-        tc.variables["CMAKE_FIND_PACKAGE_PREFER_CONFIG"] = "ON"
         if self.settings.os == "Windows":
             tc.variables["Protobuf_PROTOC_EXECUTABLE"] = os.path.join(self.deps_cpp_info["protobuf"].rootpath, "bin", "protoc.exe").replace('\\', '/')
         else:

--- a/doc/rst/configuration/src/hello_config/CMakeLists.txt
+++ b/doc/rst/configuration/src/hello_config/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.0)
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
 
 project(hello_config)
 

--- a/doc/rst/configuration/src/publisher_config/CMakeLists.txt
+++ b/doc/rst/configuration/src/publisher_config/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.0)
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
 
 project(publisher_config)
 

--- a/doc/rst/getting_started/src/hello_world/hello_world_rec/CMakeLists.txt
+++ b/doc/rst/getting_started/src/hello_world/hello_world_rec/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.0)
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
 
 project(hello_world_rec)
 

--- a/doc/rst/getting_started/src/hello_world/hello_world_snd/CMakeLists.txt
+++ b/doc/rst/getting_started/src/hello_world/hello_world_snd/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.0)
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
 
 project(hello_world_snd)
 

--- a/doc/rst/getting_started/src/hello_world_protobuf/protobuf_rec/CMakeLists.txt
+++ b/doc/rst/getting_started/src/hello_world_protobuf/protobuf_rec/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.0)
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
 
 project(protobuf_rec)
 

--- a/doc/rst/getting_started/src/hello_world_protobuf/protobuf_snd/CMakeLists.txt
+++ b/doc/rst/getting_started/src/hello_world_protobuf/protobuf_snd/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.0)
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
 
 project(protobuf_snd)
 

--- a/ecal/samples/cpp/benchmarks/counter_rec/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/counter_rec/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(counter_rec)
 
 find_package(eCAL REQUIRED)

--- a/ecal/samples/cpp/benchmarks/counter_snd/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/counter_snd/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(counter_snd)
 
 find_package(eCAL REQUIRED)

--- a/ecal/samples/cpp/benchmarks/datarate_rec/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/datarate_rec/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(datarate_rec)
 
 find_package(eCAL REQUIRED)

--- a/ecal/samples/cpp/benchmarks/datarate_snd/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/datarate_snd/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(datarate_snd)
 
 find_package(eCAL REQUIRED)

--- a/ecal/samples/cpp/benchmarks/dynsize_snd/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/dynsize_snd/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(dynsize_snd)
 
 find_package(eCAL REQUIRED)

--- a/ecal/samples/cpp/benchmarks/latency_client/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/latency_client/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(latency_client)
 
 find_package(eCAL REQUIRED)

--- a/ecal/samples/cpp/benchmarks/latency_rec/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/latency_rec/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(latency_rec)
 
 find_package(eCAL REQUIRED)

--- a/ecal/samples/cpp/benchmarks/latency_server/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/latency_server/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(latency_server)
 
 find_package(eCAL REQUIRED)

--- a/ecal/samples/cpp/benchmarks/latency_snd/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/latency_snd/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(latency_snd)
 
 find_package(eCAL REQUIRED)

--- a/ecal/samples/cpp/benchmarks/many_connections_rec/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/many_connections_rec/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(many_connections_rec)
 
 find_package(eCAL REQUIRED)

--- a/ecal/samples/cpp/benchmarks/many_connections_snd/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/many_connections_snd/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(many_connections_snd)
 
 find_package(eCAL REQUIRED)

--- a/ecal/samples/cpp/benchmarks/massive_pub_sub/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/massive_pub_sub/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(massive_pub_sub)
 
 find_package(eCAL REQUIRED)

--- a/ecal/samples/cpp/benchmarks/multiple_rec/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/multiple_rec/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(multiple_rec)
 
 find_package(eCAL REQUIRED)

--- a/ecal/samples/cpp/benchmarks/multiple_snd/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/multiple_snd/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(multiple_snd)
 
 find_package(eCAL REQUIRED)

--- a/ecal/samples/cpp/benchmarks/performance_rec/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/performance_rec/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(performance_rec)
 
 find_package(eCAL REQUIRED)

--- a/ecal/samples/cpp/benchmarks/performance_snd/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/performance_snd/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(performance_snd)
 
 find_package(eCAL REQUIRED)

--- a/ecal/samples/cpp/benchmarks/perftool/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/perftool/CMakeLists.txt
@@ -17,7 +17,6 @@
 # ========================= eCAL LICENSE =================================
 
 cmake_minimum_required(VERSION 3.13)
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
 
 project(perftool)
 

--- a/ecal/samples/cpp/benchmarks/pubsub_throughput/CMakeLists.txt
+++ b/ecal/samples/cpp/benchmarks/pubsub_throughput/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(pubsub_throughput)
 
 find_package(eCAL REQUIRED)

--- a/ecal/samples/cpp/misc/config/CMakeLists.txt
+++ b/ecal/samples/cpp/misc/config/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(config_sample)
 
 find_package(eCAL REQUIRED)

--- a/ecal/samples/cpp/misc/process/CMakeLists.txt
+++ b/ecal/samples/cpp/misc/process/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(process)
 
 find_package(eCAL REQUIRED)

--- a/ecal/samples/cpp/misc/time/CMakeLists.txt
+++ b/ecal/samples/cpp/misc/time/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(time)
 
 find_package(eCAL REQUIRED)

--- a/ecal/samples/cpp/misc/timer/CMakeLists.txt
+++ b/ecal/samples/cpp/misc/timer/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(timer)
 
 find_package(eCAL REQUIRED)

--- a/ecal/samples/cpp/monitoring/monitoring_get_services/CMakeLists.txt
+++ b/ecal/samples/cpp/monitoring/monitoring_get_services/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(monitoring_get_services)
 
 find_package(eCAL REQUIRED)

--- a/ecal/samples/cpp/monitoring/monitoring_get_topics/CMakeLists.txt
+++ b/ecal/samples/cpp/monitoring/monitoring_get_topics/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(monitoring_get_topics)
 
 find_package(eCAL REQUIRED)

--- a/ecal/samples/cpp/monitoring/monitoring_performance/CMakeLists.txt
+++ b/ecal/samples/cpp/monitoring/monitoring_performance/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(monitoring_performance)
 
 find_package(eCAL REQUIRED)

--- a/ecal/samples/cpp/monitoring/monitoring_rec/CMakeLists.txt
+++ b/ecal/samples/cpp/monitoring/monitoring_rec/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(monitoring_rec)
 
 find_package(eCAL REQUIRED)

--- a/ecal/samples/cpp/orchestration/component1/CMakeLists.txt
+++ b/ecal/samples/cpp/orchestration/component1/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(component1)
 
 find_package(eCAL REQUIRED)

--- a/ecal/samples/cpp/orchestration/component2/CMakeLists.txt
+++ b/ecal/samples/cpp/orchestration/component2/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(component2)
 
 find_package(eCAL REQUIRED)

--- a/ecal/samples/cpp/orchestration/orchestrator/CMakeLists.txt
+++ b/ecal/samples/cpp/orchestration/orchestrator/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(orchestrator)
 
 find_package(eCAL REQUIRED)

--- a/ecal/samples/cpp/pubsub/binary/binary_rec/CMakeLists.txt
+++ b/ecal/samples/cpp/pubsub/binary/binary_rec/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(binary_rec)
 
 find_package(eCAL REQUIRED)

--- a/ecal/samples/cpp/pubsub/binary/binary_snd/CMakeLists.txt
+++ b/ecal/samples/cpp/pubsub/binary/binary_snd/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(binary_snd)
 
 find_package(eCAL REQUIRED)

--- a/ecal/samples/cpp/pubsub/binary/binary_zero_copy_rec/CMakeLists.txt
+++ b/ecal/samples/cpp/pubsub/binary/binary_zero_copy_rec/CMakeLists.txt
@@ -21,7 +21,6 @@ cmake_minimum_required(VERSION 3.10)
 project(binary_zero_copy_rec)
 
 # set project properties
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
 set(binary_zero_copy_rec_src src/binary_zero_copy_rec.cpp)
 
 # find packages

--- a/ecal/samples/cpp/pubsub/binary/binary_zero_copy_snd/CMakeLists.txt
+++ b/ecal/samples/cpp/pubsub/binary/binary_zero_copy_snd/CMakeLists.txt
@@ -21,7 +21,6 @@ cmake_minimum_required(VERSION 3.10)
 project(binary_zero_copy_snd)
 
 # set project properties
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
 set(binary_zero_copy_snd_src src/binary_zero_copy_snd.cpp)
 
 # find packages

--- a/ecal/samples/cpp/pubsub/binary/ping/CMakeLists.txt
+++ b/ecal/samples/cpp/pubsub/binary/ping/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(ping)
 
 find_package(eCAL REQUIRED)

--- a/ecal/samples/cpp/pubsub/binary/pong/CMakeLists.txt
+++ b/ecal/samples/cpp/pubsub/binary/pong/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(pong)
 
 find_package(eCAL REQUIRED)

--- a/ecal/samples/cpp/services/minimal_client/CMakeLists.txt
+++ b/ecal/samples/cpp/services/minimal_client/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(minimal_client)
 
 find_package(eCAL REQUIRED)

--- a/ecal/samples/cpp/services/minimal_server/CMakeLists.txt
+++ b/ecal/samples/cpp/services/minimal_server/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(minimal_server)
 
 find_package(eCAL REQUIRED)

--- a/lang/c/samples/pubsub/string/minimal_rec/CMakeLists.txt
+++ b/lang/c/samples/pubsub/string/minimal_rec/CMakeLists.txt
@@ -18,7 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
 
 project(minimal_rec_c)
 

--- a/lang/c/samples/pubsub/string/minimal_rec_cb/CMakeLists.txt
+++ b/lang/c/samples/pubsub/string/minimal_rec_cb/CMakeLists.txt
@@ -18,7 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
 
 project(minimal_rec_cb_c)
 

--- a/lang/c/samples/pubsub/string/minimal_snd/CMakeLists.txt
+++ b/lang/c/samples/pubsub/string/minimal_snd/CMakeLists.txt
@@ -18,7 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
 
 project(minimal_snd_c)
 

--- a/lang/c/samples/services/minimal_client_c/CMakeLists.txt
+++ b/lang/c/samples/services/minimal_client_c/CMakeLists.txt
@@ -18,7 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
 
 project(minimal_client_c)
 

--- a/lang/c/samples/services/minimal_server_c/CMakeLists.txt
+++ b/lang/c/samples/services/minimal_server_c/CMakeLists.txt
@@ -18,7 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
 
 project(minimal_server_c)
 

--- a/samples/cpp/measurement/benchmark/CMakeLists.txt
+++ b/samples/cpp/measurement/benchmark/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(benchmark_hdf5)
 
 find_package(eCAL REQUIRED)

--- a/samples/cpp/measurement/measurement_read/CMakeLists.txt
+++ b/samples/cpp/measurement/measurement_read/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(measurement_read)
 
 find_package(eCAL REQUIRED)

--- a/samples/cpp/measurement/measurement_write/CMakeLists.txt
+++ b/samples/cpp/measurement/measurement_write/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(measurement_write)
 
 find_package(eCAL REQUIRED)

--- a/samples/cpp/services/ecalplayer_client/CMakeLists.txt
+++ b/samples/cpp/services/ecalplayer_client/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(ecalplayer_client)
 
 find_package(eCAL REQUIRED)

--- a/samples/cpp/services/ecalplayer_gui_client/CMakeLists.txt
+++ b/samples/cpp/services/ecalplayer_gui_client/CMakeLists.txt
@@ -23,7 +23,6 @@ if(POLICY CMP0087)
     cmake_policy(SET CMP0087 NEW)
 endif()
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
 
 project(ecalplayer_gui_client)
 

--- a/samples/cpp/services/ecalsys_client/CMakeLists.txt
+++ b/samples/cpp/services/ecalsys_client/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(ecalsys_client)
 
 find_package(eCAL REQUIRED)

--- a/samples/cpp/services/rec_client_service_cli/CMakeLists.txt
+++ b/samples/cpp/services/rec_client_service_cli/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(rec_client_service_cli)
 
 find_package(eCAL REQUIRED)

--- a/samples/cpp/services/rec_client_service_gui/CMakeLists.txt
+++ b/samples/cpp/services/rec_client_service_gui/CMakeLists.txt
@@ -23,7 +23,6 @@ if(POLICY CMP0087)
     cmake_policy(SET CMP0087 NEW)
 endif()
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
 
 project(rec_client_service_gui)
 

--- a/samples/cpp/services/rec_server_service_gui/CMakeLists.txt
+++ b/samples/cpp/services/rec_server_service_gui/CMakeLists.txt
@@ -23,7 +23,6 @@ if(POLICY CMP0087)
     cmake_policy(SET CMP0087 NEW)
 endif()
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
 
 project(rec_server_service_gui)
 

--- a/serialization/capnproto/samples/pubsub/addressbook_rec/CMakeLists.txt
+++ b/serialization/capnproto/samples/pubsub/addressbook_rec/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(addressbook_rec)
 
 find_package(CapnProto REQUIRED)

--- a/serialization/capnproto/samples/pubsub/addressbook_rec_dynamic/CMakeLists.txt
+++ b/serialization/capnproto/samples/pubsub/addressbook_rec_dynamic/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(addressbook_rec_dynamic)
 
 find_package(CapnProto REQUIRED)

--- a/serialization/capnproto/samples/pubsub/addressbook_snd/CMakeLists.txt
+++ b/serialization/capnproto/samples/pubsub/addressbook_snd/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(addressbook_snd)
 
 find_package(CapnProto REQUIRED)

--- a/serialization/flatbuffers/samples/pubsub/monster_rec/CMakeLists.txt
+++ b/serialization/flatbuffers/samples/pubsub/monster_rec/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(monster_rec)
 
 find_package(FlatBuffers REQUIRED)

--- a/serialization/flatbuffers/samples/pubsub/monster_snd/CMakeLists.txt
+++ b/serialization/flatbuffers/samples/pubsub/monster_snd/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(monster_snd)
 
 find_package(FlatBuffers REQUIRED)

--- a/serialization/protobuf/samples/pubsub/person_events_rec/CMakeLists.txt
+++ b/serialization/protobuf/samples/pubsub/person_events_rec/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(person_events_rec)
 
 find_package(eCAL REQUIRED)

--- a/serialization/protobuf/samples/pubsub/person_events_snd/CMakeLists.txt
+++ b/serialization/protobuf/samples/pubsub/person_events_snd/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(person_events_snd)
 
 find_package(eCAL REQUIRED)

--- a/serialization/protobuf/samples/pubsub/person_loopback/CMakeLists.txt
+++ b/serialization/protobuf/samples/pubsub/person_loopback/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(person_loopback)
 
 find_package(eCAL REQUIRED)

--- a/serialization/protobuf/samples/pubsub/person_rec/CMakeLists.txt
+++ b/serialization/protobuf/samples/pubsub/person_rec/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(person_rec)
 
 find_package(eCAL REQUIRED)

--- a/serialization/protobuf/samples/pubsub/person_snd/CMakeLists.txt
+++ b/serialization/protobuf/samples/pubsub/person_snd/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(person_snd)
 
 find_package(eCAL REQUIRED)

--- a/serialization/protobuf/samples/pubsub/person_snd_tcp/CMakeLists.txt
+++ b/serialization/protobuf/samples/pubsub/person_snd_tcp/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(person_snd_tcp)
 
 find_package(eCAL REQUIRED)

--- a/serialization/protobuf/samples/pubsub/person_snd_udp/CMakeLists.txt
+++ b/serialization/protobuf/samples/pubsub/person_snd_udp/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(person_snd_udp)
 
 find_package(eCAL REQUIRED)

--- a/serialization/protobuf/samples/pubsub/proto_dyn_json_rec/CMakeLists.txt
+++ b/serialization/protobuf/samples/pubsub/proto_dyn_json_rec/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(proto_dyn_json_rec)
 
 find_package(eCAL REQUIRED)

--- a/serialization/protobuf/samples/pubsub/proto_dyn_rec/CMakeLists.txt
+++ b/serialization/protobuf/samples/pubsub/proto_dyn_rec/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(proto_dyn_rec)
 
 find_package(eCAL REQUIRED)

--- a/serialization/protobuf/samples/pubsub/proto_dyn_snd/CMakeLists.txt
+++ b/serialization/protobuf/samples/pubsub/proto_dyn_snd/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(proto_dyn_snd)
 
 find_package(eCAL REQUIRED)

--- a/serialization/protobuf/samples/services/math_client/CMakeLists.txt
+++ b/serialization/protobuf/samples/services/math_client/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(math_client)
 
 find_package(eCAL REQUIRED)

--- a/serialization/protobuf/samples/services/math_server/CMakeLists.txt
+++ b/serialization/protobuf/samples/services/math_server/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(math_server)
 
 find_package(eCAL REQUIRED)

--- a/serialization/protobuf/samples/services/ping_client/CMakeLists.txt
+++ b/serialization/protobuf/samples/services/ping_client/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(ping_client)
 
 find_package(eCAL REQUIRED)

--- a/serialization/protobuf/samples/services/ping_client_dyn/CMakeLists.txt
+++ b/serialization/protobuf/samples/services/ping_client_dyn/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(ping_client_dyn)
 
 find_package(eCAL REQUIRED)

--- a/serialization/protobuf/samples/services/ping_server/CMakeLists.txt
+++ b/serialization/protobuf/samples/services/ping_server/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(ping_server)
 
 find_package(eCAL REQUIRED)

--- a/serialization/string/samples/pubsub/minimal_rec/CMakeLists.txt
+++ b/serialization/string/samples/pubsub/minimal_rec/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(minimal_rec)
 
 find_package(eCAL REQUIRED)

--- a/serialization/string/samples/pubsub/minimal_snd/CMakeLists.txt
+++ b/serialization/string/samples/pubsub/minimal_snd/CMakeLists.txt
@@ -18,8 +18,6 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
-
 project(minimal_snd)
 
 find_package(eCAL REQUIRED)


### PR DESCRIPTION
### Description
<!-- What does your PR change? -->
`CMAKE_FIND_PACKAGE_PREFER_CONFIG` was recommended to have CMake (on Windows) find the vendored version of protobuf before falling back to the system `findProtobuf.cmake` module.

However, you can just manually implement this and try and find protobuf first through `CONFIG` then fallback to a required `MODULE` if not found.

This is one less thing to get wrong, I myself have forgotten this sharp corner, more than once, and wondered why everything fell over.

Tested on Windows with a local install of the installer and it works great :smile: 

### Related issues
<!-- Type "Fixes #123" to automatically close that issue, when this PR is merged -->
- Fixes unintuitive and atypical usage causing issues. 
- Adds some missing newlines at the end of files (not a deliberate change, git was just upset they were missing and fixed them)

### Cherry-pick to
<!-- Leave empty, if you don't know. For master-only changes use "none"
- _none_
- 5.11 (old stable)
- 5.12 (current stable)
-->
