### PR TITLE
[cmake]: Fix usage after install when built with `BUILD_SHARED_LIBS=ON`

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -377,6 +377,7 @@ jobs:
       working-directory: ${{ runner.workspace }}/_build/complete/_deploy
 
     - name: Determine name of the installer for zip file
+      if: env.IS_DOWNLOAD_AVAILABLE == 'true'
       shell: powershell
       run: |
         $INSTALLER_NAME = "${{ env.ASSET_NAME }}"

--- a/lib/CustomQt/CMakeLists.txt
+++ b/lib/CustomQt/CMakeLists.txt
@@ -66,7 +66,9 @@ set(custom_qt_src
   src/QToolTipMenu.cpp
 )
 
-add_library (${PROJECT_NAME}
+# CustomQt is only used for the implementation of the GUI applications and
+# monitor plugins so it can always be static and never installed/exported
+ecal_add_static_library(${PROJECT_NAME}
   ${custom_qt_includes}
   ${custom_qt_src}
 )
@@ -75,7 +77,7 @@ target_include_directories(${PROJECT_NAME}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src
   PUBLIC  ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(${PROJECT_NAME} PUBLIC
     Qt${QT_VERSION_MAJOR}::Core
     Qt${QT_VERSION_MAJOR}::Widgets
 )

--- a/lib/EcalParser/CMakeLists.txt
+++ b/lib/EcalParser/CMakeLists.txt
@@ -42,7 +42,9 @@ set(sources
     src/functions/username.h
 )
 
-add_library (${PROJECT_NAME} 
+# QEcalParser is an internal implementation detail for applications so it can
+# always be static and not installed/exported
+ecal_add_static_library(${PROJECT_NAME}
     ${includes}
     ${sources}
 )

--- a/lib/QEcalParser/CMakeLists.txt
+++ b/lib/QEcalParser/CMakeLists.txt
@@ -67,7 +67,9 @@ else()
 endif()
 
 
-add_library (${PROJECT_NAME}
+# QEcalParser is an internal implementation detail for applications so it can
+# always be static and not installed/exported
+ecal_add_static_library(${PROJECT_NAME}
     ${qecalparser_includes}
     ${qecalparser_src}
     ${qecalparser_ui}

--- a/lib/ThreadingUtils/CMakeLists.txt
+++ b/lib/ThreadingUtils/CMakeLists.txt
@@ -33,7 +33,10 @@ set(threading_utils_src
   src/dummy.cpp # Workaround to make this project generate an output. Header only librarys do not work well with Visual Studio
 )
 
-add_library (${PROJECT_NAME} 
+# WARNING: This is only used for the play and recorder applications (CLI and GUI)
+# so it is never needed by the SDK portion of the codebase and thus can be:
+# Internal implementation - not exported/installed
+ecal_add_static_library(${PROJECT_NAME}
   ${threading_utils_includes}
   ${threading_utils_src}
 )

--- a/lib/ecal_utils/CMakeLists.txt
+++ b/lib/ecal_utils/CMakeLists.txt
@@ -38,7 +38,7 @@ set(ecal_utils_src
     src/win_cp_changer.cpp
 )
 
-ecal_add_static_library(${PROJECT_NAME}
+ecal_add_library(${PROJECT_NAME}
     ${ecal_utils_includes}
     ${ecal_utils_src}
 )

--- a/thirdparty/tcp_pubsub/build-tcp_pubsub.cmake
+++ b/thirdparty/tcp_pubsub/build-tcp_pubsub.cmake
@@ -1,13 +1,8 @@
 include_guard(GLOBAL)
 
 # Build as static library
-set(BUILD_SHARED_LIBS_OLD ${BUILD_SHARED_LIBS})
-set(BUILD_SHARED_LIBS OFF)
+set(TCP_PUBSUB_LIBRARY_TYPE STATIC)
 
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/tcp_pubsub/tcp_pubsub thirdparty/tcp_pubsub EXCLUDE_FROM_ALL SYSTEM)
-
-# Reset static / shared libs to old value
-set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS_OLD})
-unset(BUILD_SHARED_LIBS_OLD)
 
 set_property(TARGET tcp_pubsub PROPERTY FOLDER thirdparty/tcp_pubsub)

--- a/thirdparty/tcp_pubsub/build-tcp_pubsub.cmake
+++ b/thirdparty/tcp_pubsub/build-tcp_pubsub.cmake
@@ -1,5 +1,13 @@
 include_guard(GLOBAL)
 
+# Build as static library
+set(BUILD_SHARED_LIBS_OLD ${BUILD_SHARED_LIBS})
+set(BUILD_SHARED_LIBS OFF)
+
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/tcp_pubsub/tcp_pubsub thirdparty/tcp_pubsub EXCLUDE_FROM_ALL SYSTEM)
+
+# Reset static / shared libs to old value
+set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS_OLD})
+unset(BUILD_SHARED_LIBS_OLD)
 
 set_property(TARGET tcp_pubsub PROPERTY FOLDER thirdparty/tcp_pubsub)

--- a/thirdparty/tcp_pubsub/build-tcp_pubsub.cmake
+++ b/thirdparty/tcp_pubsub/build-tcp_pubsub.cmake
@@ -2,6 +2,9 @@ include_guard(GLOBAL)
 
 # Build as static library
 set(TCP_PUBSUB_LIBRARY_TYPE STATIC)
+set(TCP_PUBSUB_USE_BUILTIN_ASIO OFF)
+set(TCP_PUBSUB_USE_BUILTIN_RECYCLE OFF)
+set(TCP_PUBSUB_BUILD_TESTS OFF)
 
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/tcp_pubsub/tcp_pubsub thirdparty/tcp_pubsub EXCLUDE_FROM_ALL SYSTEM)
 


### PR DESCRIPTION
### Description
<!-- What does your PR change? -->

Fixes the build such that the installed result is usable when eCAL is built with `BUILD_SHARED_LIBS=ON`.

- `tcp_pubsub` submodule is now always built statically as it is a strictly internal dependency.
- `ecal-utils` may now be static or shared depending on `BUILD_SHARED_LIBS`
  - It was required to be installed as it was used by other static/shared libraries
  - There was no particular reason for it to always be static so now it aligns with the other non-fixed libraries
- `EcalParser, QEcalParser, CustomQt, and ThreadingUtils` are now **always static** because they were implementation details for applications and application plugins and were not required to be installed.

### Related issues
<!-- Type "Fixes #123" to automatically close that issue, when this PR is merged -->
Fixes #2014 

### Cherry-pick to
<!-- Leave empty, if you don't know. For master-only changes use "none"
- _none_
- 5.11 (old stable)
- 5.12 (current stable)
-->
