### PR TITLE
[logging] eCALLogDir returns now subfolder "logs" in special cases

### DIFF
--- a/ecal/core/include/ecal/util.h
+++ b/ecal/core/include/ecal/util.h
@@ -48,20 +48,19 @@ namespace eCAL
     ECAL_API std::string GeteCALDataDir();
 
     /**
-     * @brief Retrieve eCAL standard logging path.
-     *          This is path is for the eCAL logging files.
-     *          This path has read/write permissions for standard users.
-     * 
-     *        1. ECAL_LOG_DIR environment variable path
-     *        2. ECAL_DATA environment variable path
-     *        3. Path provided by eCAL configuration
-     *        4. Path to local eCAL directory
-     *        5. For windows: ProgramData/eCAL if available
-     *        6. System temp path if available
-     *        7. Fallback path /ecal_tmp
+     * @brief Returns the path to the eCAL log directory. Searches in following order:
      *
-     * @return  eCAL logging path if exists.
-     *          Returns empty string if no valid path is found.
+     *        1. Environment variable ECAL_LOG_DIR
+     *        2. Environment variable ECAL_DATA (also checking for logs subdirectory)
+     *        3. The path provided from the configuration
+     *        4. The path where ecal.yaml was loaded from (also checking for logs subdirectory)
+     *        5. The temporary directory (e.g. /tmp [unix], Appdata/local/Temp [win])
+     *        6. Fallback path /ecal_tmp
+     * 
+     *        In case of 5/6, a unique temporary folder will be created.
+     *        
+     * @returns The path to the eCAL log directory. The subdirectory logs might not exist yet.
+     *          Returns empty string if no root path could be found.
     **/
     ECAL_API std::string GeteCALLogDir();
 

--- a/ecal/core/src/config/ecal_path_processing.cpp
+++ b/ecal/core/src/config/ecal_path_processing.cpp
@@ -340,10 +340,12 @@ namespace eCAL
     std::string GeteCALLogDirImpl(const Util::IDirProvider& dir_provider_ /* = Util::DirProvider() */, const Util::IDirManager& dir_manager_ /* = Util::DirManager() */, const eCAL::Configuration& config_ /* = eCAL::GetConfiguration() */)
     {
       const std::string config_file_dir = dir_manager_.getDirectoryPath(eCAL::GetConfiguration().GetConfigurationFilePath());
+      const std::string ecal_data_env_dir = dir_provider_.eCALEnvVar(ECAL_DATA_VAR);
       
       const std::vector<std::string> log_paths = {
         dir_provider_.eCALEnvVar(ECAL_LOG_VAR),
-        dir_provider_.eCALEnvVar(ECAL_DATA_VAR),
+        buildPath(ecal_data_env_dir, ECAL_FOLDER_NAME_LOG),
+        ecal_data_env_dir,
         config_.logging.provider.file_config.path,
         config_file_dir
       };

--- a/ecal/core/src/config/ecal_path_processing.cpp
+++ b/ecal/core/src/config/ecal_path_processing.cpp
@@ -347,6 +347,7 @@ namespace eCAL
         buildPath(ecal_data_env_dir, ECAL_FOLDER_NAME_LOG),
         ecal_data_env_dir,
         config_.logging.provider.file_config.path,
+        buildPath(config_file_dir, ECAL_FOLDER_NAME_LOG),
         config_file_dir
       };
 

--- a/ecal/core/src/config/ecal_path_processing.h
+++ b/ecal/core/src/config/ecal_path_processing.h
@@ -208,14 +208,13 @@ namespace eCAL
      * @brief Returns the path to the eCAL log directory. Searches in following order:
      *
      *        1. Environment variable ECAL_LOG_DIR
-     *        2. Environment variable ECAL_DATA
+     *        2. Environment variable ECAL_DATA (also checking for logs subdirectory)
      *        3. The path provided from the configuration
-     *        4. The path to the local eCAL data directory
-     *        5. For windows: the system data path if available (ProgramData/eCAL)
-     *        6. The temporary directory (e.g. /tmp [unix], Appdata/local/Temp [win])
-     *        7. Fallback path /ecal_tmp
+     *        4. The path where ecal.yaml was loaded from (also checking for logs subdirectory)
+     *        5. The temporary directory (e.g. /tmp [unix], Appdata/local/Temp [win])
+     *        6. Fallback path /ecal_tmp
      * 
-     *        In case of 6/7, a unique temporary folder will be created.
+     *        In case of 5/6, a unique temporary folder will be created.
      *        
      * @returns The path to the eCAL log directory. The subdirectory logs might not exist yet.
      *          Returns empty string if no root path could be found.

--- a/ecal/tests/cpp/config_test/src/path_processing_test.cpp
+++ b/ecal/tests/cpp/config_test/src/path_processing_test.cpp
@@ -250,6 +250,7 @@ TEST(core_cpp_path_processing /*unused*/, ecal_log_order_test /*unused*/)
   // Alltogether the eCALLogDirImpl function will be called 11 times.
 
   const std::string ecal_data_env_var = "/ecal/data/env";
+  const std::string ecal_data_env_log_var = ecal_data_env_var + path_separator + ECAL_FOLDER_NAME_LOG;
   const std::string ecal_log_env_var = "/ecal/log/env";
   const std::string ecal_config_logging_dir = "/config/logging/dir";
   const std::string ecal_yaml_dir = "/dir/to/current/yaml";
@@ -265,12 +266,12 @@ TEST(core_cpp_path_processing /*unused*/, ecal_log_order_test /*unused*/)
     .InSequence(seq_env_log)
     .WillRepeatedly(testing::Return(ecal_log_env_var));
   EXPECT_CALL(mock_dir_provider, eCALEnvVar(ECAL_LOG_VAR))
-    .Times(7)
+    .Times(8)
     .InSequence(seq_env_log)
     .WillRepeatedly(testing::Return(""));
 
   EXPECT_CALL(mock_dir_provider, eCALEnvVar(ECAL_DATA_VAR))
-    .Times(4)
+    .Times(5)
     .InSequence(seq_env_data)
     .WillRepeatedly(testing::Return(ecal_data_env_var));
 
@@ -282,7 +283,7 @@ TEST(core_cpp_path_processing /*unused*/, ecal_log_order_test /*unused*/)
   // log is the third one
 
   EXPECT_CALL(mock_dir_manager, getDirectoryPath(testing::_))
-    .Times(8)
+    .Times(9)
     .InSequence(yaml_dir)
     .WillRepeatedly(testing::Return(ecal_yaml_dir));
   
@@ -307,6 +308,11 @@ TEST(core_cpp_path_processing /*unused*/, ecal_log_order_test /*unused*/)
     .WillOnce(testing::Return(true))
     .WillRepeatedly(testing::Return(false));
   
+  EXPECT_CALL(mock_dir_manager, dirExists(ecal_data_env_log_var))
+    .Times(3)
+    .WillOnce(testing::Return(true))
+    .WillRepeatedly(testing::Return(false));
+
   EXPECT_CALL(mock_dir_manager, dirExists(ecal_data_env_var))
     .Times(3)
     .WillOnce(testing::Return(true))
@@ -328,6 +334,7 @@ TEST(core_cpp_path_processing /*unused*/, ecal_log_order_test /*unused*/)
   
   // Testing with eCALData and eCALLog -DirImpl
   EXPECT_EQ(eCAL::Config::GeteCALLogDirImpl(mock_dir_provider, mock_dir_manager, config),  ecal_log_env_var);
+  EXPECT_EQ(eCAL::Config::GeteCALLogDirImpl(mock_dir_provider, mock_dir_manager, config),  ecal_data_env_log_var);
   EXPECT_EQ(eCAL::Config::GeteCALLogDirImpl(mock_dir_provider, mock_dir_manager, config),  ecal_data_env_var);
   
   EXPECT_EQ(eCAL::Config::GeteCALLogDirImpl(mock_dir_provider, mock_dir_manager, config), ecal_data_env_var);

--- a/ecal/tests/cpp/config_test/src/path_processing_test.cpp
+++ b/ecal/tests/cpp/config_test/src/path_processing_test.cpp
@@ -66,6 +66,7 @@ using DirAvailabilityMap = std::map<std::string, bool>;
 TEST(core_cpp_path_processing /*unused*/, ecal_data_log_env_vars /*unused*/)
 {
   const std::string env_ecal_conf_value = "/path/to/conf";
+  const std::string env_ecal_conf_log_value = env_ecal_conf_value + path_separator + ECAL_FOLDER_NAME_LOG;
   const std::string env_ecal_log_value = "/path/to/log";
   const std::string unique_tmp_dir = "/tmp/unique";
 
@@ -107,7 +108,7 @@ TEST(core_cpp_path_processing /*unused*/, ecal_data_log_env_vars /*unused*/)
 
   EXPECT_EQ(eCAL::Config::GeteCALDataDirImpl(mock_dir_provider, mock_dir_manager), env_ecal_conf_value);
   EXPECT_EQ(eCAL::Config::GeteCALLogDirImpl(mock_dir_provider, mock_dir_manager), env_ecal_log_value);
-  EXPECT_EQ(eCAL::Config::GeteCALLogDirImpl(mock_dir_provider, mock_dir_manager), env_ecal_conf_value);
+  EXPECT_EQ(eCAL::Config::GeteCALLogDirImpl(mock_dir_provider, mock_dir_manager), env_ecal_conf_log_value);
   
   // Now nothing is set, GeteCALDataDirImpl should return empty string
   EXPECT_EQ(eCAL::Config::GeteCALDataDirImpl(mock_dir_provider, mock_dir_manager), "");
@@ -245,15 +246,16 @@ TEST(core_cpp_path_processing /*unused*/, ecal_log_order_test /*unused*/)
   // the return value of "dirExists" can also return false.
   // So the first call will return first value. Value is set and direxists.
   // The second call will return the second value, even if the variable is still set, because dirExists will return false.
-  // Then the first call of the expected 2nd value follows: First value unset, 2nd value set and direxists = 2nd Value.
+  // The next call will return the third value, and so on.
   // This continues until the last: UniqueTmpDir call
-  // Alltogether the eCALLogDirImpl function will be called 11 times.
+  // Alltogether the eCALLogDirImpl function will be called 7 times.
 
+  const std::string ecal_log_env_var = "/ecal/log/env";
   const std::string ecal_data_env_var = "/ecal/data/env";
   const std::string ecal_data_env_log_var = ecal_data_env_var + path_separator + ECAL_FOLDER_NAME_LOG;
-  const std::string ecal_log_env_var = "/ecal/log/env";
   const std::string ecal_config_logging_dir = "/config/logging/dir";
   const std::string ecal_yaml_dir = "/dir/to/current/yaml";
+  const std::string ecal_yaml_log_dir = ecal_yaml_dir + path_separator + ECAL_FOLDER_NAME_LOG;
   const std::string unique_tmp_dir = "/tmp/unique";
 
   const MockDirProvider mock_dir_provider;
@@ -261,39 +263,62 @@ TEST(core_cpp_path_processing /*unused*/, ecal_log_order_test /*unused*/)
 
   ::testing::Sequence seq_env_log, seq_env_data, yaml_dir;
 
+  // this gets called twice with path set, 2nd time path is set but dirExists returns false
   EXPECT_CALL(mock_dir_provider, eCALEnvVar(ECAL_LOG_VAR))
     .Times(2)
     .InSequence(seq_env_log)
     .WillRepeatedly(testing::Return(ecal_log_env_var));
   EXPECT_CALL(mock_dir_provider, eCALEnvVar(ECAL_LOG_VAR))
-    .Times(8)
+    .Times(5)
     .InSequence(seq_env_log)
     .WillRepeatedly(testing::Return(""));
+  EXPECT_CALL(mock_dir_manager, dirExists(ecal_log_env_var))
+    .Times(2)
+    .WillOnce(testing::Return(true))
+    .WillRepeatedly(testing::Return(false));
 
+  // this will get called 4 times with path set, because 2 times with log subfolder
   EXPECT_CALL(mock_dir_provider, eCALEnvVar(ECAL_DATA_VAR))
-    .Times(5)
+    .Times(4)
     .InSequence(seq_env_data)
     .WillRepeatedly(testing::Return(ecal_data_env_var));
-
   EXPECT_CALL(mock_dir_provider, eCALEnvVar(ECAL_DATA_VAR))
-    .Times(5)
+    .Times(3)
     .InSequence(seq_env_data)
     .WillRepeatedly(testing::Return(""));
+  EXPECT_CALL(mock_dir_manager, dirExists(ecal_data_env_log_var))
+    .Times(3)
+    .WillOnce(testing::Return(true))
+    .WillRepeatedly(testing::Return(false));
+  EXPECT_CALL(mock_dir_manager, dirExists(ecal_data_env_var))
+    .Times(2)
+    .WillOnce(testing::Return(true))
+    .WillRepeatedly(testing::Return(false));
 
-  // log is the third one
+  // logdir from config is the third one
+  EXPECT_CALL(mock_dir_manager, dirExists(ecal_config_logging_dir))
+    .Times(1)
+    .WillOnce(testing::Return(true));
 
+  // used ecal.yaml directory
   EXPECT_CALL(mock_dir_manager, getDirectoryPath(testing::_))
-    .Times(9)
+    .Times(6)
     .InSequence(yaml_dir)
     .WillRepeatedly(testing::Return(ecal_yaml_dir));
-  
   EXPECT_CALL(mock_dir_manager, getDirectoryPath(testing::_))
     .Times(1)
     .InSequence(yaml_dir)
     .WillRepeatedly(testing::Return(""));
+  EXPECT_CALL(mock_dir_manager, dirExists(ecal_yaml_log_dir))
+    .Times(2)
+    .WillOnce(testing::Return(true))
+    .WillRepeatedly(testing::Return(false));
+  EXPECT_CALL(mock_dir_manager, dirExists(ecal_yaml_dir))
+    .Times(1)
+    .WillOnce(testing::Return(true));
 
   EXPECT_CALL(mock_dir_provider, uniqueTmpDir(::testing::Ref(mock_dir_manager)))
-    .Times(2)
+    .Times(1)
     .WillRepeatedly(testing::Return(unique_tmp_dir));
 
   auto config = eCAL::GetConfiguration();
@@ -302,51 +327,14 @@ TEST(core_cpp_path_processing /*unused*/, ecal_log_order_test /*unused*/)
   // let's assume all directories exist
   ON_CALL(mock_dir_manager, dirExists(testing::_)).WillByDefault(testing::Return(false));
   ON_CALL(mock_dir_manager, canWriteToDirectory(testing::_)).WillByDefault(testing::Return(true));
-
-  EXPECT_CALL(mock_dir_manager, dirExists(ecal_log_env_var))
-    .Times(2)
-    .WillOnce(testing::Return(true))
-    .WillRepeatedly(testing::Return(false));
-  
-  EXPECT_CALL(mock_dir_manager, dirExists(ecal_data_env_log_var))
-    .Times(3)
-    .WillOnce(testing::Return(true))
-    .WillRepeatedly(testing::Return(false));
-
-  EXPECT_CALL(mock_dir_manager, dirExists(ecal_data_env_var))
-    .Times(3)
-    .WillOnce(testing::Return(true))
-    .WillOnce(testing::Return(true))
-    .WillRepeatedly(testing::Return(false));
-
-  EXPECT_CALL(mock_dir_manager, dirExists(ecal_config_logging_dir))
-    .Times(3)
-    .WillOnce(testing::Return(true))
-    .WillOnce(testing::Return(true))
-    .WillRepeatedly(testing::Return(false));
-
-  EXPECT_CALL(mock_dir_manager, dirExists(ecal_yaml_dir))
-    .Times(3)
-    .WillOnce(testing::Return(true))
-    .WillOnce(testing::Return(true))
-    .WillRepeatedly(testing::Return(false));
-
   
   // Testing with eCALData and eCALLog -DirImpl
-  EXPECT_EQ(eCAL::Config::GeteCALLogDirImpl(mock_dir_provider, mock_dir_manager, config),  ecal_log_env_var);
-  EXPECT_EQ(eCAL::Config::GeteCALLogDirImpl(mock_dir_provider, mock_dir_manager, config),  ecal_data_env_log_var);
-  EXPECT_EQ(eCAL::Config::GeteCALLogDirImpl(mock_dir_provider, mock_dir_manager, config),  ecal_data_env_var);
-  
+  EXPECT_EQ(eCAL::Config::GeteCALLogDirImpl(mock_dir_provider, mock_dir_manager, config), ecal_log_env_var);
+  EXPECT_EQ(eCAL::Config::GeteCALLogDirImpl(mock_dir_provider, mock_dir_manager, config), ecal_data_env_log_var);
   EXPECT_EQ(eCAL::Config::GeteCALLogDirImpl(mock_dir_provider, mock_dir_manager, config), ecal_data_env_var);
   EXPECT_EQ(eCAL::Config::GeteCALLogDirImpl(mock_dir_provider, mock_dir_manager, config), ecal_config_logging_dir);
-
-  EXPECT_EQ(eCAL::Config::GeteCALLogDirImpl(mock_dir_provider, mock_dir_manager, config), ecal_config_logging_dir);
-  EXPECT_EQ(eCAL::Config::GeteCALLogDirImpl(mock_dir_provider, mock_dir_manager, config), ecal_yaml_dir);
-
   config.logging.provider.file_config.path = "";
-
+  EXPECT_EQ(eCAL::Config::GeteCALLogDirImpl(mock_dir_provider, mock_dir_manager, config), ecal_yaml_log_dir);
   EXPECT_EQ(eCAL::Config::GeteCALLogDirImpl(mock_dir_provider, mock_dir_manager, config), ecal_yaml_dir);
-  EXPECT_EQ(eCAL::Config::GeteCALLogDirImpl(mock_dir_provider, mock_dir_manager, config), unique_tmp_dir);
-
   EXPECT_EQ(eCAL::Config::GeteCALLogDirImpl(mock_dir_provider, mock_dir_manager, config), unique_tmp_dir);
 }


### PR DESCRIPTION
### Description

eCALLogDirImpl returned the standard paths of the environment variables set, as also the default path where the ecal.yaml file was loaded from. Now with this change, there is a check for the case of ECAL_DATA directory and the loaded ecal.yaml file, if a subfolder named "logs" exists. If so, take this as the logging directory.

By default the "logs" directory will be created with ecal_generate_config(.exe), so its valid to write into that path.