### PR TITLE
[core] Fixed acknowledge bug for multiple processes

### DIFF
--- a/ecal/core/src/io/shm/ecal_memfile_sync.cpp
+++ b/ecal/core/src/io/shm/ecal_memfile_sync.cpp
@@ -90,27 +90,31 @@ namespace eCAL
     }
   }
 
+  /*
+  * This function is called when a subscriber is being unregistered
+  * It only temporarily deactivates the events, such that they can be reactivated by 
+  * a call to Connect with the same process ID.
+  *
+  * This has the disadvantage, that even when a complete process is unregistered
+  * (as opposed to a subscriber which is being unregistered), the events are present until this
+  * object is destroyed (which happens during eCAL::Finalize()
+  * It would be better to provide two functions (e.g. Disconnect (upon subscription removal) and Remove (upon process removal).
+  *
+  * Also, the disconnect does not prevent the `event_snd` not to be set when the publisher writes data. 
+  * We should theoretically distinguish between not acknowledging, and not signaling send data.
+  */
   bool CSyncMemoryFile::Disconnect(const std::string& process_id_)
   {
     if (!m_created) return false;
 
-    // a local subscriber connection timed out
-    // we close the associated sync events and
-    // remove them from the event handle map
-
     const std::lock_guard<std::mutex> lock(m_event_handle_map_sync);
-    EventHandleMapT::iterator iter = m_event_handle_map.find(process_id_);
+    const EventHandleMapT::iterator iter = m_event_handle_map.find(process_id_);
     if (iter != m_event_handle_map.end())
     {
       SEventHandlePair event_pair = iter->second;
       // fire acknowledge events, to unlock blocking send function
       gSetEvent(event_pair.event_ack);
-      
-      // this fixes the problem on linux, when reconnecting of a subscriber to the same publisher
-      // lead to incongruous event handles
-      //
-      // drawback to previous implementation:
-      // events will not be closed right away, only when Destroy() or DisconnectAll() is called
+      // mark the event to be ignored by the send function.
       event_pair.event_ack_is_invalid = true;
       return true;
     }
@@ -406,6 +410,10 @@ namespace eCAL
 #endif
   }
 
+  /*
+  * This function is called upon destruction of the CSyncMemoryFile.
+  * It closes and invalidates all events that have been created by this class.
+  */
   void CSyncMemoryFile::DisconnectAll()
   {
     const std::lock_guard<std::mutex> lock(m_event_handle_map_sync);

--- a/ecal/core/src/readwrite/shm/ecal_writer_shm.cpp
+++ b/ecal/core/src/readwrite/shm/ecal_writer_shm.cpp
@@ -110,7 +110,7 @@ namespace eCAL
     if (host_name_ != m_attributes.host_name) return;
 
     // remove topic id from the id set for the given process id
-    // bool memfile_has_subscriptions(true);
+    bool memfile_has_subscriptions(true);
     {
       const std::lock_guard<std::mutex> lock(m_process_id_topic_id_set_map_sync);
       auto process_it = m_process_id_topic_id_set_map.find(process_id_);
@@ -127,26 +127,23 @@ namespace eCAL
           // we can remove the empty topic id set
           m_process_id_topic_id_set_map.erase(process_it);
           // and set the subscription state to false for later processing
-          //memfile_has_subscriptions = false;
+          memfile_has_subscriptions = false;
         }
       }
     }
-// TODO: Disconnect events immediately if there is no longer an existing subscription.
-//       Unfortunately the below Disconnect()-method leads to incongruous event handles on
-//       unix operating systems in case of a subscriber tries to reconnected to same publisher
-//       again.
-//
-//    // memory file is still connected to at least one topic id of this process id
-//    // no need to Disconnect process id
-//    if (memfile_has_subscriptions) return;
-//
-//    for (auto& memory_file : m_memory_file_vec)
-//    {
-//      memory_file->Disconnect(std::to_string(process_id_));
-//#ifndef NDEBUG
-//      Logging::Log(Logging::log_level_debug1, std::string("CDataWriterSHM::RemoveSubscription - Memory FileName: ") + memory_file->GetName() + " to ProcessId " + std::to_string(process_id_));
-//#endif
-//    }
+    // Disconnect events immediately if there is no longer an existing subscription.
+
+    // memory file is still connected to at least one topic id of this process id
+    // no need to Disconnect process id
+    if (memfile_has_subscriptions) return;
+
+    for (auto& memory_file : m_memory_file_vec)
+    {
+      memory_file->Disconnect(std::to_string(process_id_));
+#ifndef NDEBUG
+      Logging::Log(Logging::log_level_debug1, std::string("CDataWriterSHM::RemoveSubscription - Memory FileName: ") + memory_file->GetName() + " to ProcessId " + std::to_string(process_id_));
+#endif
+    }
   }
 
   Registration::ConnectionPar CDataWriterSHM::GetConnectionParameter()

--- a/ecal/core/src/readwrite/shm/ecal_writer_shm.cpp
+++ b/ecal/core/src/readwrite/shm/ecal_writer_shm.cpp
@@ -104,6 +104,10 @@ namespace eCAL
     }
   }
 
+  /*
+  * Potentially, a publisher has multiple subscribers within the same process
+  * 
+  */
   void CDataWriterSHM::RemoveSubscription(const std::string& host_name_, const int32_t process_id_, const EntityIdT& topic_id_)
   {
     // we accept local disconnections only
@@ -131,12 +135,11 @@ namespace eCAL
         }
       }
     }
-    // Disconnect events immediately if there is no longer an existing subscription.
-
     // memory file is still connected to at least one topic id of this process id
     // no need to Disconnect process id
     if (memfile_has_subscriptions) return;
 
+    // If the removed subscription was the last one, we need to temporarily disconnect the process
     for (auto& memory_file : m_memory_file_vec)
     {
       memory_file->Disconnect(std::to_string(process_id_));


### PR DESCRIPTION
### Description
When having acknowledge enabled the publisher runs into the acknowledge timeout after a subscriber stopped. The problem was, that after the subscriber got restarted, the publisher runs again into the acknowledge timeout for each Send, even if the "new old" subscriber is working fine.

With this fix, the behaviour of acknowledgement is as expected. After reconnecting the subscriber, the publisher does not run into the timeout anymore.


