### PR TITLE
[cmake] Require CXX14 for core compilation.

### DIFF
--- a/ecal/core/CMakeLists.txt
+++ b/ecal/core/CMakeLists.txt
@@ -712,6 +712,8 @@ target_link_libraries(${TARGET_NAME}
     eCAL::ecal-utils
 )
 
+target_compile_features(${TARGET_NAME} PUBLIC cxx_std_14)
+
 set_property(TARGET ${TARGET_NAME}   PROPERTY FOLDER core)
 
 ecal_install_shared_library(${TARGET_NAME})


### PR DESCRIPTION
### Description
Explicitly require C++ 14 Standard for core compilation.