### PR TITLE
[app] Path separator for log path.

### DIFF
--- a/app/play/play_core/include/ecal_play_logger.h
+++ b/app/play/play_core/include/ecal_play_logger.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@
 #include "ecal_play_globals.h"
 
 #include <ecal/ecal.h>
+#include <ecal_utils/filesystem.h>
 
 class EcalPlayLogger
 {
@@ -49,8 +50,8 @@ private:
     static const int MAXIMUM_ROTATING_FILES = 5;
     static const int FIVE_MEGABYTES = 5 * 1024 * 1024;
 
-    auto ecal_data_path = eCAL::Util::GeteCALLogDir();
-    std::string log_filename = ecal_data_path + EcalPlayGlobals::ECAL_PLAY_NAME + ".log";
+    auto ecal_log_dir = eCAL::Util::GeteCALLogDir();
+    std::string log_filename = ecal_log_dir + EcalUtils::Filesystem::NativeSeparator() + EcalPlayGlobals::ECAL_PLAY_NAME + ".log";
 
     // create console logger and rotating file logger with maximum size 5MB and maximum 5 rotating files
     try

--- a/app/play/play_core/include/ecal_play_logger.h
+++ b/app/play/play_core/include/ecal_play_logger.h
@@ -50,8 +50,8 @@ private:
     static const int MAXIMUM_ROTATING_FILES = 5;
     static const int FIVE_MEGABYTES = 5 * 1024 * 1024;
 
-    auto ecal_log_dir = eCAL::Util::GeteCALLogDir();
-    std::string log_filename = ecal_log_dir + EcalUtils::Filesystem::NativeSeparator() + EcalPlayGlobals::ECAL_PLAY_NAME + ".log";
+    const auto ecal_log_dir = eCAL::Util::GeteCALLogDir();
+    const std::string log_filename = ecal_log_dir + EcalUtils::Filesystem::NativeSeparator() + EcalPlayGlobals::ECAL_PLAY_NAME + ".log";
 
     // create console logger and rotating file logger with maximum size 5MB and maximum 5 rotating files
     try

--- a/app/rec/rec_client_core/include/rec_client_core/ecal_rec_logger.h
+++ b/app/rec/rec_client_core/include/rec_client_core/ecal_rec_logger.h
@@ -32,7 +32,6 @@
 
 #include <ecal/ecal.h>
 #include <ecal_utils/filesystem.h>
-#include <ecal_utils/string.h>
 
 namespace eCAL
 {
@@ -54,8 +53,8 @@ namespace eCAL
         static const int MAXIMUM_ROTATING_FILES = 5;
         static const int FIVE_MEGABYTES = 5 * 1024 * 1024;
 
-        auto ecal_log_dir = eCAL::Util::GeteCALLogDir();
-        std::string log_filename = EcalUtils::String::Join(std::string(1, EcalUtils::Filesystem::NativeSeparator()), std::vector<std::string>{ecal_log_dir, ECAL_REC_NAME, ".log"});
+        const auto ecal_log_dir = eCAL::Util::GeteCALLogDir();
+        const std::string log_filename = ecal_log_dir + EcalUtils::Filesystem::NativeSeparator() + ECAL_REC_NAME + ".log";
 
         // create console logger and rotating file logger with maximum size 5MB and maximum 5 rotating files
         try

--- a/app/rec/rec_client_core/include/rec_client_core/ecal_rec_logger.h
+++ b/app/rec/rec_client_core/include/rec_client_core/ecal_rec_logger.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,8 @@
 #include <rec_client_core/ecal_rec_defs.h>
 
 #include <ecal/ecal.h>
+#include <ecal_utils/filesystem.h>
+#include <ecal_utils/string.h>
 
 namespace eCAL
 {
@@ -52,8 +54,8 @@ namespace eCAL
         static const int MAXIMUM_ROTATING_FILES = 5;
         static const int FIVE_MEGABYTES = 5 * 1024 * 1024;
 
-        auto ecal_data_path = eCAL::Util::GeteCALLogDir();
-        std::string log_filename = ecal_data_path + ECAL_REC_NAME + ".log";
+        auto ecal_log_dir = eCAL::Util::GeteCALLogDir();
+        std::string log_filename = EcalUtils::String::Join(std::string(1, EcalUtils::Filesystem::NativeSeparator()), std::vector<std::string>{ecal_log_dir, ECAL_REC_NAME, ".log"});
 
         // create console logger and rotating file logger with maximum size 5MB and maximum 5 rotating files
         try

--- a/app/sys/sys_client_core/include/sys_client_core/ecal_sys_client_logger.h
+++ b/app/sys/sys_client_core/include/sys_client_core/ecal_sys_client_logger.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@
 #include <iostream>
 
 #include <ecal/ecal.h>
+#include <ecal_utils/filesystem.h>
 
 namespace eCAL
 {
@@ -52,8 +53,8 @@ namespace eCAL
         static const int MAXIMUM_ROTATING_FILES = 5;
         static const int FIVE_MEGABYTES = 5 * 1024 * 1024;
 
-        auto ecal_data_path = eCAL::Util::GeteCALLogDir();
-        std::string log_filename = ecal_data_path + ecal_sys_client + ".log";
+        auto ecal_log_dir = eCAL::Util::GeteCALLogDir();
+        std::string log_filename = ecal_log_dir + EcalUtils::Filesystem::NativeSeparator() + ecal_sys_client + ".log";
 
         // create console logger and rotating file logger with maximum size 5MB and maximum 5 rotating files
         try

--- a/app/sys/sys_client_core/include/sys_client_core/ecal_sys_client_logger.h
+++ b/app/sys/sys_client_core/include/sys_client_core/ecal_sys_client_logger.h
@@ -53,8 +53,8 @@ namespace eCAL
         static const int MAXIMUM_ROTATING_FILES = 5;
         static const int FIVE_MEGABYTES = 5 * 1024 * 1024;
 
-        auto ecal_log_dir = eCAL::Util::GeteCALLogDir();
-        std::string log_filename = ecal_log_dir + EcalUtils::Filesystem::NativeSeparator() + ecal_sys_client + ".log";
+        const auto ecal_log_dir = eCAL::Util::GeteCALLogDir();
+        const std::string log_filename = ecal_log_dir + EcalUtils::Filesystem::NativeSeparator() + ecal_sys_client + ".log";
 
         // create console logger and rotating file logger with maximum size 5MB and maximum 5 rotating files
         try

--- a/app/sys/sys_core/CMakeLists.txt
+++ b/app/sys/sys_core/CMakeLists.txt
@@ -96,6 +96,7 @@ target_link_libraries(${PROJECT_NAME}
   eCAL::app_pb
   EcalParser
   eCAL::sys_client_core
+  eCAL::ecal-utils
 )
 
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_14)

--- a/app/sys/sys_core/include/ecalsys/ecal_sys_logger.h
+++ b/app/sys/sys_core/include/ecalsys/ecal_sys_logger.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2020 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@
 #include "ecalsys/esys_defs.h"
 
 #include <ecal/ecal.h>
+#include <ecal_utils/filesystem.h>
 
 class EcalSysLogger
 {
@@ -49,8 +50,8 @@ private:
     static const int MAXIMUM_ROTATING_FILES = 5;
     static const int FIVE_MEGABYTES = 5 * 1024 * 1024;
 
-    auto ecal_data_path = eCAL::Util::GeteCALLogDir();
-    std::string log_filename = ecal_data_path + ECAL_SYS_LIB_NAME + ".log";
+    auto ecal_log_dir = eCAL::Util::GeteCALLogDir();
+    std::string log_filename = ecal_log_dir + EcalUtils::Filesystem::NativeSeparator() + ECAL_SYS_LIB_NAME + ".log";
 
     // create console logger and rotating file logger with maximum size 5MB and maximum 5 rotating files
     try

--- a/app/sys/sys_core/include/ecalsys/ecal_sys_logger.h
+++ b/app/sys/sys_core/include/ecalsys/ecal_sys_logger.h
@@ -50,8 +50,8 @@ private:
     static const int MAXIMUM_ROTATING_FILES = 5;
     static const int FIVE_MEGABYTES = 5 * 1024 * 1024;
 
-    auto ecal_log_dir = eCAL::Util::GeteCALLogDir();
-    std::string log_filename = ecal_log_dir + EcalUtils::Filesystem::NativeSeparator() + ECAL_SYS_LIB_NAME + ".log";
+    const auto ecal_log_dir = eCAL::Util::GeteCALLogDir();
+    const std::string log_filename = ecal_log_dir + EcalUtils::Filesystem::NativeSeparator() + ECAL_SYS_LIB_NAME + ".log";
 
     // create console logger and rotating file logger with maximum size 5MB and maximum 5 rotating files
     try


### PR DESCRIPTION
### Description
Previous implementation of GeteCALLogDir returned path with path separator at the end. Now it does not, so additional handling is needed.
