### PR TITLE
[msg] Publisher and Subscribers now take arguments struct for constru…

### DIFF
--- a/app/mon/mon_cli/src/ecal_mon_cli.cpp
+++ b/app/mon/mon_cli/src/ecal_mon_cli.cpp
@@ -330,11 +330,12 @@ void ProcEcho(const std::string& topic_name, int msg_count)
 {
   std::cout << "echo string message output for topic " << topic_name << "\n" << "\n";
 
-  // create string subscriber for topic topic_name_ and assign callback
-  eCAL::string::CSubscriber sub(topic_name);
   std::atomic<int> cnt(msg_count);
-  auto msg_cb = [&cnt](const std::string& msg_) { if (cnt != 0) { std::cout << msg_ << "\n"; if (cnt > 0) cnt--; } };
-  sub.SetReceiveCallback(std::bind(msg_cb, std::placeholders::_2));
+
+  // create string subscriber for topic topic_name_ and assign callback
+  eCAL::string::CSubscriber::Arguments sub_arguments;
+  sub_arguments.data_callback = [&cnt](const eCAL::STopicId& /*publisher_id_*/, const std::string& msg_, long long /*time_*/, long long /*clock_*/) { if (cnt != 0) { std::cout << msg_ << "\n"; if (cnt > 0) cnt--; } };
+  eCAL::string::CSubscriber sub(topic_name, sub_arguments);
 
   while(eCAL::Ok() && (cnt != 0))
   {
@@ -353,11 +354,11 @@ void ProcProto(const std::string& topic_name, int msg_count)
   // sleep 1000 ms
   std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 
-  // create dynamic subscribers for receiving and decoding messages and assign callback
-  eCAL::protobuf::CDynamicSubscriber sub(topic_name);
   std::atomic<int> cnt(msg_count);
-  auto msg_cb = [&cnt](const std::shared_ptr<google::protobuf::Message>& msg_) { if (cnt != 0) { std::cout << msg_->DebugString() << std::endl; if (cnt > 0) cnt--; } };
-  sub.SetReceiveCallback(std::bind(msg_cb, std::placeholders::_2));
+  // create dynamic subscribers for receiving and decoding messages and assign callback
+  eCAL::protobuf::CDynamicSubscriber::Arguments sub_arguments;
+  sub_arguments.data_callback = [&cnt](const eCAL::STopicId& /*publisher_id_*/, const const std::shared_ptr<google::protobuf::Message>& msg_, long long /*time_*/, long long /*clock_*/) { if (cnt != 0) { std::cout << msg_->DebugString() << std::endl; if (cnt > 0) cnt--; } };
+  eCAL::protobuf::CDynamicSubscriber sub(topic_name, sub_arguments);
 
   // enter main loop
   while(eCAL::Ok() && (cnt != 0))

--- a/app/mon/mon_tui/src/tui/viewmodel/message_visualization/proto.hpp
+++ b/app/mon/mon_tui/src/tui/viewmodel/message_visualization/proto.hpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,10 +60,13 @@ public:
   };
 
   ProtoMessageVisualizationViewModel(const std::string &topic)
-    : subscriber{topic}
+    : subscriber{ topic, [this]() {
+        using namespace std::placeholders;
+        eCAL::protobuf::CDynamicSubscriber::Arguments arguments;
+        arguments.data_callback = std::bind(&ProtoMessageVisualizationViewModel::OnMessage, this, _2, _3);
+        return arguments;
+      }() }
   {
-    using namespace std::placeholders;
-    subscriber.SetReceiveCallback(std::bind(&ProtoMessageVisualizationViewModel::OnMessage, this, _2, _3));
   }
 
   ProtectedMessage message() const

--- a/app/mon/mon_tui/src/tui/viewmodel/message_visualization/string.hpp
+++ b/app/mon/mon_tui/src/tui/viewmodel/message_visualization/string.hpp
@@ -48,10 +48,13 @@ class StringMessageVisualizationViewModel : public MessageVisualizationViewModel
 
 public:
   StringMessageVisualizationViewModel(const std::string &topic)
-    : subscriber{topic}
+    : subscriber{topic, [this]() {
+        using namespace std::placeholders;
+        eCAL::string::CSubscriber::Arguments arguments;
+        arguments.data_callback = std::bind(&StringMessageVisualizationViewModel::OnMessage, this, _2, _3);
+        return arguments;
+      }() }
   {
-    using namespace std::placeholders;
-    subscriber.SetReceiveCallback(std::bind(&StringMessageVisualizationViewModel::OnMessage, this, _2, _3));
   }
 
   std::string message() const

--- a/app/sys/sys_gui/src/widgets/mmawidget/mma_host_item.cpp
+++ b/app/sys/sys_gui/src/widgets/mmawidget/mma_host_item.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2020 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,9 +71,10 @@ MmaHostItem::MmaHostItem(QTreeWidget* tree_widget, const QString& hostname)
   setEnabled(false);
 
   // Create eCAL Subscriber
+  eCAL::protobuf::CSubscriber<eCAL::pb::mma::State>::Arguments mma_subscriber_arguments;
+  mma_subscriber_arguments.data_callback = std::bind(&MmaHostItem::mmaReceivedCallback, this, std::placeholders::_1, std::placeholders::_2);
   mma_subscriber = std::unique_ptr<eCAL::protobuf::CSubscriber<eCAL::pb::mma::State>>
-                    (new eCAL::protobuf::CSubscriber<eCAL::pb::mma::State>("machine_state_" + hostname_.toStdString()));
-  mma_subscriber->SetReceiveCallback(std::bind(&MmaHostItem::mmaReceivedCallback, this, std::placeholders::_1, std::placeholders::_2));
+                    (new eCAL::protobuf::CSubscriber<eCAL::pb::mma::State>("machine_state_" + hostname_.toStdString(), mma_subscriber_arguments));
 
   // Register custom Type in order to directly pass the monitoring state
   qRegisterMetaType<eCAL::pb::mma::State>("eCAL::pb::mma::State");

--- a/contrib/ecaltime/simtime/src/ecal_time_simtime.cpp
+++ b/contrib/ecaltime/simtime/src/ecal_time_simtime.cpp
@@ -45,8 +45,9 @@ bool eCAL::CSimTime::initialize()
     // needs to be fixed with an improved reference counting
     // in eCAL::Initialize ..
 
-    sim_time_subscriber = std::make_unique<eCAL::protobuf::CSubscriber<eCAL::pb::SimTime>>("__sim_time__");
-    sim_time_subscriber->SetReceiveCallback(std::bind(&eCAL::CSimTime::onSimTimeMessage, this, std::placeholders::_2));
+    eCAL::protobuf::CSubscriber<eCAL::pb::SimTime>::Arguments sim_time_subscriber_arguments;
+    sim_time_subscriber_arguments.data_callback = std::bind(&eCAL::CSimTime::onSimTimeMessage, this, std::placeholders::_2);
+    sim_time_subscriber = std::make_unique<eCAL::protobuf::CSubscriber<eCAL::pb::SimTime>>("__sim_time__", sim_time_subscriber_arguments);
     is_initialized = true;
     return true;
   }

--- a/ecal/samples/cpp/orchestration/component2/src/component2.cpp
+++ b/ecal/samples/cpp/orchestration/component2/src/component2.cpp
@@ -34,12 +34,14 @@ public:
   ComponentServiceImpl()
   {
     // create subscriber for topic 'foo'
-    subscriber_foo = std::make_unique<eCAL::protobuf::CSubscriber<component::foo>>("foo");
-    subscriber_foo->SetReceiveCallback(std::bind(&ComponentServiceImpl::on_foo_message, this, std::placeholders::_2));
+    eCAL::protobuf::CSubscriber<component::foo>::Arguments subscriber_foo_arguments;
+    subscriber_foo_arguments.data_callback = std::bind(&ComponentServiceImpl::on_foo_message, this, std::placeholders::_2);
+    subscriber_foo = std::make_unique<eCAL::protobuf::CSubscriber<component::foo>>("foo", subscriber_foo_arguments);
 
     // create subscriber for topic 'vec'
-    subscriber_vec = std::make_unique<eCAL::protobuf::CSubscriber<component::vec>>("vec");
-    subscriber_vec->SetReceiveCallback(std::bind(&ComponentServiceImpl::on_vec_message, this, std::placeholders::_2));
+    eCAL::protobuf::CSubscriber<component::vec>::Arguments subscriber_vec_arguments;
+    subscriber_vec_arguments.data_callback = std::bind(&ComponentServiceImpl::on_vec_message, this, std::placeholders::_2);
+    subscriber_vec = std::make_unique<eCAL::protobuf::CSubscriber<component::vec>>("vec", subscriber_vec_arguments);
   }
 
   // the component execute method

--- a/serialization/capnproto/samples/pubsub/addressbook_rec/src/addressbook_rec.cpp
+++ b/serialization/capnproto/samples/pubsub/addressbook_rec/src/addressbook_rec.cpp
@@ -91,11 +91,10 @@ int main()
   eCAL::Process::SetState(eCAL::Process::eSeverity::healthy, eCAL::Process::eSeverityLevel::level1, "I feel good !");
 
   // create a subscriber (topic name "addressbook")
-  eCAL::capnproto::CSubscriber<AddressBook> sub("addressbook");
-
+  eCAL::capnproto::CSubscriber<AddressBook>::Arguments sub_arguments;
   // add receive callback function (_1 = topic_id, _2 = msg, _3 = time)
-  auto callback = std::bind(OnAddressbook, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
-  sub.SetReceiveCallback(callback);
+  sub_arguments.data_callback = std::bind(OnAddressbook, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3);
+  eCAL::capnproto::CSubscriber<AddressBook> sub("addressbook", sub_arguments);
 
   // enter main loop
   while (eCAL::Ok())

--- a/serialization/capnproto/samples/pubsub/addressbook_rec_dynamic/src/addressbook_rec_dynamic.cpp
+++ b/serialization/capnproto/samples/pubsub/addressbook_rec_dynamic/src/addressbook_rec_dynamic.cpp
@@ -113,12 +113,11 @@ int main()
   eCAL::Process::SetState(eCAL::Process::eSeverity::healthy, eCAL::Process::eSeverityLevel::level1, "I feel good !");
 
   // create a subscriber (topic name "addressbook")
-  eCAL::capnproto::CDynamicSubscriber sub("addressbook");
-
-  auto lambda = [](const eCAL::STopicId& /*topic_id_*/, const capnp::DynamicValue::Reader& msg_, long long /*time_*/, long long /*clock_*/) -> void {
+  eCAL::capnproto::CDynamicSubscriber::Arguments sub_arguments;
+  sub_arguments.data_callback = [](const eCAL::STopicId& /*topic_id_*/, const capnp::DynamicValue::Reader& msg_, long long /*time_*/, long long /*clock_*/) -> void {
     dynamicPrintValue(msg_);
   };
-  sub.SetReceiveCallback(lambda);
+  eCAL::capnproto::CDynamicSubscriber sub("addressbook", sub_arguments);
 
   // enter main loop
   while (eCAL::Ok())

--- a/serialization/common/common/include/ecal/msg/publisher.h
+++ b/serialization/common/common/include/ecal/msg/publisher.h
@@ -76,29 +76,23 @@ namespace eCAL
     };
 
   public:
+    struct Arguments
+    {
+      eCAL::Publisher::Configuration config = GetPublisherConfiguration();
+      PubEventCallbackT event_callback = nullptr;
+
+      Arguments() = default;
+    };
+
     /**
      * @brief  Constructor.
      *
      * @param topic_name_  Unique topic name.
      * @param config_      Optional configuration parameters.
     **/
-    explicit CMessagePublisher(const std::string& topic_name_, const eCAL::Publisher::Configuration& config_ = GetPublisherConfiguration())
+    explicit CMessagePublisher(const std::string& topic_name_, const Arguments& arguments_ = Arguments{})
       : m_serializer{}
-      , m_publisher(topic_name_, m_serializer.GetDataTypeInformation(), config_)
-    {
-    }
-
-    /**
-     * @brief Constructor.
-     *
-     * @param topic_name_      Unique topic name.
-     * @param data_type_info_  Topic data type information (encoding, type, descriptor).
-     * @param event_callback_  The publisher event callback funtion.
-     * @param config_          Optional configuration parameters.
-    **/
-    explicit CMessagePublisher(const std::string& topic_name_, const PubEventCallbackT& event_callback_, const Publisher::Configuration& config_ = GetPublisherConfiguration())
-      : m_serializer{}
-      , m_publisher(topic_name_, m_serializer.GetDataTypeInformation(), event_callback_, config_)
+      , m_publisher(topic_name_, m_serializer.GetDataTypeInformation(), arguments_.event_callback, arguments_.config)
     {
     }
 

--- a/serialization/flatbuffers/samples/pubsub/monster_rec/monster_rec.cpp
+++ b/serialization/flatbuffers/samples/pubsub/monster_rec/monster_rec.cpp
@@ -121,11 +121,13 @@ int main(int /*argc*/, char** /*argv*/)
   // One type is a "flat" type, e.g. it uses the API which is backed by raw memory
   // The other type is an "object" type, where the type is directly mapped to e.g. std::string / std::vector ... types.
 
-  eCAL::flatbuffers::CFlatSubscriber<Game::Sample::Monster> flat_subscriber("monster");
-  flat_subscriber.SetReceiveCallback(OnFlatMonster);
-
-  eCAL::flatbuffers::CObjectSubscriber<Game::Sample::MonsterT> object_subscriber("monster");
-  object_subscriber.SetReceiveCallback(OnObjectMonster);
+  eCAL::flatbuffers::CFlatSubscriber<Game::Sample::Monster>::Arguments flat_subscriber_arguments;
+  flat_subscriber_arguments.data_callback = OnFlatMonster;
+  eCAL::flatbuffers::CFlatSubscriber<Game::Sample::Monster> flat_subscriber("monster", flat_subscriber_arguments);
+  
+  eCAL::flatbuffers::CObjectSubscriber<Game::Sample::MonsterT>::Arguments object_subscriber_arguments;
+  object_subscriber_arguments.data_callback = OnObjectMonster;
+  eCAL::flatbuffers::CObjectSubscriber<Game::Sample::MonsterT> object_subscriber("monster", object_subscriber_arguments);
 
   while(eCAL::Ok())
   {

--- a/serialization/protobuf/samples/pubsub/person_events_rec/src/person_events_rec.cpp
+++ b/serialization/protobuf/samples/pubsub/person_events_rec/src/person_events_rec.cpp
@@ -54,7 +54,9 @@ int main()
   eCAL::Process::SetState(eCAL::Process::eSeverity::healthy, eCAL::Process::eSeverityLevel::level1, "I feel good !");
 
   // create a subscriber (topic name "person")
-  eCAL::protobuf::CSubscriber<pb::People::Person> sub("person", OnEvent);
+  eCAL::protobuf::CSubscriber<pb::People::Person>::Arguments subscriber_arguments;
+  subscriber_arguments.event_callback = OnEvent;
+  eCAL::protobuf::CSubscriber<pb::People::Person> sub("person", subscriber_arguments);
 
   // start application and wait for events
   std::cout << "Please start 'person_snd_events sample." << std::endl << std::endl;

--- a/serialization/protobuf/samples/pubsub/person_events_snd/src/person_events_snd.cpp
+++ b/serialization/protobuf/samples/pubsub/person_events_snd/src/person_events_snd.cpp
@@ -54,7 +54,9 @@ int main()
   eCAL::Process::SetState(eCAL::Process::eSeverity::healthy, eCAL::Process::eSeverityLevel::level1, "I feel good !");
 
   // create a publisher (topic name "person")
-  eCAL::protobuf::CPublisher<pb::People::Person> pub("person", OnEvent);
+  eCAL::protobuf::CPublisher<pb::People::Person>::Arguments pub_arguments;
+  pub_arguments.event_callback = OnEvent;
+  eCAL::protobuf::CPublisher<pb::People::Person> pub("person", pub_arguments);
 
   // generate a class instance of Person
   pb::People::Person person;

--- a/serialization/protobuf/samples/pubsub/person_loopback/src/person_loopback.cpp
+++ b/serialization/protobuf/samples/pubsub/person_loopback/src/person_loopback.cpp
@@ -39,8 +39,8 @@ int main()
   // generate a class instance of Person
   pb::People::Person person;
 
-  eCAL::protobuf::CSubscriber<pb::People::Person> sub("person");
-  auto receive_lambda = [](const eCAL::STopicId& /*topic_id_*/, const pb::People::Person& person_, const long long /*time_*/, const long long /*clock_*/){
+  eCAL::protobuf::CSubscriber<pb::People::Person>::Arguments sub_arguments;
+  sub_arguments.data_callback = [](const eCAL::STopicId& /*topic_id_*/, const pb::People::Person& person_, const long long /*time_*/, const long long /*clock_*/){
     std::cout << "------------------------------------------" << std::endl;
     std::cout << " RECEIVED                                 " << std::endl;
     std::cout << "------------------------------------------" << std::endl;
@@ -54,7 +54,7 @@ int main()
     std::cout                                                 << std::endl;
 
   };
-  sub.SetReceiveCallback(receive_lambda);
+  eCAL::protobuf::CSubscriber<pb::People::Person> sub("person", sub_arguments);
 
   // enter main loop
   auto cnt = 0;

--- a/serialization/protobuf/samples/pubsub/person_rec/src/person_rec.cpp
+++ b/serialization/protobuf/samples/pubsub/person_rec/src/person_rec.cpp
@@ -53,8 +53,8 @@ int main()
   // set process state
   eCAL::Process::SetState(eCAL::Process::eSeverity::healthy, eCAL::Process::eSeverityLevel::level1, "I feel good !");
 
-  // create a subscriber config
-  eCAL::Subscriber::Configuration sub_config;
+  eCAL::protobuf::CSubscriber<pb::People::Person>::Arguments sub_arguments;
+  auto& sub_config = sub_arguments.config;
 
   // activate transport layer
   sub_config.layer.shm.enable = true;
@@ -62,7 +62,7 @@ int main()
   sub_config.layer.tcp.enable = true;
 
   // create a subscriber (topic name "person")
-  eCAL::protobuf::CSubscriber<pb::People::Person> sub("person", sub_config);
+  eCAL::protobuf::CSubscriber<pb::People::Person> sub("person", sub_arguments);
 
   // add receive callback function (_1 = topic_name, _2 = msg, _3 = time, _4 = clock, _5 = id)
   auto callback = std::bind(OnPerson, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4);

--- a/serialization/protobuf/samples/pubsub/person_snd_tcp/src/person_snd_tcp.cpp
+++ b/serialization/protobuf/samples/pubsub/person_snd_tcp/src/person_snd_tcp.cpp
@@ -32,8 +32,8 @@ int main()
   // set process state
   eCAL::Process::SetState(eCAL::Process::eSeverity::healthy, eCAL::Process::eSeverityLevel::level1, "I feel good !");
 
-  // create a publisher config
-  eCAL::Publisher::Configuration pub_config;
+  eCAL::protobuf::CPublisher<pb::People::Person>::Arguments pub_arguments;
+  auto& pub_config = pub_arguments.config;
   
   // switch shm and udp layer off, tcp layer on
   pub_config.layer.shm.enable = false;
@@ -41,7 +41,7 @@ int main()
   pub_config.layer.tcp.enable = true;
 
   // create a publisher (topic name "person")
-  eCAL::protobuf::CPublisher<pb::People::Person> pub("person", pub_config);
+  eCAL::protobuf::CPublisher<pb::People::Person> pub("person", pub_arguments);
 
   // generate a class instance of Person
   pb::People::Person person;

--- a/serialization/protobuf/samples/pubsub/person_snd_udp/src/person_snd_udp.cpp
+++ b/serialization/protobuf/samples/pubsub/person_snd_udp/src/person_snd_udp.cpp
@@ -33,7 +33,8 @@ int main()
   eCAL::Process::SetState(eCAL::Process::eSeverity::healthy, eCAL::Process::eSeverityLevel::level1, "I feel good !");
 
   // create a publisher config
-  eCAL::Publisher::Configuration pub_config;
+  eCAL::protobuf::CPublisher<pb::People::Person>::Arguments pub_arguments;
+  auto& pub_config = pub_arguments.config;
 
   // switch shm and tcp layer off, udp layer on
   pub_config.layer.shm.enable = false;
@@ -41,7 +42,7 @@ int main()
   pub_config.layer.tcp.enable = false;
 
   // create a publisher (topic name "person")
-  eCAL::protobuf::CPublisher<pb::People::Person> pub("person", pub_config);
+  eCAL::protobuf::CPublisher<pb::People::Person> pub("person", pub_arguments);
 
   // generate a class instance of Person
   pb::People::Person person;

--- a/serialization/protobuf/samples/pubsub/proto_dyn_json_rec/src/proto_dyn_json_rec.cpp
+++ b/serialization/protobuf/samples/pubsub/proto_dyn_json_rec/src/proto_dyn_json_rec.cpp
@@ -37,8 +37,9 @@ int main()
   eCAL::Initialize("proto_dyn");
 
   // create dynamic subscribers for receiving and decoding messages
-  eCAL::protobuf::CDynamicJSONSubscriber sub(MESSAGE_NAME);
-  sub.SetReceiveCallback(std::bind(ProtoMsgCallback, std::placeholders::_1, std::placeholders::_2));
+  eCAL::protobuf::CDynamicJSONSubscriber::Arguments sub_arguments;
+  sub_arguments.data_callback = std::bind(ProtoMsgCallback, std::placeholders::_1, std::placeholders::_2);
+  eCAL::protobuf::CDynamicJSONSubscriber sub(MESSAGE_NAME, sub_arguments);
 
   // enter main loop
   while(eCAL::Ok())

--- a/serialization/protobuf/samples/pubsub/proto_dyn_rec/src/proto_dyn_rec.cpp
+++ b/serialization/protobuf/samples/pubsub/proto_dyn_rec/src/proto_dyn_rec.cpp
@@ -282,8 +282,9 @@ int main()
   eCAL::Initialize("proto_dyn");
 
   // create dynamic subscribers for receiving and decoding messages
-  eCAL::protobuf::CDynamicSubscriber sub(MESSAGE_NAME);
-  sub.SetReceiveCallback(std::bind(ProtoMsgCallback, std::placeholders::_1, std::placeholders::_2));
+  eCAL::protobuf::CDynamicSubscriber::Arguments sub_arguments;
+  sub_arguments.data_callback = std::bind(ProtoMsgCallback, std::placeholders::_1, std::placeholders::_2);
+  eCAL::protobuf::CDynamicSubscriber sub(MESSAGE_NAME, sub_arguments);
 
   // enter main loop
   while(eCAL::Ok())

--- a/serialization/protobuf/tests/pubsub_proto_test/src/proto_dyn_subscriber_test.cpp
+++ b/serialization/protobuf/tests/pubsub_proto_test/src/proto_dyn_subscriber_test.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,9 +94,9 @@ int extract_id(const google::protobuf::Message& msg_)
 TEST_F(core_cpp_pubsub_proto_dyn, ProtoDynSubscriberTest_SendReceiveCB)
 {
   // Assert that the Subscriber can be move constructed.
-  eCAL::protobuf::CDynamicSubscriber person_dyn_rec("ProtoSubscriberTest");
-  auto person_callback = std::bind(&ProtoDynSubscriberTest::OnPerson, this, std::placeholders::_2, std::placeholders::_3);
-  person_dyn_rec.SetReceiveCallback(person_callback);
+  eCAL::protobuf::CDynamicSubscriber::Arguments person_dyn_rec_arguments;
+  person_dyn_rec_arguments.data_callback = std::bind(&ProtoDynSubscriberTest::OnPerson, this, std::placeholders::_2, std::placeholders::_3);
+  eCAL::protobuf::CDynamicSubscriber person_dyn_rec("ProtoSubscriberTest", person_dyn_rec_arguments);
 
   eCAL::protobuf::CPublisher<pb::People::Person> person_pub("ProtoSubscriberTest");
 

--- a/serialization/protobuf/tests/pubsub_proto_test/src/proto_subscriber_test.cpp
+++ b/serialization/protobuf/tests/pubsub_proto_test/src/proto_subscriber_test.cpp
@@ -78,9 +78,9 @@ using core_cpp_pubsub_proto_sub = ProtoSubscriberTest;
 TEST_F(core_cpp_pubsub_proto_sub, ProtoSubscriberTest_SendReceive)
 {
   // Assert that the Subscriber can be move constructed.
-  eCAL::protobuf::CSubscriber<pb::People::Person> person_rec("ProtoSubscriberTest");
-  auto person_callback = std::bind(&ProtoSubscriberTest::OnPerson, this);
-  person_rec.SetReceiveCallback(person_callback);
+  eCAL::protobuf::CSubscriber<pb::People::Person>::Arguments person_rec_arguments;
+  person_rec_arguments.data_callback = std::bind(&ProtoSubscriberTest::OnPerson, this);
+  eCAL::protobuf::CSubscriber<pb::People::Person> person_rec("ProtoSubscriberTest", person_rec_arguments);
 
   eCAL::protobuf::CPublisher<pb::People::Person> person_pub("ProtoSubscriberTest");
 
@@ -94,9 +94,9 @@ TEST_F(core_cpp_pubsub_proto_sub, ProtoSubscriberTest_SendReceive)
 
 TEST_F(core_cpp_pubsub_proto_sub, ProtoSubscriberTest_MoveAssignment)
 {
-  eCAL::protobuf::CSubscriber<pb::People::Person> person_rec("ProtoSubscriberTest");
-  auto person_callback = std::bind(&ProtoSubscriberTest::OnPerson, this);
-  person_rec.SetReceiveCallback(person_callback);
+  eCAL::protobuf::CSubscriber<pb::People::Person>::Arguments person_rec_arguments;
+  person_rec_arguments.data_callback = std::bind(&ProtoSubscriberTest::OnPerson, this);
+  eCAL::protobuf::CSubscriber<pb::People::Person> person_rec("ProtoSubscriberTest", person_rec_arguments);
 
   eCAL::protobuf::CSubscriber<pb::People::Person>person_moved{ std::move(person_rec) };
 
@@ -116,9 +116,9 @@ TEST_F(core_cpp_pubsub_proto_sub, ProtoSubscriberTest_MoveAssignment)
 TEST_F(core_cpp_pubsub_proto_sub, ProtoSubscriberTest_MoveConstruction)
 {
   // Assert that the Subscriber can be move constructed.
-  eCAL::protobuf::CSubscriber<pb::People::Person> person_rec("ProtoSubscriberTest");
-  auto person_callback = std::bind(&ProtoSubscriberTest::OnPerson, this);
-  person_rec.SetReceiveCallback(person_callback);
+  eCAL::protobuf::CSubscriber<pb::People::Person>::Arguments person_rec_arguments;
+  person_rec_arguments.data_callback = std::bind(&ProtoSubscriberTest::OnPerson, this);
+  eCAL::protobuf::CSubscriber<pb::People::Person> person_rec("ProtoSubscriberTest", person_rec_arguments);
 
   eCAL::protobuf::CSubscriber<pb::People::Person> person_moved{ std::move(person_rec) };
 

--- a/serialization/string/samples/pubsub/minimal_rec/src/minimal_rec.cpp
+++ b/serialization/string/samples/pubsub/minimal_rec/src/minimal_rec.cpp
@@ -35,11 +35,10 @@ int main()
   eCAL::Initialize("minimal_rec_cb");
 
   // subscriber for topic "Hello"
-  eCAL::string::CSubscriber sub("Hello");
+  eCAL::string::CSubscriber::Arguments sub_arguments;
+  sub_arguments.data_callback = [](const eCAL::STopicId& /*publisher_id_*/, const std::string& msg_, long long /*time_*/, long long /*clock_*/) { std::cout << "Received \"" << msg_ << "\"" << std::endl; };
 
-  // receive updates in a callback (lambda function)
-  auto msg_cb = [](const std::string& msg_) { std::cout << "Received \"" << msg_ << "\"" << std::endl; };
-  sub.SetReceiveCallback(std::bind(msg_cb, std::placeholders::_2));
+  eCAL::string::CSubscriber sub("Hello", sub_arguments);
 
   // idle main loop
   while (eCAL::Ok()) std::this_thread::sleep_for(std::chrono::milliseconds(500));


### PR DESCRIPTION
…ctor.

Subscribers must register data and error callbacks at object creation. Callbacks cannot be removed during runtime any longer.

### Description
This PR experiments if we want to force users to register callbacks at construction time.

Pro: Only one constructor per Publisher / Subscriber class
Con: Feels a bit clumsy. Users might want to rely on this feature (also does not yet compile because of monitor plugins, who remove their callbacks on Pause / Readd them on Resume)
