### PR TITLE
[Rec] Added mDNS support for FTP Uploads

### DIFF
--- a/app/rec/rec_client_core/src/job/ftp_upload_thread.cpp
+++ b/app/rec/rec_client_core/src/job/ftp_upload_thread.cpp
@@ -373,19 +373,19 @@ namespace eCAL
       // Try Parsing the ftp_host as an IP address. If it is not an IP address, we try to resolve it.
       bool ftp_host_is_ipv4 = false;
       {
-        struct sockaddr_in sa;
-        int result = inet_pton(AF_INET, ftp_host_.c_str(), &(sa.sin_addr));
-        ftp_host_is_ipv4 = result != 0;
+        sockaddr_in sa{};
+        const int result = inet_pton(AF_INET, ftp_host_.c_str(), &(sa.sin_addr));
+        ftp_host_is_ipv4 = (result != 0);
       }
       bool ftp_host_is_ipv6 = false;
       {
-        struct sockaddr_in6 sa;
-        int result = inet_pton(AF_INET6, ftp_host_.c_str(), &(sa.sin6_addr));
-        ftp_host_is_ipv6 = result != 0;
+        sockaddr_in6 sa{};
+        const int result = inet_pton(AF_INET6, ftp_host_.c_str(), &(sa.sin6_addr));
+        ftp_host_is_ipv6 = (result != 0);
       }
 
       // Check if the hostname already has a domain (like .local / .localdomain / etc.). If it does, we don't append .local and therefore don't resolve it beforehand.
-      bool hostname_has_domain = (ftp_host_.find('.') != std::string::npos);
+      const bool hostname_has_domain = (ftp_host_.find('.') != std::string::npos);
       
       std::string best_hostname = ftp_host_;
 
@@ -417,8 +417,8 @@ namespace eCAL
           EcalRecLogger::Instance()->debug("Trying to resolve hostname: " + hostname);
 
           std::vector<AddressInfo> address_infos = ResolveHostnameBlocking(hostname);
-          bool hostname_resolved        = !address_infos.empty();
-          bool hostname_resoled_to_ipv4 = false;
+          const bool hostname_resolved        = !address_infos.empty();
+          bool       hostname_resoled_to_ipv4 = false;
           for (const auto& address_info : address_infos)
           {
             // Check if the hostname resolves to an IPv4 address
@@ -475,7 +475,7 @@ namespace eCAL
       //       Pro: This could speed things up a little bit, as curl doesn't need to resolve the hostname again.
       //       Con: I wanted to give CURL the chance to resolve the hostname itself, as it may choose a different IP address than the one we resolved.
       //
-      std::string ftp_server     = "ftp://" + ftp_username_ + ":" + ftp_password_ + "@" + best_hostname + ":" + std::to_string(ftp_port_);
+      const std::string ftp_server     = "ftp://" + ftp_username_ + ":" + ftp_password_ + "@" + best_hostname + ":" + std::to_string(ftp_port_);
 
       // Create a list of all files to upload
       EcalRecLogger::Instance()->info("Scanning directory for upload: " + local_root_dir_);
@@ -743,7 +743,7 @@ namespace eCAL
     std::vector<FtpUploadThread::AddressInfo> FtpUploadThread::ResolveHostnameBlocking(const std::string& hostname)
     { 
       // Create Address info hints
-      addrinfo addrinfo_hints;
+      addrinfo addrinfo_hints{};
       memset(&addrinfo_hints, 0, sizeof(addrinfo_hints));
       addrinfo_hints.ai_family = AF_UNSPEC;
       addrinfo_hints.ai_socktype = SOCK_STREAM;
@@ -751,7 +751,7 @@ namespace eCAL
 
       // Query the address info for the hostname
       addrinfo* addrinfo_res = nullptr;
-      int errcode = getaddrinfo(hostname.c_str(), NULL, &addrinfo_hints, &addrinfo_res);
+      const int errcode = getaddrinfo(hostname.c_str(), nullptr, &addrinfo_hints, &addrinfo_res);
       if (errcode != 0)
       {
         return {};
@@ -766,10 +766,10 @@ namespace eCAL
         switch (addrinfo_it->ai_family)
         {
           case AF_INET:
-            addr_ptr = &((struct sockaddr_in *) addrinfo_it->ai_addr)->sin_addr;
+            addr_ptr = &(reinterpret_cast<struct sockaddr_in *>(addrinfo_it->ai_addr))->sin_addr;
             break;
           case AF_INET6:
-            addr_ptr = &((struct sockaddr_in6 *) addrinfo_it->ai_addr)->sin6_addr;
+            addr_ptr = &(reinterpret_cast<struct sockaddr_in6 *>(addrinfo_it->ai_addr))->sin6_addr;
             break;
           default:
             break;

--- a/app/rec/rec_client_core/src/job/ftp_upload_thread.h
+++ b/app/rec/rec_client_core/src/job/ftp_upload_thread.h
@@ -54,7 +54,10 @@ namespace eCAL
     public:
       // Constructor
       FtpUploadThread(const std::string&                local_root_dir
-                    , const std::string&                ftp_server
+                    , const std::string&                ftp_host
+                    , uint16_t                          ftp_port
+                    , const std::string&                ftp_username
+                    , const std::string&                ftp_password
                     , const std::string&                ftp_root_dir
                     , const std::vector<std::string>&   skip_files
                     , const std::function<Error(void)>& post_upload_function = [](){ return Error::OK; });
@@ -81,6 +84,13 @@ namespace eCAL
       // Helper methods
       /////////////////////////////////////////////
     private:
+      struct AddressInfo
+      {
+        std::string address_;   //!< IP address
+        int         family_ {}; //!< Address type (AF_INET, AF_INET6)
+      };
+
+      static std::vector<AddressInfo> ResolveHostnameBlocking(const std::string& hostname);
       static std::list<std::pair<std::string, unsigned long long>> CreateFileList(const std::string& root_dir);
       static std::string CreateTempSuffix();
 
@@ -105,7 +115,10 @@ namespace eCAL
       CURL* curl_handle;
 
       std::string              local_root_dir_;
-      std::string              ftp_server_;
+      std::string              ftp_host_;
+      uint16_t                 ftp_port_;
+      std::string              ftp_username_;
+      std::string              ftp_password_;
       std::string              ftp_root_dir_;
       std::vector<std::string> skip_files_;
 

--- a/app/rec/rec_client_core/src/job/record_job.cpp
+++ b/app/rec/rec_client_core/src/job/record_job.cpp
@@ -381,7 +381,6 @@ namespace eCAL
         }
 
         std::string local_root_dir = job_config_.GetCompleteMeasurementPath();
-        std::string ftp_server     = "ftp://" + upload_config.username_ + ":" + upload_config.password_ + "@" + upload_config.host_ + ":" + std::to_string(upload_config.port_);
         std::string upload_path    = EcalUtils::Filesystem::CleanPath("/" + upload_config.upload_path_ + "/", EcalUtils::Filesystem::Unix);
 
         if (upload_config.upload_metadata_files_)
@@ -389,7 +388,10 @@ namespace eCAL
           if (upload_config.delete_after_upload_)
           {
             ftp_upload_thread_ = std::make_unique<FtpUploadThread>(std::move(local_root_dir)
-                                                                 , std::move(ftp_server)
+                                                                 , upload_config.host_
+                                                                 , upload_config.port_
+                                                                 , upload_config.username_
+                                                                 , upload_config.password_
                                                                  , std::move(upload_path)
                                                                  , std::vector<std::string>()
                                                                  , [this]() -> Error { return this->DeleteMeasurement(true); });
@@ -397,7 +399,10 @@ namespace eCAL
           else
           {
             ftp_upload_thread_ = std::make_unique<FtpUploadThread>(std::move(local_root_dir)
-                                                                 , std::move(ftp_server)
+                                                                 , upload_config.host_
+                                                                 , upload_config.port_
+                                                                 , upload_config.username_
+                                                                 , upload_config.password_
                                                                  , std::move(upload_path)
                                                                  , std::vector<std::string>());
           }
@@ -407,7 +412,10 @@ namespace eCAL
           if (upload_config.delete_after_upload_)
           {
             ftp_upload_thread_ = std::make_unique<FtpUploadThread>(std::move(local_root_dir)
-                                                                 , std::move(ftp_server)
+                                                                 , upload_config.host_
+                                                                 , upload_config.port_
+                                                                 , upload_config.username_
+                                                                 , upload_config.password_
                                                                  , std::move(upload_path)
                                                                  , files_with_metadata_
                                                                  , [this]() -> Error { return this->DeleteMeasurement(true); });
@@ -415,7 +423,10 @@ namespace eCAL
           else
           {
             ftp_upload_thread_ = std::make_unique<FtpUploadThread>(std::move(local_root_dir)
-                                                                 , std::move(ftp_server)
+                                                                 , upload_config.host_
+                                                                 , upload_config.port_
+                                                                 , upload_config.username_
+                                                                 , upload_config.password_
                                                                  , std::move(upload_path)
                                                                  , files_with_metadata_);
           }


### PR DESCRIPTION
### Description
Added mDNS support for FTP Uploads. As CURL does not support backup hostnames, the hostname is probed beforehand to check which variant can be resolved.

- For plain hostnames, eCAL rec will probe [`Hostname`, `Hostname.local`] in that order
    - The variant that can be resolved to an IPv4 address is preferred
    - `Hostname` is preferred over `Hostname.local`
- Hostnames that already contain a `.` are used as-is. No .local is added and therefore, the probing step is skipped
- If the Hostname is an IPv4/v6 address, the probing step is skipped and the address is used as-is

### Related issues
- Fixes #1531