### PR TITLE
[core] Provide serializer.h for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ int main(int argc, char** argv)
   eCAL::Initialize(argc, argv, "Hello World Publisher");
 
   // Create a String Publisher that publishes on the topic "hello_world_topic"
-  eCAL::string::CPublisher<std::string> publisher("hello_world_topic");
+  eCAL::string::CPublisher publisher("hello_world_topic");
 
   // Infinite loop
   while (eCAL::Ok())

--- a/doc/rst/configuration/src/publisher_config/main.cpp
+++ b/doc/rst/configuration/src/publisher_config/main.cpp
@@ -19,13 +19,13 @@ int main(int argc, char** argv)
   pub_config.layer.tcp.enable = false;
 
   // create publisher 1
-  eCAL::string::CPublisher<std::string> pub_1("topic_1", pub_config);
+  eCAL::string::CPublisher pub_1("topic_1", pub_config);
 
   // enable for the second publisher also tcp
   pub_config.layer.tcp.enable = true;
 
   // create publisher 2
-  eCAL::string::CPublisher<std::string> pub_2("topic_2", pub_config);
+  eCAL::string::CPublisher pub_2("topic_2", pub_config);
 
   int counter {0};
   while (eCAL::Ok())

--- a/doc/rst/getting_started/src/hello_world/hello_world_rec/main.cpp
+++ b/doc/rst/getting_started/src/hello_world/hello_world_rec/main.cpp
@@ -16,7 +16,7 @@ int main(int argc, char** argv)
   eCAL::Initialize("Hello World Subscriber");
 
   // Create a subscriber that listenes on the "hello_world_topic"
-  eCAL::string::CSubscriber<std::string> subscriber("hello_world_topic");
+  eCAL::string::CSubscriber subscriber("hello_world_topic");
 
   // Set the Callback
   subscriber.SetReceiveCallback(std::bind(&HelloWorldCallback, std::placeholders::_2));

--- a/doc/rst/getting_started/src/hello_world/hello_world_snd/main.cpp
+++ b/doc/rst/getting_started/src/hello_world/hello_world_snd/main.cpp
@@ -10,7 +10,7 @@ int main(int argc, char** argv)
   eCAL::Initialize("Hello World Publisher");
 
   // Create a String Publisher that publishes on the topic "hello_world_topic"
-  eCAL::string::CPublisher<std::string> publisher("hello_world_topic");
+  eCAL::string::CPublisher publisher("hello_world_topic");
 
   // Create a counter, so something changes in our message
   int counter = 0;

--- a/serialization/flatbuffers/flatbuffers/CMakeLists.txt
+++ b/serialization/flatbuffers/flatbuffers/CMakeLists.txt
@@ -38,6 +38,7 @@ target_sources(flatbuffers_core
     FILES
       include/ecal/msg/flatbuffers/publisher.h
       include/ecal/msg/flatbuffers/subscriber.h  
+      include/ecal/msg/flatbuffers/serializer.h
 )
 
 target_compile_features(flatbuffers_core INTERFACE cxx_std_17)

--- a/serialization/protobuf/protobuf/CMakeLists.txt
+++ b/serialization/protobuf/protobuf/CMakeLists.txt
@@ -93,6 +93,8 @@ target_sources(protobuf_core
       include/ecal/msg/protobuf/publisher.h
       include/ecal/msg/protobuf/server.h
       include/ecal/msg/protobuf/subscriber.h
+      include/ecal/msg/protobuf/serializer.h
+
 )
 
 target_compile_features(protobuf_core INTERFACE cxx_std_14)

--- a/serialization/string/string/CMakeLists.txt
+++ b/serialization/string/string/CMakeLists.txt
@@ -32,7 +32,8 @@ target_sources(string_base
     TYPE HEADERS
     BASE_DIRS include
     FILES
-      include/ecal/msg/string/message.h   
+      include/ecal/msg/string/message.h
+      include/ecal/msg/string/serializer.h  
 )
 
 target_compile_features(string_base INTERFACE cxx_std_14)


### PR DESCRIPTION
### Description
The new serialization pub/sub need also the serializer.h, which was not provided in the installation before.

In addition, samples in doc are fixed to the new implementation.