### PR TITLE
[msg] Avoid deadlocking with CMessageSubscriber

### DIFF
--- a/app/mon/mon_plugins/capnproto_reflection/src/plugin_widget.cpp
+++ b/app/mon/mon_plugins/capnproto_reflection/src/plugin_widget.cpp
@@ -58,8 +58,10 @@ PluginWidget::PluginWidget(const QString& topic_name, const QString& topic_type,
   ui_.publish_timestamp_warning_label->setVisible(false);
 
   // Add eCAL Callbacks
-  subscriber_.SetReceiveCallback(std::bind(&PluginWidget::onProtoMessageCallback, this, std::placeholders::_2, std::placeholders::_3));
-  subscriber_.SetErrorCallback(std::bind(&PluginWidget::onProtoErrorCallback, this, std::placeholders::_1));
+  subscriber_.SetReceiveCallback(
+    std::bind(&PluginWidget::onProtoMessageCallback, this, std::placeholders::_2, std::placeholders::_3),
+    std::bind(&PluginWidget::onProtoErrorCallback, this, std::placeholders::_1)
+  );
 
   // Button connections
   connect(ui_.expand_button, &QPushButton::clicked, [this]() { tree_view_->expandAll();   });
@@ -322,14 +324,15 @@ void PluginWidget::onUpdate()
 void PluginWidget::onResume()
 {
   // Add eCAL Callbacks
-  subscriber_.SetReceiveCallback(std::bind(&PluginWidget::onProtoMessageCallback, this, std::placeholders::_2, std::placeholders::_3));
-  subscriber_.SetErrorCallback(std::bind(&PluginWidget::onProtoErrorCallback, this, std::placeholders::_1));
+  subscriber_.SetReceiveCallback(
+    std::bind(&PluginWidget::onProtoMessageCallback, this, std::placeholders::_2, std::placeholders::_3),
+    std::bind(&PluginWidget::onProtoErrorCallback, this, std::placeholders::_1)
+  );
 }
 
 void PluginWidget::onPause()
 {
   subscriber_.RemoveReceiveCallback();
-  subscriber_.RemoveErrorCallback();
 }
 
 QWidget* PluginWidget::getWidget()

--- a/app/mon/mon_plugins/protobuf_reflection/src/plugin_widget.cpp
+++ b/app/mon/mon_plugins/protobuf_reflection/src/plugin_widget.cpp
@@ -59,8 +59,10 @@ PluginWidget::PluginWidget(const QString& topic_name, const QString& topic_type,
   ui_.publish_timestamp_warning_label->setVisible(false);
 
   // Add eCAL Callbacks
-  subscriber_.SetReceiveCallback(std::bind(&PluginWidget::onProtoMessageCallback, this, std::placeholders::_2, std::placeholders::_3));
-  subscriber_.SetErrorCallback(std::bind(&PluginWidget::onProtoErrorCallback, this, std::placeholders::_1));
+  subscriber_.SetReceiveCallback(
+    std::bind(&PluginWidget::onProtoMessageCallback, this, std::placeholders::_2, std::placeholders::_3),
+    std::bind(&PluginWidget::onProtoErrorCallback, this, std::placeholders::_1)
+  );
 
   // Button connections
   connect(ui_.expand_button, &QPushButton::clicked, [this]() { tree_view_->expandAll();   });
@@ -106,7 +108,6 @@ PluginWidget::~PluginWidget()
 #endif // NDEBUG
 
   subscriber_.RemoveReceiveCallback();
-  subscriber_.RemoveErrorCallback();
   
   {
     std::lock_guard<std::mutex> lock(proto_message_mutex_);
@@ -319,14 +320,15 @@ void PluginWidget::onUpdate()
 void PluginWidget::onResume()
 {
   // Add eCAL Callbacks
-  subscriber_.SetReceiveCallback(std::bind(&PluginWidget::onProtoMessageCallback, this, std::placeholders::_2, std::placeholders::_3));
-  subscriber_.SetErrorCallback(std::bind(&PluginWidget::onProtoErrorCallback, this, std::placeholders::_1));
+  subscriber_.SetReceiveCallback(
+    std::bind(&PluginWidget::onProtoMessageCallback, this, std::placeholders::_2, std::placeholders::_3),
+    std::bind(&PluginWidget::onProtoErrorCallback, this, std::placeholders::_1)
+    );
 }
 
 void PluginWidget::onPause()
 {
   subscriber_.RemoveReceiveCallback();
-  subscriber_.RemoveErrorCallback();
 }
 
 QWidget* PluginWidget::getWidget()

--- a/app/mon/mon_plugins/signals_plotting/src/plugin_widget.cpp
+++ b/app/mon/mon_plugins/signals_plotting/src/plugin_widget.cpp
@@ -73,8 +73,10 @@ PluginWidget::PluginWidget(const QString& topic_name, const QString& topic_type,
   ui_.publish_timestamp_warning_label->setVisible(false);
 
   // Add eCAL Callbacks
-  subscriber_.SetReceiveCallback(std::bind(&PluginWidget::onProtoMessageCallback, this, std::placeholders::_2, std::placeholders::_3));
-  subscriber_.SetErrorCallback(std::bind(&PluginWidget::onProtoErrorCallback, this, std::placeholders::_1));
+  subscriber_.SetReceiveCallback(
+    std::bind(&PluginWidget::onProtoMessageCallback, this, std::placeholders::_2, std::placeholders::_3),
+    std::bind(&PluginWidget::onProtoErrorCallback, this, std::placeholders::_1)
+  );
 
   // Button connections
   connect(ui_.expand_button, &QPushButton::clicked, [this]() { tree_view_->expandAll();   });
@@ -128,7 +130,6 @@ PluginWidget::~PluginWidget()
 #endif // NDEBUG
 
   subscriber_.RemoveReceiveCallback();
-  subscriber_.RemoveErrorCallback();
 
   {
     std::lock_guard<std::mutex> lock(proto_message_mutex_);

--- a/ecal/core/src/pubsub/ecal_subscriber.cpp
+++ b/ecal/core/src/pubsub/ecal_subscriber.cpp
@@ -59,19 +59,9 @@ namespace eCAL
     if (g_subgate() != nullptr) g_subgate()->Unregister(m_subscriber_impl->GetTopicName(), m_subscriber_impl);
   }
 
-  CSubscriber::CSubscriber(CSubscriber&& rhs) noexcept :
-    m_subscriber_impl(std::move(rhs.m_subscriber_impl))
-  {
-  }
+  CSubscriber::CSubscriber(CSubscriber&& rhs) noexcept = default;
 
-  CSubscriber& CSubscriber::operator=(CSubscriber&& rhs) noexcept
-  {
-    if (this != &rhs)
-    {
-      m_subscriber_impl = std::move(rhs.m_subscriber_impl);
-    }
-    return *this;
-  }
+  CSubscriber& CSubscriber::operator=(CSubscriber&& rhs) noexcept = default;
 
   bool CSubscriber::SetReceiveCallback(ReceiveCallbackT callback_)
   {

--- a/ecal/core/src/pubsub/ecal_subscriber_impl.h
+++ b/ecal/core/src/pubsub/ecal_subscriber_impl.h
@@ -67,6 +67,14 @@ namespace eCAL
     CSubscriberImpl(const SDataTypeInformation& topic_info_, const eCAL::eCALReader::SAttributes& attr_);
     ~CSubscriberImpl();
 
+    // Delete copy constructor and copy assignment operator
+    CSubscriberImpl(const CSubscriberImpl&) = delete;
+    CSubscriberImpl& operator=(const CSubscriberImpl&) = delete;
+
+    // Delete move constructor and move assignment operator
+    CSubscriberImpl(CSubscriberImpl&&) = delete;
+    CSubscriberImpl& operator=(CSubscriberImpl&&) = delete;
+
     bool Read(std::string& buf_, long long* time_ = nullptr, int rcv_timeout_ms_ = 0);
 
     bool SetReceiveCallback(ReceiveCallbackT callback_);

--- a/serialization/protobuf/tests/pubsub_proto_test/src/proto_subscriber_test.cpp
+++ b/serialization/protobuf/tests/pubsub_proto_test/src/proto_subscriber_test.cpp
@@ -111,7 +111,7 @@ TEST_F(core_cpp_pubsub_proto_sub, ProtoSubscriberTest_MoveConstruction)
   pub_config.layer.shm.acknowledge_timeout_ms = 500;
   eCAL::protobuf::CPublisher<pb::People::Person> person_pub("ProtoSubscriberTest", pub_config);
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+  std::this_thread::sleep_for(std::chrono::milliseconds(2000));
 
   // Start publishing (With acknowledge?)
   std::thread person_pub_thread([this, &person_pub, &stop_publishing, &numbers_of_sends]() {
@@ -119,7 +119,6 @@ TEST_F(core_cpp_pubsub_proto_sub, ProtoSubscriberTest_MoveConstruction)
     {
       SendPerson(person_pub);
       ++numbers_of_sends;
-      //std::this_thread::sleep_for(std::chrono::milliseconds(0));
     }
     });
 

--- a/serialization/protobuf/tests/pubsub_proto_test/src/proto_subscriber_test.cpp
+++ b/serialization/protobuf/tests/pubsub_proto_test/src/proto_subscriber_test.cpp
@@ -92,45 +92,49 @@ TEST_F(core_cpp_pubsub_proto_sub, ProtoSubscriberTest_SendReceive)
   ASSERT_EQ(1, received_callbacks);
 }
 
-TEST_F(core_cpp_pubsub_proto_sub, ProtoSubscriberTest_MoveAssignment)
-{
-  eCAL::protobuf::CSubscriber<pb::People::Person> person_rec("ProtoSubscriberTest");
-  auto person_callback = std::bind(&ProtoSubscriberTest::OnPerson, this);
-  person_rec.SetReceiveCallback(person_callback);
-
-  eCAL::protobuf::CSubscriber<pb::People::Person>person_moved{ std::move(person_rec) };
-
-  ASSERT_EQ("ProtoSubscriberTest", person_moved.GetTopicName());
-
-  // Assert that the move constructed object can receive something
-  eCAL::protobuf::CPublisher<pb::People::Person> person_pub("ProtoSubscriberTest");
-
-  std::this_thread::sleep_for(std::chrono::milliseconds(2000));
-
-  ASSERT_TRUE(SendPerson(person_pub));
-  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-  // assert that the OnPerson callback has been called once.
-  ASSERT_EQ(1, received_callbacks);
-}
-
 TEST_F(core_cpp_pubsub_proto_sub, ProtoSubscriberTest_MoveConstruction)
 {
+
   // Assert that the Subscriber can be move constructed.
-  eCAL::protobuf::CSubscriber<pb::People::Person> person_rec("ProtoSubscriberTest");
+  std::vector<eCAL::protobuf::CSubscriber<pb::People::Person>> subscribers;
+  subscribers.reserve(1000);
+
+  subscribers.emplace_back("ProtoSubscriberTest");
+  auto& person_rec = subscribers[0];
   auto person_callback = std::bind(&ProtoSubscriberTest::OnPerson, this);
   person_rec.SetReceiveCallback(person_callback);
 
-  eCAL::protobuf::CSubscriber<pb::People::Person> person_moved{ std::move(person_rec) };
-
-  ASSERT_EQ("ProtoSubscriberTest", person_moved.GetTopicName());
-
+  std::atomic<bool> stop_publishing(false);
+  int numbers_of_sends = 0;
   // Assert that the move constructed object can receive something
-  eCAL::protobuf::CPublisher<pb::People::Person> person_pub("ProtoSubscriberTest");
+  eCAL::Publisher::Configuration pub_config;
+  pub_config.layer.shm.acknowledge_timeout_ms = 500;
+  eCAL::protobuf::CPublisher<pb::People::Person> person_pub("ProtoSubscriberTest", pub_config);
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(2000));
-
-  ASSERT_TRUE(SendPerson(person_pub));
   std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-  // assert that the OnPerson callback has been called once.
-  ASSERT_EQ(1, received_callbacks);
+
+  // Start publishing (With acknowledge?)
+  std::thread person_pub_thread([this, &person_pub, &stop_publishing, &numbers_of_sends]() {
+    while (!stop_publishing)
+    {
+      SendPerson(person_pub);
+      ++numbers_of_sends;
+      //std::this_thread::sleep_for(std::chrono::milliseconds(0));
+    }
+    });
+
+  for (int i = 0; i < 999; ++i)
+  {
+    subscribers.emplace_back(std::move(subscribers[i]));
+    std::this_thread::yield();
+  }
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+
+  stop_publishing = true;
+  person_pub_thread.join();
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  ASSERT_EQ(numbers_of_sends, received_callbacks.load());
 }


### PR DESCRIPTION
Implement `CMessageSubscriber` callbacks with lambdas instead of member functions, which greatly simplifies handling in case of moving.
`SetReceiveCallback` function now takes both data and error callback, so that these functions are available atomically.

### Description
With the previous implementation, it's easily possible to deadlock eCAL when simulatenously setting callbacks and receiving data.
This is no longer the case with the proposed implementation, as the `CMessageSubscriber` no longer contains any locks.
At the same time, it fixes the move constructor / assignment of the `CMessageSubscriber`.