### PR TITLE
[dependencies] Add support for ftxui 6.0.0.

### DIFF
--- a/app/mon/mon_tui/src/tui/ftxui_version_compatibility.hpp
+++ b/app/mon/mon_tui/src/tui/ftxui_version_compatibility.hpp
@@ -16,56 +16,16 @@
  *
  * ========================= eCAL LICENSE =================================
 */
+
 #pragma once
 
-#include <ftxui/dom/elements.hpp>
-#include <ftxui/component/component.hpp>
-
-#include "tui/view/component/scroller.hpp"
-
-#include <tui/ftxui_version_compatibility.hpp>
-
-
-namespace ftxui
-{
-
-Element indent(Element child)
-{
-  return hbox({
-      text("  "),
-      child
-  });
-}
-
-Element indentRight(Element child)
-{
-  return hbox({
-      child,
-      text("  ")
-  });
-}
-
-class IndentBase : public ComponentBase
-{
-  Component child;
-public:
-  IndentBase(Component child_) : child{child_}
-  {
-    Add(child);
-  }
-
-  Element FTXUI_COMPATIBILITY_RENDER() override
-  {
-    return hbox({
-      text("  "),
-      child->Render()
-    });
-  }
-};
-
-Component Indent(Component child)
-{
-  return std::make_shared<IndentBase>(child);
-}
-
-}
+// Usage:
+// ftxui::Element FTXUI_COMPATIBILITY_RENDER() override {
+//   using namespace ftxui;
+//   return text("Hello, world!") | border;
+// }
+#if FTXUI_VERSION_MAJOR >= 6
+#define FTXUI_COMPATIBILITY_RENDER() OnRender()
+#else
+#define FTXUI_COMPATIBILITY_RENDER() Render()
+#endif

--- a/app/mon/mon_tui/src/tui/view/command_line.hpp
+++ b/app/mon/mon_tui/src/tui/view/command_line.hpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,7 +108,11 @@ public:
     return true;
   }
 
+#if FTXUI_VERSION_MAJOR >= 6
+  ftxui::Element OnRender() override
+#else
   ftxui::Element Render() override
+#endif
   {
     using namespace ftxui;
 

--- a/app/mon/mon_tui/src/tui/view/command_line.hpp
+++ b/app/mon/mon_tui/src/tui/view/command_line.hpp
@@ -27,6 +27,7 @@
 #include "tui/view/view.hpp"
 
 #include "tui/viewmodel/command_line.hpp"
+#include "tui/ftxui_version_compatibility.hpp"
 
 class CommandLineView : public View
 {
@@ -108,11 +109,7 @@ public:
     return true;
   }
 
-#if FTXUI_VERSION_MAJOR >= 6
-  ftxui::Element OnRender() override
-#else
-  ftxui::Element Render() override
-#endif
+  ftxui::Element FTXUI_COMPATIBILITY_RENDER() override
   {
     using namespace ftxui;
 

--- a/app/mon/mon_tui/src/tui/view/component/data_table.hpp
+++ b/app/mon/mon_tui/src/tui/view/component/data_table.hpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -820,7 +820,11 @@ public:
     return ComponentBase::OnEvent(event);
   }
 
+#if FTXUI_VERSION_MAJOR >= 6
+  Element OnRender() override
+#else
   Element Render() override
+#endif
   {
     std::lock_guard<std::mutex> lock{data_mutex};
     return vbox(

--- a/app/mon/mon_tui/src/tui/view/component/data_table.hpp
+++ b/app/mon/mon_tui/src/tui/view/component/data_table.hpp
@@ -38,6 +38,8 @@
 
 #include <ftxui/component/component.hpp>
 
+#include <tui/ftxui_version_compatibility.hpp>
+
 namespace ftxui
 {
 
@@ -820,11 +822,7 @@ public:
     return ComponentBase::OnEvent(event);
   }
 
-#if FTXUI_VERSION_MAJOR >= 6
-  Element OnRender() override
-#else
-  Element Render() override
-#endif
+  Element FTXUI_COMPATIBILITY_RENDER() override
   {
     std::lock_guard<std::mutex> lock{data_mutex};
     return vbox(

--- a/app/mon/mon_tui/src/tui/view/component/decorator.hpp
+++ b/app/mon/mon_tui/src/tui/view/component/decorator.hpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,11 @@ public:
     Add(child);
   }
 
+#if FTXUI_VERSION_MAJOR >= 6
+  Element OnRender() override
+#else
   Element Render() override
+#endif
   {
     return hbox({
       text("  "),

--- a/app/mon/mon_tui/src/tui/view/component/focus_manager.hpp
+++ b/app/mon/mon_tui/src/tui/view/component/focus_manager.hpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,7 +97,12 @@ class FocusManager : public ftxui::ContainerBase
  public:
   using ftxui::ContainerBase::ContainerBase;
 
-  ftxui::Element Render() override {
+#if FTXUI_VERSION_MAJOR >= 6
+  ftxui::Element OnRender() override
+#else
+  ftxui::Element Render() override
+#endif
+  {
     using namespace ftxui;
     Elements elements;
     for (auto& it : children_)

--- a/app/mon/mon_tui/src/tui/view/component/focus_manager.hpp
+++ b/app/mon/mon_tui/src/tui/view/component/focus_manager.hpp
@@ -20,6 +20,7 @@
 
 #include <ftxui/component/component_base.hpp>
 #include <ftxui/component/event.hpp>
+#include <tui/ftxui_version_compatibility.hpp>
 
 namespace ftxui {
 class ContainerBase : public ComponentBase {
@@ -97,11 +98,7 @@ class FocusManager : public ftxui::ContainerBase
  public:
   using ftxui::ContainerBase::ContainerBase;
 
-#if FTXUI_VERSION_MAJOR >= 6
-  ftxui::Element OnRender() override
-#else
-  ftxui::Element Render() override
-#endif
+  ftxui::Element FTXUI_COMPATIBILITY_RENDER() override
   {
     using namespace ftxui;
     Elements elements;

--- a/app/mon/mon_tui/src/tui/view/component/scroller.hpp
+++ b/app/mon/mon_tui/src/tui/view/component/scroller.hpp
@@ -32,6 +32,8 @@
 #include "ftxui/dom/requirement.hpp"
 #include "ftxui/screen/box.hpp"
 
+#include <tui/ftxui_version_compatibility.hpp>
+
 namespace ftxui
 {
 class ScrollerBase : public ComponentBase
@@ -41,16 +43,12 @@ class ScrollerBase : public ComponentBase
   ScrollerBase(Component child) : selected_{selected_dummy} { Add(child); }
 
  private:
-#if FTXUI_VERSION_MAJOR >= 6
-  Element OnRender() final
-#else
-  Element Render() final
-#endif
+  Element FTXUI_COMPATIBILITY_RENDER() final
   {
     auto focused = Focused() ? focus : ftxui::select;
     auto style = Focused() ? inverted : nothing;
 
-    Element background = ComponentBase::Render();
+    Element background = ComponentBase::FTXUI_COMPATIBILITY_RENDER();
     background->ComputeRequirement();
     size_ = background->requirement().min_y;
     auto el =  dbox({

--- a/app/mon/mon_tui/src/tui/view/component/scroller.hpp
+++ b/app/mon/mon_tui/src/tui/view/component/scroller.hpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,11 @@ class ScrollerBase : public ComponentBase
   ScrollerBase(Component child) : selected_{selected_dummy} { Add(child); }
 
  private:
+#if FTXUI_VERSION_MAJOR >= 6
+  Element OnRender() final
+#else
   Element Render() final
+#endif
   {
     auto focused = Focused() ? focus : ftxui::select;
     auto style = Focused() ? inverted : nothing;

--- a/app/mon/mon_tui/src/tui/view/component/tree.hpp
+++ b/app/mon/mon_tui/src/tui/view/component/tree.hpp
@@ -25,6 +25,8 @@
 
 #include "tui/view/component/decorator.hpp"
 
+#include <tui/ftxui_version_compatibility.hpp>
+
 namespace ftxui
 {
 
@@ -170,11 +172,7 @@ public:
     Add(tree);
   }
 
-#if FTXUI_VERSION_MAJOR >= 6
-  Element OnRender() override
-#else
-  Element Render() override
-#endif
+  Element FTXUI_COMPATIBILITY_RENDER() override
   {
     return tree->Render();
   }

--- a/app/mon/mon_tui/src/tui/view/component/tree.hpp
+++ b/app/mon/mon_tui/src/tui/view/component/tree.hpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -170,7 +170,11 @@ public:
     Add(tree);
   }
 
+#if FTXUI_VERSION_MAJOR >= 6
+  Element OnRender() override
+#else
   Element Render() override
+#endif
   {
     return tree->Render();
   }

--- a/app/mon/mon_tui/src/tui/view/help.hpp
+++ b/app/mon/mon_tui/src/tui/view/help.hpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,7 +108,11 @@ public:
     return *view_model;
   }
 
+#if FTXUI_VERSION_MAJOR >= 6
+  ftxui::Element OnRender() override
+#else
   ftxui::Element Render() override
+#endif
   {
     using namespace ftxui;
     return view->Render();

--- a/app/mon/mon_tui/src/tui/view/help.hpp
+++ b/app/mon/mon_tui/src/tui/view/help.hpp
@@ -30,6 +30,7 @@
 #include "tui/view/component/decorator.hpp"
 
 #include "tui/viewmodel/help.hpp"
+#include "tui/ftxui_version_compatibility.hpp"
 
 #include "ecal_mon_tui_defs.h"
 
@@ -108,11 +109,7 @@ public:
     return *view_model;
   }
 
-#if FTXUI_VERSION_MAJOR >= 6
-  ftxui::Element OnRender() override
-#else
-  ftxui::Element Render() override
-#endif
+  ftxui::Element FTXUI_COMPATIBILITY_RENDER() override
   {
     using namespace ftxui;
     return view->Render();

--- a/app/mon/mon_tui/src/tui/view/log_details.hpp
+++ b/app/mon/mon_tui/src/tui/view/log_details.hpp
@@ -28,6 +28,7 @@
 #include "tui/view/component/decorator.hpp"
 
 #include "tui/viewmodel/logs.hpp"
+#include "tui/ftxui_version_compatibility.hpp"
 
 class LogDetailsView : public View
 {
@@ -42,11 +43,7 @@ public:
     return *view_model;
   }
 
-#if FTXUI_VERSION_MAJOR >= 6
-  ftxui::Element OnRender() override
-#else
-  ftxui::Element Render() override
-#endif
+  ftxui::Element FTXUI_COMPATIBILITY_RENDER() override
   {
     using namespace ftxui;
 

--- a/app/mon/mon_tui/src/tui/view/log_details.hpp
+++ b/app/mon/mon_tui/src/tui/view/log_details.hpp
@@ -42,7 +42,11 @@ public:
     return *view_model;
   }
 
+#if FTXUI_VERSION_MAJOR >= 6
+  ftxui::Element OnRender() override
+#else
   ftxui::Element Render() override
+#endif
   {
     using namespace ftxui;
 

--- a/app/mon/mon_tui/src/tui/view/message_visualization/messaage_vizualization.hpp
+++ b/app/mon/mon_tui/src/tui/view/message_visualization/messaage_vizualization.hpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,11 @@ public:
     return *view_model;
   }
 
+#if FTXUI_VERSION_MAJOR >= 6
+  ftxui::Element OnRender() override
+#else
   ftxui::Element Render() override
+#endif
   {
     using namespace ftxui;
 

--- a/app/mon/mon_tui/src/tui/view/message_visualization/messaage_vizualization.hpp
+++ b/app/mon/mon_tui/src/tui/view/message_visualization/messaage_vizualization.hpp
@@ -25,6 +25,8 @@
 
 #include "tui/viewmodel/message_visualization/message_visualization.hpp"
 
+#include "tui/ftxui_version_compatibility.hpp"
+
 class MessageVisualizationView : public View
 {
   std::shared_ptr<MessageVisualizationViewModel> view_model;
@@ -41,11 +43,7 @@ public:
     return *view_model;
   }
 
-#if FTXUI_VERSION_MAJOR >= 6
-  ftxui::Element OnRender() override
-#else
-  ftxui::Element Render() override
-#endif
+  ftxui::Element FTXUI_COMPATIBILITY_RENDER() override
   {
     using namespace ftxui;
 

--- a/app/mon/mon_tui/src/tui/view/message_visualization/proto.hpp
+++ b/app/mon/mon_tui/src/tui/view/message_visualization/proto.hpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/mon/mon_tui/src/tui/view/process_details.hpp
+++ b/app/mon/mon_tui/src/tui/view/process_details.hpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,11 @@ public:
     return *view_model;
   }
 
+#if FTXUI_VERSION_MAJOR >= 6
+  ftxui::Element OnRender() override
+#else
   ftxui::Element Render() override
+#endif
   {
     using namespace ftxui;
 

--- a/app/mon/mon_tui/src/tui/view/process_details.hpp
+++ b/app/mon/mon_tui/src/tui/view/process_details.hpp
@@ -28,6 +28,8 @@
 
 #include "tui/viewmodel/processes.hpp"
 
+#include "tui/ftxui_version_compatibility.hpp"
+
 class ProcessDetailsView : public View
 {
   std::shared_ptr<ProcessesViewModel> view_model;
@@ -41,11 +43,7 @@ public:
     return *view_model;
   }
 
-#if FTXUI_VERSION_MAJOR >= 6
-  ftxui::Element OnRender() override
-#else
-  ftxui::Element Render() override
-#endif
+  ftxui::Element FTXUI_COMPATIBILITY_RENDER() override
   {
     using namespace ftxui;
 

--- a/app/mon/mon_tui/src/tui/view/service_details.hpp
+++ b/app/mon/mon_tui/src/tui/view/service_details.hpp
@@ -31,6 +31,7 @@
 #include "tui/view/component/decorator.hpp"
 
 #include "tui/viewmodel/services.hpp"
+#include "tui/ftxui_version_compatibility.hpp"
 
 class ServiceDetailsView : public View
 {
@@ -86,11 +87,7 @@ public:
     return *view_model;
   }
 
-#if FTXUI_VERSION_MAJOR >= 6
-  ftxui::Element OnRender() override
-#else
-  ftxui::Element Render() override
-#endif
+  ftxui::Element FTXUI_COMPATIBILITY_RENDER() override
   {
     using namespace ftxui;
 

--- a/app/mon/mon_tui/src/tui/view/service_details.hpp
+++ b/app/mon/mon_tui/src/tui/view/service_details.hpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,7 +86,11 @@ public:
     return *view_model;
   }
 
+#if FTXUI_VERSION_MAJOR >= 6
+  ftxui::Element OnRender() override
+#else
   ftxui::Element Render() override
+#endif
   {
     using namespace ftxui;
 

--- a/app/mon/mon_tui/src/tui/view/shell.hpp
+++ b/app/mon/mon_tui/src/tui/view/shell.hpp
@@ -35,6 +35,7 @@
 #include "tui/view/command_line.hpp"
 
 #include "tui/viewmodel/shell.hpp"
+#include "tui/ftxui_version_compatibility.hpp"
 
 class ShellView : public View
 {
@@ -150,11 +151,7 @@ public:
     }
   }
 
-#if FTXUI_VERSION_MAJOR >= 6
-  ftxui::Element OnRender() override
-#else
-  ftxui::Element Render() override
-#endif
+  ftxui::Element FTXUI_COMPATIBILITY_RENDER() override
   {
     using namespace ftxui;
 

--- a/app/mon/mon_tui/src/tui/view/shell.hpp
+++ b/app/mon/mon_tui/src/tui/view/shell.hpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -150,7 +150,11 @@ public:
     }
   }
 
+#if FTXUI_VERSION_MAJOR >= 6
+  ftxui::Element OnRender() override
+#else
   ftxui::Element Render() override
+#endif
   {
     using namespace ftxui;
 

--- a/app/mon/mon_tui/src/tui/view/system_information.hpp
+++ b/app/mon/mon_tui/src/tui/view/system_information.hpp
@@ -32,6 +32,7 @@
 #include "tui/view/component/decorator.hpp"
 
 #include "tui/viewmodel/system_information.hpp"
+#include "tui/ftxui_version_compatibility.hpp"
 
 class SystemInformationView : public View
 {
@@ -58,11 +59,7 @@ public:
     return *view_model;
   }
 
-#if FTXUI_VERSION_MAJOR >= 6
-  ftxui::Element OnRender() override
-#else
-  ftxui::Element Render() override
-#endif
+  ftxui::Element FTXUI_COMPATIBILITY_RENDER() override
   {
     return view->Render();
   }

--- a/app/mon/mon_tui/src/tui/view/system_information.hpp
+++ b/app/mon/mon_tui/src/tui/view/system_information.hpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,11 @@ public:
     return *view_model;
   }
 
+#if FTXUI_VERSION_MAJOR >= 6
+  ftxui::Element OnRender() override
+#else
   ftxui::Element Render() override
+#endif
   {
     return view->Render();
   }

--- a/app/mon/mon_tui/src/tui/view/table.hpp
+++ b/app/mon/mon_tui/src/tui/view/table.hpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -135,7 +135,11 @@ public:
     return nullptr;
   }
 
-  virtual ftxui::Element Render() override
+#if FTXUI_VERSION_MAJOR >= 6
+  virtual  ftxui::Element OnRender() override
+#else
+  virtual  ftxui::Element Render() override
+#endif
   {
     using namespace ftxui;
 

--- a/app/mon/mon_tui/src/tui/view/table.hpp
+++ b/app/mon/mon_tui/src/tui/view/table.hpp
@@ -36,6 +36,8 @@
 
 #include "tui/viewmodel/table.hpp"
 
+#include "tui/ftxui_version_compatibility.hpp"
+
 template<typename T>
 class TableView : public View
 {
@@ -135,11 +137,7 @@ public:
     return nullptr;
   }
 
-#if FTXUI_VERSION_MAJOR >= 6
-  virtual  ftxui::Element OnRender() override
-#else
-  virtual  ftxui::Element Render() override
-#endif
+  ftxui::Element FTXUI_COMPATIBILITY_RENDER() override
   {
     using namespace ftxui;
 

--- a/app/mon/mon_tui/src/tui/view/topic_details.hpp
+++ b/app/mon/mon_tui/src/tui/view/topic_details.hpp
@@ -25,6 +25,8 @@
 #include "tui/view/component/decorator.hpp"
 #include "tui/view/message_visualization/factory.hpp"
 
+#include "tui/ftxui_version_compatibility.hpp"
+
 #include "tui/viewmodel/topics.hpp"
 
 class TopicDetailsView : public View
@@ -95,11 +97,7 @@ public:
     return *view_model;
   }
 
-#if FTXUI_VERSION_MAJOR >= 6
-  ftxui::Element OnRender() override
-#else
-  ftxui::Element Render() override
-#endif
+  ftxui::Element FTXUI_COMPATIBILITY_RENDER() override
   {
     using namespace ftxui;
 

--- a/app/mon/mon_tui/src/tui/view/topic_details.hpp
+++ b/app/mon/mon_tui/src/tui/view/topic_details.hpp
@@ -95,7 +95,11 @@ public:
     return *view_model;
   }
 
+#if FTXUI_VERSION_MAJOR >= 6
+  ftxui::Element OnRender() override
+#else
   ftxui::Element Render() override
+#endif
   {
     using namespace ftxui;
 


### PR DESCRIPTION
ftxui has released a new major version.
This branch tries to ensure compatibility with the new release and all older releases.

Todo: It seems that 6.0.0 breaks the ability to select an item from the list of topics. This needs to be investigated.
![image](https://github.com/user-attachments/assets/8a55db8d-51fa-40cb-8dad-0577f80ddf26)
(background ftxui 6.0.0, foreground ftxui 5.0.0 - the elements are no longer selectable).

(This PR does *not* update the submodule, so the current build is still using 5.0.0)

@brakmic-aleksandar There is no chance that you might quickly look into this? I am not quite sure where to start.