### PR TITLE
[setup] Set eCAL Launcher to be linked on the userdesktop instead of common desktop

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -147,13 +147,13 @@ jobs:
       run: ctest -C Release -V
       working-directory: ${{ runner.workspace }}/_build/complete
 
-    - name: Pack SDK
-      run: cpack -C Debug
-      working-directory: ${{ runner.workspace }}/_build/sdk
-
     - name: Pack complete setup
       run: cpack -C Release
       working-directory: ${{ runner.workspace }}/_build/complete
+    
+    - name: Pack SDK
+      run: cpack -C Debug
+      working-directory: ${{ runner.workspace }}/_build/sdk
 
     - name: Get Project version from git tag
       shell: powershell

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -147,13 +147,13 @@ jobs:
       run: ctest -C Release -V
       working-directory: ${{ runner.workspace }}/_build/complete
 
-    - name: Pack complete setup
-      run: cpack -C Release
-      working-directory: ${{ runner.workspace }}/_build/complete
-    
     - name: Pack SDK
       run: cpack -C Debug
       working-directory: ${{ runner.workspace }}/_build/sdk
+
+    - name: Pack complete setup
+      run: cpack -C Release
+      working-directory: ${{ runner.workspace }}/_build/complete
 
     - name: Get Project version from git tag
       shell: powershell

--- a/cpack/innosetup/ecal_setup.iss.in
+++ b/cpack/innosetup/ecal_setup.iss.in
@@ -147,7 +147,7 @@ Name: "{group}\eCAL Sys";                             Filename: "{app}\bin\ecal_
 Name: "{group}\Configuration\Edit ecal.yaml";         Filename: "{commonappdata}\eCAL\ecal.yaml";                  Components: runtime
 
 Name: "{group}\{cm:UninstallProgram,{#AppName}}";     Filename: "{uninstallexe}"
-Name: "{commondesktop}\eCAL Launcher";                Filename: "{app}\bin\ecal_launcher.exe"; Tasks: desktopicon; Components: applications
+Name: "{userdesktop}\eCAL Launcher";                  Filename: "{app}\bin\ecal_launcher.exe"; Tasks: desktopicon; Components: applications
 
 [Registry]
 ; Root key HKA is only available in Version 6 and above


### PR DESCRIPTION
### Description
s.a.