### PR TITLE
[bugfix] Allow compatibility with CMake 4.0

### DIFF
--- a/cmake/helper_functions/ecal_helper_functions.cmake
+++ b/cmake/helper_functions/ecal_helper_functions.cmake
@@ -67,3 +67,11 @@ macro(ecal_restore_warning_level)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_OLD}")
   endif()
 endmacro()
+
+macro(ecal_variable_push var_name)
+  list(APPEND ecal_${var_name}_old "${${var_name}}")
+endmacro()
+
+macro(ecal_variable_pop var_name)
+  list(POP_BACK ecal_${var_name}_old "${var_name}")
+endmacro()

--- a/doc/samples/cpp/configuration/hello_config/CMakeLists.txt
+++ b/doc/samples/cpp/configuration/hello_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.16)
 
 project(hello_config)
 

--- a/doc/samples/cpp/configuration/publisher_config/CMakeLists.txt
+++ b/doc/samples/cpp/configuration/publisher_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.16)
 
 project(publisher_config)
 

--- a/doc/samples/cpp/protobuf/hello_world_rec/CMakeLists.txt
+++ b/doc/samples/cpp/protobuf/hello_world_rec/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.16)
 
 project(protobuf_rec)
 

--- a/doc/samples/cpp/protobuf/hello_world_snd/CMakeLists.txt
+++ b/doc/samples/cpp/protobuf/hello_world_snd/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.16)
 
 project(protobuf_snd)
 

--- a/doc/samples/cpp/string/hello_world_rec/CMakeLists.txt
+++ b/doc/samples/cpp/string/hello_world_rec/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.16)
 
 project(hello_world_rec)
 

--- a/doc/samples/cpp/string/hello_world_snd/CMakeLists.txt
+++ b/doc/samples/cpp/string/hello_world_snd/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.16)
 
 project(hello_world_snd)
 

--- a/thirdparty/protobuf/build-protobuf.cmake
+++ b/thirdparty/protobuf/build-protobuf.cmake
@@ -23,7 +23,10 @@ if(MSVC)
 endif()
 
 ecal_disable_all_warnings()
+ecal_variable_push(CMAKE_POLICY_VERSION_MINIMUM)
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/protobuf/cmake thirdparty/protobuf SYSTEM)
+ecal_variable_pop(CMAKE_POLICY_VERSION_MINIMUM)
 ecal_restore_warning_level()
 
 if (NOT TARGET protobuf::libprotobuf)

--- a/thirdparty/termcolor/build-termcolor.cmake
+++ b/thirdparty/termcolor/build-termcolor.cmake
@@ -1,3 +1,6 @@
 include_guard(GLOBAL)
 
+ecal_variable_push(CMAKE_POLICY_VERSION_MINIMUM)
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/termcolor thirdparty/termcolor EXCLUDE_FROM_ALL SYSTEM)
+ecal_variable_pop(CMAKE_POLICY_VERSION_MINIMUM)

--- a/thirdparty/yaml-cpp/build-yaml-cpp.cmake
+++ b/thirdparty/yaml-cpp/build-yaml-cpp.cmake
@@ -10,4 +10,7 @@ set(YAML_CPP_BUILD_CONTRIB OFF CACHE BOOL "My option" FORCE)
 # the correct IDE folder
 set(CMAKE_FOLDER "thirdparty/yaml-cpp")
 
+ecal_variable_push(CMAKE_POLICY_VERSION_MINIMUM)
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/yaml-cpp thirdparty/yaml-cpp EXCLUDE_FROM_ALL SYSTEM)
+ecal_variable_pop(CMAKE_POLICY_VERSION_MINIMUM)


### PR DESCRIPTION
Allow eCAL to successfully build with CMake 4.0

closes #2041 