### PR TITLE
CI: Use shallow submodules and more system packages

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -30,8 +30,16 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
       with:
-        submodules:  'true'
+        submodules:  'false'
         fetch-depth: 0
+        filter: 'tree:0' # Download all commits but blobs and trees on demand
+
+    - name: Update / download Submodules (selected ones)
+      run: |
+        cd $GITHUB_WORKSPACE
+        git submodule init
+        git submodule deinit thirdparty/hdf5/hdf5 thirdparty/protobuf/protobuf
+        git submodule update --single-branch --depth 1
 
     - name: Display Python version
       run: python -c "import sys; print(sys.version)"

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -23,24 +23,38 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        sudo apt update
+        common_packages=(
+          ninja-build
+          doxygen
+          graphviz
+          libcurl4-openssl-dev
+          libprotobuf-dev libprotoc-dev protobuf-compiler
+          libhdf5-dev
+          libyaml-cpp-dev
+          libspdlog-dev
+          libgtest-dev libgmock-dev
+        )
+        specific_packages=()
 
         if [[ ${{ matrix.os }} == ubuntu-24.04* ]]; then
-            sudo apt-get install ninja-build doxygen graphviz libcurl4-openssl-dev libprotobuf-dev libprotoc-dev protobuf-compiler libhdf5-dev libyaml-cpp-dev
-            sudo apt-get install qt6-base-dev qt6-svg-dev
-            sudo apt-get install libgtest-dev
-            sudo apt-get install python3 python3-venv python3-dev
+          specific_packages=(
+            qt6-base-dev qt6-svg-dev
+            python3 python3-venv python3-dev
+          )
         elif [[ ${{ matrix.os }} == ubuntu-22.04* ]]; then
-            sudo apt-get install ninja-build doxygen graphviz libcurl4-openssl-dev libprotobuf-dev libprotoc-dev protobuf-compiler libhdf5-dev libyaml-cpp-dev
-            sudo apt-get install qtbase5-dev libqt5opengl5-dev libqt5svg5-dev 
-            sudo apt-get install libgtest-dev
-            sudo apt-get install python3 python3-venv python3-dev
+          specific_packages=(
+            qtbase5-dev libqt5opengl5-dev libqt5svg5-dev
+            python3 python3-venv python3-dev
+          )
         elif [[ ${{ matrix.os }} == ubuntu-20.04* ]]; then
-            sudo apt-get install ninja-build doxygen graphviz libcurl4-openssl-dev libprotobuf-dev libprotoc-dev protobuf-compiler libhdf5-dev libyaml-cpp-dev
-            sudo apt-get install qt5-default libqt5opengl5-dev libqt5svg5-dev 
-            sudo apt-get install libgtest-dev
-            sudo apt-get install python3.9 python3.9-venv python3.9-dev
+          specific_packages=(
+            qt5-default libqt5opengl5-dev libqt5svg5-dev
+            python3.9 python3.9-venv python3.9-dev
+          )
         fi
+
+        sudo apt-get update
+        sudo apt-get install --no-install-recommends "${common_packages[@]}" "${specific_packages[@]}"
 
     - name: Set variables
       run: |
@@ -129,11 +143,13 @@ jobs:
         -DECAL_THIRDPARTY_BUILD_TINYXML2=ON \
         -DECAL_THIRDPARTY_BUILD_FINEFTP=ON \
         -DECAL_THIRDPARTY_BUILD_CURL=OFF \
-        -DECAL_THIRDPARTY_BUILD_GTEST=ON \
+        -DECAL_THIRDPARTY_BUILD_GTEST=OFF \
         -DECAL_THIRDPARTY_BUILD_HDF5=OFF \
         -DECAL_THIRDPARTY_BUILD_RECYCLE=ON \
         -DECAL_THIRDPARTY_BUILD_TCP_PUBSUB=ON \
         -DECAL_THIRDPARTY_BUILD_QWT=ON \
+        -DECAL_THIRDPARTY_BUILD_SPDLOG=OFF \
+        -DECAL_THIRDPARTY_BUILD_YAML-CPP=OFF \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_SYSCONFDIR=/etc \
         -DCMAKE_INSTALL_PREFIX=/usr \

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -74,6 +74,7 @@ jobs:
       with:
         submodules:  'false'
         fetch-depth: 0
+        filter: 'tree:0' # Download all commits but blobs and trees on demand
 
     - name: Update / download Submodules (selected ones)
       run: |
@@ -82,7 +83,11 @@ jobs:
         git submodule deinit thirdparty/curl/curl
         git submodule deinit thirdparty/hdf5/hdf5
         git submodule deinit thirdparty/protobuf/protobuf
-        git submodule update
+        git submodule deinit \
+          thirdparty/gtest/googletest \
+          thirdparty/spdlog/spdlog \
+          thirdparty/yaml-cpp/yaml-cpp
+        git submodule update --single-branch --depth 1
 
     - name: Create venv for building docs
       shell: bash

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -35,8 +35,16 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
       with:
-        submodules:  'true'
+        submodules:  'false'
         fetch-depth: 0
+        filter: 'tree:0' # Download all commits but blobs and trees on demand
+
+    - name: Update / download Submodules (selected ones)
+      run: |
+        cd %GITHUB_WORKSPACE%
+        git submodule init
+        git submodule update --single-branch --depth 1
+      shell: cmd
 
     - name: Create Python virtualenv
       run: |

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -16,8 +16,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules:  'true'
+          submodules:  'false'
           fetch-depth: 0
+          filter: 'tree:0' # Download all commits but blobs and trees on demand
+
+      - name: Update / download Submodules (selected ones)
+        run: |
+          git submodule update --init --single-branch --depth 1
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.22

--- a/contrib/ecaltime/linuxptp/CMakeLists.txt
+++ b/contrib/ecaltime/linuxptp/CMakeLists.txt
@@ -19,6 +19,8 @@
 project(ecaltime-linuxptp)
 
 find_package(yaml-cpp REQUIRED)
+include(${ECAL_PROJECT_ROOT}/thirdparty/yaml-cpp/compatibility-yaml-cpp.cmake)
+yaml_cpp_create_compatibility_targets()
 
 set(ecal_time_linuxptp_src
   src/ecal_time_linuxptp.cpp

--- a/ecal/tests/cpp/pubsub_test/src/pubsub_test_shm.cpp
+++ b/ecal/tests/cpp/pubsub_test/src/pubsub_test_shm.cpp
@@ -23,7 +23,9 @@
 #include <ecal/pubsub/subscriber.h>
 
 #include <atomic>
+#include <condition_variable>
 #include <functional>
+#include <mutex>
 #include <string>
 #include <thread>
 

--- a/thirdparty/yaml-cpp/compatibility-yaml-cpp.cmake
+++ b/thirdparty/yaml-cpp/compatibility-yaml-cpp.cmake
@@ -1,3 +1,5 @@
+include_guard(GLOBAL)
+
 # Create targets to be compatible with yaml-cpp < 0.8.0
 macro(yaml_cpp_create_compatibility_targets)
   if (NOT TARGET yaml-cpp::yaml-cpp AND TARGET yaml-cpp)


### PR DESCRIPTION
### Description
<!-- What does your PR change? -->

Aims to speed up CI times in two ways:

1. By doing shallow clones of the submodules and main repo
2. By building less vendored code, instead using system packages were suitable.

Effect:

This speeds up CI runs by up to roughly 2 minutes (there is a _lot_ of variance). Less than I was hoping, but is ~10% in the best case.

Detailed changes:

- The eCAL repo is now checkedout using `--filter=tree:0`. This is like a less aggressive shallow clone; the commits are fetched but their contents are fetched on-demand. This lets the tag-based versioning to continue to work but minimises the data transferred.
- More unneeded submodules are de-initialized.
- Ubuntu:
  - package lists are now split into common and specific to reduce repetition.
  - `spdlog` and `gmock` have been added to the installed packages.
  - `spdlog`, `gtest`, and `yaml-cpp` are no longer built from the submodules.
    - The `gtest` and `yaml-cpp` packages were being installed and then ignored and built from source...
  - Packages are not installed without "recommendations" to reduce implicit dependencies.
- Added missing compatability function call for `yaml-cpp` in `linuxptp` (exposed by above changes)
- Added missing includes to shm test (exposed by above changes)

### Related issues
<!-- Type "Fixes #123" to automatically close that issue, when this PR is merged -->
- 
