### PR TITLE
core/minor-fixes-2025-04-07

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -620,7 +620,7 @@ message(STATUS "ECAL_USE_FLATBUFFERS                                : ${ECAL_USE
 message(STATUS "ECAL_USE_FTXUI                                      : ${ECAL_USE_FTXUI}")
 message(STATUS "BUILD_SHARED_LIBS                                   : ${BUILD_SHARED_LIBS}")
 message(STATUS "ECAL_BUILD_DOCS                                     : ${ECAL_BUILD_DOCS}")
-message(STATUS "ECAL_BUILD_DOCS_SAMPLES"                            : ${ECAL_BUILD_DOCS_SAMPLES})
+message(STATUS "ECAL_BUILD_DOCS_SAMPLES                             : ${ECAL_BUILD_DOCS_SAMPLES}")
 message(STATUS "ECAL_BUILD_APPS                                     : ${ECAL_BUILD_APPS}")
 message(STATUS "ECAL_BUILD_APP_SDK                                  : ${ECAL_BUILD_APP_SDK}")
 message(STATUS "ECAL_BUILD_SAMPLES                                  : ${ECAL_BUILD_SAMPLES}")

--- a/ecal/core/include/ecal/config/logging.h
+++ b/ecal/core/include/ecal/config/logging.h
@@ -60,7 +60,7 @@ namespace eCAL
 
       struct Configuration
       {
-        Sink                console { true,  log_level_warning | log_level_error | log_level_fatal };                   //!< default: true, log_level_warning | log_level_error | log_level_fatal
+        Sink                console { true,  log_level_info | log_level_warning | log_level_error | log_level_fatal };  //!< default: true, log_level_info | log_level_warning | log_level_error | log_level_fatal
         Sink                file    { false, log_level_none };                                                          //!< default: false, log_level_none
         Sink                udp     { true,  log_level_info | log_level_warning | log_level_error | log_level_fatal };  //!< default: true, log_level_info | log_level_warning | log_level_error | log_level_fatal
         


### PR DESCRIPTION
### Description

Two minor fixes:

- fixed log issues in CMakeLists.txt
- log_level_info level default active for logging sink console (as it was set in 5.x)