### PR TITLE
[fix] Mutex and test ODR violations

### DIFF
--- a/ecal/core/src/io/mtx/linux/ecal_named_mutex_impl.cpp
+++ b/ecal/core/src/io/mtx/linux/ecal_named_mutex_impl.cpp
@@ -35,13 +35,13 @@
 #include <cstdint>
 #include <string>
 
-struct alignas(8) named_mutex
+struct alignas(8) eCAL::CNamedMutexImpl::named_mutex_t
 {
   pthread_mutex_t  mtx;
   pthread_cond_t   cvar;
   uint8_t          locked;
 };
-typedef struct named_mutex named_mutex_t;
+using named_mutex_t = eCAL::CNamedMutexImpl::named_mutex_t;
 
 namespace
 {

--- a/ecal/core/src/io/mtx/linux/ecal_named_mutex_impl.h
+++ b/ecal/core/src/io/mtx/linux/ecal_named_mutex_impl.h
@@ -27,7 +27,6 @@
 #include <cstdint>
 #include <string>
 
-typedef struct named_mutex named_mutex_t;
 
 namespace eCAL
 {
@@ -51,6 +50,7 @@ namespace eCAL
 
     bool Lock(int64_t timeout_) final;
     void Unlock() final;
+    struct named_mutex_t;
   private:
     named_mutex_t* m_mutex_handle;
     std::string m_named;

--- a/ecal/core/src/io/mtx/linux/ecal_named_mutex_robust_clocklock_impl.cpp
+++ b/ecal/core/src/io/mtx/linux/ecal_named_mutex_robust_clocklock_impl.cpp
@@ -33,11 +33,11 @@
 #include <cstdint>
 #include <string>
 
-struct alignas(8) named_mutex
+struct alignas(8) eCAL::CNamedMutexRobustClockLockImpl::named_mutex_t
 {
   pthread_mutex_t  mtx;
 };
-typedef struct named_mutex named_mutex_t;
+using named_mutex_t = eCAL::CNamedMutexRobustClockLockImpl::named_mutex_t;
 
 namespace
 {

--- a/ecal/core/src/io/mtx/linux/ecal_named_mutex_robust_clocklock_impl.h
+++ b/ecal/core/src/io/mtx/linux/ecal_named_mutex_robust_clocklock_impl.h
@@ -27,8 +27,6 @@
 #include <cstdint>
 #include <string>
 
-typedef struct named_mutex named_mutex_t;
-
 namespace eCAL
 {
   class CNamedMutexRobustClockLockImpl : public CNamedMutexImplBase
@@ -53,6 +51,7 @@ namespace eCAL
     bool Lock(int64_t timeout_) final;
     void Unlock() final;
 
+    struct named_mutex_t;
   private:
     named_mutex_t* m_mutex_handle;
     std::string m_named;

--- a/ecal/tests/cpp/registration_test_public/src/registration_getpublisherids.cpp
+++ b/ecal/tests/cpp/registration_test_public/src/registration_getpublisherids.cpp
@@ -29,14 +29,14 @@
 #include <vector>
 
 // struct to hold the test parameters
-struct TestParams
+struct PublisherTestParams
 {
   int publisher_count = 0;
   eCAL::Configuration configuration;
 };
 
 // test class that accepts TestParams as a parameter
-class TestFixture : public ::testing::TestWithParam<TestParams>
+class PublisherTestFixture : public ::testing::TestWithParam<PublisherTestParams>
 {
 protected:
   void SetUp() override
@@ -53,7 +53,7 @@ protected:
   }
 };
 
-TEST_P(TestFixture, GetPublisherIDsReturnsCorrectNumber)
+TEST_P(PublisherTestFixture, GetPublisherIDsReturnsCorrectNumber)
 {
   {
     // create publishers for testing
@@ -95,7 +95,7 @@ TEST_P(TestFixture, GetPublisherIDsReturnsCorrectNumber)
   ASSERT_EQ(pub_ids2.size(), 0);
 }
 
-TEST_P(TestFixture, PublisherEventCallbackIsTriggered)
+TEST_P(PublisherTestFixture, PublisherEventCallbackIsTriggered)
 {
   std::atomic<size_t> created_publisher_num(0);
   std::atomic<size_t> deleted_publisher_num(0);
@@ -157,9 +157,9 @@ TEST_P(TestFixture, PublisherEventCallbackIsTriggered)
 // instantiate the test suite with different configurations and publisher counts
 INSTANTIATE_TEST_SUITE_P(
   core_cpp_registration_public,
-  TestFixture,
+  PublisherTestFixture,
   ::testing::Values(
-    TestParams{ 10, []() {
+    PublisherTestParams{ 10, []() {
       // shm
       eCAL::Configuration config;
       config.communication_mode                = eCAL::eCommunicationMode::local;
@@ -168,7 +168,7 @@ INSTANTIATE_TEST_SUITE_P(
       config.registration.registration_timeout = 200;
       return config;
     }() },
-    TestParams{ 10, []() {
+    PublisherTestParams{ 10, []() {
       // shm + shm transport domain
       eCAL::Configuration config;
       config.communication_mode                = eCAL::eCommunicationMode::local;
@@ -176,7 +176,7 @@ INSTANTIATE_TEST_SUITE_P(
       config.registration.shm_transport_domain = "abc";
       return config;
     }() },
-    TestParams{ 10, []() {
+    PublisherTestParams{ 10, []() {
       // udp network
       eCAL::Configuration config;
       config.communication_mode                  = eCAL::eCommunicationMode::network;
@@ -185,7 +185,7 @@ INSTANTIATE_TEST_SUITE_P(
       config.registration.registration_timeout   = 200;
       return config;
     }() },
-    TestParams{ 10, []() {
+    PublisherTestParams{ 10, []() {
       // udp local
       eCAL::Configuration config;
       config.communication_mode                = eCAL::eCommunicationMode::local;

--- a/ecal/tests/cpp/registration_test_public/src/registration_getsubscriberids.cpp
+++ b/ecal/tests/cpp/registration_test_public/src/registration_getsubscriberids.cpp
@@ -29,14 +29,14 @@
 #include <vector>
 
 // struct to hold the test parameters
-struct TestParams
+struct SubscriberTestParams
 {
   int subscriber_count = 0;
   eCAL::Configuration configuration;
 };
 
 // test class that accepts TestParams as a parameter
-class TestFixture : public ::testing::TestWithParam<TestParams>
+class SubscriberTestFixture : public ::testing::TestWithParam<SubscriberTestParams>
 {
 protected:
   void SetUp() override
@@ -53,7 +53,7 @@ protected:
   }
 };
 
-TEST_P(TestFixture, GetSubscriberIDsReturnsCorrectNumber)
+TEST_P(SubscriberTestFixture, GetSubscriberIDsReturnsCorrectNumber)
 {
   {
     // create subscribers for testing
@@ -95,7 +95,7 @@ TEST_P(TestFixture, GetSubscriberIDsReturnsCorrectNumber)
   ASSERT_EQ(sub_ids2.size(), 0);
 }
 
-TEST_P(TestFixture, SubscriberEventCallbackIsTriggered)
+TEST_P(SubscriberTestFixture, SubscriberEventCallbackIsTriggered)
 {
   std::atomic<size_t> created_subscriber_num(0);
   std::atomic<size_t> deleted_subscriber_num(0);
@@ -157,9 +157,9 @@ TEST_P(TestFixture, SubscriberEventCallbackIsTriggered)
 // instantiate the test suite with different configurations and subscriber counts
 INSTANTIATE_TEST_SUITE_P(
   core_cpp_registration_public,
-  TestFixture,
+  SubscriberTestFixture,
   ::testing::Values(
-    TestParams{ 10, []() {
+    SubscriberTestParams{ 10, []() {
       // shm
       eCAL::Configuration config;
       config.communication_mode                = eCAL::eCommunicationMode::local;
@@ -168,7 +168,7 @@ INSTANTIATE_TEST_SUITE_P(
       config.registration.registration_timeout = 200;
       return config;
     }() },
-    TestParams{10, []() {
+    SubscriberTestParams{10, []() {
       // shm + shm transport domain
       eCAL::Configuration config;
       config.communication_mode                = eCAL::eCommunicationMode::local;
@@ -176,7 +176,7 @@ INSTANTIATE_TEST_SUITE_P(
       config.registration.shm_transport_domain = "abc";
       return config;
     }() },
-    TestParams{ 10, []() {
+    SubscriberTestParams{ 10, []() {
       // udp network
       eCAL::Configuration config;
       config.communication_mode = eCAL::eCommunicationMode::network;
@@ -185,7 +185,7 @@ INSTANTIATE_TEST_SUITE_P(
       config.registration.registration_timeout = 200;
       return config;
     }() },
-    TestParams{ 10, []() {
+    SubscriberTestParams{ 10, []() {
       // udp local
       eCAL::Configuration config;
       config.communication_mode = eCAL::eCommunicationMode::local;


### PR DESCRIPTION
### Description
<!-- What does your PR change? -->

Fixes two instances of ODR violations:

1. From `::named_mutex`
2. From test fixtures

### Related issues
<!-- Type "Fixes #123" to automatically close that issue, when this PR is merged -->
- 
Closes #2111 