### PR TITLE
fix: Use asio to validate ipv4 address strings instead of regex

### DIFF
--- a/ecal/core/include/ecal/types/custom_data_types.h
+++ b/ecal/core/include/ecal/types/custom_data_types.h
@@ -27,9 +27,6 @@
 #include "ecal/os.h"
 
 #include <string>
-#include <iostream>
-#include <limits>
-#include <stdexcept>
 
 namespace eCAL
 {
@@ -53,13 +50,13 @@ namespace eCAL
       ECAL_API IpAddressV4& operator=(const std::string& ip_string_);
       ECAL_API IpAddressV4& operator=(const char* ip_string_);
       ECAL_API operator const std::string&() const;
-      ECAL_API bool operator==(const eCAL::Types::IpAddressV4& rhs) const;  
+      ECAL_API bool operator==(const eCAL::Types::IpAddressV4& rhs) const;
       ECAL_API friend bool operator==(eCAL::Types::IpAddressV4 lhs, const char* ip_string_);
       ECAL_API friend bool operator==(const char* ip_string_, eCAL::Types::IpAddressV4 rhs);
       ECAL_API friend bool operator==(eCAL::Types::IpAddressV4 lhs, const std::string& ip_string_);
       ECAL_API friend bool operator==(const std::string& ip_string_, eCAL::Types::IpAddressV4 rhs);
 
-    private:            
+    private:
       ECAL_API void validateIpString(const std::string& ip_address_);
 
       std::string m_ip_address{};

--- a/ecal/core/include/ecal/types/custom_data_types.h
+++ b/ecal/core/include/ecal/types/custom_data_types.h
@@ -36,8 +36,7 @@ namespace eCAL
   namespace Types
   {
     /**
-     * @brief  Class for evaluation and storing an IPv4/IPv6 address.
-     *         Invalid addresses: 255.255.255.255, 127.0.0.1, 0.0.0.0
+     * @brief  Class for evaluation and storing an IPv4 address.
      *
      * @param ip_address_  The IP address as std::string.
      * 

--- a/ecal/core/src/types/ecal_custom_data_types.cpp
+++ b/ecal/core/src/types/ecal_custom_data_types.cpp
@@ -45,10 +45,15 @@ namespace eCAL
     {
       asio::error_code ec{};
       const auto ip = asio::ip::make_address_v4(ip_address_, ec);
-      static_cast<void>(ip);
       if (ec) {
         throw std::invalid_argument("[IpAddressV4] Invalid IPv4 address: " +
                                     ip_address_);
+      }
+      if (ip.to_string() != ip_address_) {
+        throw std::invalid_argument(
+            "[IpAddressV4] IPv4 address: " + ip.to_string() +
+            " reinterpreted by the platform as " + ip_address_ +
+            " please use the full explicit form");
       }
       m_ip_address = ip_address_;
     }

--- a/ecal/core/src/types/ecal_custom_data_types.cpp
+++ b/ecal/core/src/types/ecal_custom_data_types.cpp
@@ -24,15 +24,11 @@
 #include "ecal/types/custom_data_types.h"
 
 #include <array>
-#include <regex>
 #include <algorithm>
 #include <cctype>
 #include <ecal_def.h>
 
-namespace{
-  const std::regex IPV4_DEC_REGEX = std::regex("^((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]|[0-9])\\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9][0-9]|[0-9])$");
-  const std::regex IPV4_HEX_REGEX = std::regex("^([0-9a-fA-F]{1,2}\\.){3}[0-9a-fA-F]{1,2}$");
-}
+#include <asio/ip/address_v4.hpp>
 
 namespace eCAL
 {
@@ -50,16 +46,14 @@ namespace eCAL
 
     void IpAddressV4::validateIpString(const std::string& ip_address_)
     {
-      if (  std::regex_match(ip_address_, IPV4_DEC_REGEX)
-         || std::regex_match(ip_address_, IPV4_HEX_REGEX)
-      )
-      {        
-        m_ip_address = ip_address_;
+      asio::error_code ec{};
+      const auto ip = asio::ip::make_address_v4(ip_address_, ec);
+      static_cast<void>(ip);
+      if (ec) {
+        throw std::invalid_argument("[IpAddressV4] Invalid IPv4 address: " +
+                                    ip_address_);
       }
-      else
-      {
-        throw std::invalid_argument("[IpAddressV4] No valid IP address: " + ip_address_);
-      }
+      m_ip_address = ip_address_;
     }
 
     const std::string& IpAddressV4::Get() const                         { return m_ip_address; }

--- a/ecal/core/src/types/ecal_custom_data_types.cpp
+++ b/ecal/core/src/types/ecal_custom_data_types.cpp
@@ -21,12 +21,9 @@
  * @brief  Definition of custom data types.
 **/
 
+#include <stdexcept>
+#include <utility>
 #include "ecal/types/custom_data_types.h"
-
-#include <array>
-#include <algorithm>
-#include <cctype>
-#include <ecal_def.h>
 
 #include <asio/ip/address_v4.hpp>
 
@@ -60,13 +57,11 @@ namespace eCAL
     IpAddressV4& IpAddressV4::operator=(const std::string& ip_string_)  { this->validateIpString(ip_string_); return *this; }
     IpAddressV4& IpAddressV4::operator=(const char* ip_string_)         { this->validateIpString(ip_string_); return *this; }
     IpAddressV4::operator const std::string&() const                    { return m_ip_address; }
-    
-    std::ostream& operator<<(std::ostream& os, const IpAddressV4& ipv4) { os << ipv4.Get(); return os; }
 
     bool IpAddressV4::operator==(const eCAL::Types::IpAddressV4& rhs) const        { return m_ip_address == rhs.Get(); }
     bool operator==(eCAL::Types::IpAddressV4 lhs, const char* ip_string_)          { return lhs.Get() == std::string(ip_string_); }
-    bool operator==(const char* ip_string_, eCAL::Types::IpAddressV4 rhs)          { return rhs == ip_string_; }
+    bool operator==(const char* ip_string_, eCAL::Types::IpAddressV4 rhs)          { return std::move(rhs) == ip_string_; }
     bool operator==(eCAL::Types::IpAddressV4 lhs, const std::string& ip_string_)   { return lhs.Get() == ip_string_; }
-    bool operator==(const std::string& ip_string_, eCAL::Types::IpAddressV4 rhs)   { return rhs == ip_string_; }
+    bool operator==(const std::string& ip_string_, eCAL::Types::IpAddressV4 rhs)   { return std::move(rhs) == ip_string_; }
   }  
 }

--- a/ecal/tests/cpp/config_test/src/config_test.cpp
+++ b/ecal/tests/cpp/config_test/src/config_test.cpp
@@ -141,3 +141,13 @@ TEST(core_cpp_config /*unused*/, config_custom_datatypes_tests /*unused*/)
 
   EXPECT_EQ(config1.transport_layer.udp.network.group, testValue);
 }
+
+TEST(core_cpp_config /*unused*/, config_custom_ipv4_datatype /*unused*/)
+{
+  EXPECT_THROW(eCAL::Types::IpAddressV4("192.168.256.0"), std::invalid_argument);
+  EXPECT_NO_THROW(eCAL::Types::IpAddressV4("192.168.1.0"));
+  EXPECT_NO_THROW(eCAL::Types::IpAddressV4("255.255.255.240"));
+  EXPECT_NO_THROW(eCAL::Types::IpAddressV4("255.255.255.255"));
+  EXPECT_NO_THROW(eCAL::Types::IpAddressV4("0.0.0.0"));
+  EXPECT_THROW(eCAL::Types::IpAddressV4("FF.FF.FF.F0"), std::invalid_argument);
+}

--- a/ecal/tests/cpp/config_test/src/config_test.cpp
+++ b/ecal/tests/cpp/config_test/src/config_test.cpp
@@ -107,7 +107,7 @@ TEST(core_cpp_config /*unused*/, user_config_death_test /*unused*/)
 
   // Test the IpAddressV4 class with wrong values
   ASSERT_THROW(
-    SetValue(custom_config.transport_layer.udp.network.group, "42"),
+    SetValue(custom_config.transport_layer.udp.network.group, "string text 42"),
     std::invalid_argument);
 
   // Test the IpAddressV4 class with invalid addresses

--- a/ecal/tests/cpp/config_test/src/config_test.cpp
+++ b/ecal/tests/cpp/config_test/src/config_test.cpp
@@ -107,7 +107,7 @@ TEST(core_cpp_config /*unused*/, user_config_death_test /*unused*/)
 
   // Test the IpAddressV4 class with wrong values
   ASSERT_THROW(
-    SetValue(custom_config.transport_layer.udp.network.group, "string text 42"),
+    SetValue(custom_config.transport_layer.udp.network.group, "42"),
     std::invalid_argument);
 
   // Test the IpAddressV4 class with invalid addresses
@@ -145,6 +145,10 @@ TEST(core_cpp_config /*unused*/, config_custom_datatypes_tests /*unused*/)
 TEST(core_cpp_config /*unused*/, config_custom_ipv4_datatype /*unused*/)
 {
   EXPECT_THROW(eCAL::Types::IpAddressV4("192.168.256.0"), std::invalid_argument);
+  EXPECT_THROW(eCAL::Types::IpAddressV4("192.168.1.1:50"), std::invalid_argument);
+  EXPECT_THROW(eCAL::Types::IpAddressV4("192.168.1"), std::invalid_argument);
+  EXPECT_THROW(eCAL::Types::IpAddressV4("192.168"), std::invalid_argument);
+  EXPECT_THROW(eCAL::Types::IpAddressV4("192"), std::invalid_argument);
   EXPECT_NO_THROW(eCAL::Types::IpAddressV4("192.168.1.0"));
   EXPECT_NO_THROW(eCAL::Types::IpAddressV4("255.255.255.240"));
   EXPECT_NO_THROW(eCAL::Types::IpAddressV4("255.255.255.255"));


### PR DESCRIPTION
### Description
<!-- What does your PR change? -->

Replaces use of `std::regex` to validate ipv4 address strings with asio.

Does technically remove support of expressing IPv4 addresses in hex but I suspect that didn't work anyway (as at least one usage path leads into an `asio::ip::make_address` call).

Tidies up some whitespace/headers and clang-tidy reports as well.

### Related issues
<!-- Type "Fixes #123" to automatically close that issue, when this PR is merged -->
Closes #2124 