### PR TITLE
[sample] naming conventions aligned

### DIFF
--- a/ecal/samples/cpp/pubsub/binary/blob_receive/src/blob_receive.cpp
+++ b/ecal/samples/cpp/pubsub/binary/blob_receive/src/blob_receive.cpp
@@ -42,7 +42,7 @@ void OnReceive(const eCAL::STopicId& /*topic_id_*/, const eCAL::SDataTypeInforma
 int main()
 {
   // initialize eCAL API
-  eCAL::Initialize("blob_receive");
+  eCAL::Initialize("blob receive c++");
 
   // subscriber for topic "blob"
   eCAL::CSubscriber sub("blob");

--- a/ecal/samples/cpp/pubsub/binary/blob_send/src/blob_send.cpp
+++ b/ecal/samples/cpp/pubsub/binary/blob_send/src/blob_send.cpp
@@ -25,7 +25,7 @@
 int main()
 {
   // initialize eCAL API
-  eCAL::Initialize("blob_send");
+  eCAL::Initialize("blob send c++");
 
   // publisher for topic "blob"
   eCAL::CPublisher pub("blob");

--- a/ecal/samples/cpp/pubsub/binary/table_receive/src/table_receive.cpp
+++ b/ecal/samples/cpp/pubsub/binary/table_receive/src/table_receive.cpp
@@ -73,7 +73,7 @@ void OnReceive(const eCAL::STopicId& /*topic_id_*/, const eCAL::SDataTypeInforma
 
 int main()
 {
-  const char* nodeName  = "table_receive";
+  const char* nodeName  = "table receive c++";
   const char* topicName = "table";
 
   // initialize eCAL API

--- a/ecal/samples/cpp/pubsub/binary/table_send/src/table_send.cpp
+++ b/ecal/samples/cpp/pubsub/binary/table_send/src/table_send.cpp
@@ -116,7 +116,7 @@ private:
 
 int main()
 {
-  const char* nodeName       = "table_send";
+  const char* nodeName       = "table send c++";
   const char* topicName      = "table";
   const char* structTypeName = "STable";
 

--- a/ecal/samples/cpp/services/mirror_client/src/mirror_client.cpp
+++ b/ecal/samples/cpp/services/mirror_client/src/mirror_client.cpp
@@ -27,9 +27,9 @@
 int main()
 {
   // initialize eCAL API
-  eCAL::Initialize("minimal client");
+  eCAL::Initialize("mirror client c++");
 
-  // create minimal service client
+  // create binary service client
   const eCAL::CServiceClient mirror_client("mirror", { {"echo", {}, {} } });
 
   // callback for service response

--- a/ecal/samples/cpp/services/mirror_server/src/mirror_server.cpp
+++ b/ecal/samples/cpp/services/mirror_server/src/mirror_server.cpp
@@ -42,7 +42,7 @@ int OnEchoCallback(const eCAL::SServiceMethodInformation& method_info_, const st
 int OnReverseCallback(const eCAL::SServiceMethodInformation& method_info_, const std::string& request_, std::string& response_)
 {
   response_.resize(request_.size());
-  std::copy(request_.rbegin(), request_.rend(), response_.rbegin());
+  std::copy(request_.rbegin(), request_.rend(), response_.begin());
 
   std::cout << "Method   : '" << method_info_.method_name << "' called" << std::endl;
   std::cout << "Request  : " << request_ << std::endl;
@@ -57,7 +57,7 @@ int OnReverseCallback(const eCAL::SServiceMethodInformation& method_info_, const
 int main()
 {
   // initialize eCAL API
-  eCAL::Initialize("mirror server");
+  eCAL::Initialize("mirror server c++");
 
   // create binary service server
   eCAL::CServiceServer mirror_server("mirror");

--- a/lang/c/samples/pubsub/string/hello_receive/src/hello_receive.c
+++ b/lang/c/samples/pubsub/string/hello_receive/src/hello_receive.c
@@ -38,7 +38,7 @@ int main()
   struct eCAL_SDataTypeInformation data_type_information;
 
   // initialize eCAL API
-  eCAL_Initialize("hello_receive_c", NULL, NULL);
+  eCAL_Initialize("hello receive c", NULL, NULL);
 
   // create subscriber "hello"
   memset(&data_type_information, 0, sizeof(struct eCAL_SDataTypeInformation));

--- a/lang/c/samples/pubsub/string/hello_send/src/hello_send.c
+++ b/lang/c/samples/pubsub/string/hello_send/src/hello_send.c
@@ -31,7 +31,7 @@ int main()
   int cnt = 0;
 
   // initialize eCAL API
-  eCAL_Initialize("hello_send_c", NULL, NULL);
+  eCAL_Initialize("hello send c", NULL, NULL);
 
   // create publisher "Hello"
   memset(&data_type_information, 0, sizeof(struct eCAL_SDataTypeInformation));


### PR DESCRIPTION
### Description

- slightly aligned unit names (hello_send > hello send) and tailor the name with the language (c, c++, c#)
- logic bugfix fix in mirror server c++ (reverse was not working)
