### PR TITLE
[CI] Use ccache on MacOS

### DIFF
--- a/.github/actions/ccache-prepare/action.yml
+++ b/.github/actions/ccache-prepare/action.yml
@@ -1,0 +1,41 @@
+name: 'Prepare for ccache use'
+description: 'Sets up ccache environment variables and GitHub actions cache'
+
+inputs:
+  key-root:
+    description: 'Root of the cache key to use'
+    required: true
+  cache-dir:
+    description: 'Directory to store the compilation cache in'
+    default: ${GITHUB_WORKSPACE}/.ccache
+    required: false
+outputs:
+  cache-primary-key:
+    description: 'A resolved cache key for which cache match was attempted'
+    value: ${{ steps.cache-restore.outputs.cache-primary-key }}
+
+runs:
+  using: composite
+  steps:
+    - run: |
+        _ccache_settings="
+        CCACHE_BASE_DIR=${GITHUB_WORKSPACE}
+        CCACHE_DIR=${{ inputs.cache-dir }}
+        CCACHE_COMPRESS=true
+        CCACHE_COMPRESSLEVEL=6
+        CCACHE_MAXSIZE=100M
+        CMAKE_C_COMPILER_LAUNCHER=ccache
+        CMAKE_CXX_COMPILER_LAUNCHER=ccache
+        "
+        echo "Using ccache variables: ${_ccache_settings}"
+        echo "${_ccache_settings}" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Restore ccache cache
+      id: cache-restore
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ inputs.cache-dir }}
+        key: ${{ inputs.key-root }}-ccache-${{ github.run_id }}
+        restore-keys: |
+          ${{ inputs.key-root }}-ccache-

--- a/.github/actions/ccache-save/action.yml
+++ b/.github/actions/ccache-save/action.yml
@@ -1,0 +1,31 @@
+name: 'Save ccache cache'
+description: 'Saves the ccache cache'
+
+inputs:
+  key:
+    description: 'An explicit key for saving the cache'
+    required: true
+  cache-dir:
+    description: 'Directory the compilation cache is stored in'
+    default: ${GITHUB_WORKSPACE}/.ccache
+    required: false
+
+runs:
+  using: composite
+  steps:
+
+    - name: Clear old cache entries
+      run: ccache --evict-older-than 3600s
+      shell: bash
+
+    - name: Show stats, then zero
+      run: |
+        ccache --show-stats
+        ccache --zero-stats
+      shell: bash
+
+    - name: Save ccache cache
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ inputs.cache-dir }}
+        key: ${{ inputs.key }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -25,7 +25,7 @@ jobs:
       run: brew install qt@5
 
     - name: Install Dependencies
-      run: brew install ninja doxygen graphviz protobuf hdf5@1.10 pkg-config capnp
+      run: brew install ninja protobuf hdf5@1.10 pkg-config capnp ccache
 
     - name: Checkout
       uses: actions/checkout@v4
@@ -36,30 +36,46 @@ jobs:
 
     - name: Update / download Submodules (selected ones)
       run: |
-        cd $GITHUB_WORKSPACE
-        git submodule init
-        git submodule deinit thirdparty/hdf5/hdf5 thirdparty/protobuf/protobuf
-        git submodule update --single-branch --depth 1
+        git submodule update --init --single-branch --depth 1 \
+          thirdparty/asio/asio \
+          thirdparty/ecaludp/ecaludp \
+          thirdparty/fineftp/fineftp-server \
+          thirdparty/ftxui/ftxui \
+          thirdparty/gtest/googletest \
+          thirdparty/qwt/qwt \
+          thirdparty/recycle/recycle \
+          thirdparty/spdlog/spdlog \
+          thirdparty/tclap/tclap \
+          thirdparty/tcp_pubsub/tcp_pubsub \
+          thirdparty/termcolor/termcolor \
+          thirdparty/tinyxml2/tinyxml2 \
+          thirdparty/yaml-cpp/yaml-cpp
 
-    - name: Display Python version
-      run: python -c "import sys; print(sys.version)"
-        
-    - name: Install Python requirements
-      run: |
-        sudo pip3 install -r "$GITHUB_WORKSPACE/doc/requirements.txt" --break-system-packages
+    # - name: Display Python version
+    #   run: python -c "import sys; print(sys.version)"
+    #     
+    # - name: Install Python requirements
+    #   run: |
+    #     sudo pip3 install -r "$GITHUB_WORKSPACE/doc/requirements.txt" --break-system-packages
+
+    - name: Prepare ccache and restore cache
+      id: ccache_cache-restore
+      uses: ./.github/actions/ccache-prepare
+      with:
+        key-root: macos-13
+        cache-dir: ${{ github.workspace }}/.ccache
 
     - name: CMake
+      id: cmake-configure
       run: |
-        mkdir "${{ runner.workspace }}/_build"
-        cd "${{ runner.workspace }}/_build"
-        cmake $GITHUB_WORKSPACE -G "Ninja" \
+        cmake -S . -B _build -G "Ninja" \
         -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=cmake/submodule_dependencies.cmake \
         -DECAL_USE_HDF5=ON \
         -DECAL_USE_QT=ON \
         -DECAL_USE_CURL=ON \
         -DECAL_USE_CAPNPROTO=ON \
         -DECAL_USE_FTXUI=ON \
-        -DECAL_BUILD_DOCS=ON \
+        -DECAL_BUILD_DOCS=OFF \
         -DECAL_BUILD_APPS=ON \
         -DECAL_BUILD_SAMPLES=ON \
         -DECAL_BUILD_TIMEPLUGINS=ON \
@@ -79,6 +95,7 @@ jobs:
         -DECAL_THIRDPARTY_BUILD_RECYCLE=ON \
         -DECAL_THIRDPARTY_BUILD_TCP_PUBSUB=ON \
         -DECAL_THIRDPARTY_BUILD_QWT=ON \
+        -DECAL_THIRDPARTY_BUILD_YAML-CPP=ON \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_PREFIX_PATH="/usr/local/opt/hdf5@1.10;/usr/local/opt/qt@5" \
         -DCMAKE_CXX_STANDARD=17 \
@@ -88,8 +105,16 @@ jobs:
       shell: bash
 
     - name: Build Release
-      run: cmake --build . --config Release
-      working-directory: ${{ runner.workspace }}/_build
+      run: |
+        echo "${{ steps.cmake-configure.outcome }}"
+        cmake --build _build --config Release
+
+    - name: Save ccache cache to GitHub
+      uses: ./.github/actions/ccache-save
+      with:
+        key: ${{steps.ccache_cache-restore.outputs.cache-primary-key}}
+        cache-dir: ${{ github.workspace }}/.ccache
+      if: ${{ always() && steps.cmake-configure.outcome == 'success' }}
 
 #    - name: Build Documentation C
 #      run: cmake --build . --target documentation_c

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -53,7 +53,7 @@ jobs:
 
     # - name: Display Python version
     #   run: python -c "import sys; print(sys.version)"
-    #     
+    #
     # - name: Install Python requirements
     #   run: |
     #     sudo pip3 install -r "$GITHUB_WORKSPACE/doc/requirements.txt" --break-system-packages
@@ -101,7 +101,7 @@ jobs:
         -DCMAKE_CXX_STANDARD=17 \
         -DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON \
         -DPython_FIND_STRATEGY=LOCATION \
-        -DPython_FIND_REGISTRY=NEVER        
+        -DPython_FIND_REGISTRY=NEVER
       shell: bash
 
     - name: Build Release

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -1,14 +1,5 @@
 name: Build Ubuntu
 
-env:
-  CCACHE_BASEDIR: ${GITHUB_WORKSPACE}
-  CCACHE_DIR: ${GITHUB_WORKSPACE}/.ccache
-  CCACHE_COMPRESS: true
-  CCACHE_COMPRESSLEVEL: 6
-  CCACHE_MAXSIZE: 100M
-  CMAKE_C_COMPILER_LAUNCHER: ccache
-  CMAKE_CXX_COMPILER_LAUNCHER: ccache
-
 on:
   push:
   pull_request:
@@ -108,14 +99,12 @@ jobs:
         pip install wheel setuptools
         pip install -r "$GITHUB_WORKSPACE/doc/requirements.txt"
 
-    - name: Restore ccache cache
+    - name: Prepare ccache and restore cache
       id: ccache_cache-restore
-      uses: actions/cache/restore@v4
+      uses: ./.github/actions/ccache-prepare
       with:
-        path: .ccache
-        key: ${{matrix.os}}-ccache-${{ github.run_id }}
-        restore-keys: |
-          ${{matrix.os}}-ccache-
+        key-root: ${{ matrix.os }}
+        cache-dir: ${{ github.workspace }}/.ccache
 
     - name: CMake
       id: cmake-configure
@@ -166,12 +155,11 @@ jobs:
       run: |
         cmake --build _build --parallel -- -k 0
 
-    - name: Save ccache cache
-      id: ccache_cache-save
-      uses: actions/cache/save@v4
+    - name: Save ccache cache to GitHub
+      uses: ./.github/actions/ccache-save
       with:
-        path: .ccache
         key: ${{steps.ccache_cache-restore.outputs.cache-primary-key}}
+        cache-dir: ${{ github.workspace }}/.ccache
       # Always save cache if configure succeeded (even if the build failed)
       if: ${{ always() && steps.cmake-configure.outcome == 'success' }}
 

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -172,7 +172,7 @@ add_custom_target(documentation_sphinx ALL
     #${SPHINX_APIDOC} -f
     #-o ${DOC_SOURCE_DIRECTORY}/_apidoc/ ${PYTHON_SOURCE_DIRECTORY}
     COMMAND ${SPHINX_EXECUTABLE}
-        -q -b html
+        -q -b html -j auto
         -c "${DOC_SOURCE_DIRECTORY}"
         -d "${SPHINX_CACHE_DIR}"
         -Dbreathe_projects.eCAL=${DOXYGEN_XML_OUTPUT}


### PR DESCRIPTION
### Description
<!-- What does your PR change? -->

Integrates ccache into the MacOS workflow:

- The sphinx documentation is now built with multiple threads (have not measured the impact)
- The ccache steps have been extracted into composite actions to prevent duplication
- Building documentation on MacOS was disabled as it was not used and the Ubuntu workflow already builds it to ensure validity.

### Related issues
<!-- Type "Fixes #123" to automatically close that issue, when this PR is merged -->
- Follow on from #2108
