### PR TITLE
[CI] Use ccache on Windows

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -64,12 +64,28 @@ jobs:
 
       shell: cmd
 
+      # Using ccache on Windows requires the Ninja generator
+      # This action calls vcvarsall for us to setup the desired toolchain
+    - name: Setup MSVC toolchain
+      uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: x64
+        toolset: 14.29 # v141 / vs2019
+
+    - name: Prepare ccache and restore cache
+      id: ccache_cache-restore
+      uses: ./.github/actions/ccache-prepare
+      with:
+        key-root: windows-2019
+        cache-dir: ${{ github.workspace }}/.ccache
+
     - name: CMake SDK
       run: |
         mkdir "${{ runner.workspace }}\_build\sdk\"
         cd "${{ runner.workspace }}/_build/sdk"
 
-        cmake %GITHUB_WORKSPACE% -G "Visual Studio 16 2019" -A x64 -T v142 ^
+        cmake %GITHUB_WORKSPACE% -G "Ninja" ^
+        -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl ^
         -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=cmake/submodule_dependencies.cmake ^
         -DECAL_USE_HDF5=ON ^
         -DECAL_USE_QT=ON ^
@@ -105,10 +121,12 @@ jobs:
       shell: cmd
 
     - name: CMake Complete
+      id: cmake-configure
       run: |
         CALL "${{ runner.workspace }}\.venv\Scripts\activate.bat"
         cd "${{ runner.workspace }}/_build/complete"
-        cmake %GITHUB_WORKSPACE% -G "Visual Studio 16 2019" -A x64 -T v142 ^
+        cmake %GITHUB_WORKSPACE% -G "Ninja" ^
+        -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl ^
         -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=cmake/submodule_dependencies.cmake ^
         -DECAL_USE_HDF5=ON ^
         -DECAL_USE_QT=ON ^
@@ -121,7 +139,7 @@ jobs:
         -DECAL_BUILD_SAMPLES=ON ^
         -DECAL_BUILD_TIMEPLUGINS=ON ^
         -DECAL_BUILD_PY_BINDING=OFF ^
-        -DECAL_BUILD_CSHARP_BINDING=ON ^
+        -DECAL_BUILD_CSHARP_BINDING=OFF ^
         -DECAL_BUILD_TESTS=ON ^
         -DECAL_INSTALL_SAMPLE_SOURCES=ON ^
         -DECAL_USE_NPCAP=ON ^
@@ -150,7 +168,21 @@ jobs:
     - name: Build Release
       run: cmake --build . --config Release
       working-directory: ${{ runner.workspace }}/_build/complete
-    
+
+    - name: Save ccache cache to GitHub
+      uses: ./.github/actions/ccache-save
+      with:
+        key: ${{steps.ccache_cache-restore.outputs.cache-primary-key}}
+        cache-dir: ${{ github.workspace }}/.ccache
+      # Always save cache if configure succeeded (even if the build failed)
+      if: ${{ always() && steps.cmake-configure.outcome == 'success' }}
+
+    - name: Create eCAL install tree for for C# bindings
+      run: |
+        cmake --install "${{ runner.workspace }}/_build/complete" ^
+        --prefix "${{ runner.workspace }}/_install/complete"
+      shell: cmd
+
     - name: Run Tests
       run: ctest -C Release -V
       working-directory: ${{ runner.workspace }}/_build/complete

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -27,12 +27,12 @@ jobs:
         archives: 'qtbase qtsvg'
         cache: 'true'
 
-    - name: Install Dependencies
+    - name: Install doxygen
       # Pin to latest doxygen version.
       run: choco install doxygen.install --version=1.13.2
 
-    - name: Uninstall Chocolatey
-      run: move "$env:PROGRAMDATA\chocolatey" "$env:PROGRAMDATA\_chocolatey"
+    - name: Install ccache
+      run: choco install ccache --version=4.11.2
 
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -18,12 +18,14 @@ jobs:
 
     steps:
     - name: Install Qt
-      uses: jurplel/install-qt-action@v3
+      uses: jurplel/install-qt-action@v4
       with:
-        setup-python: 'false'
-        version: '6.6.1'
+        setup-python: 'true'
+        version: '6.6.*'
         target: 'desktop'
         arch: 'win64_msvc2019_64'
+        archives: 'qtbase qtsvg'
+        cache: 'true'
 
     - name: Install Dependencies
       # Pin to latest doxygen version.

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -43,9 +43,7 @@ jobs:
 
     - name: Update / download Submodules (selected ones)
       run: |
-        cd %GITHUB_WORKSPACE%
-        git submodule init
-        git submodule update --single-branch --depth 1
+        git submodule update --init --single-branch --depth 1
       shell: cmd
 
     - name: Create Python virtualenv

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -183,6 +183,26 @@ jobs:
         --prefix "${{ runner.workspace }}/_install/complete"
       shell: cmd
 
+    - name: Configure C# bindings
+      run: |
+        cmake -S lang/csharp -B "${{ runner.workspace }}/_build/csharp" ^
+        -G "Visual Studio 16 2019" -A x64 -T v142 ^
+        -DBUILD_SHARED_LIBS=OFF ^
+        -DCMAKE_PREFIX_PATH="${{ runner.workspace }}/_install/complete" ^
+        -DCMAKE_BUILD_TYPE=Release ^
+        -DCMAKE_CONFIGURATION_TYPES=Release ^
+        -DECAL_CSHARP_BUILD_SAMPLES=ON ^
+        -DECAL_CSHARP_BUILD_TESTS=ON ^
+        -DECAL_PROJECT_ROOT="${{ github.workspace }}"
+      shell: cmd
+
+    - name: Build C# bindings
+      run: cmake --build "${{ runner.workspace }}/_build/csharp" --config Release
+      shell: cmd
+
+    - name: Run C# Tests
+      run: ctest -C Release -V --test-dir "${{ runner.workspace }}/_build/csharp"
+
     - name: Run Tests
       run: ctest -C Release -V
       working-directory: ${{ runner.workspace }}/_build/complete
@@ -190,6 +210,10 @@ jobs:
     - name: Pack SDK
       run: cpack -C Debug
       working-directory: ${{ runner.workspace }}/_build/sdk
+
+    - name: Package C# Bindings
+      run: cpack -C Release -DCPACK_COMPONENTS_ALL="runtime"
+      working-directory: ${{ runner.workspace }}/_build/csharp
 
     - name: Pack complete setup
       run: cpack -C Release

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -158,7 +158,7 @@ jobs:
         -DBUILD_SHARED_LIBS=OFF ^
         -DCMAKE_PREFIX_PATH="%ProgramFiles%/Cap'n Proto/lib/cmake/CapnProto" ^
         -DCMAKE_BUILD_TYPE=Release ^
-        -DECAL_CPACK_PACK_WITH_INNOSETUP=ON        
+        -DECAL_CPACK_PACK_WITH_INNOSETUP=ON
       shell: cmd
 
     - name: Build SDK
@@ -227,7 +227,7 @@ jobs:
 
         #remove the leading 'v' from the tag, if it exists
         $VERSION = $VERSION -replace '^v', ''
-        
+
         echo "VERSION=$VERSION" >> "$Env:GITHUB_ENV"
 
     - name: Set output binary name
@@ -294,7 +294,7 @@ jobs:
         $AUTH_CREDENTIAL = $Env:JENKINS_USERNAME + ':' + $Env:JENKINS_API_TOKEN
         $AUTH_ENCODED = [System.Text.Encoding]::UTF8.GetBytes($AUTH_CREDENTIAL)
         $AUTH_INFO = [System.Convert]::ToBase64String($AUTH_ENCODED)
-        
+
         $CRUMB_HEADERS = @{
           'Authorization'="Basic $($AUTH_INFO)"
         }
@@ -350,7 +350,7 @@ jobs:
               Write-Output "    ** determination of the new build number failed after $COUNTER_LIMIT tries" 
               Exit 1
           }
-          
+
           $RESPONSE = Invoke-WebRequest -Uri $QUEUE_URL
           $RES_CODE = $RESPONSE.StatusCode
           Write-Output "    ++ build number retrieval - HTTP status code: $RES_CODE"
@@ -397,7 +397,7 @@ jobs:
                   Break
                 } else {
                   Write-Output "    ** build failure"
-                  Exit 1        
+                  Exit 1
                 }
               }
             } else {

--- a/cpack/innosetup/ecal_setup.iss.in
+++ b/cpack/innosetup/ecal_setup.iss.in
@@ -26,6 +26,7 @@
 #define OutputName              str("ecal-")+str(AppVersion)+str("-win64")
 #define ComponentStagingDir     "@CPACK_TEMPORARY_INSTALL_DIRECTORY@"
 #define DebugSdkStagingDir      StringChange(ComponentStagingDir, "/complete/", "/sdk/")
+#define CSharpStagingDir        StringChange(StringChange(ComponentStagingDir, "/complete/", "/csharp/"), "/eCAL-", "/ecal_csharp-")
 #define OutputDir               "@CPACK_PACKAGE_DIRECTORY@/@CPACK_OUTPUT_FILE_PREFIX@"
 #define LicenseFile             "@CPACK_RESOURCE_FILE_LICENSE@"
 
@@ -84,6 +85,8 @@ Source: "{#ComponentStagingDir}\configuration\etc\ecaltime.yaml";  DestDir: "{ap
 Source: "{#ComponentStagingDir}\_configuration\etc\ecal.yaml";    DestDir: "{app}\etc\"; Tasks: not replaceconf; Flags: ignoreversion skipifsourcedoesntexist confirmoverwrite; Components: runtime
 Source: "{#ComponentStagingDir}\_configuration\etc\ecal.yaml";    DestDir: "{app}\etc\"; Tasks: replaceconf;     Flags: ignoreversion skipifsourcedoesntexist;                  Components: runtime
 Source: "{#ComponentStagingDir}\_configuration\etc\ecaltime.yaml"; DestDir: "{app}\etc\";                         Flags: ignoreversion skipifsourcedoesntexist;                  Components: runtime
+
+Source: "{#CSharpStagingDir}\runtime\*";              DestDir: "{app}";      Flags: ignoreversion recursesubdirs; Components: runtime
 
 ; applications
 Source: "{#ComponentStagingDir}\app\*";               DestDir: "{app}";                   Flags: ignoreversion recursesubdirs;     Components: applications

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -179,7 +179,7 @@ add_custom_target(documentation_sphinx ALL
         "${DOC_SOURCE_DIRECTORY}"
         "${SPHINX_HTML_DIR}"
     COMMENT "Building HTML documentation with Sphinx"
-    DEPENDS documentation_run_doxygen documentation_copy_rst_files _ecal_core_py _ecal_hdf5_py documentation_copy_sample_files documentation_copy_config_file
+    DEPENDS documentation_run_doxygen documentation_copy_rst_files documentation_copy_sample_files documentation_copy_config_file
 )
     
 set_property(TARGET documentation_sphinx  PROPERTY FOLDER docs)

--- a/lang/csharp/CMakeLists.txt
+++ b/lang/csharp/CMakeLists.txt
@@ -17,7 +17,14 @@
 # ========================= eCAL LICENSE =================================
 
 # C# build, can be executed standalone against an eCAL installation
-project(ecal_csharp)
+cmake_minimum_required(VERSION 3.15)
+
+find_package(CMakeFunctions CONFIG REQUIRED)
+git_revision_information()
+
+project(ecal_csharp
+  VERSION "${GIT_REVISION_MAJOR}.${GIT_REVISION_MINOR}.${GIT_REVISION_PATCH}"
+)
 
 include(GNUInstallDirs)
 
@@ -26,8 +33,17 @@ include(GNUInstallDirs)
 # Because the Prototbuf Version used for C# bindings is independent from the one we get from the submodules / conan
 macro(get_csharp_protobuf_version)
 find_package(Protobuf REQUIRED)
-if (${Protobuf_VERSION_MAJOR} GREATER 3)
-set(ECAL_CSHARP_PROTOBUF_VERSION "3.${Protobuf_VERSION_MAJOR}.${Protobuf_VERSION_MINOR}")
+if (${Protobuf_VERSION} VERSION_GREATER_EQUAL 4)
+  if(NOT DEFINED Protobuf_VERSION_MINOR OR NOT DEFINED Protobuf_VERSION_PATCH)
+    string(REPLACE "." ";" _ecal_protobuf_version "${Protobuf_VERSION}")
+    # list(GET _ecal_protobuf_version 0 Protobuf_VERSION_MAJOR)
+    list(GET _ecal_protobuf_version 1 Protobuf_VERSION_MINOR)
+    list(GET _ecal_protobuf_version 2 Protobuf_VERSION_PATCH)
+  endif()
+  if(Protobuf_VERSION_MINOR STREQUAL "NOTFOUND" OR Protobuf_VERSION_PATCH STREQUAL "NOTFOUND")
+    message(FATAL_ERROR "Unable to determine Protobuf version")
+  endif()
+set(ECAL_CSHARP_PROTOBUF_VERSION "3.${Protobuf_VERSION_MINOR}.${Protobuf_VERSION_PATCH}")
 else ()
 set(ECAL_CSHARP_PROTOBUF_VERSION "${Protobuf_VERSION}")
 endif ()
@@ -50,6 +66,7 @@ add_subdirectory(Eclipse.eCAL.Protobuf.Test)
 endif()
 
 if (ECAL_CSHARP_BUILD_SAMPLES)
+enable_testing()
 add_subdirectory(Eclipse.eCAL.Core.Samples)
 add_subdirectory(Eclipse.eCAL.Protobuf.Samples)
 add_subdirectory(Eclipse.eCAL.String.Samples)
@@ -59,3 +76,10 @@ if (ECAL_CSHARP_BUILD_SAMPLES OR ECAL_CSHARP_BUILD_TESTS)
 #Contains the person.proto which are being compiled to cs files
 add_subdirectory(Eclipse.eCAL.Protobuf.Samples.Datatypes)
 endif()
+
+if(WIN32)
+  set(CPACK_GENERATOR "External")
+  set(CPACK_EXTERNAL_ENABLE_STAGING ON)
+endif()
+SET(CPACK_OUTPUT_FILE_PREFIX _deploy) # WARN: Undocumented, should use CPACK_PACKAGE_DIRECTORY
+include(CPack)

--- a/thirdparty/udpcap/build-udpcap.cmake
+++ b/thirdparty/udpcap/build-udpcap.cmake
@@ -20,6 +20,11 @@ set(UDPCAP_THIRDPARTY_USE_BUILTIN_ASIO OFF)
 # Add udpcap library from subdirectory
 add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/udpcap" "${eCAL_BINARY_DIR}/thirdparty/udpcap" EXCLUDE_FROM_ALL SYSTEM)
 
+# ecaludp delay loads wpcap.dll and Ninja does not implicitly link delayimp.lib
+# unlike the Visual Studio generators.
+# So we explictly set it to be linked
+target_link_options(udpcap PUBLIC delayimp.lib)
+
 # Reset static / shared libs to old value
 set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS_OLD})
 unset(BUILD_SHARED_LIBS_OLD)


### PR DESCRIPTION
### Description
<!-- What does your PR change? -->

Updates the Windows workflow to make use of ccache. In total this brings a CI run down from ~40 minutes to ~20 minutes. The largest gain is speeding up the release build 10x from 20 minutes to **2**. The largest steps are the release testing, debug (SDK) build (because ccache does not work with /Zi), and packaging. 

### Detailed changes

This PR is also ordered into logical commits (with commit messages).

- `install-qt-action` updated to v4
  - `setup-python` was enabled to allow it pick an appropriate python version for us (currently 3.10)
  - The qt version was relaxed to select the most recent 6.6 patch version
  - The `archives` option is set to minimize the qt install
  - Caching is now enabled
- Initializing and updating of the submodules combined to one line
  - (The windows build uses all submodules so the explicit list is ommited)
- `ccache` is used for building
  - Currently it only works for the release build because ccache does not support the `/Zi` flag
  - Using ccache with Windows requires using Ninja as the generator
  - The `msvc-dev-cmd` action is used to select the msvc toolset as if `vcvarsall` was used
  - CMake requires a Visual Studio generator to use the C# language so the C# bindings have been disabled from the SDK build (and handled separately)
  - As udpcap delay loads `wpcap.dll` it is required for consumers to link with `delayimp.lib`. Visual Studio will add this implicitly but for Ninja it must be explicitly added.
- Dedicated steps added for C#
  - The complete release build is installed into a temporary tree for the C# subproject to use
  - Multiple changes were made to `lang/csharp/CMakeLists.txt` to make it standalone:
    - The missing `cmake_minimum_required` was added
    - The project version is set in the same way as for the main eCAL project
    - The handling of protobuf versions (of 4.x or newer) was fixed.
    - Testing was enabled (**note:** No tests are actually registered with CTest so no tests are run)
    - CPack variables are set for packaging similar to the main eCAL project
- The documentation build no longer depends on the Python modules being built
  - Ninja was failing as those targets weren't enabled
  - It is unclear to me why this was present.
- The innosetup script was updated to include the C# bindings being built separately
- Some whitespace was trimmed

### Potential further work

Splitting the workflow into multiple parallel jobs could further reduce the time needed. Such as moving the Debug and documentation to be built in parallel to the Release build critical path and later brought together for final packaging.

Just doing the Debug build in parallel would get things closer to ~16 minutes. But it all comes at increased complexity.

### Related issues
<!-- Type "Fixes #123" to automatically close that issue, when this PR is merged -->
- Follow on from #2108 #2127 #2134  
