### PR TITLE
[CP #2160 > support/v6.0] [Submodules] Updated asio to 1.34.2 and fixed compatibility of udp samples with asio >= 1.33

### DIFF
--- a/ecal/core/src/io/udp/ecal_udp_sample_receiver_asio.cpp
+++ b/ecal/core/src/io/udp/ecal_udp_sample_receiver_asio.cpp
@@ -40,7 +40,7 @@ namespace eCAL
     {
       // initialize io context
       m_io_context = std::make_unique<asio::io_context>();
-      m_work       = std::make_unique<asio::io_context::work>(*m_io_context);
+      m_work       = std::make_unique<work_guard_t>(m_io_context->get_executor());
 
       // create the socket and set all socket options
       InitializeSocket(attr_);

--- a/ecal/core/src/io/udp/ecal_udp_sample_receiver_asio.h
+++ b/ecal/core/src/io/udp/ecal_udp_sample_receiver_asio.h
@@ -55,7 +55,8 @@ namespace eCAL
       void Receive();
 
       std::unique_ptr<asio::io_context>       m_io_context;
-      std::unique_ptr<asio::io_context::work> m_work;
+      using work_guard_t = asio::executor_work_guard<asio::io_context::executor_type>;
+      std::unique_ptr<work_guard_t>           m_work;
       std::unique_ptr<ecaludp::Socket>        m_socket;
 
       asio::ip::udp::endpoint                 m_sender_endpoint;

--- a/ecal/core/src/io/udp/ecal_udp_sample_receiver_npcap.cpp
+++ b/ecal/core/src/io/udp/ecal_udp_sample_receiver_npcap.cpp
@@ -36,7 +36,7 @@ namespace eCAL
     {
       // initialize io context
       m_io_context = std::make_unique<asio::io_context>();
-      m_work       = std::make_unique<asio::io_context::work>(*m_io_context);
+      m_work       = std::make_unique<work_guard_t>(m_io_context->get_executor());
 
       // create the socket and set all socket options
       InitializeSocket(attr_);

--- a/ecal/core/src/io/udp/ecal_udp_sample_receiver_npcap.h
+++ b/ecal/core/src/io/udp/ecal_udp_sample_receiver_npcap.h
@@ -55,7 +55,8 @@ namespace eCAL
       void Receive();
 
       std::unique_ptr<asio::io_context>       m_io_context;
-      std::unique_ptr<asio::io_context::work> m_work;
+      using work_guard_t = asio::executor_work_guard<asio::io_context::executor_type>;
+      std::unique_ptr<work_guard_t>           m_work;
       std::unique_ptr<ecaludp::SocketNpcap>   m_socket;
 
       asio::ip::udp::endpoint                 m_sender_endpoint;


### PR DESCRIPTION
This is a manual cherry pick as replacement for #2162

Original PR was #2160