### PR TITLE
[python] Fix monitoring for legacy API (monitoring activation was bro…

### DIFF
--- a/lang/python/core/ecal/core/core.py
+++ b/lang/python/core/ecal/core/core.py
@@ -25,14 +25,28 @@
 
 import ecal._ecal_core_py as _ecal
 
-def initialize(unit_name):
+INIT_PUBLISHER  = 0x001
+INIT_SUBSCRIBER = 0x002
+INIT_SERVICE    = 0x004
+INIT_MONITORING = 0x008
+INIT_LOGGING    = 0x010
+INIT_TIMESYNC   = 0x020
+INIT_ALL        = INIT_PUBLISHER | INIT_SUBSCRIBER | INIT_SERVICE | INIT_MONITORING | INIT_LOGGING | INIT_TIMESYNC;
+INIT_DEFAULT    = INIT_PUBLISHER | INIT_SUBSCRIBER | INIT_SERVICE | INIT_LOGGING | INIT_TIMESYNC;
+
+def initialize(unit_name, components = None):
   """ initialize eCAL API
 
   :param unit_name: instance unit name
   :type unit_name:  string
+  :param components: components to initialize
+  :type components: int
 
   """
-  return _ecal.initialize(unit_name)
+  if (components is not None):
+    return _ecal.initialize_components(unit_name, components)
+  else:
+    return _ecal.initialize(unit_name)
 
 
 def finalize():

--- a/lang/python/core/src/ecal_clang.cpp
+++ b/lang/python/core/src/ecal_clang.cpp
@@ -159,6 +159,15 @@ int ecal_initialize(const char* unit_name_)
 }
 
 /****************************************/
+/*      ecal_initialize                 */
+/****************************************/
+int ecal_initialize_components(const char* unit_name_, unsigned int components)
+{
+  std::string unit_name = (unit_name_ != nullptr) ? std::string(unit_name_) : std::string("");
+  return static_cast<int>(!eCAL::Initialize(unit_name, components));
+}
+
+/****************************************/
 /*      ecal_finalize                   */
 /****************************************/
 int ecal_finalize()
@@ -752,20 +761,4 @@ bool client_call_method_async(ECAL_HANDLE handle_, const char* method_name_, con
   {
     return(false);
   }
-}
-
-/****************************************/
-/*      mon_initialize                  */
-/****************************************/
-int mon_initialize()
-{
-  return(eCAL::Initialize("", eCAL::Init::Monitoring));
-}
-
-/****************************************/
-/*      mon_finalize                    */
-/****************************************/
-int mon_finalize()
-{
-  return(ecal_finalize());
 }

--- a/lang/python/core/src/ecal_clang.h
+++ b/lang/python/core/src/ecal_clang.h
@@ -57,13 +57,21 @@ const char* ecal_getdate();
 /**
  * @brief Initialize eCAL API.
  *
- * @param argc_        Number of command line arguments.
- * @param argv_        Array of command line arguments.
  * @param unit_name_   Defines the name of the eCAL unit.
  *
  * @return Zero if succeeded.
 **/
 int ecal_initialize(const char* unit_name_);
+
+/**
+ * @brief Initialize eCAL API.
+ *
+ * @param unit_name_   Defines the name of the eCAL unit.
+ * @param unit_name_   Defines the components to initialize.
+ *
+ * @return Zero if succeeded.
+**/
+int ecal_initialize_components(const char* unit_name_, unsigned int components);
 
 /**
  * @brief Finalize eCAL API.
@@ -489,20 +497,3 @@ bool client_call_method(ECAL_HANDLE handle_, const char* method_name_, const cha
  * @return  True if succeeded.
 **/
 bool client_call_method_async(ECAL_HANDLE handle_, const char* method_name_, const char* request_, int request_len_, int timeout_);
-
-/*************************************************************************/
-/*  monitoring                                                           */
-/*************************************************************************/
-/**
- * @brief Initialize eCAL monitoring API.
- *
- * @return Zero if succeeded, 1 if already initialized, -1 if failed.
-**/
-int mon_initialize();
-
-/**
- * @brief Finalize eCAL monitoring API.
- *
- * @return Zero if succeeded, 1 if already initialized, -1 if failed.
-**/
-int mon_finalize();

--- a/lang/python/core/src/ecal_wrap.cxx
+++ b/lang/python/core/src/ecal_wrap.cxx
@@ -34,6 +34,8 @@
 #include <unordered_map>
 #include <atomic>
 
+#include <iostream>
+
 
 /****************************************/
 /*      types                           */
@@ -91,6 +93,26 @@ PyObject* initialize(PyObject* /*self*/, PyObject* args)
   int init{ 0 };
   Py_BEGIN_ALLOW_THREADS
     init = ecal_initialize(unit_name);
+  Py_END_ALLOW_THREADS
+
+  return(Py_BuildValue("i", init));
+}
+
+/****************************************/
+/*      initialize components           */
+/****************************************/
+PyObject* initialize_components(PyObject* /*self*/, PyObject* args)
+{
+  char* unit_name = nullptr;
+  unsigned int components = eCAL::Init::Default;
+
+  if (!PyArg_ParseTuple(args, "si", &unit_name, &components))
+    return nullptr;
+
+  /* pass argument to the initialize function */
+  int init{ 0 };
+  Py_BEGIN_ALLOW_THREADS
+    init = ecal_initialize_components(unit_name, components);
   Py_END_ALLOW_THREADS
 
   return(Py_BuildValue("i", init));
@@ -919,7 +941,8 @@ PyObject* client_rem_response_callback(PyObject* /*self*/, PyObject* args)   // 
 /****************************************/
 PyObject* mon_initialize(PyObject* /*self*/, PyObject* /*args*/)
 {
-  return(Py_BuildValue("i", mon_initialize()));
+  std::cout << "calling mon_initialize is deprecated and does not have any effect.\n";
+  return(Py_BuildValue("i", 0));
 }
 
 /****************************************/
@@ -927,7 +950,8 @@ PyObject* mon_initialize(PyObject* /*self*/, PyObject* /*args*/)
 /****************************************/
 PyObject* mon_finalize(PyObject* /*self*/, PyObject* /*args*/)
 {
-  return(Py_BuildValue("i", mon_finalize()));
+  std::cout << "calling mon_finalize is deprecated and does not have any effect.\n";
+  return(Py_BuildValue("i", 0));
 }
 
 /****************************************/
@@ -1304,6 +1328,7 @@ PyObject* mon_logging(PyObject* /*self*/, PyObject* /*args*/)
 static PyMethodDef _ecal_methods[] = 
 {
   {"initialize",                    initialize,                    METH_VARARGS,  "initialize(unit_name)"},
+  {"initialize_components",         initialize_components,         METH_VARARGS,  "initialize(unit_name, components)"},
   {"finalize",                      finalize,                      METH_NOARGS,   "finalize()"},
   {"is_initialized",                is_initialized,                METH_NOARGS,   "is_initialized()"},
 

--- a/lang/python/samples/core/monitoring/monitoring.py
+++ b/lang/python/samples/core/monitoring/monitoring.py
@@ -1,6 +1,6 @@
 # ========================= eCAL LICENSE =================================
 #
-# Copyright (C) 2016 - 2019 Continental Corporation
+# Copyright (C) 2016 - 2025 Continental Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,11 +26,8 @@ def main():
   # print eCAL version and date
   print("eCAL {} ({})\n".format(ecal_core.getversion(), ecal_core.getdate()))
   
-  # initialize eCAL API
-  ecal_core.initialize("monitoring")
-  
-  # initialize eCAL monitoring API
-  ecal_core.mon_initialize()
+  # initialize eCAL API, including monitoring
+  ecal_core.initialize("monitoring", ecal_core.INIT_ALL)
   time.sleep(2)
   
   # print eCAL entities

--- a/lang/python/samples/core/monitoring/monitoring_json.py
+++ b/lang/python/samples/core/monitoring/monitoring_json.py
@@ -1,6 +1,6 @@
 # ========================= eCAL LICENSE =================================
 #
-# Copyright (C) 2016 - 2024 Continental Corporation
+# Copyright (C) 2016 - 2025 Continental Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -76,11 +76,8 @@ def main():
   # print eCAL version and date
   print("eCAL {} ({})\n".format(ecal_core.getversion(), ecal_core.getdate()))
   
-  # initialize eCAL API
-  ecal_core.initialize("monitoring")
-  
-  # initialize eCAL monitoring API
-  ecal_core.mon_initialize()
+  # initialize eCAL API, including monitoring
+  ecal_core.initialize("monitoring", ecal_core.INIT_ALL)
   time.sleep(2)
   
   # print eCAL entities


### PR DESCRIPTION
…ken,  since eCAL 6 can only be initialized once).

### Description
Fixes the inability to use Monitoring in Python..