### PR TITLE
[GH Actions] Fixed checkout of submodules

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Update / download Submodules (selected ones)
       run: |
-        git submodule update --init --single-branch --depth 1 \
+        git submodule update --init \
           thirdparty/asio/asio \
           thirdparty/ecaludp/ecaludp \
           thirdparty/fineftp/fineftp-server \

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -79,7 +79,7 @@ jobs:
 
     - name: Initialize required submodules
       run: |
-        git submodule update --init --single-branch --depth 1 \
+        git submodule update --init \
           thirdparty/asio/asio \
           thirdparty/ecaludp/ecaludp \
           thirdparty/fineftp/fineftp-server \

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Update / download Submodules (selected ones)
       run: |
-        git submodule update --init --single-branch --depth 1
+        git submodule update --init
       shell: cmd
 
     - name: Create Python virtualenv

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Update / download Submodules (selected ones)
         run: |
-          git submodule update --init --single-branch --depth 1
+          git submodule update --init
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.22


### PR DESCRIPTION
The old shallow checkout prevented checking out the QWT commit, as there was a newer commit on the branch. The issue was introduced with https://github.com/eclipse-ecal/ecal/pull/2108