### PR TITLE
[apps] Fix Qt5WinExtras deployment

### DIFF
--- a/app/mon/mon_gui/CMakeLists.txt
+++ b/app/mon/mon_gui/CMakeLists.txt
@@ -263,11 +263,12 @@ elseif(WIN32)
     qt_add_windeployqt_postbuild(--no-system-d3d-compiler --no-compiler-runtime --no-opengl-sw --pdb "$<TARGET_FILE:${PROJECT_NAME}>")
 
     get_target_property(_qmake_executable Qt5::qmake IMPORTED_LOCATION)
+    string(CONFIGURE "$<TARGET_FILE:${PROJECT_NAME}>" _target_file_path)
     get_filename_component(_qt_bin_dir "${_qmake_executable}" DIRECTORY)
     find_program(WINDEPLOYQT_EXECUTABLE windeployqt HINTS "${_qt_bin_dir}")
     install(CODE
         "
-        set(_file ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Release/ecal_mon_gui.exe)
+        set(_file \"${_target_file_path}\")
         execute_process(
                 COMMAND \"${CMAKE_COMMAND}\" -E
                     env PATH=\"${_qt_bin_dir}\" \"${WINDEPLOYQT_EXECUTABLE}\"

--- a/app/play/play_gui/CMakeLists.txt
+++ b/app/play/play_gui/CMakeLists.txt
@@ -217,7 +217,7 @@ elseif(WIN32)
     find_program(WINDEPLOYQT_EXECUTABLE windeployqt HINTS "${_qt_bin_dir}")
     install(CODE
         "
-        set(_file ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Release/ecal_mon_gui.exe)
+        set(_file ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Release/ecal_play_gui.exe)
         execute_process(
                 COMMAND \"${CMAKE_COMMAND}\" -E
                     env PATH=\"${_qt_bin_dir}\" \"${WINDEPLOYQT_EXECUTABLE}\"

--- a/app/play/play_gui/CMakeLists.txt
+++ b/app/play/play_gui/CMakeLists.txt
@@ -213,11 +213,12 @@ elseif(WIN32)
     qt_add_windeployqt_postbuild(--no-system-d3d-compiler --no-compiler-runtime --no-opengl-sw --pdb "$<TARGET_FILE:${PROJECT_NAME}>")
 
     get_target_property(_qmake_executable Qt5::qmake IMPORTED_LOCATION)
+    string(CONFIGURE "$<TARGET_FILE:${PROJECT_NAME}>" _target_file_path)
     get_filename_component(_qt_bin_dir "${_qmake_executable}" DIRECTORY)
     find_program(WINDEPLOYQT_EXECUTABLE windeployqt HINTS "${_qt_bin_dir}")
     install(CODE
         "
-        set(_file ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Release/ecal_play_gui.exe)
+        set(_file \"${_target_file_path}\")
         execute_process(
                 COMMAND \"${CMAKE_COMMAND}\" -E
                     env PATH=\"${_qt_bin_dir}\" \"${WINDEPLOYQT_EXECUTABLE}\"

--- a/app/rec/rec_gui/CMakeLists.txt
+++ b/app/rec/rec_gui/CMakeLists.txt
@@ -253,7 +253,7 @@ elseif(WIN32)
     find_program(WINDEPLOYQT_EXECUTABLE windeployqt HINTS "${_qt_bin_dir}")
     install(CODE
         "
-        set(_file ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Release/ecal_mon_gui.exe)
+        set(_file ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Release/ecal_rec_gui.exe)
         execute_process(
                 COMMAND \"${CMAKE_COMMAND}\" -E
                     env PATH=\"${_qt_bin_dir}\" \"${WINDEPLOYQT_EXECUTABLE}\"

--- a/app/rec/rec_gui/CMakeLists.txt
+++ b/app/rec/rec_gui/CMakeLists.txt
@@ -249,9 +249,7 @@ elseif(WIN32)
     qt_add_windeployqt_postbuild(--no-system-d3d-compiler --no-compiler-runtime --no-opengl-sw --pdb "$<TARGET_FILE:${PROJECT_NAME}>")
 
     get_target_property(_qmake_executable Qt5::qmake IMPORTED_LOCATION)
-    
     string(CONFIGURE "$<TARGET_FILE:${PROJECT_NAME}>" _target_file_path)
-
     get_filename_component(_qt_bin_dir "${_qmake_executable}" DIRECTORY)
     find_program(WINDEPLOYQT_EXECUTABLE windeployqt HINTS "${_qt_bin_dir}")
     install(CODE

--- a/app/rec/rec_gui/CMakeLists.txt
+++ b/app/rec/rec_gui/CMakeLists.txt
@@ -249,11 +249,14 @@ elseif(WIN32)
     qt_add_windeployqt_postbuild(--no-system-d3d-compiler --no-compiler-runtime --no-opengl-sw --pdb "$<TARGET_FILE:${PROJECT_NAME}>")
 
     get_target_property(_qmake_executable Qt5::qmake IMPORTED_LOCATION)
+    
+    string(CONFIGURE "$<TARGET_FILE:${PROJECT_NAME}>" _target_file_path)
+
     get_filename_component(_qt_bin_dir "${_qmake_executable}" DIRECTORY)
     find_program(WINDEPLOYQT_EXECUTABLE windeployqt HINTS "${_qt_bin_dir}")
     install(CODE
         "
-        set(_file ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Release/ecal_rec_gui.exe)
+        set(_file \"${_target_file_path}\")
         execute_process(
                 COMMAND \"${CMAKE_COMMAND}\" -E
                     env PATH=\"${_qt_bin_dir}\" \"${WINDEPLOYQT_EXECUTABLE}\"


### PR DESCRIPTION
### Description
Previously while building eCAL with Qt5 the Qt5WinExtras was missing in the deployment. This is now fixed, that the correct dependencies of eCAL Recorder and eCAL Player get installed.
