### PR TITLE
[sdk] All language bindings now return void / None on set/remove rece…

### DIFF
--- a/lang/c/core/include/ecal_c/pubsub/subscriber.h
+++ b/lang/c/core/include/ecal_c/pubsub/subscriber.h
@@ -64,7 +64,7 @@ extern "C"
    *
    * @return Zero if succeeded, non-zero otherwise.
   **/
-  ECALC_API int eCAL_Subscriber_SetReceiveCallback(eCAL_Subscriber* subscriber_, eCAL_ReceiveCallbackT callback_, void* callback_user_argument_);
+  ECALC_API void eCAL_Subscriber_SetReceiveCallback(eCAL_Subscriber* subscriber_, eCAL_ReceiveCallbackT callback_, void* callback_user_argument_);
 
   /**
    * @brief Remove callback function for incoming receives.
@@ -73,7 +73,7 @@ extern "C"
    * 
    * @return Zero if succeeded, non-zero otherwise.
   **/
-  ECALC_API int eCAL_Subscriber_RemoveReceiveCallback(eCAL_Subscriber* subscriber_);
+  ECALC_API void eCAL_Subscriber_RemoveReceiveCallback(eCAL_Subscriber* subscriber_);
 
   /**
    * @brief Query the number of connected publishers.

--- a/lang/c/core/src/subscriber.cpp
+++ b/lang/c/core/src/subscriber.cpp
@@ -100,7 +100,7 @@ extern "C"
     delete subscriber_;
   }
 
-  ECALC_API int eCAL_Subscriber_SetReceiveCallback(eCAL_Subscriber* subscriber_, eCAL_ReceiveCallbackT callback_, void* callback_user_argument_)
+  ECALC_API void eCAL_Subscriber_SetReceiveCallback(eCAL_Subscriber* subscriber_, eCAL_ReceiveCallbackT callback_, void* callback_user_argument_)
   {
     assert(subscriber_ != NULL && callback_ != NULL);
     const auto callback = [callback_, callback_user_argument_](const eCAL::STopicId& publisher_id_, const eCAL::SDataTypeInformation& data_type_information_, const eCAL::SReceiveCallbackData& receive_callback_data_)
@@ -116,13 +116,13 @@ extern "C"
       callback_(&publisher_id_c, &data_type_information_c, &receive_callback_data_c, callback_user_argument_);
     };
 
-    return static_cast<int>(!subscriber_->handle->SetReceiveCallback(callback));
+    static_cast<void>(subscriber_->handle->SetReceiveCallback(callback));
   }
 
-  ECALC_API int eCAL_Subscriber_RemoveReceiveCallback(eCAL_Subscriber* subscriber_)
+  ECALC_API void eCAL_Subscriber_RemoveReceiveCallback(eCAL_Subscriber* subscriber_)
   {
     assert(subscriber_ != NULL);
-    return static_cast<int>(!subscriber_->handle->RemoveReceiveCallback());
+    static_cast<void>(!subscriber_->handle->RemoveReceiveCallback());
   }
 
   ECALC_API size_t eCAL_Subscriber_GetPublisherCount(eCAL_Subscriber* subscriber_)

--- a/lang/c/tests/pubsub_test/src/pubsub_test.cpp
+++ b/lang/c/tests/pubsub_test/src/pubsub_test.cpp
@@ -78,7 +78,7 @@ TEST_F(pubsub_test_c, subscriber)
   EXPECT_NE(nullptr, subscriber);
 
   // test setting receivecallback
-  EXPECT_EQ(0, eCAL_Subscriber_SetReceiveCallback(subscriber, OnReceive, NULL));
+  eCAL_Subscriber_SetReceiveCallback(subscriber, OnReceive, NULL);
 
   // test GetTopicId
   EXPECT_STREQ(topic_name, eCAL_Subscriber_GetTopicId(subscriber)->topic_name);
@@ -116,7 +116,7 @@ TEST_F(pubsub_test_c, pubsub)
   int callback_count = 0;
 
   // add callback
-  EXPECT_EQ(0, eCAL_Subscriber_SetReceiveCallback(subscriber, OnReceive, &callback_count));
+  eCAL_Subscriber_SetReceiveCallback(subscriber, OnReceive, &callback_count);
 
   // sleep here because otherwise it takes to long to set the receive-callback
   eCAL_Process_SleepMS(2000);
@@ -139,10 +139,10 @@ TEST_F(pubsub_test_c, pubsub)
 TEST_F(pubsub_test_c, sub_RemoveReceiveCallback) 
 {
   // add callback
-  EXPECT_EQ(0, eCAL_Subscriber_SetReceiveCallback(subscriber, OnReceive, NULL));
+  eCAL_Subscriber_SetReceiveCallback(subscriber, OnReceive, NULL);
 
   // actual test to remove it again
-  EXPECT_EQ(0, eCAL_Subscriber_RemoveReceiveCallback(subscriber)); 
+  eCAL_Subscriber_RemoveReceiveCallback(subscriber); 
 }
 
 TEST_F(pubsub_test_c, sub_GetPublisherCount) 

--- a/lang/csharp/Eclipse.eCAL.Core/include/pubsub/clr_subscriber.h
+++ b/lang/csharp/Eclipse.eCAL.Core/include/pubsub/clr_subscriber.h
@@ -89,17 +89,13 @@ namespace Eclipse {
          * @brief Sets or overwrites the receive callback.
          *
          * @param callback The callback function to set.
-         *
-         * @return True if the operation succeeded; otherwise false.
          */
-        bool SetReceiveCallback(ReceiveCallbackDelegate^ callback);
+        void SetReceiveCallback(ReceiveCallbackDelegate^ callback);
 
         /**
          * @brief Removes the receive callback.
-         *
-         * @return True if the operation succeeded; otherwise false.
          */
-        bool RemoveReceiveCallback();
+        void RemoveReceiveCallback();
 
         /**
          * @brief Queries the number of connected publishers.

--- a/lang/csharp/Eclipse.eCAL.Core/src/clr_subscriber.cpp
+++ b/lang/csharp/Eclipse.eCAL.Core/src/clr_subscriber.cpp
@@ -187,18 +187,18 @@ Subscriber::!Subscriber()
 }
 
 // Set a receive callback.
-bool Subscriber::SetReceiveCallback(ReceiveCallbackDelegate^ callback)
+void Subscriber::SetReceiveCallback(ReceiveCallbackDelegate^ callback)
 {
   m_receiveCallback = callback;
   auto nativeCallback = CreateNativeReceiveCallback(callback);
-  return m_native_subscriber->SetReceiveCallback(nativeCallback);
+  static_cast<void>(m_native_subscriber->SetReceiveCallback(nativeCallback));
 }
 
 // Remove the receive callback.
-bool Subscriber::RemoveReceiveCallback()
+void Subscriber::RemoveReceiveCallback()
 {
   m_receiveCallback = nullptr;
-  return m_native_subscriber->RemoveReceiveCallback();
+  static_cast<void>(m_native_subscriber->RemoveReceiveCallback());
 }
 
 // Get the number of publishers.

--- a/lang/csharp/Eclipse.eCAL.String/StringSubscriber.cs
+++ b/lang/csharp/Eclipse.eCAL.String/StringSubscriber.cs
@@ -71,9 +71,9 @@ namespace Eclipse.eCAL.Core
      *
      * @return True if the callback was successfully removed; otherwise, false.
      */
-    public bool RemoveReceiveCallback()
+    public void RemoveReceiveCallback()
     {
-      return binarySubscriber.RemoveReceiveCallback();
+      binarySubscriber.RemoveReceiveCallback();
     }
 
     /**

--- a/lang/python/src/nanobind_core/src/core/pubsub/py_subscriber.cpp
+++ b/lang/python/src/nanobind_core/src/core/pubsub/py_subscriber.cpp
@@ -79,11 +79,15 @@ void AddPubsubSubscriber(nanobind::module_& module)
         };
 
         nb::gil_scoped_release release;
-        return self.SetReceiveCallback(wrapped_callback);
+        static_cast<void>(self.SetReceiveCallback(wrapped_callback));
       },
       nb::arg("callback"))
-    .def("remove_receive_callback", &CSubscriber::RemoveReceiveCallback,
-      "Remove a previously set receive callback.")
+    .def("remove_receive_callback",
+          [](CSubscriber &self) {
+              static_cast<void>(self.RemoveReceiveCallback());
+          },
+          "Remove a previously set receive callback."
+        )
     .def("get_publisher_count", &CSubscriber::GetPublisherCount,
       "Get the number of connected publishers.")
     .def("get_topic_name", &CSubscriber::GetTopicName,


### PR DESCRIPTION
…ive callback functions.

### Description
Now only the C++ API returns bool on set/remove receive functions, all language / message apis return void (as nothing can actually go wrong in those functions).
