### PR TITLE
fixed another rust link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Visit the eCAL Documentation at 🌐 https://ecal.io for more information.
 * eCAL is fast (1 - 20 GB/s, depends on payload size. Check the measured performance [here](https://eclipse-ecal.github.io/ecal/advanced/performance.html))
 * eCAL provides both publish-subscribe and server-client patterns
 * eCAL is brokerless
-* eCAL provides a C++ and C interface for easy integration into other languages (like python, csharp or [rust](https://github.com/kopernikusai/ecal-rs))
+* eCAL provides a C++ and C interface for easy integration into other languages (like python, csharp or [rust](https://github.com/eclipse-ecal/rustecal))
 * eCAL can be used in conjunction with Matlab Simulink as [eCAL Simulink Toolbox](https://de.mathworks.com/matlabcentral/fileexchange/92825-ecal-toolbox) for simulation and prototyping
 * eCAL has powerful tools for [recording](https://eclipse-ecal.github.io/ecal/getting_started/recorder.html), [replay](https://eclipse-ecal.github.io/ecal/getting_started/player.html) and [monitoring](https://eclipse-ecal.github.io/ecal/getting_started/monitor.html) all your data flows - decentralized
 * eCAL is simple and zero-conf. No complex configuration for communication details and QOS settings are needed


### PR DESCRIPTION
### Description
There was another link to ecal-rs that is now fixed to rustecal.