### PR TITLE
[ecal monitor] Use Delegates to properly display byte sizes for transmitted data.

### DIFF
--- a/app/mon/mon_gui/CMakeLists.txt
+++ b/app/mon/mon_gui/CMakeLists.txt
@@ -47,6 +47,9 @@ set(source_files
     src/ecalmon_globals.h
     src/main.cpp
     src/util.h
+    
+    src/custom_types/byte_size.cpp
+    src/custom_types/byte_size.h
 
     src/plugin/plugin_manager.cpp
     src/plugin/plugin_manager.h

--- a/app/mon/mon_gui/src/custom_types/byte_size.cpp
+++ b/app/mon/mon_gui/src/custom_types/byte_size.cpp
@@ -17,26 +17,24 @@
  * ========================= eCAL LICENSE =================================
 */
 
-#include "ecalmon.h"
-#include <QtWidgets/QApplication>
-#include <custom_types/byte_size.h>
-#include <ecal/ecal.h>
+#include "custom_types/byte_size.h"
 
-int main(int argc, char *argv[])
+QString ByteSize::toString(int precision) const
 {
-  QApplication a(argc, argv);
+  // Binary (IEC) units: B, KiB, MiB, GiB, …
+  static constexpr const char* units[] = { "B", "KiB", "MiB", "GiB", "TiB", "PiB" };
 
-  qRegisterMetaType<QVector<int>>("QVector<int>");
-  qRegisterMetaType<ByteSize>("ByteSize");
+  double value = double(m_bytes);
+  int    idx   = 0;
+  // divide by 1024 until we're under 1024 or out of units
+  while (value >= 1024.0 && idx < (int)(sizeof(units)/sizeof(*units)) - 1) {
+    value /= 1024.0;
+    ++idx;
+  }
+  // e.g. QString::number(1.23456, 'f', 2) -> "1.23"
+  return QString::number(value, 'f', precision) + ' ' + units[idx];
+}
 
-  a.setOrganizationName      ("Continental");
-  a.setOrganizationDomain    ("continental-corporation.com");
-  a.setApplicationName       ("ecalmongui");
-  a.setApplicationDisplayName("eCAL Monitor");
-
-  Ecalmon* w = new Ecalmon();
-  w->setAttribute(Qt::WidgetAttribute::WA_DeleteOnClose);
-
-  w->show();
-  return a.exec();
+bool ByteSize::operator<(const ByteSize& other) const {
+  return m_bytes < other.m_bytes;
 }

--- a/app/mon/mon_gui/src/custom_types/byte_size.h
+++ b/app/mon/mon_gui/src/custom_types/byte_size.h
@@ -17,26 +17,36 @@
  * ========================= eCAL LICENSE =================================
 */
 
-#include "ecalmon.h"
-#include <QtWidgets/QApplication>
-#include <custom_types/byte_size.h>
-#include <ecal/ecal.h>
+#pragma once
 
-int main(int argc, char *argv[])
+#include <QtGlobal>
+#include <QString>
+#include <QMetaType>
+#include <cstdint>
+#include <QStyledItemDelegate>
+
+class ByteSize
 {
-  QApplication a(argc, argv);
+public:
+    explicit ByteSize(uint64_t bytes = 0) : m_bytes(bytes) {}
 
-  qRegisterMetaType<QVector<int>>("QVector<int>");
-  qRegisterMetaType<ByteSize>("ByteSize");
+    QString toString(int precision = 2) const;
 
-  a.setOrganizationName      ("Continental");
-  a.setOrganizationDomain    ("continental-corporation.com");
-  a.setApplicationName       ("ecalmongui");
-  a.setApplicationDisplayName("eCAL Monitor");
+    bool operator<(const ByteSize &other) const;
 
-  Ecalmon* w = new Ecalmon();
-  w->setAttribute(Qt::WidgetAttribute::WA_DeleteOnClose);
 
-  w->show();
-  return a.exec();
-}
+private:
+    uint64_t m_bytes;
+};
+
+Q_DECLARE_METATYPE(ByteSize)
+
+class ByteSizeDelegate : public QStyledItemDelegate {
+public:
+  using QStyledItemDelegate::QStyledItemDelegate;
+  QString displayText(const QVariant& v, const QLocale& /*loc*/) const override {
+    if (v.canConvert<ByteSize>())
+      return v.value<ByteSize>().toString();
+    return QStyledItemDelegate::displayText(v, {});
+  }
+};

--- a/app/mon/mon_gui/src/util.h
+++ b/app/mon/mon_gui/src/util.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,10 +24,18 @@
 #include <QUuid>
 #include <QUrl>
 
+#include <custom_types/byte_size.h>
+
 namespace QtUtil
 {
   inline QString variantToString(const QVariant& variant)
   {
+    // 1) handle your custom metatype first:
+    if (variant.userType() == qMetaTypeId<ByteSize>()) {
+      return variant.value<ByteSize>().toString();
+    }
+
+
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
     switch (variant.typeId())
 #else

--- a/app/mon/mon_gui/src/widgets/ecalmon_tree_widget/host_widget.cpp
+++ b/app/mon/mon_gui/src/widgets/ecalmon_tree_widget/host_widget.cpp
@@ -18,6 +18,7 @@
 */
 
 #include "host_widget.h"
+#include "custom_types/byte_size.h"
 
 HostWidget::HostWidget(QWidget *parent)
   : EcalmonTreeWidget(parent)
@@ -67,6 +68,8 @@ HostWidget::HostWidget(QWidget *parent)
 
   // Set the initial Tree Group
   ui_.group_by_combobox->setCurrentIndex(0);
+  ui_.tree_view->setItemDelegateForColumn((int)HostTreeModel::Columns::SENT_DATA, new ByteSizeDelegate(ui_.tree_view));
+  ui_.tree_view->setItemDelegateForColumn((int)HostTreeModel::Columns::RECEIVED_DATA, new ByteSizeDelegate(ui_.tree_view));
 
   // Save the initial state for the resetLayout function
   saveInitialState();

--- a/app/mon/mon_gui/src/widgets/ecalmon_tree_widget/topic_widget.cpp
+++ b/app/mon/mon_gui/src/widgets/ecalmon_tree_widget/topic_widget.cpp
@@ -21,8 +21,8 @@
 
 #include "widgets/models/item_data_roles.h"
 #include "widgets/models/tree_item_type.h"
-
 #include "widgets/visualisation_widget/visualisation_window.h"
+#include "custom_types/byte_size.h"
 
 #include "ecalmon.h"
 
@@ -163,6 +163,8 @@ TopicWidget::TopicWidget(QWidget *parent)
 
   // Set the initial Tree Group
   ui_.group_by_combobox->setCurrentIndex(1);
+
+  ui_.tree_view->setItemDelegateForColumn((int)TopicTreeModel::Columns::TOPIC_SIZE, new ByteSizeDelegate(ui_.tree_view));
 
   // Save the initial state for the resetLayout function
   saveInitialState();

--- a/app/mon/mon_gui/src/widgets/models/host_tree_item.cpp
+++ b/app/mon/mon_gui/src/widgets/models/host_tree_item.cpp
@@ -18,6 +18,7 @@
 */
 
 #include "host_tree_item.h"
+#include "custom_types/byte_size.h"
 
 #include <QColor>
 #include <QFont>
@@ -63,11 +64,11 @@ QVariant HostTreeItem::data(Columns column, Qt::ItemDataRole role) const
     }
     else if (column == Columns::SENT_DATA)
     {
-      return data_sent_bytes_;
+      return QVariant::fromValue(ByteSize(data_sent_bytes_));
     }
     else if (column == Columns::RECEIVED_DATA)
     {
-      return data_received_bytes_;
+      return QVariant::fromValue(ByteSize(data_received_bytes_));
     }
     else
     {
@@ -81,12 +82,6 @@ QVariant HostTreeItem::data(Columns column, Qt::ItemDataRole role) const
     {
       QString raw_data = data(column, (Qt::ItemDataRole)ItemDataRoles::RawDataRole).toString(); //-V1016
       return (!raw_data.isEmpty() ? raw_data : "- ? -");
-    }
-    else if ((column == Columns::SENT_DATA)
-         || (column  == Columns::RECEIVED_DATA))
-    {
-      long long raw_data = data(column, (Qt::ItemDataRole)ItemDataRoles::RawDataRole).toLongLong(); //-V1016
-      return QString::number(raw_data / 1024.0, 'f', 2);
     }
     else
     {

--- a/app/mon/mon_gui/src/widgets/models/host_tree_model.h
+++ b/app/mon/mon_gui/src/widgets/models/host_tree_model.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,8 +77,8 @@ private:
     { Columns::HOST_NAME,        "Host" },
     { Columns::PUBLISHER_COUNT,  "Publisher" },
     { Columns::SUBSCRIBER_COUNT, "Subscriber" },
-    { Columns::SENT_DATA,        "Pub. Traffic [KiB/s]" },
-    { Columns::RECEIVED_DATA,    "Sub. Traffic [KiB/s]" },
+    { Columns::SENT_DATA,        "Pub. Traffic [/s]" },
+    { Columns::RECEIVED_DATA,    "Sub. Traffic [/s]" },
     { Columns::PUBLISHER_COUNT,  "OS" },
   };
 

--- a/app/mon/mon_gui/src/widgets/models/topic_tree_item.cpp
+++ b/app/mon/mon_gui/src/widgets/models/topic_tree_item.cpp
@@ -18,6 +18,7 @@
 */
 
 #include "topic_tree_item.h"
+#include "custom_types/byte_size.h"
 
 #include <QFont>
 #include <QString>
@@ -104,7 +105,7 @@ QVariant TopicTreeItem::data(Columns column, Qt::ItemDataRole role) const
     }
     else if (column == Columns::TOPIC_SIZE)
     {
-      return topic_.topic_size();
+      return QVariant::fromValue(ByteSize(topic_.topic_size()));
     }
     else if (column == Columns::CONNECTIONS_LOCAL)
     {
@@ -226,6 +227,10 @@ QVariant TopicTreeItem::data(Columns column, Qt::ItemDataRole role) const
     {
       const std::string& raw_data = topic_.datatype_information().descriptor_information();
       return static_cast<int>(raw_data.size());
+    }
+    else if (column == Columns::TOPIC_SIZE)
+    {
+      return topic_.topic_size();
     }
 
     return data(column, (Qt::ItemDataRole)ItemDataRoles::RawDataRole); //-V1016

--- a/app/mon/mon_gui/src/widgets/models/topic_tree_model.h
+++ b/app/mon/mon_gui/src/widgets/models/topic_tree_model.h
@@ -101,7 +101,7 @@ private:
     { Columns::TOPIC_TYPE,             "Topic Type" },
     { Columns::TOPIC_DESCRIPTOR,       "Descriptor" },
     { Columns::TRANSPORT_LAYER,        "Layer" },
-    { Columns::TOPIC_SIZE,             "Size [Byte]" },
+    { Columns::TOPIC_SIZE,             "Size" },
     { Columns::CONNECTIONS_LOCAL,      "Loc. Connections" },
     { Columns::CONNECTIONS_EXTERNAL,   "Ext. Connections" },
     { Columns::MESSAGE_DROPS,          "Drops" },


### PR DESCRIPTION
In eCAL Monitor GUI, it's hard to properly understand the size of sent data when it gets bigger.
This PR will display data rates in the format of 10.0B, 1.34 KiB, 100.00 MiB or 1.49 GiB.