### PR TITLE
[gh-actions] Update Windows CI Runner

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -254,7 +254,7 @@ jobs:
 
   sign-windows-installer:
     if: github.repository == 'eclipse-ecal/ecal'
-    runs-on: windows-2019
+    runs-on: windows-2022
     needs: build-windows
 
     steps:


### PR DESCRIPTION
Replacing windows-2019 GitHub Action runner image with newer windows-2022 image due to deprecation. 
See https://github.com/actions/runner-images/issues/12045 and https://github.com/eclipse-ecal/ecal/issues/2195