### PR TITLE
[fix] Remove some warnings in C samples.

### DIFF
--- a/lang/c/tests/pubsub_test/src/pubsub_test.cpp
+++ b/lang/c/tests/pubsub_test/src/pubsub_test.cpp
@@ -55,8 +55,9 @@ class pubsub_test_c : public ::testing::Test {
 void OnReceive(const struct eCAL_STopicId* topic_id_, const struct eCAL_SDataTypeInformation* data_type_information_, const struct eCAL_SReceiveCallbackData* callback_data_, void* user_argument_)
 {
   // unused arguments
+  (void)topic_id_;
   (void)data_type_information_;
-  (void)user_argument_;
+  (void)callback_data_;
   int* cnt = (int*)user_argument_;
   (*cnt)++;
 }

--- a/lang/c/tests/services_test/src/services_test.cpp
+++ b/lang/c/tests/services_test/src/services_test.cpp
@@ -48,6 +48,7 @@ class services_test_c : public ::testing::Test
 
 int OnMethodCallback(const struct eCAL_SServiceMethodInformation* method_info_, const void* request_, size_t request_length_, void** response_, size_t* response_length_, void* user_argument_)
 {
+  (void)method_info_;
   (void)user_argument_;
 
   // In order pass the server response properly to the callback API, the underlying memory needs to be allocated 


### PR DESCRIPTION
### Description
Fixes unused argument warnings
