### PR TITLE
[ecalhdf5] Fix bug of double escaping channel names.

### DIFF
--- a/contrib/ecalhdf5/src/eh5_meas_api_v3.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_api_v3.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -236,7 +236,7 @@ bool eCAL::eh5::v3::HDF5Meas::HasChannel(const eCAL::eh5::SChannel& channel) con
   bool ret_val = false;
   if (hdf_meas_impl_)
   {
-    ret_val = hdf_meas_impl_->HasChannel(GetEscapedTopicname(channel));
+    ret_val = hdf_meas_impl_->HasChannel(SEscapedChannel::fromSChannel(channel));
   }
 
   return ret_val;
@@ -247,7 +247,7 @@ eCAL::eh5::DataTypeInformation eCAL::eh5::v3::HDF5Meas::GetChannelDataTypeInform
   eCAL::eh5::DataTypeInformation ret_val;
   if (hdf_meas_impl_)
   {
-    ret_val = hdf_meas_impl_->GetChannelDataTypeInformation(GetEscapedTopicname(channel));
+    ret_val = hdf_meas_impl_->GetChannelDataTypeInformation(SEscapedChannel::fromSChannel(channel));
   }
 
   return ret_val;
@@ -257,7 +257,7 @@ void eCAL::eh5::v3::HDF5Meas::SetChannelDataTypeInformation(const SChannel& chan
 {
   if (hdf_meas_impl_)
   {
-    hdf_meas_impl_->SetChannelDataTypeInformation(GetEscapedTopicname(channel), info);
+    hdf_meas_impl_->SetChannelDataTypeInformation(SEscapedChannel::fromSChannel(channel), info);
   }
 }
 
@@ -266,7 +266,7 @@ long long eCAL::eh5::v3::HDF5Meas::GetMinTimestamp(const SChannel& channel) cons
   long long ret_val = 0;
   if (hdf_meas_impl_)
   {
-    ret_val = hdf_meas_impl_->GetMinTimestamp(GetEscapedTopicname(channel));
+    ret_val = hdf_meas_impl_->GetMinTimestamp(SEscapedChannel::fromSChannel(channel));
   }
 
   return ret_val;
@@ -277,7 +277,7 @@ long long eCAL::eh5::v3::HDF5Meas::GetMaxTimestamp(const SChannel& channel) cons
   long long ret_val = 0;
   if (hdf_meas_impl_)
   {
-    ret_val = hdf_meas_impl_->GetMaxTimestamp(GetEscapedTopicname(channel));
+    ret_val = hdf_meas_impl_->GetMaxTimestamp(SEscapedChannel::fromSChannel(channel));
   }
 
   return ret_val;
@@ -288,7 +288,7 @@ bool eCAL::eh5::v3::HDF5Meas::GetEntriesInfo(const SChannel& channel, EntryInfoS
   bool ret_val = false;
   if (hdf_meas_impl_)
   {
-    ret_val = hdf_meas_impl_->GetEntriesInfo(GetEscapedTopicname(channel), entries);
+    ret_val = hdf_meas_impl_->GetEntriesInfo(SEscapedChannel::fromSChannel(channel), entries);
   }
 
   return ret_val;
@@ -299,7 +299,7 @@ bool eCAL::eh5::v3::HDF5Meas::GetEntriesInfoRange(const SChannel& channel, long 
   bool ret_val = false;
   if (hdf_meas_impl_ && begin < end)
   {
-    ret_val = hdf_meas_impl_->GetEntriesInfoRange(GetEscapedTopicname(channel), begin, end, entries);
+    ret_val = hdf_meas_impl_->GetEntriesInfoRange(SEscapedChannel::fromSChannel(channel), begin, end, entries);
   }
 
   return ret_val;
@@ -340,7 +340,7 @@ bool eCAL::eh5::v3::HDF5Meas::AddEntryToFile(const SWriteEntry& entry)
   bool ret_val = false;
   if (hdf_meas_impl_)
   {
-    return hdf_meas_impl_->AddEntryToFile(GetEscapedEntry(entry));
+    return hdf_meas_impl_->AddEntryToFile(SEscapedWriteEntry::fromSWriteEntry(entry));
   }
 
   return ret_val;

--- a/contrib/ecalhdf5/src/eh5_meas_api_v3.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_api_v3.cpp
@@ -224,7 +224,7 @@ std::set<eCAL::eh5::SChannel> eCAL::eh5::v3::HDF5Meas::GetChannels() const
     auto escaped_channels = hdf_meas_impl_->GetChannels();
     for (const auto& escaped_channel : escaped_channels)
     {
-      ret_val.emplace(GetUnescapedString(escaped_channel.name), escaped_channel.id);
+      ret_val.emplace(escaped_channel.toSChannel());
     }
   }
 

--- a/contrib/ecalhdf5/src/eh5_meas_dir.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_dir.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -187,9 +187,9 @@ void eCAL::eh5::HDF5MeasDir::SetOneFilePerChannelEnabled(bool enabled)
   one_file_per_channel_ = enabled;
 }
 
-std::set<eCAL::eh5::SChannel> eCAL::eh5::HDF5MeasDir::GetChannels() const
+std::set<eCAL::eh5::SEscapedChannel> eCAL::eh5::HDF5MeasDir::GetChannels() const
 {
-  std::set<eCAL::eh5::SChannel> channels;
+  std::set<eCAL::eh5::SEscapedChannel> channels;
 
   for (const auto& chn : channels_info_)
     channels.insert(chn.first);
@@ -197,12 +197,12 @@ std::set<eCAL::eh5::SChannel> eCAL::eh5::HDF5MeasDir::GetChannels() const
   return channels;
 }
 
-bool eCAL::eh5::HDF5MeasDir::HasChannel(const eCAL::eh5::SChannel& channel) const
+bool eCAL::eh5::HDF5MeasDir::HasChannel(const eCAL::eh5::SEscapedChannel& channel) const
 {
   return channels_info_.find(channel) != channels_info_.end();
 }
 
-eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5MeasDir::GetChannelDataTypeInformation(const SChannel& channel) const
+eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5MeasDir::GetChannelDataTypeInformation(const SEscapedChannel& channel) const
 {
   eCAL::eh5::DataTypeInformation ret_val;
 
@@ -215,7 +215,7 @@ eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5MeasDir::GetChannelDataTypeInforma
 }
 
 // TODO: this seems fishy. Do we need to escape?
-void eCAL::eh5::HDF5MeasDir::SetChannelDataTypeInformation(const SChannel& channel, const eCAL::eh5::DataTypeInformation& info)
+void eCAL::eh5::HDF5MeasDir::SetChannelDataTypeInformation(const SEscapedChannel& channel, const eCAL::eh5::DataTypeInformation& info)
 {
   // Get an existing writer or create a new one
   auto file_writer_it = GetWriter(channel);
@@ -225,7 +225,7 @@ void eCAL::eh5::HDF5MeasDir::SetChannelDataTypeInformation(const SChannel& chann
   channels_info_[channel] = ChannelInfo(info);
 }
 
-long long eCAL::eh5::HDF5MeasDir::GetMinTimestamp(const SChannel& channel) const
+long long eCAL::eh5::HDF5MeasDir::GetMinTimestamp(const SEscapedChannel& channel) const
 {
   long long min_timestamp = std::numeric_limits<long long>::max();
   const auto& channel_entries = entries_by_chn_.find(channel);
@@ -241,7 +241,7 @@ long long eCAL::eh5::HDF5MeasDir::GetMinTimestamp(const SChannel& channel) const
   return min_timestamp;
 }
 
-long long eCAL::eh5::HDF5MeasDir::GetMaxTimestamp(const SChannel& channel) const
+long long eCAL::eh5::HDF5MeasDir::GetMaxTimestamp(const SEscapedChannel& channel) const
 {
   long long max_timestamp = std::numeric_limits<long long>::min();
   const auto& channel_entries = entries_by_chn_.find(channel);
@@ -257,7 +257,7 @@ long long eCAL::eh5::HDF5MeasDir::GetMaxTimestamp(const SChannel& channel) const
   return max_timestamp;
 }
 
-bool eCAL::eh5::HDF5MeasDir::GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const
+bool eCAL::eh5::HDF5MeasDir::GetEntriesInfo(const SEscapedChannel& channel, EntryInfoSet& entries) const
 {
   entries.clear();
 
@@ -272,7 +272,7 @@ bool eCAL::eh5::HDF5MeasDir::GetEntriesInfo(const SChannel& channel, EntryInfoSe
   return !entries.empty();
 }
 
-bool eCAL::eh5::HDF5MeasDir::GetEntriesInfoRange(const SChannel& channel, long long begin, long long end, EntryInfoSet& entries) const
+bool eCAL::eh5::HDF5MeasDir::GetEntriesInfoRange(const SEscapedChannel& channel, long long begin, long long end, EntryInfoSet& entries) const
 {
   entries.clear();
 
@@ -319,7 +319,7 @@ void eCAL::eh5::HDF5MeasDir::SetFileBaseName(const std::string& base_name)
   base_name_ = base_name;
 }
 
-bool eCAL::eh5::HDF5MeasDir::AddEntryToFile(const SWriteEntry& entry)
+bool eCAL::eh5::HDF5MeasDir::AddEntryToFile(const SEscapedWriteEntry& entry)
 {
   if ((access_ == v3::eAccessType::RDONLY)
     || (output_dir_.empty())
@@ -441,8 +441,8 @@ bool eCAL::eh5::HDF5MeasDir::OpenRX(const std::string& path, v3::eAccessType acc
       auto channels = reader->GetChannels();
       for (const auto& channel : channels)
       {
-        auto escaped_channel = GetEscapedTopicname(channel);
-        auto info = reader->GetChannelDataTypeInformation(escaped_channel);
+        auto info = reader->GetChannelDataTypeInformation(channel);
+        auto escaped_channel = SEscapedChannel::fromSChannel(channel);
 
         auto& channel_info = channels_info_[escaped_channel];
         channel_info.info = info;
@@ -472,7 +472,7 @@ bool eCAL::eh5::HDF5MeasDir::OpenRX(const std::string& path, v3::eAccessType acc
   return !file_readers_.empty();
 }
 
-::eCAL::eh5::HDF5MeasDir::FileWriterMap::iterator eCAL::eh5::HDF5MeasDir::GetWriter(const SChannel& channel)
+::eCAL::eh5::HDF5MeasDir::FileWriterMap::iterator eCAL::eh5::HDF5MeasDir::GetWriter(const SEscapedChannel& channel)
 {
   const auto& channel_name{ channel.name };
   // Look for an existing writer. When creating 1 file per channel, the channel

--- a/contrib/ecalhdf5/src/eh5_meas_dir.h
+++ b/contrib/ecalhdf5/src/eh5_meas_dir.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@
 #include "hdf5.h"
 
 #include "ecalhdf5/eh5_meas.h"
+#include "escape.h"
 
 namespace eCAL
 {
@@ -131,7 +132,7 @@ namespace eCAL
        *
        * @return       channel names & ids
        **/
-      std::set<eCAL::eh5::SChannel> GetChannels() const override;
+      std::set<eCAL::eh5::SEscapedChannel> GetChannels() const override;
 
       /**
        * @brief Check if channel exists in measurement
@@ -140,7 +141,7 @@ namespace eCAL
        *
        * @return       true if exists, false otherwise
       **/
-      bool HasChannel(const eCAL::eh5::SChannel& channel) const override;
+      bool HasChannel(const eCAL::eh5::SEscapedChannel& channel) const override;
 
       /**
        * @brief Get data type information of the given channel
@@ -149,7 +150,7 @@ namespace eCAL
        *
        * @return              channel type
       **/
-      DataTypeInformation GetChannelDataTypeInformation(const SChannel& channel) const override;
+      DataTypeInformation GetChannelDataTypeInformation(const SEscapedChannel& channel) const override;
 
       /**
        * @brief Set data type information of the given channel
@@ -159,7 +160,7 @@ namespace eCAL
        *
        * @return              channel type
       **/
-      void SetChannelDataTypeInformation(const SChannel& channel, const DataTypeInformation& info) override;
+      void SetChannelDataTypeInformation(const SEscapedChannel& channel, const DataTypeInformation& info) override;
 
       /**
       * @brief Gets minimum timestamp for specified channel
@@ -168,7 +169,7 @@ namespace eCAL
       *
       * @return                minimum timestamp value
       **/
-      long long GetMinTimestamp(const SChannel& channel) const override;
+      long long GetMinTimestamp(const SEscapedChannel& channel) const override;
 
       /**
       * @brief Gets maximum timestamp for specified channel
@@ -177,7 +178,7 @@ namespace eCAL
       *
       * @return                maximum timestamp value
       **/
-      long long GetMaxTimestamp(const SChannel& channel) const override;
+      long long GetMaxTimestamp(const SEscapedChannel& channel) const override;
 
       /**
       * @brief Gets the header info for all data entries for the given channel
@@ -188,7 +189,7 @@ namespace eCAL
       *
       * @return                    true if succeeds, false if it fails
       **/
-      bool GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const override;
+      bool GetEntriesInfo(const SEscapedChannel& channel, EntryInfoSet& entries) const override;
 
       /**
       * @brief Gets the header info for data entries for the given channel included in given time range (begin->end)
@@ -201,7 +202,7 @@ namespace eCAL
       *
       * @return                   true if succeeds, false if it fails
       **/
-      bool GetEntriesInfoRange(const SChannel& channel, long long begin, long long end, EntryInfoSet& entries) const override;
+      bool GetEntriesInfoRange(const SEscapedChannel& channel, long long begin, long long end, EntryInfoSet& entries) const override;
 
       /**
       * @brief Gets data size of a specific entry
@@ -243,7 +244,7 @@ namespace eCAL
       *
       * @return               true if succeeds, false if it fails
       **/
-      bool AddEntryToFile(const SWriteEntry& entry) override;
+      bool AddEntryToFile(const SEscapedWriteEntry& entry) override;
 
       typedef std::function<void(void)> CallbackFunction;
       /**
@@ -288,9 +289,9 @@ namespace eCAL
       };
 
       typedef std::list<eCAL::eh5::v3::HDF5Meas*>        HDF5Files;
-      typedef std::unordered_map<SChannel, ChannelInfo>  ChannelInfoUMap;
+      typedef std::unordered_map<SEscapedChannel, ChannelInfo>  ChannelInfoUMap;
       typedef std::unordered_map<long long, EntryInfo>   EntriesByIdUMap;
-      typedef std::unordered_map<SChannel, EntryInfoSet> EntriesByChannelUMap;
+      typedef std::unordered_map<SEscapedChannel, EntryInfoSet> EntriesByChannelUMap;
 
       HDF5Files              file_readers_;
       ChannelInfoUMap        channels_info_;
@@ -350,7 +351,7 @@ namespace eCAL
        * 
        * @return an iterator to the writer
        */
-      FileWriterMap::iterator GetWriter(const SChannel& channel);
+      FileWriterMap::iterator GetWriter(const SEscapedChannel& channel);
     };
   }  //  namespace eh5
 }  //  namespace eCAL

--- a/contrib/ecalhdf5/src/eh5_meas_dir.h
+++ b/contrib/ecalhdf5/src/eh5_meas_dir.h
@@ -288,10 +288,10 @@ namespace eCAL
         {}
       };
 
-      typedef std::list<eCAL::eh5::v3::HDF5Meas*>        HDF5Files;
-      typedef std::unordered_map<SEscapedChannel, ChannelInfo>  ChannelInfoUMap;
-      typedef std::unordered_map<long long, EntryInfo>   EntriesByIdUMap;
-      typedef std::unordered_map<SEscapedChannel, EntryInfoSet> EntriesByChannelUMap;
+      using HDF5Files = std::list<eCAL::eh5::v3::HDF5Meas*>;
+      using ChannelInfoUMap = std::unordered_map<SEscapedChannel, ChannelInfo>;
+      using EntriesByIdUMap = std::unordered_map<long long, EntryInfo>;
+      using EntriesByChannelUMap =  std::unordered_map<SEscapedChannel, EntryInfoSet>;
 
       HDF5Files              file_readers_;
       ChannelInfoUMap        channels_info_;

--- a/contrib/ecalhdf5/src/eh5_meas_file_v1.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v1.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -144,27 +144,27 @@ void eCAL::eh5::HDF5MeasFileV1::SetOneFilePerChannelEnabled(bool /*enabled*/)
   ReportUnsupportedAction();
 }
 
-std::set<eCAL::eh5::SChannel> eCAL::eh5::HDF5MeasFileV1::GetChannels() const
+std::set<eCAL::eh5::SEscapedChannel> eCAL::eh5::HDF5MeasFileV1::GetChannels() const
 {
-  std::set<eCAL::eh5::SChannel> channels;
+  std::set<eCAL::eh5::SEscapedChannel> channels;
 
   std::string channel_name;
   GetAttributeValue(file_id_, kChnNameAttribTitle, channel_name);
 
   if (!channel_name.empty())
-    channels.insert(eCAL::experimental::measurement::base::CreateChannel(channel_name));
+    channels.insert({ channel_name, 0 });
 
   return channels;
 }
 
-bool eCAL::eh5::HDF5MeasFileV1::HasChannel(const eCAL::eh5::SChannel& channel) const
+bool eCAL::eh5::HDF5MeasFileV1::HasChannel(const eCAL::eh5::SEscapedChannel& channel) const
 {
   auto channels = GetChannels();
 
   return std::find(channels.cbegin(), channels.cend(), channel) != channels.end();
 }
 
-eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5MeasFileV1::GetChannelDataTypeInformation(const SChannel& channel) const
+eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5MeasFileV1::GetChannelDataTypeInformation(const SEscapedChannel& channel) const
 {
   std::string type;
 
@@ -179,12 +179,12 @@ eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5MeasFileV1::GetChannelDataTypeInfo
   return CreateInfo(type, description);
 }
 
-void eCAL::eh5::HDF5MeasFileV1::SetChannelDataTypeInformation(const SChannel& /*channel*/, const eCAL::eh5::DataTypeInformation& /*info*/)
+void eCAL::eh5::HDF5MeasFileV1::SetChannelDataTypeInformation(const SEscapedChannel& /*channel*/, const eCAL::eh5::DataTypeInformation& /*info*/)
 {
   ReportUnsupportedAction();
 }
 
-long long eCAL::eh5::HDF5MeasFileV1::GetMinTimestamp(const SChannel& /*channel_name*/) const
+long long eCAL::eh5::HDF5MeasFileV1::GetMinTimestamp(const SEscapedChannel& /*channel_name*/) const
 {
   long long ret_val = 0;
 
@@ -196,7 +196,7 @@ long long eCAL::eh5::HDF5MeasFileV1::GetMinTimestamp(const SChannel& /*channel_n
   return ret_val;
 }
 
-long long eCAL::eh5::HDF5MeasFileV1::GetMaxTimestamp(const SChannel& /*channel_name*/) const
+long long eCAL::eh5::HDF5MeasFileV1::GetMaxTimestamp(const SEscapedChannel& /*channel_name*/) const
 {
   long long ret_val = 0;
 
@@ -208,7 +208,7 @@ long long eCAL::eh5::HDF5MeasFileV1::GetMaxTimestamp(const SChannel& /*channel_n
   return ret_val;
 }
 
-bool eCAL::eh5::HDF5MeasFileV1::GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const
+bool eCAL::eh5::HDF5MeasFileV1::GetEntriesInfo(const SEscapedChannel& channel, EntryInfoSet& entries) const
 {
   entries.clear();
 
@@ -244,7 +244,7 @@ bool eCAL::eh5::HDF5MeasFileV1::GetEntriesInfo(const SChannel& channel, EntryInf
   return (status >= 0);
 }
 
-bool eCAL::eh5::HDF5MeasFileV1::GetEntriesInfoRange(const SChannel& /*channel_name*/, long long begin, long long end, EntryInfoSet& entries) const
+bool eCAL::eh5::HDF5MeasFileV1::GetEntriesInfoRange(const SEscapedChannel& /*channel_name*/, long long begin, long long end, EntryInfoSet& entries) const
 {
   bool ret_val = false;
 
@@ -305,7 +305,7 @@ void eCAL::eh5::HDF5MeasFileV1::SetFileBaseName(const std::string& /*base_name*/
   ReportUnsupportedAction();
 }
 
-bool eCAL::eh5::HDF5MeasFileV1::AddEntryToFile(const SWriteEntry& /*entry*/)
+bool eCAL::eh5::HDF5MeasFileV1::AddEntryToFile(const SEscapedWriteEntry& /*entry*/)
 {
   ReportUnsupportedAction();
   return false;

--- a/contrib/ecalhdf5/src/eh5_meas_file_v1.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v1.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@
 
 #include "hdf5.h"
 #include "eh5_meas_impl.h"
+#include "escape.h"
 
 namespace eCAL
 {
@@ -122,7 +123,7 @@ namespace eCAL
        *
        * @return       channel names & ids
       **/
-      std::set<eCAL::eh5::SChannel> GetChannels() const override;
+      std::set<eCAL::eh5::SEscapedChannel> GetChannels() const override;
 
       /**
        * @brief Check if channel exists in measurement
@@ -131,7 +132,7 @@ namespace eCAL
        *
        * @return       true if exists, false otherwise
       **/
-      bool HasChannel(const eCAL::eh5::SChannel& channel) const override;
+      bool HasChannel(const eCAL::eh5::SEscapedChannel& channel) const override;
 
       /**
        * @brief Get data type information of the given channel
@@ -140,7 +141,7 @@ namespace eCAL
        *
        * @return              channel type
       **/
-      DataTypeInformation GetChannelDataTypeInformation(const SChannel& channel) const override;
+      DataTypeInformation GetChannelDataTypeInformation(const SEscapedChannel& channel) const override;
 
       /**
        * @brief Set data type information of the given channel
@@ -150,7 +151,7 @@ namespace eCAL
        *
        * @return              channel type
       **/
-      void SetChannelDataTypeInformation(const SChannel& channel, const DataTypeInformation& info) override;
+      void SetChannelDataTypeInformation(const SEscapedChannel& channel, const DataTypeInformation& info) override;
 
       /**
       * @brief Gets minimum timestamp for specified channel
@@ -159,7 +160,7 @@ namespace eCAL
       *
       * @return                minimum timestamp value
       **/
-      long long GetMinTimestamp(const SChannel& channel) const override;
+      long long GetMinTimestamp(const SEscapedChannel& channel) const override;
 
       /**
       * @brief Gets maximum timestamp for specified channel
@@ -168,7 +169,7 @@ namespace eCAL
       *
       * @return                maximum timestamp value
       **/
-      long long GetMaxTimestamp(const SChannel& channel) const override;
+      long long GetMaxTimestamp(const SEscapedChannel& channel) const override;
 
       /**
       * @brief Gets the header info for all data entries for the given channel
@@ -179,7 +180,7 @@ namespace eCAL
       *
       * @return                    true if succeeds, false if it fails
       **/
-      bool GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const override;
+      bool GetEntriesInfo(const SEscapedChannel& channel, EntryInfoSet& entries) const override;
 
       /**
       * @brief Gets the header info for data entries for the given channel included in given time range (begin->end)
@@ -192,7 +193,7 @@ namespace eCAL
       *
       * @return                   true if succeeds, false if it fails
       **/
-      bool GetEntriesInfoRange(const SChannel& channel, long long begin, long long end, EntryInfoSet& entries) const override;
+      bool GetEntriesInfoRange(const SEscapedChannel& channel, long long begin, long long end, EntryInfoSet& entries) const override;
 
       /**
       * @brief Gets data size of a specific entry
@@ -234,7 +235,7 @@ namespace eCAL
       *
       * @return               true if succeeds, false if it fails
       **/
-      bool AddEntryToFile(const SWriteEntry& entry) override;
+      bool AddEntryToFile(const SEscapedWriteEntry& entry) override;
 
       typedef std::function<void(void)> CallbackFunction;
       /**

--- a/contrib/ecalhdf5/src/eh5_meas_file_v2.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v2.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -122,9 +122,9 @@ void eCAL::eh5::HDF5MeasFileV2::SetOneFilePerChannelEnabled(bool /*enabled*/)
 {
 }
 
-std::set<eCAL::eh5::SChannel> eCAL::eh5::HDF5MeasFileV2::GetChannels() const
+std::set<eCAL::eh5::SEscapedChannel> eCAL::eh5::HDF5MeasFileV2::GetChannels() const
 {
-  std::set<eCAL::eh5::SChannel> channels_set;
+  std::set<eCAL::eh5::SEscapedChannel> channels_set;
 
   std::string combined_channel_names;
   GetAttribute(file_id_, kChnAttrTitle, combined_channel_names);
@@ -133,19 +133,19 @@ std::set<eCAL::eh5::SChannel> eCAL::eh5::HDF5MeasFileV2::GetChannels() const
   EcalUtils::String::Split(combined_channel_names, ",", channel_name_list);
 
   for (const auto& channel_name : channel_name_list)
-    channels_set.insert(eCAL::experimental::measurement::base::CreateChannel(channel_name));
+    channels_set.insert({ channel_name, 0 });
 
   return channels_set;
 }
 
-bool eCAL::eh5::HDF5MeasFileV2::HasChannel(const eCAL::eh5::SChannel& channel) const
+bool eCAL::eh5::HDF5MeasFileV2::HasChannel(const eCAL::eh5::SEscapedChannel& channel) const
 {
   auto channels = GetChannels();
 
   return std::find(channels.cbegin(), channels.cend(), channel) != channels.end();
 }
 
-eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5MeasFileV2::GetChannelDataTypeInformation(const SChannel& channel) const
+eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5MeasFileV2::GetChannelDataTypeInformation(const SEscapedChannel& channel) const
 {
   std::string type;
   std::string description;
@@ -164,12 +164,12 @@ eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5MeasFileV2::GetChannelDataTypeInfo
   return CreateInfo(type, description);
 }
 
-void eCAL::eh5::HDF5MeasFileV2::SetChannelDataTypeInformation(const SChannel& /*channel*/ , const eCAL::eh5::DataTypeInformation& /*info*/)
+void eCAL::eh5::HDF5MeasFileV2::SetChannelDataTypeInformation(const SEscapedChannel& /*channel*/ , const eCAL::eh5::DataTypeInformation& /*info*/)
 {
 }
 
 
-long long eCAL::eh5::HDF5MeasFileV2::GetMinTimestamp(const SChannel& channel) const
+long long eCAL::eh5::HDF5MeasFileV2::GetMinTimestamp(const SEscapedChannel& channel) const
 {
   long long ret_val = 0;
   EntryInfoSet entries;
@@ -182,7 +182,7 @@ long long eCAL::eh5::HDF5MeasFileV2::GetMinTimestamp(const SChannel& channel) co
   return ret_val;
 }
 
-long long eCAL::eh5::HDF5MeasFileV2::GetMaxTimestamp(const SChannel& channel) const
+long long eCAL::eh5::HDF5MeasFileV2::GetMaxTimestamp(const SEscapedChannel& channel) const
 {
   long long ret_val = 0;
   EntryInfoSet entries;
@@ -195,7 +195,7 @@ long long eCAL::eh5::HDF5MeasFileV2::GetMaxTimestamp(const SChannel& channel) co
   return ret_val;
 }
 
-bool eCAL::eh5::HDF5MeasFileV2::GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const
+bool eCAL::eh5::HDF5MeasFileV2::GetEntriesInfo(const SEscapedChannel& channel, EntryInfoSet& entries) const
 {
   entries.clear();
 
@@ -229,7 +229,7 @@ bool eCAL::eh5::HDF5MeasFileV2::GetEntriesInfo(const SChannel& channel, EntryInf
   return (status >= 0);
 }
 
-bool eCAL::eh5::HDF5MeasFileV2::GetEntriesInfoRange(const SChannel& channel, long long begin, long long end, EntryInfoSet& entries) const
+bool eCAL::eh5::HDF5MeasFileV2::GetEntriesInfoRange(const SEscapedChannel& channel, long long begin, long long end, EntryInfoSet& entries) const
 {
   bool ret_val = false;
   EntryInfoSet all_entries;
@@ -294,7 +294,7 @@ void eCAL::eh5::HDF5MeasFileV2::SetFileBaseName(const std::string& /*base_name*/
 
 }
 
-bool eCAL::eh5::HDF5MeasFileV2::AddEntryToFile(const SWriteEntry& /*entry*/)
+bool eCAL::eh5::HDF5MeasFileV2::AddEntryToFile(const SEscapedWriteEntry& /*entry*/)
 {
     return false;
 }

--- a/contrib/ecalhdf5/src/eh5_meas_file_v2.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v2.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@
 
 #include "hdf5.h"
 #include "eh5_meas_impl.h"
+#include "escape.h"
 
 namespace eCAL
 {
@@ -122,7 +123,7 @@ namespace eCAL
        *
        * @return       channel names & ids
       **/
-      std::set<eCAL::eh5::SChannel> GetChannels() const override;
+      std::set<eCAL::eh5::SEscapedChannel> GetChannels() const override;
 
       /**
        * @brief Check if channel exists in measurement
@@ -131,7 +132,7 @@ namespace eCAL
        *
        * @return       true if exists, false otherwise
       **/
-      bool HasChannel(const eCAL::eh5::SChannel& channel) const override;
+      bool HasChannel(const eCAL::eh5::SEscapedChannel& channel) const override;
 
       /**
        * @brief Get data type information of the given channel
@@ -140,7 +141,7 @@ namespace eCAL
        *
        * @return              channel type
       **/
-      DataTypeInformation GetChannelDataTypeInformation(const SChannel& channel) const override;
+      DataTypeInformation GetChannelDataTypeInformation(const SEscapedChannel& channel) const override;
 
       /**
        * @brief Set data type information of the given channel
@@ -150,7 +151,7 @@ namespace eCAL
        *
        * @return              channel type
       **/
-      void SetChannelDataTypeInformation(const SChannel& channel, const DataTypeInformation& info) override;
+      void SetChannelDataTypeInformation(const SEscapedChannel& channel, const DataTypeInformation& info) override;
 
       /**
       * @brief Gets minimum timestamp for specified channel
@@ -159,7 +160,7 @@ namespace eCAL
       *
       * @return                minimum timestamp value
       **/
-      long long GetMinTimestamp(const SChannel& channel) const override;
+      long long GetMinTimestamp(const SEscapedChannel& channel) const override;
 
       /**
       * @brief Gets maximum timestamp for specified channel
@@ -168,7 +169,7 @@ namespace eCAL
       *
       * @return                maximum timestamp value
       **/
-      long long GetMaxTimestamp(const SChannel& channel) const override;
+      long long GetMaxTimestamp(const SEscapedChannel& channel) const override;
 
       /**
       * @brief Gets the header info for all data entries for the given channel
@@ -179,7 +180,7 @@ namespace eCAL
       *
       * @return                    true if succeeds, false if it fails
       **/
-      bool GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const override;
+      bool GetEntriesInfo(const SEscapedChannel& channel, EntryInfoSet& entries) const override;
 
       /**
       * @brief Gets the header info for data entries for the given channel included in given time range (begin->end)
@@ -192,7 +193,7 @@ namespace eCAL
       *
       * @return                   true if succeeds, false if it fails
       **/
-      bool GetEntriesInfoRange(const SChannel& channel, long long begin, long long end, EntryInfoSet& entries) const override;
+      bool GetEntriesInfoRange(const SEscapedChannel& channel, long long begin, long long end, EntryInfoSet& entries) const override;
 
       /**
       * @brief Gets data size of a specific entry
@@ -234,7 +235,7 @@ namespace eCAL
       *
       * @return               true if succeeds, false if it fails
       **/
-      bool AddEntryToFile(const SWriteEntry& entry) override;
+      bool AddEntryToFile(const SEscapedWriteEntry& entry) override;
 
 
       typedef std::function<void(void)> CallbackFunction;

--- a/contrib/ecalhdf5/src/eh5_meas_file_v3.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v3.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ namespace eCAL
     HDF5MeasFileV3::~HDF5MeasFileV3()
     = default;
 
-    bool HDF5MeasFileV3::GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const
+    bool HDF5MeasFileV3::GetEntriesInfo(const SEscapedChannel& channel, EntryInfoSet& entries) const
     {
       entries.clear();
 

--- a/contrib/ecalhdf5/src/eh5_meas_file_v3.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v3.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@
 #include <string>
 
 #include "eh5_meas_file_v2.h"
+#include "escape.h"
 
 namespace eCAL
 {
@@ -60,7 +61,7 @@ namespace eCAL
       *
       * @return                    true if succeeds, false if it fails
       **/
-      bool GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const override;
+      bool GetEntriesInfo(const SEscapedChannel& channel, EntryInfoSet& entries) const override;
     };
   }  //  namespace eh5
 }  //  namespace eCAL

--- a/contrib/ecalhdf5/src/eh5_meas_file_v4.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v4.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ namespace eCAL
     HDF5MeasFileV4::~HDF5MeasFileV4()
     = default;
 
-    bool HDF5MeasFileV4::GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const
+    bool HDF5MeasFileV4::GetEntriesInfo(const SEscapedChannel& channel, EntryInfoSet& entries) const
     {
       entries.clear();
 

--- a/contrib/ecalhdf5/src/eh5_meas_file_v4.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v4.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@
 #include <string>
 
 #include "eh5_meas_file_v3.h"
+#include "escape.h"
 
 namespace eCAL
 {
@@ -60,7 +61,7 @@ namespace eCAL
       *
       * @return                    true if succeeds, false if it fails
       **/
-      bool GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const override;
+      bool GetEntriesInfo(const SEscapedChannel& channel, EntryInfoSet& entries) const override;
     };
   }  //  namespace eh5
 }  //  namespace eCAL

--- a/contrib/ecalhdf5/src/eh5_meas_file_v5.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v5.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ namespace eCAL
     HDF5MeasFileV5::~HDF5MeasFileV5()
     = default;
 
-    bool HDF5MeasFileV5::GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const
+    bool HDF5MeasFileV5::GetEntriesInfo(const SEscapedChannel& channel, EntryInfoSet& entries) const
     {
       entries.clear();
 

--- a/contrib/ecalhdf5/src/eh5_meas_file_v5.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v5.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@
 #include <string>
 
 #include "eh5_meas_file_v4.h"
+#include "escape.h"
 
 namespace eCAL
 {
@@ -60,7 +61,7 @@ namespace eCAL
       *
       * @return                    true if succeeds, false if it fails
       **/
-      bool GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const override;
+      bool GetEntriesInfo(const SEscapedChannel& channel, EntryInfoSet& entries) const override;
     };
   }  //  namespace eh5
 }  //  namespace eCAL

--- a/contrib/ecalhdf5/src/eh5_meas_file_v6.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v6.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,9 +44,9 @@ namespace eCAL
 
     // Channels have to be obtained differently, the names themselves are written in the header
     // for channel, id, we need to traverse the file format and get them.
-    std::set<eCAL::eh5::SChannel> HDF5MeasFileV6::GetChannels() const
+    std::set<eCAL::eh5::SEscapedChannel> HDF5MeasFileV6::GetChannels() const
     {
-      std::set<eCAL::eh5::SChannel> channels;
+      std::set<eCAL::eh5::SEscapedChannel> channels;
       // V2 Channel function will return (channel_name, 0)
       // so we will take those channel_names
       const auto channels_v2 = HDF5MeasFileV2::GetChannels();
@@ -69,7 +69,7 @@ namespace eCAL
       return channels;
     }
 
-    bool HDF5MeasFileV6::HasChannel(const eCAL::eh5::SChannel& channel) const
+    bool HDF5MeasFileV6::HasChannel(const eCAL::eh5::SEscapedChannel& channel) const
     {
       bool has_channel_name = HasGroup(file_id_, channel.name);
       if (!has_channel_name)
@@ -83,7 +83,7 @@ namespace eCAL
       return has_channel_id;
     }
 
-    eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5MeasFileV6::GetChannelDataTypeInformation(const SChannel& channel) const
+    eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5MeasFileV6::GetChannelDataTypeInformation(const SEscapedChannel& channel) const
     {
       std::string type_name;
       std::string type_encoding;
@@ -113,7 +113,7 @@ namespace eCAL
       return eCAL::eh5::DataTypeInformation{ type_name, type_encoding, type_descriptor };
     }
 
-    bool eCAL::eh5::HDF5MeasFileV6::GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const
+    bool eCAL::eh5::HDF5MeasFileV6::GetEntriesInfo(const SEscapedChannel& channel, EntryInfoSet& entries) const
      {
       if (!this->IsOk()) return false;
 

--- a/contrib/ecalhdf5/src/eh5_meas_file_v6.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v6.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@
 #include <string>
 
 #include "eh5_meas_file_v5.h"
+#include "escape.h"
 
 namespace eCAL
 {
@@ -56,7 +57,7 @@ namespace eCAL
        *
        * @return       channel names & ids
       **/
-      std::set<eCAL::eh5::SChannel> GetChannels() const override;
+      std::set<eCAL::eh5::SEscapedChannel> GetChannels() const override;
 
       /**
        * @brief Check if channel exists in measurement
@@ -65,11 +66,11 @@ namespace eCAL
        *
        * @return       true if exists, false otherwise
       **/
-      bool HasChannel(const eCAL::eh5::SChannel& channel) const override;
+      bool HasChannel(const eCAL::eh5::SEscapedChannel& channel) const override;
 
-      DataTypeInformation GetChannelDataTypeInformation(const SChannel& channel) const override;
+      DataTypeInformation GetChannelDataTypeInformation(const SEscapedChannel& channel) const override;
 
-      bool GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const override;
+      bool GetEntriesInfo(const SEscapedChannel& channel, EntryInfoSet& entries) const override;
     };
   }  //  namespace eh5
 }  //  namespace eCAL

--- a/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -127,50 +127,50 @@ void eCAL::eh5::HDF5MeasFileWriterV5::SetOneFilePerChannelEnabled(bool /*enabled
 {
 }
 
-std::set<eCAL::eh5::SChannel> eCAL::eh5::HDF5MeasFileWriterV5::GetChannels() const
+std::set<eCAL::eh5::SEscapedChannel> eCAL::eh5::HDF5MeasFileWriterV5::GetChannels() const
 {
   // UNSUPPORTED FUNCTIONs
-  return std::set<eCAL::eh5::SChannel>();
+  return std::set<eCAL::eh5::SEscapedChannel>();
 }
 
-bool eCAL::eh5::HDF5MeasFileWriterV5::HasChannel(const eCAL::eh5::SChannel& /*channel*/ ) const
+bool eCAL::eh5::HDF5MeasFileWriterV5::HasChannel(const eCAL::eh5::SEscapedChannel& /*channel*/ ) const
 {
   // UNSUPPORTED FUNCTION
   return false;
 }
 
-eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5MeasFileWriterV5::GetChannelDataTypeInformation(const SChannel& /*channel*/) const
+eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5MeasFileWriterV5::GetChannelDataTypeInformation(const SEscapedChannel& /*channel*/) const
 {
   // UNSUPPORTED FUNCTION
   return eCAL::eh5::DataTypeInformation{};
 }
 
-void eCAL::eh5::HDF5MeasFileWriterV5::SetChannelDataTypeInformation(const SChannel& channel, const eCAL::eh5::DataTypeInformation& info)
+void eCAL::eh5::HDF5MeasFileWriterV5::SetChannelDataTypeInformation(const SEscapedChannel& channel, const eCAL::eh5::DataTypeInformation& info)
 {
   auto type_descriptor = FromInfo(info);
   channels_[channel.name].Type = type_descriptor.first;
   channels_[channel.name].Description = type_descriptor.second;
 }
 
-long long eCAL::eh5::HDF5MeasFileWriterV5::GetMinTimestamp(const SChannel& /*channel*/) const
+long long eCAL::eh5::HDF5MeasFileWriterV5::GetMinTimestamp(const SEscapedChannel& /*channel*/) const
 {
   // UNSUPPORTED FUNCTION
   return -1;
 }
 
-long long eCAL::eh5::HDF5MeasFileWriterV5::GetMaxTimestamp(const SChannel& /*channel*/) const
+long long eCAL::eh5::HDF5MeasFileWriterV5::GetMaxTimestamp(const SEscapedChannel& /*channel*/) const
 {
   // UNSUPPORTED FUNCTION
   return -1;
 }
 
-bool eCAL::eh5::HDF5MeasFileWriterV5::GetEntriesInfo(const SChannel& /*channel*/, EntryInfoSet& /*entries*/) const
+bool eCAL::eh5::HDF5MeasFileWriterV5::GetEntriesInfo(const SEscapedChannel& /*channel*/, EntryInfoSet& /*entries*/) const
 {
   // UNSUPPORTED FUNCTION
   return false;
 }
 
-bool eCAL::eh5::HDF5MeasFileWriterV5::GetEntriesInfoRange(const SChannel& /*channel*/, long long /*begin*/, long long /*end*/, EntryInfoSet& /*entries*/) const
+bool eCAL::eh5::HDF5MeasFileWriterV5::GetEntriesInfoRange(const SEscapedChannel& /*channel*/, long long /*begin*/, long long /*end*/, EntryInfoSet& /*entries*/) const
 {
   // UNSUPPORTED FUNCTION
   return false;
@@ -193,7 +193,7 @@ void eCAL::eh5::HDF5MeasFileWriterV5::SetFileBaseName(const std::string& base_na
   base_name_ = base_name;
 }
 
-bool eCAL::eh5::HDF5MeasFileWriterV5::AddEntryToFile(const SWriteEntry& entry)
+bool eCAL::eh5::HDF5MeasFileWriterV5::AddEntryToFile(const SEscapedWriteEntry& entry)
 {
   if (!IsOk()) file_id_ = Create();
   if (!IsOk())

--- a/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_writer_v5.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@
 #include "eh5_meas_impl.h"
 
 #include "hdf5.h"
+#include "escape.h"
 
 namespace eCAL
 {
@@ -129,7 +130,7 @@ namespace eCAL
        *
        * @return       channel names & ids
       **/
-      std::set<eCAL::eh5::SChannel> GetChannels() const override;
+      std::set<eCAL::eh5::SEscapedChannel> GetChannels() const override;
 
       /**
        * @brief Check if channel exists in measurement
@@ -138,7 +139,7 @@ namespace eCAL
        *
        * @return       true if exists, false otherwise
       **/
-      bool HasChannel(const eCAL::eh5::SChannel & channel) const override;
+      bool HasChannel(const eCAL::eh5::SEscapedChannel & channel) const override;
 
       /**
        * @brief Get data type information of the given channel
@@ -147,7 +148,7 @@ namespace eCAL
        *
        * @return              channel type
       **/
-      DataTypeInformation GetChannelDataTypeInformation(const SChannel& channel) const override;
+      DataTypeInformation GetChannelDataTypeInformation(const SEscapedChannel& channel) const override;
 
       /**
        * @brief Set data type information of the given channel
@@ -157,7 +158,7 @@ namespace eCAL
        *
        * @return              channel type
       **/
-      void SetChannelDataTypeInformation(const SChannel& channel, const DataTypeInformation & info) override;
+      void SetChannelDataTypeInformation(const SEscapedChannel& channel, const DataTypeInformation & info) override;
 
       /**
       * @brief Gets minimum timestamp for specified channel
@@ -166,7 +167,7 @@ namespace eCAL
       *
       * @return                minimum timestamp value
       **/
-      long long GetMinTimestamp(const SChannel& channel) const override;
+      long long GetMinTimestamp(const SEscapedChannel& channel) const override;
 
       /**
       * @brief Gets maximum timestamp for specified channel
@@ -175,7 +176,7 @@ namespace eCAL
       *
       * @return                maximum timestamp value
       **/
-      long long GetMaxTimestamp(const SChannel& channel) const override;
+      long long GetMaxTimestamp(const SEscapedChannel& channel) const override;
 
       /**
       * @brief Gets the header info for all data entries for the given channel
@@ -186,7 +187,7 @@ namespace eCAL
       *
       * @return                    true if succeeds, false if it fails
       **/
-      bool GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const override;
+      bool GetEntriesInfo(const SEscapedChannel& channel, EntryInfoSet& entries) const override;
 
       /**
       * @brief Gets the header info for data entries for the given channel included in given time range (begin->end)
@@ -199,7 +200,7 @@ namespace eCAL
       *
       * @return                   true if succeeds, false if it fails
       **/
-      bool GetEntriesInfoRange(const SChannel& channel, long long begin, long long end, EntryInfoSet& entries) const override;
+      bool GetEntriesInfoRange(const SEscapedChannel& channel, long long begin, long long end, EntryInfoSet& entries) const override;
 
       /**
       * @brief Gets data size of a specific entry
@@ -241,7 +242,7 @@ namespace eCAL
       *
       * @return               true if succeeds, false if it fails
       **/
-      bool AddEntryToFile(const SWriteEntry& entry) override;
+      bool AddEntryToFile(const SEscapedWriteEntry& entry) override;
 
       using CallbackFunction = std::function<void ()>;
       /**

--- a/contrib/ecalhdf5/src/eh5_meas_file_writer_v6.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_writer_v6.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@
 **/
 
 #include "eh5_meas_file_writer_v6.h"
-#include "escape.h"
 
 #ifdef WIN32
 #include <windows.h>
@@ -134,49 +133,49 @@ void eCAL::eh5::HDF5MeasFileWriterV6::SetOneFilePerChannelEnabled(bool /*enabled
 {
 }
 
-std::set<eCAL::eh5::SChannel> eCAL::eh5::HDF5MeasFileWriterV6::GetChannels() const
+std::set<eCAL::eh5::SEscapedChannel> eCAL::eh5::HDF5MeasFileWriterV6::GetChannels() const
 {
   // UNSUPPORTED FUNCTION
-  return std::set<eCAL::eh5::SChannel>();
+  return std::set<eCAL::eh5::SEscapedChannel>();
 }
 
-bool eCAL::eh5::HDF5MeasFileWriterV6::HasChannel(const eCAL::eh5::SChannel& /*channel*/) const
+bool eCAL::eh5::HDF5MeasFileWriterV6::HasChannel(const eCAL::eh5::SEscapedChannel& /*channel*/) const
 {
   // UNSUPPORTED FUNCTION
   return false;
 }
 
-eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5MeasFileWriterV6::GetChannelDataTypeInformation(const SChannel& /*channel*/) const
+eCAL::eh5::DataTypeInformation eCAL::eh5::HDF5MeasFileWriterV6::GetChannelDataTypeInformation(const SEscapedChannel& /*channel*/) const
 {
   // UNSUPPORTED FUNCTION
   return eCAL::eh5::DataTypeInformation{};
 }
 
-void eCAL::eh5::HDF5MeasFileWriterV6::SetChannelDataTypeInformation(const SChannel& channel , const eCAL::eh5::DataTypeInformation& info)
+void eCAL::eh5::HDF5MeasFileWriterV6::SetChannelDataTypeInformation(const SEscapedChannel& channel , const eCAL::eh5::DataTypeInformation& info)
 {
   channels_[channel.name][channel.id].Info = info;
 }
 
 
-long long eCAL::eh5::HDF5MeasFileWriterV6::GetMinTimestamp(const SChannel& /*channel_name*/) const
+long long eCAL::eh5::HDF5MeasFileWriterV6::GetMinTimestamp(const SEscapedChannel& /*channel_name*/) const
 {
   // UNSUPPORTED FUNCTION
   return -1;
 }
 
-long long eCAL::eh5::HDF5MeasFileWriterV6::GetMaxTimestamp(const SChannel&  /*channel_name*/) const
+long long eCAL::eh5::HDF5MeasFileWriterV6::GetMaxTimestamp(const SEscapedChannel&  /*channel_name*/) const
 {
   // UNSUPPORTED FUNCTION
   return -1;
 }
 
-bool eCAL::eh5::HDF5MeasFileWriterV6::GetEntriesInfo(const SChannel&  /*channel_name*/, EntryInfoSet& /*entries*/) const
+bool eCAL::eh5::HDF5MeasFileWriterV6::GetEntriesInfo(const SEscapedChannel&  /*channel_name*/, EntryInfoSet& /*entries*/) const
 {
   // UNSUPPORTED FUNCTION
   return false;
 }
 
-bool eCAL::eh5::HDF5MeasFileWriterV6::GetEntriesInfoRange(const SChannel&  /*channel_name*/, long long /*begin*/, long long /*end*/, EntryInfoSet& /*entries*/) const
+bool eCAL::eh5::HDF5MeasFileWriterV6::GetEntriesInfoRange(const SEscapedChannel&  /*channel_name*/, long long /*begin*/, long long /*end*/, EntryInfoSet& /*entries*/) const
 {
   // UNSUPPORTED FUNCTION
   return false;
@@ -199,7 +198,7 @@ void eCAL::eh5::HDF5MeasFileWriterV6::SetFileBaseName(const std::string& base_na
   base_name_ = base_name;
 }
 
-bool eCAL::eh5::HDF5MeasFileWriterV6::AddEntryToFile(const SWriteEntry& entry)
+bool eCAL::eh5::HDF5MeasFileWriterV6::AddEntryToFile(const SEscapedWriteEntry& entry)
 {
   if (!IsOk()) file_id_ = Create();
   if (!IsOk())

--- a/contrib/ecalhdf5/src/eh5_meas_file_writer_v6.h
+++ b/contrib/ecalhdf5/src/eh5_meas_file_writer_v6.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@
 #include "eh5_meas_impl.h"
 
 #include "hdf5.h"
+#include "escape.h"
 
 namespace eCAL
 {
@@ -129,7 +130,7 @@ namespace eCAL
        *
        * @return       channel names & ids
       **/
-      std::set<eCAL::eh5::SChannel> GetChannels() const override;
+      std::set<eCAL::eh5::SEscapedChannel> GetChannels() const override;
 
       /**
        * @brief Check if channel exists in measurement
@@ -138,7 +139,7 @@ namespace eCAL
        *
        * @return       true if exists, false otherwise
       **/
-      bool HasChannel(const eCAL::eh5::SChannel & channel) const override;
+      bool HasChannel(const eCAL::eh5::SEscapedChannel & channel) const override;
 
       /**
        * @brief Get data type information of the given channel
@@ -147,7 +148,7 @@ namespace eCAL
        *
        * @return              channel type
       **/
-      DataTypeInformation GetChannelDataTypeInformation(const SChannel & channel) const override;
+      DataTypeInformation GetChannelDataTypeInformation(const SEscapedChannel & channel) const override;
 
       /**
        * @brief Set data type information of the given channel
@@ -157,7 +158,7 @@ namespace eCAL
        *
        * @return              channel type
       **/
-      void SetChannelDataTypeInformation(const SChannel& channel, const eCAL::eh5::DataTypeInformation& info) override;
+      void SetChannelDataTypeInformation(const SEscapedChannel& channel, const eCAL::eh5::DataTypeInformation& info) override;
 
       /**
       * @brief Gets minimum timestamp for specified channel
@@ -166,7 +167,7 @@ namespace eCAL
       *
       * @return                minimum timestamp value
       **/
-      long long GetMinTimestamp(const SChannel& channel) const override;
+      long long GetMinTimestamp(const SEscapedChannel& channel) const override;
 
       /**
       * @brief Gets maximum timestamp for specified channel
@@ -175,7 +176,7 @@ namespace eCAL
       *
       * @return                maximum timestamp value
       **/
-      long long GetMaxTimestamp(const SChannel& channele) const override;
+      long long GetMaxTimestamp(const SEscapedChannel& channele) const override;
 
       /**
       * @brief Gets the header info for all data entries for the given channel
@@ -186,7 +187,7 @@ namespace eCAL
       *
       * @return                    true if succeeds, false if it fails
       **/
-      bool GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const override;
+      bool GetEntriesInfo(const SEscapedChannel& channel, EntryInfoSet& entries) const override;
 
       /**
       * @brief Gets the header info for data entries for the given channel included in given time range (begin->end)
@@ -199,7 +200,7 @@ namespace eCAL
       *
       * @return                   true if succeeds, false if it fails
       **/
-      bool GetEntriesInfoRange(const SChannel& channel, long long begin, long long end, EntryInfoSet& entries) const override;
+      bool GetEntriesInfoRange(const SEscapedChannel& channel, long long begin, long long end, EntryInfoSet& entries) const override;
 
       /**
       * @brief Gets data size of a specific entry
@@ -241,7 +242,7 @@ namespace eCAL
       *
       * @return               true if succeeds, false if it fails
       **/
-      bool AddEntryToFile(const SWriteEntry& entry) override;
+      bool AddEntryToFile(const SEscapedWriteEntry& entry) override;
 
       using CallbackFunction = std::function<void ()>;
       /**

--- a/contrib/ecalhdf5/src/eh5_meas_impl.h
+++ b/contrib/ecalhdf5/src/eh5_meas_impl.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include "ecalhdf5/eh5_types.h"
+#include "escape.h"
 
 namespace eCAL
 {
@@ -113,7 +114,7 @@ namespace eCAL
        *
        * @return       channel names & ids
       **/
-      virtual std::set<eCAL::eh5::SChannel> GetChannels() const = 0;
+      virtual std::set<eCAL::eh5::SEscapedChannel> GetChannels() const = 0;
 
       /**
       * @brief Check if channel exists in measurement
@@ -122,7 +123,7 @@ namespace eCAL
       *
       * @return       true if exists, false otherwise
       **/
-      virtual bool HasChannel(const eCAL::eh5::SChannel& channel) const = 0;
+      virtual bool HasChannel(const SEscapedChannel& channel) const = 0;
 
       /**
        * @brief Get data type information of the given channel
@@ -131,7 +132,7 @@ namespace eCAL
        *
        * @return              channel type
       **/
-      virtual DataTypeInformation GetChannelDataTypeInformation(const SChannel& channel) const = 0;
+      virtual DataTypeInformation GetChannelDataTypeInformation(const SEscapedChannel& channel) const = 0;
 
       /**
        * @brief Set data type information of the given channel
@@ -141,7 +142,7 @@ namespace eCAL
        *
        * @return              channel type
       **/
-      virtual void SetChannelDataTypeInformation(const SChannel& channel, const eCAL::eh5::DataTypeInformation& info) = 0;
+      virtual void SetChannelDataTypeInformation(const SEscapedChannel& channel, const eCAL::eh5::DataTypeInformation& info) = 0;
 
       /**
       * @brief Gets minimum timestamp for specified channel
@@ -150,7 +151,7 @@ namespace eCAL
       *
       * @return                minimum timestamp value
       **/
-      virtual long long GetMinTimestamp(const SChannel& channel) const = 0;
+      virtual long long GetMinTimestamp(const SEscapedChannel& channel) const = 0;
 
       /**
       * @brief Gets maximum timestamp for specified channel
@@ -159,7 +160,7 @@ namespace eCAL
       *
       * @return                maximum timestamp value
       **/
-      virtual long long GetMaxTimestamp(const SChannel& channel) const = 0;
+      virtual long long GetMaxTimestamp(const SEscapedChannel& channel) const = 0;
 
       /**
       * @brief Gets the header info for all data entries for the given channel
@@ -170,7 +171,7 @@ namespace eCAL
       *
       * @return                    true if succeeds, false if it fails
       **/
-      virtual bool GetEntriesInfo(const SChannel& channel, EntryInfoSet& entries) const = 0;
+      virtual bool GetEntriesInfo(const SEscapedChannel& channel, EntryInfoSet& entries) const = 0;
 
       /**
       * @brief Gets the header info for data entries for the given channel included in given time range (begin->end)
@@ -183,7 +184,7 @@ namespace eCAL
       *
       * @return                   true if succeeds, false if it fails
       **/
-      virtual bool GetEntriesInfoRange(const SChannel& channel, long long begin, long long end, EntryInfoSet& entries) const = 0;
+      virtual bool GetEntriesInfoRange(const SEscapedChannel& channel, long long begin, long long end, EntryInfoSet& entries) const = 0;
 
       /**
       * @brief Gets data size of a specific entry
@@ -225,7 +226,7 @@ namespace eCAL
       *
       * @return               true if succeeds, false if it fails
       **/
-      virtual bool AddEntryToFile(const SWriteEntry& entry) = 0;
+      virtual bool AddEntryToFile(const SEscapedWriteEntry& entry) = 0;
 
       typedef std::function<void(void)> CallbackFunction;
       /**

--- a/contrib/ecalhdf5/src/escape.cpp
+++ b/contrib/ecalhdf5/src/escape.cpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -574,18 +574,6 @@ namespace eCAL
     std::string GetEscapedTopicname(const std::string& non_escaped_topicname)
     {
       return GetEscapedString(non_escaped_topicname, is_reserved_topicname_);
-    }
-
-    SChannel GetEscapedTopicname(const SChannel& input)
-    {
-        return SChannel(GetEscapedTopicname(input.name), input.id);
-    }
-
-    SWriteEntry GetEscapedEntry(const SWriteEntry& input)
-    {
-      SWriteEntry escaped_entry{ input };
-      escaped_entry.channel = GetEscapedTopicname(input.channel);
-      return escaped_entry;
     }
 
     std::string GetEscapedFilename(const std::string& non_escaped_filename)

--- a/contrib/ecalhdf5/src/escape.h
+++ b/contrib/ecalhdf5/src/escape.h
@@ -41,6 +41,11 @@ namespace eCAL
         return SEscapedChannel{ GetEscapedTopicname(input.name), input.id };
       }
 
+      SChannel toSChannel() const
+      {
+        return SChannel(GetUnescapedString(name), id);
+      }
+
       bool operator==(const SEscapedChannel& other) const
       {
         return std::tie(id, name) == std::tie(other.id, other.name);

--- a/contrib/ecalhdf5/src/escape.h
+++ b/contrib/ecalhdf5/src/escape.h
@@ -33,8 +33,8 @@ namespace eCAL
 
     struct SEscapedChannel
     {
-      std::string name;
-      SChannel::id_t id;
+      std::string name{ "" };
+      SChannel::id_t id{ 0 };
 
       static SEscapedChannel fromSChannel(const SChannel& input)
       {
@@ -98,8 +98,8 @@ namespace std {
   struct hash<eCAL::eh5::SEscapedChannel> {
     std::size_t operator()(const eCAL::eh5::SEscapedChannel& data) const {
       // Combine the hash of the string and the integer
-      std::size_t h1 = std::hash<std::string>{}(data.name);
-      std::size_t h2 = std::hash<eCAL::experimental::measurement::base::Channel::id_t>{}(data.id);
+      const std::size_t h1 = std::hash<std::string>{}(data.name);
+      const std::size_t h2 = std::hash<eCAL::experimental::measurement::base::Channel::id_t>{}(data.id);
 
       // Combine the two hashes (this is a common technique)
       return h1 ^ (h2 << 1); // XOR and shift

--- a/contrib/ecalhdf5/src/escape.h
+++ b/contrib/ecalhdf5/src/escape.h
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2024 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <string>
+#include <tuple>
 #include <ecalhdf5/eh5_types.h>
 
 namespace eCAL
@@ -27,9 +28,76 @@ namespace eCAL
   namespace eh5
   {
     std::string GetEscapedTopicname(const std::string& input);
-    SChannel    GetEscapedTopicname(const SChannel& input);
-    SWriteEntry GetEscapedEntry(const SWriteEntry& input);
     std::string GetEscapedFilename(const std::string& input);
     std::string GetUnescapedString(const std::string& input);
+
+    struct SEscapedChannel
+    {
+      std::string name;
+      SChannel::id_t id;
+
+      static SEscapedChannel fromSChannel(const SChannel& input)
+      {
+        return SEscapedChannel{ GetEscapedTopicname(input.name), input.id };
+      }
+
+      bool operator==(const SEscapedChannel& other) const
+      {
+        return std::tie(id, name) == std::tie(other.id, other.name);
+      }
+
+      bool operator!=(const SEscapedChannel& other) const
+      {
+        return !(*this == other);
+      }
+
+      bool operator<(const SEscapedChannel& other) const
+      {
+        return std::tie(id, name) < std::tie(other.id, other.name);
+      }
+    };
+
+    struct SEscapedWriteEntry
+    {
+      // channel
+      SEscapedChannel channel;
+
+      // data
+      const void* data = nullptr;
+      unsigned long long size = 0;
+
+      // metadata
+      long long snd_timestamp = 0;
+      long long rcv_timestamp = 0;
+      long long sender_id = 0; // Unique ID which may be set by sender
+      long long clock = 0;
+
+      static SEscapedWriteEntry fromSWriteEntry(const SWriteEntry& input)
+      {
+        SEscapedWriteEntry escaped_entry;
+        escaped_entry.channel = SEscapedChannel::fromSChannel(input.channel);
+        escaped_entry.data = input.data;
+        escaped_entry.size = input.size;
+        escaped_entry.snd_timestamp = input.snd_timestamp;
+        escaped_entry.rcv_timestamp = input.rcv_timestamp;
+        escaped_entry.sender_id = input.sender_id;
+        escaped_entry.clock = input.clock;
+        return escaped_entry;
+      }
+    };
   }
+}
+
+namespace std {
+  template <>
+  struct hash<eCAL::eh5::SEscapedChannel> {
+    std::size_t operator()(const eCAL::eh5::SEscapedChannel& data) const {
+      // Combine the hash of the string and the integer
+      std::size_t h1 = std::hash<std::string>{}(data.name);
+      std::size_t h2 = std::hash<eCAL::experimental::measurement::base::Channel::id_t>{}(data.id);
+
+      // Combine the two hashes (this is a common technique)
+      return h1 ^ (h2 << 1); // XOR and shift
+    }
+  };
 }


### PR DESCRIPTION
- Adds new testcase
- Introduces strong type so that it is clear where and where not channel names have been escaped.