### PR TITLE
[GH Action] Fixed comment of used VS Toolchain

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -70,7 +70,7 @@ jobs:
       uses: ilammy/msvc-dev-cmd@v1
       with:
         arch: x64
-        toolset: 14.29 # v141 / vs2019
+        toolset: 14.29 # v142 / vs2019
 
     - name: Prepare ccache and restore cache
       id: ccache_cache-restore


### PR DESCRIPTION
We are using v142 (which is correct and desired) but the comment stated v141

