### PR TITLE
Updated find_package Protobuf to CONFIG REQUIRED to support external …

### DIFF
--- a/app/app_pb/CMakeLists.txt
+++ b/app/app_pb/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 project(app_pb)
 
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 set(ProtoFiles
   ${CMAKE_CURRENT_SOURCE_DIR}/src/ecal/app/pb/mma/mma.proto

--- a/app/mma/CMakeLists.txt
+++ b/app/mma/CMakeLists.txt
@@ -19,7 +19,7 @@
 project(mma)
 
 find_package(Threads REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 set(mma_src
   include/interruptable_timer.h

--- a/app/mon/mon_cli/CMakeLists.txt
+++ b/app/mon/mon_cli/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 project(mon_cli)
 
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 find_package(tclap REQUIRED)
 
 set(ecalmon_cli_src

--- a/app/mon/mon_gui/CMakeLists.txt
+++ b/app/mon/mon_gui/CMakeLists.txt
@@ -30,7 +30,7 @@ project(mon_gui)
 find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core Widgets)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Widgets)
 
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 if(ECAL_USE_NPCAP)
   find_package(udpcap REQUIRED)

--- a/app/mon/mon_plugins/protobuf_reflection/CMakeLists.txt
+++ b/app/mon/mon_plugins/protobuf_reflection/CMakeLists.txt
@@ -24,7 +24,7 @@ project(mon_plugin_protobuf_reflection VERSION 0.1.0)
 find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core Widgets)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Widgets)
 
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC OFF) # Reason for being turned off: AutoUIC will prevent VS from detecting changes in .ui files

--- a/app/mon/mon_plugins/signals_plotting/CMakeLists.txt
+++ b/app/mon/mon_plugins/signals_plotting/CMakeLists.txt
@@ -23,7 +23,7 @@ project(mon_plugin_signals_plotting VERSION 1.0.0)
 find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core Widgets)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Widgets)
 
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 find_package(qwt REQUIRED)
 
 set(CMAKE_AUTOMOC ON)

--- a/app/mon/mon_tui/CMakeLists.txt
+++ b/app/mon/mon_tui/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 project(mon_tui)
 
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 find_package(tclap REQUIRED)
 find_package(ftxui REQUIRED)
 

--- a/app/play/play_core/CMakeLists.txt
+++ b/app/play/play_core/CMakeLists.txt
@@ -19,7 +19,7 @@
 project(play_core)
 
 find_package(Threads REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 find_package(spdlog REQUIRED)
 
 set(source_files

--- a/app/rec/rec_client_cli/CMakeLists.txt
+++ b/app/rec/rec_client_cli/CMakeLists.txt
@@ -17,7 +17,7 @@
 # ========================= eCAL LICENSE =================================
 
 find_package(tclap REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 find_package(tclap REQUIRED)
 
 set(PROJECT_NAME rec_client)

--- a/app/rec/rec_client_core/CMakeLists.txt
+++ b/app/rec/rec_client_core/CMakeLists.txt
@@ -17,7 +17,7 @@
 # ========================= eCAL LICENSE =================================
 
 find_package(Threads REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 find_package(spdlog REQUIRED)
 
 if (ECAL_USE_CURL)

--- a/app/rec/rec_gui/CMakeLists.txt
+++ b/app/rec/rec_gui/CMakeLists.txt
@@ -43,7 +43,7 @@ if (WIN32 AND (${QT_VERSION_MAJOR} EQUAL 5))
 endif()
 
 find_package(tclap REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC OFF) # Reason for being turned off: AutoUIC will prevent VS from detecting changes in .ui files

--- a/app/rec/rec_server_cli/CMakeLists.txt
+++ b/app/rec/rec_server_cli/CMakeLists.txt
@@ -19,7 +19,7 @@
 project(rec)
 
 find_package(tclap REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 find_package(termcolor REQUIRED)
 
 set(source_files

--- a/app/rec/rec_server_core/CMakeLists.txt
+++ b/app/rec/rec_server_core/CMakeLists.txt
@@ -17,7 +17,7 @@
 # ========================= eCAL LICENSE =================================
 
 find_package(Threads REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 find_package(spdlog REQUIRED)
 find_package(fineftp REQUIRED)
 find_package(tinyxml2 REQUIRED)

--- a/app/sys/sys_cli/CMakeLists.txt
+++ b/app/sys/sys_cli/CMakeLists.txt
@@ -19,7 +19,7 @@
 project(sys)
 
 find_package(tclap REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 find_package(termcolor REQUIRED)
 
 set(source_files

--- a/app/sys/sys_client_cli/CMakeLists.txt
+++ b/app/sys/sys_client_cli/CMakeLists.txt
@@ -20,7 +20,7 @@ set(PROJECT_NAME sys_client)
 
 find_package(spdlog REQUIRED)
 find_package(tclap REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 set(source_files
   src/ecal_sys_client_cli.cpp

--- a/app/sys/sys_client_core/CMakeLists.txt
+++ b/app/sys/sys_client_core/CMakeLists.txt
@@ -17,7 +17,7 @@
 # ========================= eCAL LICENSE =================================
 
 find_package(Threads REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 find_package(spdlog REQUIRED)
 
 set(PROJECT_NAME sys_client_core)

--- a/app/sys/sys_core/CMakeLists.txt
+++ b/app/sys/sys_core/CMakeLists.txt
@@ -19,7 +19,7 @@
 project(sys_core)
 
 find_package(Threads REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 find_package(spdlog REQUIRED)
 find_package(tinyxml2 REQUIRED)
 

--- a/app/sys/sys_gui/CMakeLists.txt
+++ b/app/sys/sys_gui/CMakeLists.txt
@@ -31,7 +31,7 @@ find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core Widgets)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Widgets)
 
 find_package(tclap REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC OFF) # Reason for being turned off: AutoUIC will prevent VS from detecting changes in .ui files

--- a/contrib/ecaltime/ecaltime_pb/CMakeLists.txt
+++ b/contrib/ecaltime/ecaltime_pb/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 project(ecaltime_pb)
 
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 set(ProtoFiles
   ${CMAKE_CURRENT_SOURCE_DIR}/src/ecal/ecaltime/pb/sim_time.proto

--- a/contrib/ecaltime/simtime/CMakeLists.txt
+++ b/contrib/ecaltime/simtime/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 project(ecaltime-simtime)
 
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 set(ecal_time_simtime_src
   src/ecal_time_simtime.cpp

--- a/doc/rst/getting_started/cmake_integration.rst
+++ b/doc/rst/getting_started/cmake_integration.rst
@@ -25,7 +25,7 @@ The CMakeLists.txt looks as follows:
 Protobuf entity integration
 ===========================
 
-In addtition to the previous example, you will need to call ``find_package(Protobuf REQUIRED)``.
+In addtition to the previous example, you will need to call ``find_package(Protobuf CONFIG REQUIRED)``.
 Furthermore you want to handle the generation of the protobuf headers for your language.
 
 .. literalinclude:: files/CMakeLists/protobuf/CMakeLists.txt

--- a/doc/rst/getting_started/files/CMakeLists/protobuf/CMakeLists.txt
+++ b/doc/rst/getting_started/files/CMakeLists/protobuf/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Tell CMake to find the eCAL installation and the protobuf library.
 find_package(eCAL REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 # Set a list all source files for the project.
 # In our case it is only one file, but can be simply extended to multiple files.

--- a/ecal/core_pb/CMakeLists.txt
+++ b/ecal/core_pb/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 project(core_pb)
 
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 set(ProtoFiles
   ${CMAKE_CURRENT_SOURCE_DIR}/src/ecal/core/pb/datatype.proto

--- a/ecal/samples/cpp/monitoring/logging_rec/CMakeLists.txt
+++ b/ecal/samples/cpp/monitoring/logging_rec/CMakeLists.txt
@@ -21,7 +21,7 @@ cmake_minimum_required(VERSION 3.15)
 project(logging_rec)
 
 find_package(eCAL REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 set(logging_rec_src
     src/logging_rec.cpp

--- a/ecal/samples/cpp/monitoring/monitoring_performance/CMakeLists.txt
+++ b/ecal/samples/cpp/monitoring/monitoring_performance/CMakeLists.txt
@@ -21,7 +21,7 @@ cmake_minimum_required(VERSION 3.15)
 project(monitoring_performance)
 
 find_package(eCAL REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 set(monitoring_performance_src
     src/monitoring_performance.cpp

--- a/ecal/samples/cpp/monitoring/monitoring_rec/CMakeLists.txt
+++ b/ecal/samples/cpp/monitoring/monitoring_rec/CMakeLists.txt
@@ -21,7 +21,7 @@ cmake_minimum_required(VERSION 3.15)
 project(monitoring_rec)
 
 find_package(eCAL REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 set(monitoring_rec_src
     src/monitoring_rec.cpp

--- a/ecal/samples/cpp/orchestration/component1/CMakeLists.txt
+++ b/ecal/samples/cpp/orchestration/component1/CMakeLists.txt
@@ -21,7 +21,7 @@ cmake_minimum_required(VERSION 3.15)
 project(component1)
 
 find_package(eCAL REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 set(component1_src
     src/component1.cpp

--- a/ecal/samples/cpp/orchestration/component2/CMakeLists.txt
+++ b/ecal/samples/cpp/orchestration/component2/CMakeLists.txt
@@ -21,7 +21,7 @@ cmake_minimum_required(VERSION 3.15)
 project(component2)
 
 find_package(eCAL REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 set(component2_src
     src/component2.cpp

--- a/ecal/samples/cpp/orchestration/orchestrator/CMakeLists.txt
+++ b/ecal/samples/cpp/orchestration/orchestrator/CMakeLists.txt
@@ -21,7 +21,7 @@ cmake_minimum_required(VERSION 3.15)
 project(orchestrator)
 
 find_package(eCAL REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 set(orchestrator_src
     src/orchestrator.cpp

--- a/lang/csharp/CMakeLists.txt
+++ b/lang/csharp/CMakeLists.txt
@@ -32,7 +32,7 @@ include(GNUInstallDirs)
 # We should do this differently, but then we need to install protoc via nuget or similar...
 # Because the Prototbuf Version used for C# bindings is independent from the one we get from the submodules / conan
 macro(get_csharp_protobuf_version)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 if (${Protobuf_VERSION} VERSION_GREATER_EQUAL 4)
   if(NOT DEFINED Protobuf_VERSION_MINOR OR NOT DEFINED Protobuf_VERSION_PATCH)
     string(REPLACE "." ";" _ecal_protobuf_version "${Protobuf_VERSION}")

--- a/lang/csharp/Eclipse.eCAL.Protobuf.Datatypes/CMakeLists.txt
+++ b/lang/csharp/Eclipse.eCAL.Protobuf.Datatypes/CMakeLists.txt
@@ -21,7 +21,7 @@ include(CSharpUtilities)
 # We need this for protoc. It's a bit stupid, because we don't really need a C++ package here
 # let's check if we can do something with nuget instead maybe
 
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 include(protobuf_csharp_helper.cmake)
 
 project(Eclipse.eCAL.Protobuf.Datatypes LANGUAGES CSharp)

--- a/lang/csharp/Eclipse.eCAL.Protobuf.Samples.Datatypes/CMakeLists.txt
+++ b/lang/csharp/Eclipse.eCAL.Protobuf.Samples.Datatypes/CMakeLists.txt
@@ -21,7 +21,7 @@ include(CSharpUtilities)
 # We need this for protoc. It's a bit stupid, because we don't really need a C++ package here
 # let's check if we can do something with nuget instead maybe
 
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 include(protobuf_csharp_helper.cmake)
 
 project(Eclipse.eCAL.Protobuf.Samples.Datatypes LANGUAGES CSharp)

--- a/serialization/protobuf/protobuf/CMakeLists.txt
+++ b/serialization/protobuf/protobuf/CMakeLists.txt
@@ -20,7 +20,7 @@
 # Protobuf base functionality
 ##########################
 
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 ecal_add_library(protobuf_base)
 add_library(eCAL::protobuf_base ALIAS protobuf_base)
 

--- a/serialization/protobuf/samples/measurement/CMakeLists.txt
+++ b/serialization/protobuf/samples/measurement/CMakeLists.txt
@@ -21,7 +21,7 @@ cmake_minimum_required(VERSION 3.15)
 project(person_measurement)
 
 find_package(eCAL REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 macro(create_measurement_sample target_name sample_sources)
   ecal_add_sample(${target_name} ${sample_sources})

--- a/serialization/protobuf/samples/pubsub/person_events_rec/CMakeLists.txt
+++ b/serialization/protobuf/samples/pubsub/person_events_rec/CMakeLists.txt
@@ -21,7 +21,7 @@ cmake_minimum_required(VERSION 3.15)
 project(person_events_rec)
 
 find_package(eCAL REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 set(person_events_rec_src
     src/person_events_rec.cpp

--- a/serialization/protobuf/samples/pubsub/person_events_snd/CMakeLists.txt
+++ b/serialization/protobuf/samples/pubsub/person_events_snd/CMakeLists.txt
@@ -21,7 +21,7 @@ cmake_minimum_required(VERSION 3.15)
 project(person_events_snd)
 
 find_package(eCAL REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 set(person_events_snd_src
     src/person_events_snd.cpp

--- a/serialization/protobuf/samples/pubsub/person_loopback/CMakeLists.txt
+++ b/serialization/protobuf/samples/pubsub/person_loopback/CMakeLists.txt
@@ -21,7 +21,7 @@ cmake_minimum_required(VERSION 3.15)
 project(person_loopback)
 
 find_package(eCAL REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 set(person_loopback_src
     src/person_loopback.cpp

--- a/serialization/protobuf/samples/pubsub/person_receive/CMakeLists.txt
+++ b/serialization/protobuf/samples/pubsub/person_receive/CMakeLists.txt
@@ -21,7 +21,7 @@ cmake_minimum_required(VERSION 3.15)
 project(person_receive)
 
 find_package(eCAL REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 set(person_receive_src
     src/person_receive.cpp

--- a/serialization/protobuf/samples/pubsub/person_send/CMakeLists.txt
+++ b/serialization/protobuf/samples/pubsub/person_send/CMakeLists.txt
@@ -21,7 +21,7 @@ cmake_minimum_required(VERSION 3.15)
 project(person_send)
 
 find_package(eCAL REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 set(person_send_src
     src/person_send.cpp

--- a/serialization/protobuf/samples/pubsub/proto_dyn_json_rec/CMakeLists.txt
+++ b/serialization/protobuf/samples/pubsub/proto_dyn_json_rec/CMakeLists.txt
@@ -21,7 +21,7 @@ cmake_minimum_required(VERSION 3.15)
 project(proto_dyn_json_rec)
 
 find_package(eCAL REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 set(proto_dyn_json_rec_src
     src/proto_dyn_json_rec.cpp

--- a/serialization/protobuf/samples/pubsub/proto_dyn_rec/CMakeLists.txt
+++ b/serialization/protobuf/samples/pubsub/proto_dyn_rec/CMakeLists.txt
@@ -21,7 +21,7 @@ cmake_minimum_required(VERSION 3.15)
 project(proto_dyn_rec)
 
 find_package(eCAL REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 set(proto_dyn_rec_src
     src/proto_dyn_rec.cpp

--- a/serialization/protobuf/samples/services/math_client/CMakeLists.txt
+++ b/serialization/protobuf/samples/services/math_client/CMakeLists.txt
@@ -21,7 +21,7 @@ cmake_minimum_required(VERSION 3.15)
 project(math_client)
 
 find_package(eCAL REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 set(math_client_src
     src/math_client.cpp

--- a/serialization/protobuf/samples/services/math_server/CMakeLists.txt
+++ b/serialization/protobuf/samples/services/math_server/CMakeLists.txt
@@ -21,7 +21,7 @@ cmake_minimum_required(VERSION 3.15)
 project(math_server)
 
 find_package(eCAL REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 set(math_server_src
     src/math_server.cpp

--- a/serialization/protobuf/samples/services/ping_client/CMakeLists.txt
+++ b/serialization/protobuf/samples/services/ping_client/CMakeLists.txt
@@ -21,7 +21,7 @@ cmake_minimum_required(VERSION 3.15)
 project(ping_client)
 
 find_package(eCAL REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 set(ping_client_src
     src/ping_client.cpp

--- a/serialization/protobuf/samples/services/ping_client_dyn/CMakeLists.txt
+++ b/serialization/protobuf/samples/services/ping_client_dyn/CMakeLists.txt
@@ -21,7 +21,7 @@ cmake_minimum_required(VERSION 3.15)
 project(ping_client_dyn)
 
 find_package(eCAL REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 set(ping_client_dyn_src
     src/ping_client_dyn.cpp

--- a/serialization/protobuf/samples/services/ping_server/CMakeLists.txt
+++ b/serialization/protobuf/samples/services/ping_server/CMakeLists.txt
@@ -21,7 +21,7 @@ cmake_minimum_required(VERSION 3.15)
 project(ping_server)
 
 find_package(eCAL REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 set(ping_server_src
     src/ping_server.cpp

--- a/serialization/protobuf/tests/clientserver_proto_test/CMakeLists.txt
+++ b/serialization/protobuf/tests/clientserver_proto_test/CMakeLists.txt
@@ -20,7 +20,7 @@ project(test_clientserver_proto)
 
 find_package(Threads REQUIRED)
 find_package(GTest REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 create_targets_protobuf()
 

--- a/serialization/protobuf/tests/dynproto_test/CMakeLists.txt
+++ b/serialization/protobuf/tests/dynproto_test/CMakeLists.txt
@@ -20,7 +20,7 @@ project(test_dynproto)
 
 find_package(Threads REQUIRED)
 find_package(GTest REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 create_targets_protobuf()
 

--- a/serialization/protobuf/tests/ecal_proto_test/CMakeLists.txt
+++ b/serialization/protobuf/tests/ecal_proto_test/CMakeLists.txt
@@ -20,7 +20,7 @@ project(test_ecal_proto)
 
 find_package(Threads REQUIRED)
 find_package(GTest REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 create_targets_protobuf()
 

--- a/serialization/protobuf/tests/pubsub_proto_test/CMakeLists.txt
+++ b/serialization/protobuf/tests/pubsub_proto_test/CMakeLists.txt
@@ -20,7 +20,7 @@ project(test_pubsub_proto)
 
 find_package(Threads REQUIRED)
 find_package(GTest REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 create_targets_protobuf()
 

--- a/serialization/string/samples/measurement/CMakeLists.txt
+++ b/serialization/string/samples/measurement/CMakeLists.txt
@@ -21,7 +21,7 @@ cmake_minimum_required(VERSION 3.15)
 project(hello_measurement)
 
 find_package(eCAL REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
 macro(create_measurement_sample target_name sample_sources)
   ecal_add_sample(${target_name} ${sample_sources})


### PR DESCRIPTION
### Description
Changes: `find_package(Protobuf REQUIRED)` to `find_package(Protobuf CONFIG REQUIRED)`

Supports Protobuf <=5.29.X (See note about std::string_view https://github.com/eclipse-ecal/ecal/issues/1187#issuecomment-2780681182)

Without this change I was able to use manual protobuf build as I was getting errors:
```
/usr/bin/ld: CMakeFiles/math_client.dir/protobuf/math.pb.cc.o: undefined reference to symbol '_ZN4absl12lts_2024011612log_internal15LogMessageFatalC1EPKci'
/usr/bin/ld: /usr/local/lib/libabsl_log_internal_message.so.2401.0.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```

This should not affect users that set ` -DECAL_THIRDPARTY_BUILD_PROTOBUF=ON` or install the protobuf from Ubuntu.

### Building external protobuf
```
git clone https://github.com/protocolbuffers/protobuf.git
cd protobuf
git checkout v29.5
mkdir build
cd build
cmake .. -Dprotobuf_BUILD_SHARED_LIBS=ON -Dprotobuf_BUILD_TESTS=OFF -DABSL_PROPAGATE_CXX_STD=ON
make -j
sudo make install
```

eCAL Build
```
cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=cmake/submodule_dependencies.cmake -DECAL_THIRDPARTY_BUILD_PROTOBUF=OFF -DECAL_THIRDPARTY_BUILD_CURL=OFF -DECAL_THIRDPARTY_BUILD_HDF5=OFF -DECAL_THIRDPARTY_BUILD_QWT=OFF
```

### Related issues
https://github.com/eclipse-ecal/ecal/issues/1187
