### PR TITLE
[Sys] Added Ecal Parser Evaluation to target Hostname field

### DIFF
--- a/app/sys/sys_cli/src/ecalsys_service.cpp
+++ b/app/sys/sys_cli/src/ecalsys_service.cpp
@@ -26,6 +26,7 @@
 #include "ecalsys_service.h"
 
 #include <ecalsys/proto_helpers.h>
+#include <EcalParser/EcalParser.h>
 
 extern bool exit_command_received;
 
@@ -42,7 +43,7 @@ namespace
       tasks.remove_if(
         [](std::shared_ptr<EcalSysTask> task)
       {
-        return task->GetTarget() != eCAL::Process::GetHostName();
+        return EcalParser::Evaluate(task->GetTarget(), false) != eCAL::Process::GetHostName();
       });
     }
     return tasks;

--- a/app/sys/sys_cli/src/ecalsys_util.cpp
+++ b/app/sys/sys_cli/src/ecalsys_util.cpp
@@ -24,6 +24,8 @@
 #include "ecalsys_util.h"
 #include <iostream>
 
+#include <EcalParser/EcalParser.h>
+
 #ifdef ECAL_OS_WINDOWS
 #include <conio.h>
 #else
@@ -77,9 +79,9 @@ bool WaitForClients(std::shared_ptr<EcalSys> ecalsys_inst)
   std::string current_host = eCAL::Process::GetHostName();
   for (auto task : ecalsys_inst->GetTaskList())
   {
-    if (task->GetTarget() != current_host)
+    if (EcalParser::Evaluate(task->GetTarget(), false) != current_host)
     {
-      targets.emplace(task->GetTarget());
+      targets.emplace(EcalParser::Evaluate(task->GetTarget(), false));
     }
   }
 

--- a/app/sys/sys_core/src/ecal_sys.cpp
+++ b/app/sys/sys_core/src/ecal_sys.cpp
@@ -599,7 +599,7 @@ void EcalSys::StartTasks()
   if (options.local_tasks_only)
   {
     auto task_list = GetTaskList();
-    task_list.remove_if([](const std::shared_ptr<EcalSysTask> t) -> bool { return EcalParser::Evaluate(t->GetTarget(), false) != eCAL::Process::GetHostName(); });
+    task_list.remove_if([](const std::shared_ptr<EcalSysTask>& t) -> bool { return EcalParser::Evaluate(t->GetTarget(), false) != eCAL::Process::GetHostName(); });
     StartTaskList(task_list);
   }
   else if (options.use_localhost_for_all_tasks)
@@ -619,7 +619,7 @@ void EcalSys::StopTasks()
   if (options.local_tasks_only)
   {
     auto task_list = GetTaskList();
-    task_list.remove_if([](const std::shared_ptr<EcalSysTask> t) -> bool { return EcalParser::Evaluate(t->GetTarget(), false) != eCAL::Process::GetHostName(); });
+    task_list.remove_if([](const std::shared_ptr<EcalSysTask>& t) -> bool { return EcalParser::Evaluate(t->GetTarget(), false) != eCAL::Process::GetHostName(); });
     StopTaskList(task_list, true, true);
   }
   else
@@ -635,7 +635,7 @@ void EcalSys::RestartTasks()
   if (options.local_tasks_only)
   {
     auto task_list = GetTaskList();
-    task_list.remove_if([](const std::shared_ptr<EcalSysTask> t) -> bool { return EcalParser::Evaluate(t->GetTarget(), false) != eCAL::Process::GetHostName(); });
+    task_list.remove_if([](const std::shared_ptr<EcalSysTask>& t) -> bool { return EcalParser::Evaluate(t->GetTarget(), false) != eCAL::Process::GetHostName(); });
     RestartTaskList(GetTaskList(), true, true);
   }
   else if (options.use_localhost_for_all_tasks)

--- a/app/sys/sys_core/src/ecal_sys.cpp
+++ b/app/sys/sys_core/src/ecal_sys.cpp
@@ -34,6 +34,8 @@
 #pragma warning(pop)
 #endif
 
+#include <EcalParser/EcalParser.h>
+
 #include <ecal_utils/string.h>
 
 #include "ecalsys/esys_defs.h"
@@ -597,7 +599,7 @@ void EcalSys::StartTasks()
   if (options.local_tasks_only)
   {
     auto task_list = GetTaskList();
-    task_list.remove_if([](const std::shared_ptr<EcalSysTask> t) -> bool { return t->GetTarget() != eCAL::Process::GetHostName(); });
+    task_list.remove_if([](const std::shared_ptr<EcalSysTask> t) -> bool { return EcalParser::Evaluate(t->GetTarget(), false) != eCAL::Process::GetHostName(); });
     StartTaskList(task_list);
   }
   else if (options.use_localhost_for_all_tasks)
@@ -617,7 +619,7 @@ void EcalSys::StopTasks()
   if (options.local_tasks_only)
   {
     auto task_list = GetTaskList();
-    task_list.remove_if([](const std::shared_ptr<EcalSysTask> t) -> bool { return t->GetTarget() != eCAL::Process::GetHostName(); });
+    task_list.remove_if([](const std::shared_ptr<EcalSysTask> t) -> bool { return EcalParser::Evaluate(t->GetTarget(), false) != eCAL::Process::GetHostName(); });
     StopTaskList(task_list, true, true);
   }
   else
@@ -633,7 +635,7 @@ void EcalSys::RestartTasks()
   if (options.local_tasks_only)
   {
     auto task_list = GetTaskList();
-    task_list.remove_if([](const std::shared_ptr<EcalSysTask> t) -> bool { return t->GetTarget() != eCAL::Process::GetHostName(); });
+    task_list.remove_if([](const std::shared_ptr<EcalSysTask> t) -> bool { return EcalParser::Evaluate(t->GetTarget(), false) != eCAL::Process::GetHostName(); });
     RestartTaskList(GetTaskList(), true, true);
   }
   else if (options.use_localhost_for_all_tasks)

--- a/app/sys/sys_core/src/ecal_sys_monitor.cpp
+++ b/app/sys/sys_core/src/ecal_sys_monitor.cpp
@@ -210,7 +210,7 @@ void EcalSysMonitor::RestartBySeverity()
 
     std::lock_guard<std::recursive_mutex> task_lock(task->mutex);
     // tasks on other hosts than local won't be restarted if the flag local_tasks_only is set
-    if ((m_ecalsys_instance.GetOptions().local_tasks_only == true) && (EcalParser::Evaluate(task->GetTarget(), false) != eCAL::Process::GetHostName()))
+    if ((m_ecalsys_instance.GetOptions().local_tasks_only) && (EcalParser::Evaluate(task->GetTarget(), false) != eCAL::Process::GetHostName()))
     {
       continue;
     }

--- a/app/sys/sys_core/src/ecal_sys_monitor.cpp
+++ b/app/sys/sys_core/src/ecal_sys_monitor.cpp
@@ -35,7 +35,7 @@
 #include <ecal_utils/ecal_utils.h>
 #include <ecal_utils/filesystem.h>
 
-
+#include <EcalParser/EcalParser.h>
 
 EcalSysMonitor::EcalSysMonitor(EcalSys& ecalsys_instance, std::chrono::nanoseconds loop_time)
   : InterruptibleLoopThread(loop_time)
@@ -210,7 +210,7 @@ void EcalSysMonitor::RestartBySeverity()
 
     std::lock_guard<std::recursive_mutex> task_lock(task->mutex);
     // tasks on other hosts than local won't be restarted if the flag local_tasks_only is set
-    if ((m_ecalsys_instance.GetOptions().local_tasks_only == true) && (task->GetTarget() != eCAL::Process::GetHostName()))
+    if ((m_ecalsys_instance.GetOptions().local_tasks_only == true) && (EcalParser::Evaluate(task->GetTarget(), false) != eCAL::Process::GetHostName()))
     {
       continue;
     }

--- a/app/sys/sys_core/src/taskaction_threads/start_task_list_thread.cpp
+++ b/app/sys/sys_core/src/taskaction_threads/start_task_list_thread.cpp
@@ -24,6 +24,8 @@
 #include <map>
 #include <future>
 
+#include <EcalParser/EcalParser.h>
+
 StartTaskListThread::StartTaskListThread(const std::list<std::shared_ptr<EcalSysTask>>& task_list, const std::shared_ptr<eCAL::sys::ConnectionManager>& connection_manager, const std::string& target_override)
   : TaskListThread(task_list, connection_manager)
   , m_target_override(target_override)
@@ -79,8 +81,9 @@ void StartTaskListThread::Run()
       // Create primitive StartTaskParameters struct for ecal_sys_client API
       if (m_target_override.empty())
       {
-        start_tasks_param_map[task->GetTarget()].push_back(eCAL::sys::task_helpers::ToSysClientStartParameters_NoLock(task));
-        original_task_ptr_map[task->GetTarget()].push_back(task);
+        auto evaluated_target = EcalParser::Evaluate(task->GetTarget(), false);
+        start_tasks_param_map[evaluated_target].push_back(eCAL::sys::task_helpers::ToSysClientStartParameters_NoLock(task));
+        original_task_ptr_map[evaluated_target].push_back(task);
       }
       else
       {

--- a/app/sys/sys_core/src/taskaction_threads/stop_task_list_thread.cpp
+++ b/app/sys/sys_core/src/taskaction_threads/stop_task_list_thread.cpp
@@ -27,6 +27,8 @@
 
 #include <map>
 
+#include <EcalParser/EcalParser.h>
+
 StopTaskListThread::StopTaskListThread(const std::list<std::shared_ptr<EcalSysTask>>& task_list, const std::shared_ptr<eCAL::sys::ConnectionManager>& connection_manager, bool request_shutdown, bool kill_process, bool by_name, std::chrono::nanoseconds wait_for_shutdown)
   : TaskListThread     (task_list, connection_manager)
   , m_request_shutdown (request_shutdown)
@@ -53,7 +55,7 @@ void StopTaskListThread::Run()
     // If the host that the task has been started on is unknown we try to stop it on the configured target
     std::string host_to_stop_on = task->GetHostStartedOn();
     if (host_to_stop_on == "")
-      host_to_stop_on = task->GetTarget();
+      host_to_stop_on = EcalParser::Evaluate(task->GetTarget(), false);
 
 
     // Create primitive StopTaskParameters struct for ecal_sys_client API

--- a/app/sys/sys_core/src/taskaction_threads/update_from_cloud_task_list_thread.cpp
+++ b/app/sys/sys_core/src/taskaction_threads/update_from_cloud_task_list_thread.cpp
@@ -26,6 +26,7 @@
 #include <map>
 #include <future>
 
+#include <EcalParser/EcalParser.h>
 
 UpdateFromCloudTaskListThread::UpdateFromCloudTaskListThread(const std::list<std::shared_ptr<EcalSysTask>>& task_list_to_update, const std::list<std::shared_ptr<EcalSysTask>>& all_tasks, const std::shared_ptr<eCAL::sys::ConnectionManager>& connection_manager, bool use_localhost_for_all_tasks)
   : TaskListThread               (task_list_to_update, connection_manager)
@@ -62,8 +63,8 @@ void UpdateFromCloudTaskListThread::Run()
     }
     else
     {
-      host_tasklist_map        [ecalsys_task->GetTarget()].push_back(task);
-      host_originaltasklist_map[ecalsys_task->GetTarget()].push_back(ecalsys_task);
+      host_tasklist_map        [EcalParser::Evaluate(ecalsys_task->GetTarget(), false)].push_back(task);
+      host_originaltasklist_map[EcalParser::Evaluate(ecalsys_task->GetTarget(), false)].push_back(ecalsys_task);
     }
   }
 
@@ -72,7 +73,7 @@ void UpdateFromCloudTaskListThread::Run()
     if (m_use_localhost_for_all_tasks)
       host_all_original_tasks_map[eCAL::Process::GetHostName()].push_back(ecalsys_task);
     else
-      host_all_original_tasks_map[ecalsys_task->GetTarget()].push_back(ecalsys_task);
+      host_all_original_tasks_map[EcalParser::Evaluate(ecalsys_task->GetTarget(), false)].push_back(ecalsys_task);
   }
 
   // Match the tasks!!!

--- a/app/sys/sys_gui/src/ecalsys_service.cpp
+++ b/app/sys/sys_gui/src/ecalsys_service.cpp
@@ -25,6 +25,7 @@
 #include "ecalsys/ecal_sys_logger.h"
 
 #include <ecalsys/proto_helpers.h>
+#include <EcalParser/EcalParser.h>
 
 namespace
 {
@@ -39,7 +40,7 @@ namespace
       tasks.remove_if(
         [](std::shared_ptr<EcalSysTask> task)
       {
-        return QString::compare(task->GetTarget().c_str(), eCAL::Process::GetHostName().c_str(), Qt::CaseSensitivity::CaseInsensitive) != 0;
+        return QString::compare(QString::fromStdString(EcalParser::Evaluate(task->GetTarget(), false)), eCAL::Process::GetHostName().c_str(), Qt::CaseSensitivity::CaseInsensitive) != 0;
       });
     }
     return tasks;

--- a/app/sys/sys_gui/src/widgets/groupwidget/group_widget.cpp
+++ b/app/sys/sys_gui/src/widgets/groupwidget/group_widget.cpp
@@ -24,6 +24,8 @@
 #include <QMenu>
 #include <QSettings>
 
+#include <EcalParser/EcalParser.h>
+
 #include "widgets/treemodels/tree_data_roles.h"
 #include "widgets/treemodels/tree_item_types.h"
 #include "CustomQt/QStableSortFilterProxyModel.h"
@@ -782,7 +784,7 @@ bool GroupWidget::checkTargetsReachable(const std::list<std::shared_ptr<EcalSysT
   std::set<std::string> target_set;
   for (auto& task : task_list)
   {
-    target_set.emplace(task->GetTarget());
+    target_set.emplace(EcalParser::Evaluate(task->GetTarget(), false));
   }
   return checkTargetsReachable(target_set);
 }

--- a/app/sys/sys_gui/src/widgets/taskwidget/task_widget.cpp
+++ b/app/sys/sys_gui/src/widgets/taskwidget/task_widget.cpp
@@ -965,7 +965,7 @@ void TaskWidget::startAllTasks(const std::string& target_override)
       tasks.remove_if(
         [](std::shared_ptr<EcalSysTask> task) 
         {
-          return QString::compare(task->GetTarget().c_str(), eCAL::Process::GetHostName().c_str(), Qt::CaseSensitivity::CaseInsensitive) != 0;
+          return QString::compare(QString::fromStdString(EcalParser::Evaluate(task->GetTarget(), false)), eCAL::Process::GetHostName().c_str(), Qt::CaseSensitivity::CaseInsensitive) != 0;
         });
     }
     else if (!options.use_localhost_for_all_tasks && options.check_target_reachability)
@@ -999,7 +999,7 @@ void TaskWidget::stopAllTasks(bool shutdown_request, bool kill_tasks)
     tasks.remove_if(
       [](std::shared_ptr<EcalSysTask> task)
       {
-        return QString::compare(task->GetTarget().c_str(), eCAL::Process::GetHostName().c_str(), Qt::CaseSensitivity::CaseInsensitive) != 0;
+        return QString::compare(QString::fromStdString(EcalParser::Evaluate(task->GetTarget(), false)), eCAL::Process::GetHostName().c_str(), Qt::CaseSensitivity::CaseInsensitive) != 0;
       });
   }
   Globals::EcalSysInstance()->StopTaskList(tasks, shutdown_request, kill_tasks);
@@ -1019,7 +1019,7 @@ void TaskWidget::restartAllTasks(bool shutdown_request, bool kill_tasks, const s
       tasks.remove_if(
         [](std::shared_ptr<EcalSysTask> task) 
         {
-          return QString::compare(task->GetTarget().c_str(), eCAL::Process::GetHostName().c_str(), Qt::CaseSensitivity::CaseInsensitive) != 0;
+          return QString::compare(QString::fromStdString(EcalParser::Evaluate(task->GetTarget(), false)), eCAL::Process::GetHostName().c_str(), Qt::CaseSensitivity::CaseInsensitive) != 0;
         });
     }
     else if (!options.use_localhost_for_all_tasks && options.check_target_reachability)
@@ -2423,7 +2423,7 @@ bool TaskWidget::checkTargetsReachable(const std::list<std::shared_ptr<EcalSysTa
   std::set<std::string> target_set;
   for (auto& task : task_list)
   {
-    target_set.emplace(task->GetTarget());
+    target_set.emplace(EcalParser::Evaluate(task->GetTarget(), false));
   }
   return checkTargetsReachable(target_set);
 }

--- a/app/sys/sys_gui/src/widgets/taskwidget/task_widget.ui
+++ b/app/sys/sys_gui/src/widgets/taskwidget/task_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>830</width>
-    <height>591</height>
+    <height>626</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -609,7 +609,7 @@
             </widget>
            </item>
            <item row="0" column="1">
-            <widget class="QLineEdit" name="target_lineedit">
+            <widget class="QEcalParserLineEdit" name="target_lineedit">
              <property name="minimumSize">
               <size>
                <width>20</width>

--- a/app/sys/sys_gui/src/widgets/treemodels/task_tree_item.cpp
+++ b/app/sys/sys_gui/src/widgets/treemodels/task_tree_item.cpp
@@ -26,6 +26,8 @@
 #include "tree_item_types.h"
 #include "tree_data_roles.h"
 
+#include <EcalParser/EcalParser.h>
+
 TaskTreeItem::TaskTreeItem(std::shared_ptr<EcalSysTask> task)
   : QAbstractTreeItem()
   , task_(task)
@@ -176,14 +178,14 @@ QVariant TaskTreeItem::data(Columns column, Qt::ItemDataRole role) const
 
     // Strike out everything that is not on this host
     if (options.local_tasks_only
-      && (QString::compare(task_->GetTarget().c_str(), eCAL::Process::GetHostName().c_str(), Qt::CaseSensitivity::CaseInsensitive) != 0))
+      && (QString::compare(QString::fromStdString(EcalParser::Evaluate(task_->GetTarget(), false)), eCAL::Process::GetHostName().c_str(), Qt::CaseSensitivity::CaseInsensitive) != 0))
     {
       font.setStrikeOut(true);
     }
     // Strike out the Hostnames of all Tasks that are not local
     else if ((options.use_localhost_for_all_tasks)
       && (column == Columns::TARGET_NAME)
-      && (QString::compare(task_->GetTarget().c_str(), eCAL::Process::GetHostName().c_str(), Qt::CaseSensitivity::CaseInsensitive) != 0))
+      && (QString::compare(QString::fromStdString(EcalParser::Evaluate(task_->GetTarget(), false)), eCAL::Process::GetHostName().c_str(), Qt::CaseSensitivity::CaseInsensitive) != 0))
     {
       font.setStrikeOut(true);
     }
@@ -223,7 +225,7 @@ QVariant TaskTreeItem::data(Columns column, Qt::ItemDataRole role) const
     if (options.local_tasks_only)
     {
       // Grey out everything that is not on this host
-      if (QString::compare(task_->GetTarget().c_str(), eCAL::Process::GetHostName().c_str(), Qt::CaseSensitivity::CaseInsensitive) != 0)
+      if (QString::compare(QString::fromStdString(EcalParser::Evaluate(task_->GetTarget(), false)), eCAL::Process::GetHostName().c_str(), Qt::CaseSensitivity::CaseInsensitive) != 0)
       {
         return QColor(128, 128, 128);
       }
@@ -236,7 +238,7 @@ QVariant TaskTreeItem::data(Columns column, Qt::ItemDataRole role) const
     {
       // Grey out the Hostnames of all Tasks that are not local
       if (column == Columns::TARGET_NAME
-        && QString::compare(task_->GetTarget().c_str(), eCAL::Process::GetHostName().c_str(), Qt::CaseSensitivity::CaseInsensitive) != 0)
+        && QString::compare(QString::fromStdString(EcalParser::Evaluate(task_->GetTarget(), false)), eCAL::Process::GetHostName().c_str(), Qt::CaseSensitivity::CaseInsensitive) != 0)
       {
         return QColor(128, 128, 128);
       }


### PR DESCRIPTION
### Description
The Hostname can now be programmed with the Ecal Parser syntax known from the Executable path, arguments, etc.

Limitation: TARGET functions are never evaluated, as the Hostname determines the target and cannot be evaluated *on* it for obvious reasons. Thus, something like `$TARGET{ENV my_env}` would never be evaluated.

Fixes #1940

<img width="1037" height="713" alt="grafik" src="https://github.com/user-attachments/assets/07b2fd35-be0e-47d6-b203-03b6f10bd674" />

