### PR TITLE
Add GitHub Action to Trigger Test Suite (ecal-test-suite)

### DIFF
--- a/.github/workflows/test-suite-trigger.yml
+++ b/.github/workflows/test-suite-trigger.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Trigger test suite if token is set
         run: |
           if [ -z "${{ secrets.ECAL_TEST_SUITE_DISPATCH_GITHUB_TOKEN}}" ]; then
-            echo "INFO: TEST_SUITE_TOKEN  is not set."
+            echo "INFO: ECAL_TEST_SUITE_DISPATCH_GITHUB_TOKENis not set."
             echo "Skipping test trigger."
           else
             echo "Triggering test suite..."

--- a/.github/workflows/test-suite-trigger.yml
+++ b/.github/workflows/test-suite-trigger.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Test reports and logs
         run: |
           if [ -z "${{ secrets.ECAL_TEST_SUITE_DISPATCH_GITHUB_TOKEN}}" ]; then
-            echo "INFO: TEST_SUITE_TOKEN  is not set."
+            echo "INFO: ECAL_TEST_SUITE_DISPATCH_GITHUB_TOKEN is not set."
             echo "Skipping test trigger."
           else
             echo "Test in ecal test suite has been triggered."

--- a/.github/workflows/test-suite-trigger.yml
+++ b/.github/workflows/test-suite-trigger.yml
@@ -1,0 +1,57 @@
+name: Trigger ecal-test-suite
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  trigger-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine correct SHA
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "COMMIT_SHA=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
+          else
+            echo "COMMIT_SHA=${{ github.sha }}" >> $GITHUB_ENV
+          fi
+
+      - name: Trigger test suite if token is set
+        run: |
+          if [ -z "${{ secrets.TEST_SUITE_TOKEN }}" ]; then
+            echo "INFO: TEST_SUITE_TOKEN  is not set."
+            echo "Skipping test trigger."
+          else
+            echo "Triggering test suite..."
+            curl -X POST https://api.github.com/repos/eclipse-ecal/ecal-test-suite/dispatches \
+              -H "Accept: application/vnd.github.v3+json" \
+              -H "Authorization: token ${{ secrets.TEST_SUITE_TOKEN }}" \
+              -d '{
+                "event_type": "run-tests",
+                "client_payload": {
+                  "sha": "'"${{ env.COMMIT_SHA }}"'",
+                  "repo": "'"${{ github.repository }}"'",
+                  "run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                }
+              }'
+          fi
+
+      - name: Test reports and logs
+        run: |
+          if [ -z "${{ secrets.TEST_SUITE_TOKEN }}" ]; then
+            echo "INFO: TEST_SUITE_TOKEN  is not set."
+            echo "Skipping test trigger."
+          else
+            echo "Test in ecal test suite has been triggered."
+            echo ""
+            echo "View status and logs:"
+            echo "https://github.com/eclipse-ecal/ecal-test-suite/actions"
+            echo ""
+            echo "Test report (available after completion):"
+            echo "https://eclipse-ecal.github.io/ecal-test-suite/"
+          fi

--- a/.github/workflows/test-suite-trigger.yml
+++ b/.github/workflows/test-suite-trigger.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Trigger test suite if token is set
         run: |
-          if [ -z "${{ secrets.TEST_SUITE_TOKEN }}" ]; then
+          if [ -z "${{ secrets.ECAL_TEST_SUITE_DISPATCH_GITHUB_TOKEN}}" ]; then
             echo "INFO: TEST_SUITE_TOKEN  is not set."
             echo "Skipping test trigger."
           else

--- a/.github/workflows/test-suite-trigger.yml
+++ b/.github/workflows/test-suite-trigger.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Test reports and logs
         run: |
-          if [ -z "${{ secrets.TEST_SUITE_TOKEN }}" ]; then
+          if [ -z "${{ secrets.ECAL_TEST_SUITE_DISPATCH_GITHUB_TOKEN}}" ]; then
             echo "INFO: TEST_SUITE_TOKEN  is not set."
             echo "Skipping test trigger."
           else

--- a/.github/workflows/test-suite-trigger.yml
+++ b/.github/workflows/test-suite-trigger.yml
@@ -30,7 +30,7 @@ jobs:
             echo "Triggering test suite..."
             curl -X POST https://api.github.com/repos/eclipse-ecal/ecal-test-suite/dispatches \
               -H "Accept: application/vnd.github.v3+json" \
-              -H "Authorization: token ${{ secrets.TEST_SUITE_TOKEN }}" \
+              -H "Authorization: token ${{ secrets.ECAL_TEST_SUITE_DISPATCH_GITHUB_TOKEN}}" \
               -d '{
                 "event_type": "run-tests",
                 "client_payload": {


### PR DESCRIPTION
## Summary

This PR introduces a new GitHub Actions workflow (`.github/workflows/trigger-tests.yml`) that automatically triggers the `ecal-test-suite` whenever a pull request or push is made to the `master` branch of this repository.

The workflow uses a `repository_dispatch` event to trigger a remote test run and links the corresponding test results back to the related commit or pull request.

## What’s Included

- Trigger on:
  - Push to `master`
  - Pull request to `master`
  - Manual `workflow_dispatch`

- Sends a `repository_dispatch` with:
  - Commit SHA
  - Originating repository
  - Link to the current workflow run

- Points to the official test suite repository:
  https://github.com/eclipse-ecal/ecal-test-suite

- Outputs links to:
  - Test reports: https://eclipse-ecal.github.io/ecal-test-suite/

## Motivation

This enables automated integration testing across repositories and ensures:

- Early detection of interface-breaking changes
- Centralized test reporting via GitHub Pages
- CI status visibility in pull requests using commit status feedback

## Related Pull Requests

- See also: [eclipse-ecal/ecal-test-suite#1](https://github.com/eclipse-ecal/ecal-test-suite/pull/1)
