### PR TITLE
Updated color scheme to Eclipse Orange

### DIFF
--- a/doc/_static/css/sphinx-book-theme-1.1.2-ecaladdon.css
+++ b/doc/_static/css/sphinx-book-theme-1.1.2-ecaladdon.css
@@ -1,12 +1,12 @@
 html[data-theme=dark],
 html[data-theme=light] {
-    --pst-color-primary: #ffa500;
+    --pst-color-primary: #F79422;
 }
 
 html[data-theme=light] {
-    --pst-color-secondary: #CC8400;
+    --pst-color-secondary: #C56C07;
 }
 
 html[data-theme=dark] {
-    --pst-color-secondary: #FFC04D;
+    --pst-color-secondary: #FAB76B;
 }


### PR DESCRIPTION
Switched to the Eclipse Foundation orange as main color. Continental will be AUMOVIO (with new color scheme) in the future and eCAL has been an Eclipse Project for quite some time, so I think it is OK to make that change

Eclipse-orange is `#F79422` / `rgb(247,148,34)` / `hsl(32,93%,55%)`

- [X] Documentation CSS
- [ ] Documentation SVGs with orange color scheme
- [ ] Logos (Installer, logo dir, favicon, documentation)
- [ ] eCAL Launcher