### PR TITLE
Publish to PyPi workflow addition to build wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -33,3 +33,22 @@ jobs:
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
+
+  publish_wheels:
+    name: Publish wheels to PyPi
+    if: startsWith(github.ref, 'refs/tags')
+    needs: [build_wheels]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+            pattern: "cibw-wheels-*"
+            path: dist/
+      - name: Move wheels to dist folder
+        run: >
+          mv dist/**/*.whl dist/;
+          rm -r dist/cibw-wheels-*
+      - name: Publish packages to Pypi
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
### Description

Adds a job to the existing `build_wheels` workflow to publish the built `.whl` files to PyPi on tagged commits. The maintainers of Ecal will still need to go and setup trusted publishing for this project and link the github repo to the package in PyPi before this can succeed.

### Related issues

#1161 
