### PR TITLE
[build] Avoid mirror_server name clash with HDF5

### DIFF
--- a/ecal/samples/cpp/services/mirror_client/CMakeLists.txt
+++ b/ecal/samples/cpp/services/mirror_client/CMakeLists.txt
@@ -18,7 +18,7 @@
 
 cmake_minimum_required(VERSION 3.15)
 
-project(mirror_client)
+project(mirror_client_cpp)
 
 find_package(eCAL REQUIRED)
 

--- a/ecal/samples/cpp/services/mirror_server/CMakeLists.txt
+++ b/ecal/samples/cpp/services/mirror_server/CMakeLists.txt
@@ -18,7 +18,8 @@
 
 cmake_minimum_required(VERSION 3.15)
 
-project(mirror_server)
+# The target name mirror_server is used by HDF5
+project(mirror_server_cpp)
 
 find_package(eCAL REQUIRED)
 


### PR DESCRIPTION
### Description
<!-- What does your PR change? -->

HDF5 may provide a CMake target with the name `mirror_server` as they have an executable of the same name.
If you try to configure eCAL with such an HDF5 package, HDF5 support enabled, and the `mirror_server` sample enabled it will fail as the target will already exist.

To get around this I simply appended `_cpp` to the problematic samples (as there is also `mirror_server_c`)

Eg: The Arch Linux HDF5 package has `mirror_server` included: https://archlinux.org/packages/extra/x86_64/hdf5/

### Related issues
<!-- Type "Fixes #123" to automatically close that issue, when this PR is merged -->
- 
