### PR TITLE
[build] Static app helper libraries

### DIFF
--- a/app/mon/mon_plugins/monitor_tree_view/CMakeLists.txt
+++ b/app/mon/mon_plugins/monitor_tree_view/CMakeLists.txt
@@ -37,7 +37,8 @@ set(source_files
 
 set(CMAKE_AUTOMOC ON)
 
-add_library(${PROJECT_NAME} ${source_files})
+# Internal helper library for eCAL plugins
+add_library(${PROJECT_NAME} STATIC ${source_files})
 add_library(eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME} PUBLIC src)

--- a/app/play/play_core/CMakeLists.txt
+++ b/app/play/play_core/CMakeLists.txt
@@ -43,7 +43,8 @@ set(source_files
   src/measurement_container.h
 ) 
 
-add_library(${PROJECT_NAME} ${source_files})
+# Internal helper library for eCAL applications
+add_library(${PROJECT_NAME} STATIC ${source_files})
 add_library(eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME} PRIVATE src)

--- a/app/rec/rec_client_core/CMakeLists.txt
+++ b/app/rec/rec_client_core/CMakeLists.txt
@@ -78,7 +78,8 @@ if (ECAL_USE_CURL)
         )
 endif()
 
-add_library (${PROJECT_NAME} ${source_files})
+# Internal helper library for eCAL applications
+add_library (${PROJECT_NAME} STATIC ${source_files})
 add_library (eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME} PRIVATE src)

--- a/app/rec/rec_server_core/CMakeLists.txt
+++ b/app/rec/rec_server_core/CMakeLists.txt
@@ -56,7 +56,8 @@ set(source_files
     src/recorder/remote_recorder.h
 ) 
 
-add_library (${PROJECT_NAME} ${source_files})
+# Internal helper library for eCAL applications
+add_library (${PROJECT_NAME} STATIC ${source_files})
 add_library (eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME} PRIVATE src)

--- a/app/sys/sys_client_core/CMakeLists.txt
+++ b/app/sys/sys_client_core/CMakeLists.txt
@@ -34,7 +34,8 @@ set(source_files
   src/task.cpp
 ) 
 
-add_library (${PROJECT_NAME} ${source_files})
+# Internal helper library for eCAL applications
+add_library (${PROJECT_NAME} STATIC ${source_files})
 add_library (eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME} PRIVATE src)

--- a/app/sys/sys_core/CMakeLists.txt
+++ b/app/sys/sys_core/CMakeLists.txt
@@ -74,7 +74,8 @@ set(ecalsyscore_src
   src/task/task_group.cpp
 )
 
-add_library(${PROJECT_NAME} ${ecalsyscore_src})
+# Internal helper library for eCAL applications
+add_library(${PROJECT_NAME} STATIC ${ecalsyscore_src})
 add_library(eCAL::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME}


### PR DESCRIPTION
### Description
<!-- What does your PR change? -->

Made these changes a while ago but forgot to get them upstreamed :grimacing: 

The apps have some common functionality libraries that are not installed and only used to support the apps.
As such, if CMake `BUILD_SHARED_LIBS` is on (as is typical of Linux packaging builds) these common/helper libraries are built as shared libraries but don't get installed and the apps can't run (as the libraries are missing).

To fix, I simply made them all static so they don't need to be installed, as they don't appear to be meant for external use.

### Related issues
<!-- Type "Fixes #123" to automatically close that issue, when this PR is merged -->
- 
