### PR TITLE
[apps] Assign supporting Linux desktop files to the app component

### DIFF
--- a/app/play/play_gui/CMakeLists.txt
+++ b/app/play/play_gui/CMakeLists.txt
@@ -274,8 +274,12 @@ ecal_install_app(${PROJECT_NAME} START_MENU_NAME "eCAL Player")
 # install files required for linux mimetypes and icon
 if (UNIX)
     INSTALL (FILES "${CMAKE_CURRENT_LIST_DIR}/mimetype/ecal-play.xml"
-            DESTINATION "${CMAKE_INSTALL_DATADIR}/mime/packages/")
+            DESTINATION "${CMAKE_INSTALL_DATADIR}/mime/packages/"
+            COMPONENT app
+    )
 
     INSTALL (FILES "${CMAKE_CURRENT_LIST_DIR}/mimetype/application-ecalmeas.svg"
-            DESTINATION "${CMAKE_INSTALL_DATADIR}/icons/Humanity/scalable/mimetypes/")
+            DESTINATION "${CMAKE_INSTALL_DATADIR}/icons/Humanity/scalable/mimetypes/"
+            COMPONENT app
+    )
 endif()

--- a/app/rec/rec_gui/CMakeLists.txt
+++ b/app/rec/rec_gui/CMakeLists.txt
@@ -310,8 +310,12 @@ ecal_install_app(${PROJECT_NAME} START_MENU_NAME "eCAL Recorder")
 # install files required for linux mimetypes and icon
 if (UNIX)
     INSTALL (FILES "${CMAKE_CURRENT_LIST_DIR}/mimetype/ecal-rec.xml"
-            DESTINATION "${CMAKE_INSTALL_DATADIR}/mime/packages/")
+            DESTINATION "${CMAKE_INSTALL_DATADIR}/mime/packages/"
+            COMPONENT app
+    )
 
     INSTALL (FILES "${CMAKE_CURRENT_LIST_DIR}/mimetype/application-ecalrec.svg"
-            DESTINATION "${CMAKE_INSTALL_DATADIR}/icons/Humanity/scalable/mimetypes/")
+            DESTINATION "${CMAKE_INSTALL_DATADIR}/icons/Humanity/scalable/mimetypes/"
+            COMPONENT app
+    )
 endif()

--- a/app/sys/sys_gui/CMakeLists.txt
+++ b/app/sys/sys_gui/CMakeLists.txt
@@ -264,10 +264,14 @@ set_property(TARGET ${PROJECT_NAME} PROPERTY FOLDER app/sys)
 # install files required for linux mimetypes and icon
 if (UNIX)
     INSTALL (FILES "${CMAKE_CURRENT_LIST_DIR}/mimetype/ecal-sys.xml"
-            DESTINATION "${CMAKE_INSTALL_DATADIR}/mime/packages/")
+            DESTINATION "${CMAKE_INSTALL_DATADIR}/mime/packages/"
+            COMPONENT app
+    )
 
     INSTALL (FILES "${CMAKE_CURRENT_LIST_DIR}/mimetype/application-ecalsys.svg"
-            DESTINATION "${CMAKE_INSTALL_DATADIR}/icons/Humanity/scalable/mimetypes/")
+            DESTINATION "${CMAKE_INSTALL_DATADIR}/icons/Humanity/scalable/mimetypes/"
+            COMPONENT app
+    )
 endif()
 
 ecal_install_app(${PROJECT_NAME} START_MENU_NAME "eCAL Sys")

--- a/cmake/helper_functions/ecal_install_functions.cmake
+++ b/cmake/helper_functions/ecal_install_functions.cmake
@@ -85,10 +85,14 @@ function(ecal_install_app TARGET_NAME)
                    COPYONLY)
 
    INSTALL(FILES "${CMAKE_CURRENT_BINARY_DIR}/appmenu/ecal_${TARGET_NAME}.png"
-           DESTINATION "${CMAKE_INSTALL_DATADIR}/icons/hicolor/256x256/apps/")
+           DESTINATION "${CMAKE_INSTALL_DATADIR}/icons/hicolor/256x256/apps/"
+           COMPONENT app
+   )
 
     INSTALL(FILES "${CMAKE_CURRENT_BINARY_DIR}/appmenu/ecal_${TARGET_NAME}.desktop"
-            DESTINATION "${CMAKE_INSTALL_DATADIR}/applications/")
+            DESTINATION "${CMAKE_INSTALL_DATADIR}/applications/"
+            COMPONENT app
+    )
   endif()
 ecal_install_pdbs(TARGET ${TARGET_NAME} DESTINATION "${eCAL_install_app_dir}" COMPONENT app)       
 endfunction()


### PR DESCRIPTION
### Description
<!-- What does your PR change? -->

There were a number of supporting files for Linux eCAL apps that were not assigned the `app` CMake component.
With this change the `app` component now includes these desktop files instead of the `Unspecified` component.

### Related issues
<!-- Type "Fixes #123" to automatically close that issue, when this PR is merged -->
- 
