### PR TITLE
[GH Action] Only build CPython wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -28,6 +28,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.22
         env:
           CIBW_ARCHS: auto64
+          CIBW_BUILD: cp3*-*
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
PyPy wheels were untested and probably didn't work anyways. So we can save some time and not build them.