### PR TITLE
[benchmark] Disable benchmarks in GitHub actions on forks

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -195,6 +195,7 @@ jobs:
     #---------------------------------------------------------------------------------------------------
     
   run-benchmarks:
+    if: github.repository == 'eclipse-ecal/ecal'
     if: github.ref_name == 'master'
     needs: build-ubuntu
     

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -195,8 +195,7 @@ jobs:
     #---------------------------------------------------------------------------------------------------
     
   run-benchmarks:
-    if: github.repository == 'eclipse-ecal/ecal'
-    if: github.ref_name == 'master'
+    if: github.repository == 'eclipse-ecal/ecal' && github.ref_name == 'master'
     needs: build-ubuntu
     
     strategy:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -265,7 +265,7 @@ jobs:
     # --------------------------------------------------------------------------------------------------
     
   run-benchmarks:
-    if: github.repository == 'eclipse-ecal/ecal' && if: github.ref_name == 'master'
+    if: github.repository == 'eclipse-ecal/ecal' && github.ref_name == 'master'
     runs-on: windows-2022
     needs: build-windows
     

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -265,6 +265,7 @@ jobs:
     # --------------------------------------------------------------------------------------------------
     
   run-benchmarks:
+    if: github.repository == 'eclipse-ecal/ecal'
     if: github.ref_name == 'master'
     runs-on: windows-2022
     needs: build-windows

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -265,8 +265,7 @@ jobs:
     # --------------------------------------------------------------------------------------------------
     
   run-benchmarks:
-    if: github.repository == 'eclipse-ecal/ecal'
-    if: github.ref_name == 'master'
+    if: github.repository == 'eclipse-ecal/ecal' && if: github.ref_name == 'master'
     runs-on: windows-2022
     needs: build-windows
     


### PR DESCRIPTION
The current actions run the benchmarks and then post the results to Bencher. Posting to Bencher requires a token. Action runs on forks will thus fail. With these changes the benchmarks only run on the eclipse-ecal repository.
