### PR TITLE
[CMake / Qt] Windeployqt calls are now waiting for each other

### DIFF
--- a/app/mon/mon_gui/CMakeLists.txt
+++ b/app/mon/mon_gui/CMakeLists.txt
@@ -250,11 +250,21 @@ if ((WIN32 OR APPLE) AND (${QT_VERSION_MAJOR} GREATER_EQUAL 6))
         NO_UNSUPPORTED_PLATFORM_ERROR
     )
 
-    # Add a postbuild script that will also execute the created script via cmake -P
-    # This is necessary to make the application startable / debuggable from the build directory.
-    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -DQT_DEPLOY_PREFIX=$<TARGET_FILE_DIR:${PROJECT_NAME}> -DQT_DEPLOY_BIN_DIR=. -P ${qt_deploy_script}
-    )
+    # Add a postbuild command that will also execute the created script via cmake -P.
+    # On Windows we use a custom exclusive_command command, which prevents
+    # different instances of windeployqt to access the same files at the same
+    # time.
+    # Running windeployqt is necessary to make the application startable / debuggable from the build directory.
+    if (WIN32)
+        add_exclusive_command_as_postbuild(
+            ${PROJECT_NAME}
+            ${CMAKE_COMMAND} -DQT_DEPLOY_PREFIX=$<TARGET_FILE_DIR:${PROJECT_NAME}> -DQT_DEPLOY_BIN_DIR=. -P ${qt_deploy_script}
+        )
+    else()
+        add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -DQT_DEPLOY_PREFIX=$<TARGET_FILE_DIR:${PROJECT_NAME}> -DQT_DEPLOY_BIN_DIR=. -P ${qt_deploy_script}
+        )
+    endif()
 
     # Use the script for deploying the qt dlls in the install dir
     install(SCRIPT ${qt_deploy_script})

--- a/app/play/play_gui/CMakeLists.txt
+++ b/app/play/play_gui/CMakeLists.txt
@@ -197,11 +197,21 @@ if ((WIN32 OR APPLE) AND (${QT_VERSION_MAJOR} GREATER_EQUAL 6))
         NO_UNSUPPORTED_PLATFORM_ERROR
     )
 
-    # Add a postbuild script that will also execute the created script via cmake -P
-    # This is necessary to make the application startable / debuggable from the build directory.
-    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -DQT_DEPLOY_PREFIX=$<TARGET_FILE_DIR:${PROJECT_NAME}> -DQT_DEPLOY_BIN_DIR=. -P ${qt_deploy_script}
-    )
+    # Add a postbuild command that will also execute the created script via cmake -P.
+    # On Windows we use a custom exclusive_command command, which prevents
+    # different instances of windeployqt to access the same files at the same
+    # time.
+    # Running windeployqt is necessary to make the application startable / debuggable from the build directory.
+    if (WIN32)
+        add_exclusive_command_as_postbuild(
+            ${PROJECT_NAME}
+            ${CMAKE_COMMAND} -DQT_DEPLOY_PREFIX=$<TARGET_FILE_DIR:${PROJECT_NAME}> -DQT_DEPLOY_BIN_DIR=. -P ${qt_deploy_script}
+        )
+    else()
+        add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -DQT_DEPLOY_PREFIX=$<TARGET_FILE_DIR:${PROJECT_NAME}> -DQT_DEPLOY_BIN_DIR=. -P ${qt_deploy_script}
+        )
+    endif()
 
     # Use the script for deploying the qt dlls in the install dir
     install(SCRIPT ${qt_deploy_script})

--- a/app/rec/rec_gui/CMakeLists.txt
+++ b/app/rec/rec_gui/CMakeLists.txt
@@ -233,11 +233,21 @@ if ((WIN32 OR APPLE) AND (${QT_VERSION_MAJOR} GREATER_EQUAL 6))
         NO_UNSUPPORTED_PLATFORM_ERROR
     )
 
-    # Add a postbuild script that will also execute the created script via cmake -P
-    # This is necessary to make the application startable / debuggable from the build directory.
-    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -DQT_DEPLOY_PREFIX=$<TARGET_FILE_DIR:${PROJECT_NAME}> -DQT_DEPLOY_BIN_DIR=. -P ${qt_deploy_script}
-    )
+    # Add a postbuild command that will also execute the created script via cmake -P.
+    # On Windows we use a custom exclusive_command command, which prevents
+    # different instances of windeployqt to access the same files at the same
+    # time.
+    # Running windeployqt is necessary to make the application startable / debuggable from the build directory.
+    if (WIN32)
+        add_exclusive_command_as_postbuild(
+            ${PROJECT_NAME}
+            ${CMAKE_COMMAND} -DQT_DEPLOY_PREFIX=$<TARGET_FILE_DIR:${PROJECT_NAME}> -DQT_DEPLOY_BIN_DIR=. -P ${qt_deploy_script}
+        )
+    else()
+        add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -DQT_DEPLOY_PREFIX=$<TARGET_FILE_DIR:${PROJECT_NAME}> -DQT_DEPLOY_BIN_DIR=. -P ${qt_deploy_script}
+        )
+    endif()
 
     # Use the script for deploying the qt dlls in the install dir
     install(SCRIPT ${qt_deploy_script})

--- a/app/sys/sys_gui/CMakeLists.txt
+++ b/app/sys/sys_gui/CMakeLists.txt
@@ -222,11 +222,21 @@ if ((WIN32 OR APPLE) AND (${QT_VERSION_MAJOR} GREATER_EQUAL 6))
         NO_UNSUPPORTED_PLATFORM_ERROR
     )
 
-    # Add a postbuild script that will also execute the created script via cmake -P
-    # This is necessary to make the application startable / debuggable from the build directory.
-    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -DQT_DEPLOY_PREFIX=$<TARGET_FILE_DIR:${PROJECT_NAME}> -DQT_DEPLOY_BIN_DIR=. -P ${qt_deploy_script}
-    )
+    # Add a postbuild command that will also execute the created script via cmake -P.
+    # On Windows we use a custom exclusive_command command, which prevents
+    # different instances of windeployqt to access the same files at the same
+    # time.
+    # Running windeployqt is necessary to make the application startable / debuggable from the build directory.
+    if (WIN32)
+        add_exclusive_command_as_postbuild(
+            ${PROJECT_NAME}
+            ${CMAKE_COMMAND} -DQT_DEPLOY_PREFIX=$<TARGET_FILE_DIR:${PROJECT_NAME}> -DQT_DEPLOY_BIN_DIR=. -P ${qt_deploy_script}
+        )
+    else()
+        add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -DQT_DEPLOY_PREFIX=$<TARGET_FILE_DIR:${PROJECT_NAME}> -DQT_DEPLOY_BIN_DIR=. -P ${qt_deploy_script}
+        )
+    endif()
 
     # Use the script for deploying the qt dlls in the install dir
     install(SCRIPT ${qt_deploy_script})

--- a/app/util/launcher/CMakeLists.txt
+++ b/app/util/launcher/CMakeLists.txt
@@ -122,11 +122,21 @@ if ((WIN32 OR APPLE) AND (${QT_VERSION_MAJOR} GREATER_EQUAL 6))
         NO_UNSUPPORTED_PLATFORM_ERROR
     )
 
-    # Add a postbuild script that will also execute the created script via cmake -P
-    # This is necessary to make the application startable / debuggable from the build directory.
-    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -DQT_DEPLOY_PREFIX=$<TARGET_FILE_DIR:${PROJECT_NAME}> -DQT_DEPLOY_BIN_DIR=. -P ${qt_deploy_script}
-    )
+    # Add a postbuild command that will also execute the created script via cmake -P.
+    # On Windows we use a custom exclusive_command command, which prevents
+    # different instances of windeployqt to access the same files at the same
+    # time.
+    # Running windeployqt is necessary to make the application startable / debuggable from the build directory.
+    if (WIN32)
+        add_exclusive_command_as_postbuild(
+            ${PROJECT_NAME}
+            ${CMAKE_COMMAND} -DQT_DEPLOY_PREFIX=$<TARGET_FILE_DIR:${PROJECT_NAME}> -DQT_DEPLOY_BIN_DIR=. -P ${qt_deploy_script}
+        )
+    else()
+        add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -DQT_DEPLOY_PREFIX=$<TARGET_FILE_DIR:${PROJECT_NAME}> -DQT_DEPLOY_BIN_DIR=. -P ${qt_deploy_script}
+        )
+    endif()
 
     # Use the script for deploying the qt dlls in the install dir
     install(SCRIPT ${qt_deploy_script})

--- a/samples/cpp/services/ecalplayer_gui_client/CMakeLists.txt
+++ b/samples/cpp/services/ecalplayer_gui_client/CMakeLists.txt
@@ -102,11 +102,21 @@ if ((WIN32 OR APPLE) AND (${QT_VERSION_MAJOR} GREATER_EQUAL 6))
         NO_UNSUPPORTED_PLATFORM_ERROR
     )
 
-    # Add a postbuild script that will also execute the created script via cmake -P
-    # This is necessary to make the application startable / debuggable from the build directory.
-    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -DQT_DEPLOY_PREFIX=$<TARGET_FILE_DIR:${PROJECT_NAME}> -DQT_DEPLOY_BIN_DIR=. -P ${qt_deploy_script}
-    )
+    # Add a postbuild command that will also execute the created script via cmake -P.
+    # On Windows we use a custom exclusive_command command, which prevents
+    # different instances of windeployqt to access the same files at the same
+    # time.
+    # Running windeployqt is necessary to make the application startable / debuggable from the build directory.
+    if (WIN32)
+        add_exclusive_command_as_postbuild(
+            ${PROJECT_NAME}
+            ${CMAKE_COMMAND} -DQT_DEPLOY_PREFIX=$<TARGET_FILE_DIR:${PROJECT_NAME}> -DQT_DEPLOY_BIN_DIR=. -P ${qt_deploy_script}
+        )
+    else()
+        add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -DQT_DEPLOY_PREFIX=$<TARGET_FILE_DIR:${PROJECT_NAME}> -DQT_DEPLOY_BIN_DIR=. -P ${qt_deploy_script}
+        )
+    endif()
 
     # Use the script for deploying the qt dlls in the install dir
     install(SCRIPT ${qt_deploy_script})

--- a/samples/cpp/services/rec_client_service_gui/CMakeLists.txt
+++ b/samples/cpp/services/rec_client_service_gui/CMakeLists.txt
@@ -101,11 +101,21 @@ if ((WIN32 OR APPLE) AND (${QT_VERSION_MAJOR} GREATER_EQUAL 6))
         NO_UNSUPPORTED_PLATFORM_ERROR
     )
 
-    # Add a postbuild script that will also execute the created script via cmake -P
-    # This is necessary to make the application startable / debuggable from the build directory.
-    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -DQT_DEPLOY_PREFIX=$<TARGET_FILE_DIR:${PROJECT_NAME}> -DQT_DEPLOY_BIN_DIR=. -P ${qt_deploy_script}
-    )
+    # Add a postbuild command that will also execute the created script via cmake -P.
+    # On Windows we use a custom exclusive_command command, which prevents
+    # different instances of windeployqt to access the same files at the same
+    # time.
+    # Running windeployqt is necessary to make the application startable / debuggable from the build directory.
+    if (WIN32)
+        add_exclusive_command_as_postbuild(
+            ${PROJECT_NAME}
+            ${CMAKE_COMMAND} -DQT_DEPLOY_PREFIX=$<TARGET_FILE_DIR:${PROJECT_NAME}> -DQT_DEPLOY_BIN_DIR=. -P ${qt_deploy_script}
+        )
+    else()
+        add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -DQT_DEPLOY_PREFIX=$<TARGET_FILE_DIR:${PROJECT_NAME}> -DQT_DEPLOY_BIN_DIR=. -P ${qt_deploy_script}
+        )
+    endif()
 
     # Use the script for deploying the qt dlls in the install dir
     install(SCRIPT ${qt_deploy_script})

--- a/samples/cpp/services/rec_server_service_gui/CMakeLists.txt
+++ b/samples/cpp/services/rec_server_service_gui/CMakeLists.txt
@@ -105,11 +105,21 @@ if ((WIN32 OR APPLE) AND (${QT_VERSION_MAJOR} GREATER_EQUAL 6))
         NO_UNSUPPORTED_PLATFORM_ERROR
     )
 
-    # Add a postbuild script that will also execute the created script via cmake -P
-    # This is necessary to make the application startable / debuggable from the build directory.
-    add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -DQT_DEPLOY_PREFIX=$<TARGET_FILE_DIR:${PROJECT_NAME}> -DQT_DEPLOY_BIN_DIR=. -P ${qt_deploy_script}
-    )
+    # Add a postbuild command that will also execute the created script via cmake -P.
+    # On Windows we use a custom exclusive_command command, which prevents
+    # different instances of windeployqt to access the same files at the same
+    # time.
+    # Running windeployqt is necessary to make the application startable / debuggable from the build directory.
+    if (WIN32)
+        add_exclusive_command_as_postbuild(
+            ${PROJECT_NAME}
+            ${CMAKE_COMMAND} -DQT_DEPLOY_PREFIX=$<TARGET_FILE_DIR:${PROJECT_NAME}> -DQT_DEPLOY_BIN_DIR=. -P ${qt_deploy_script}
+        )
+    else()
+        add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -DQT_DEPLOY_PREFIX=$<TARGET_FILE_DIR:${PROJECT_NAME}> -DQT_DEPLOY_BIN_DIR=. -P ${qt_deploy_script}
+        )
+    endif()
 
     # Use the script for deploying the qt dlls in the install dir
     install(SCRIPT ${qt_deploy_script})

--- a/thirdparty/cmakefunctions/cmake_functions/cmake_functions.cmake
+++ b/thirdparty/cmakefunctions/cmake_functions/cmake_functions.cmake
@@ -8,6 +8,7 @@ set (file_list_include
 if(WIN32)
   list(APPEND file_list_include
     qt/qt_windeployqt.cmake
+    qt/exclusive_command.cmake
   )
 endif()
 
@@ -19,6 +20,7 @@ set(file_list_no_include
 if(WIN32)
   list(APPEND file_list_no_include
     qt/qt_windeployqt_threadsafe_cmake.bat.in
+    qt/exclusive_command.ps1
   )
 endif()
 

--- a/thirdparty/cmakefunctions/cmake_functions/qt/exclusive_command.cmake
+++ b/thirdparty/cmakefunctions/cmake_functions/qt/exclusive_command.cmake
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.17) #CMAKE_CURRENT_FUNCTION_LIST_DIR has been added in 3.17
+
+# Define the function to add the PowerShell script as a post-build command
+function(add_exclusive_command_as_postbuild target)
+    # Get the directory where the CMakeLists.txt is located (same as PowerShell script)
+    get_filename_component(SCRIPT_DIR "${CMAKE_CURRENT_FUNCTION_LIST_DIR}" ABSOLUTE)
+
+    # Define the PowerShell script path
+    set(PS1_SCRIPT "${SCRIPT_DIR}/exclusive_command.ps1")
+
+    # Add the post-build command for the target
+    add_custom_command(
+        TARGET ${target} POST_BUILD
+        COMMAND powershell -NoProfile -ExecutionPolicy Bypass -File "${PS1_SCRIPT}" ${ARGN}
+        COMMENT "Running PowerShell script after building ${target}..."
+    )
+endfunction()

--- a/thirdparty/cmakefunctions/cmake_functions/qt/exclusive_command.ps1
+++ b/thirdparty/cmakefunctions/cmake_functions/qt/exclusive_command.ps1
@@ -1,0 +1,61 @@
+
+
+# param(
+#     [Parameter(
+#         Mandatory=$True,
+#         Position = 0
+#     )]
+#     [string]
+#     $command,
+    
+#     [Parameter(
+#         Mandatory=$False,
+#         ValueFromRemainingArguments=$true,
+#         Position = 1
+#     )][string[]]
+#     $arguments
+# )
+
+$command   = $args[0]
+$arguments = $args[1..($args.Count - 1)]
+
+# Define a unique name for the mutex to be used across multiple script executions
+$mutexName = "Global\EcalExclusiveCommandMutex"
+
+# Function to acquire the lock (mutex)
+function Acquire-Lock {
+    $global:mutex = New-Object System.Threading.Mutex($false, $mutexName)
+    Write-Host "[eCAL exclusive command]: Attempting to acquire the lock..."
+    
+    try {
+        # Wait for the mutex to be acquired (this is a blocking call until the lock is acquired)
+        $global:mutex.WaitOne()
+        Write-Host "[eCAL exclusive command]: Lock acquired."
+    } catch {
+        Write-Error "[eCAL exclusive command]: Failed to acquire the lock: $_"
+        exit 1
+    }
+}
+
+# Function to release the lock
+function Release-Lock {
+    Write-Host "[eCAL exclusive command] Releasing lock..."
+    $global:mutex.ReleaseMutex()
+    $global:mutex.Dispose()
+}
+
+# Main execution flow
+try {
+    # Acquire the lock before running the command
+    Acquire-Lock
+
+    # Execute the command with the list of arguments
+    Write-Host "[eCAL exclusive command] Executing command: `"$command`" $($arguments -join ' ')"
+    Start-Process $command -ArgumentList $arguments -Wait -NoNewWindow
+
+} catch {
+    Write-Error "[eCAL exclusive command] An error occurred: $_"
+} finally {
+    # Ensure that the lock is released after execution
+    Release-Lock
+}

--- a/thirdparty/qwt/CMakeLists.txt
+++ b/thirdparty/qwt/CMakeLists.txt
@@ -325,11 +325,21 @@ if(QWT_TARGET_PROPERTY_TYPE STREQUAL "SHARED_LIBRARY")
             NO_UNSUPPORTED_PLATFORM_ERROR
         )
 
-        # Add a postbuild script that will also execute the created script via cmake -P
-        # This is necessary to make the application startable / debuggable from the build directory.
+    # Add a postbuild command that will also execute the created script via cmake -P.
+    # On Windows we use a custom exclusive_command command, which prevents
+    # different instances of windeployqt to access the same files at the same
+    # time.
+    # Running windeployqt is necessary to make the application startable / debuggable from the build directory.
+    if (WIN32)
+        add_exclusive_command_as_postbuild(
+            ${PROJECT_NAME}
+            ${CMAKE_COMMAND} -DQT_DEPLOY_PREFIX=$<TARGET_FILE_DIR:${PROJECT_NAME}> -DQT_DEPLOY_BIN_DIR=. -P ${qt_deploy_script}
+        )
+    else()
         add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
             COMMAND ${CMAKE_COMMAND} -DQT_DEPLOY_PREFIX=$<TARGET_FILE_DIR:${PROJECT_NAME}> -DQT_DEPLOY_BIN_DIR=. -P ${qt_deploy_script}
         )
+    endif()
 
         # Use the script for deploying the qt dlls in the install dir
         install(SCRIPT ${qt_deploy_script})


### PR DESCRIPTION
This prevents the build to fail by multiple windeployqt instances trying to write the same dlls at the same time.