### PR TITLE
[Python] Fix self-referencing issue causing nanobind leak warnings.

### DIFF
--- a/lang/python/README.md
+++ b/lang/python/README.md
@@ -51,6 +51,8 @@ subscriber = StringSubscriber("hello_topic")
 subscriber.set_receive_callback(callback)
 
 input()
+
+subscriber.remove_receive_callback()
 ecal_core.finalize()
 ```
 

--- a/lang/python/src/msg/ecal/msg/common/core.py
+++ b/lang/python/src/msg/ecal/msg/common/core.py
@@ -90,12 +90,14 @@ class MessageSubscriber(typing.Generic[T]):
     to the appropriate user-provided callback.
     """
     
+    deserializer = self._deserializer
+
     def internal_receive_callback(publisher_id, data_type_info, data):
       if data_callback is None and error_callback is None:
         return
 
       try:
-        msg = self._deserializer.deserialize(data.buffer, data_type_info)
+        msg = deserializer.deserialize(data.buffer, data_type_info)
         if data_callback is not None:
           data_callback(publisher_id, ReceiveCallbackData(message=msg, send_timestamp=data.send_timestamp, send_clock=data.send_clock))
       except SerializationError as error:

--- a/lang/python/src/nanobind_core/src/core/pubsub/py_publisher.cpp
+++ b/lang/python/src/nanobind_core/src/core/pubsub/py_publisher.cpp
@@ -43,7 +43,7 @@ void AddPubsubPublisher(nanobind::module_& module)
               // Call the Python callback, forwarding the arguments.
               event_callback_(std::forward<decltype(args)>(args)...);
             }
-            catch (std::exception e)
+            catch (const std::exception& e)
             {
               std::cout << "Error invoking event callback: " << e.what() << std::endl;
             }

--- a/lang/python/src/nanobind_core/src/core/pubsub/py_subscriber.cpp
+++ b/lang/python/src/nanobind_core/src/core/pubsub/py_subscriber.cpp
@@ -45,7 +45,7 @@ void AddPubsubSubscriber(nanobind::module_& module)
               // Call the Python callback, forwarding the arguments.
               event_callback_(std::forward<decltype(args)>(args)...);
             }
-            catch (std::exception e)
+            catch (const std::exception& e)
             {
               std::cout << "Error invoking event callback: " << e.what() << std::endl;
             }
@@ -72,7 +72,7 @@ void AddPubsubSubscriber(nanobind::module_& module)
             // Call the Python callback, forwarding the arguments.
             (*python_callback_pointer)(std::forward<decltype(args)>(args)...);
           }
-          catch (std::exception e)
+          catch (const std::exception& e)
           {
             std::cout << "Error invoking callback: " << e.what() << std::endl;
           }
@@ -93,7 +93,7 @@ void AddPubsubSubscriber(nanobind::module_& module)
     .def("get_data_type_information", &CSubscriber::GetDataTypeInformation,
       "Get the topic's data type information.")
     .def("__repr__", [](const CSubscriber& pub) {
-    return "<Publisher topic='" + pub.GetTopicName() + "' subscribers=" +
+    return "<Subscriber topic='" + pub.GetTopicName() + "' publishers=" +
       std::to_string(pub.GetPublisherCount()) + ">";
       });
 }


### PR DESCRIPTION
A reference to self in the Python message callbacks disabled proper Python cleanup.

Catch exceptions by reference and correct one typo.