### PR TITLE
[ecal_mon_tui] Set frequency calculation to Hz

### DIFF
--- a/app/mon/mon_tui/src/model/data/topic.hpp
+++ b/app/mon/mon_tui/src/model/data/topic.hpp
@@ -53,6 +53,6 @@ struct Topic
   int32_t message_drops;
   int64_t data_id;
   int64_t data_clock;
-  int32_t data_frequency;
+  int32_t data_frequency_mhz;
   std::map<std::string, std::string> attributes;
 };

--- a/app/mon/mon_tui/src/model/monitor.hpp
+++ b/app/mon/mon_tui/src/model/monitor.hpp
@@ -215,7 +215,7 @@ class MonitorModel
       topic.message_drops = t.message_drops();
       topic.data_id = t.data_id();
       topic.data_clock = t.data_clock();
-      topic.data_frequency = t.data_frequency();
+      topic.data_frequency_mhz = t.data_frequency();
     }
 
     for(auto &s: *mon_.mutable_services())

--- a/app/mon/mon_tui/src/tui/viewmodel/topics.hpp
+++ b/app/mon/mon_tui/src/tui/viewmodel/topics.hpp
@@ -1,6 +1,6 @@
 /* ========================= eCAL LICENSE =================================
  *
- * Copyright (C) 2016 - 2019 Continental Corporation
+ * Copyright (C) 2016 - 2025 Continental Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ public:
   };
 
   TopicsViewModel(std::shared_ptr<MonitorModel> model_)
-    : TableViewModel<Topic>({"Id", "Host", "Process", "Topic", "Encoding", "Type", "Direction", "Layer", "Size", "DataClock", "Frequency"})
+    : TableViewModel<Topic>({"Id", "Host", "Process", "Topic", "Encoding", "Type", "Direction", "Layer", "Size", "DataClock", "Frequency(Hz)"})
   {
     title = "Topics";
 
@@ -73,8 +73,16 @@ public:
       case Column::DataClock:
         return std::to_string(value.data_clock);
       case Column::Frequency:
-        return std::to_string(value.data_frequency);
+        return roundToTwoDecimalsAsString(value.data_frequency_mhz / 1000.0f);
       default: return "";
     }
   }
+
+  private:
+    static std::string roundToTwoDecimalsAsString(double value) {
+        std::ostringstream stream;
+        stream << std::fixed << std::setprecision(2) << value;
+        return stream.str();
+    }
+
 };


### PR DESCRIPTION
### Description
- Change frequency calcualation to Hz (before mHz)
- Rename member variable accordingly to mHz
- Added "(Hz)" to header information

### Related issues
- Fixes #2259
