### PR TITLE
[core] Make State variables atomic.

### DIFF
--- a/ecal/core/CMakeLists.txt
+++ b/ecal/core/CMakeLists.txt
@@ -97,6 +97,7 @@ set(ecal_config_src
     src/config/configuration.cpp
     src/config/ecal_path_processing.cpp
     src/config/ecal_path_processing.h
+    src/types/atomics.cpp
     src/types/ecal_custom_data_types.cpp
 )
 if (ECAL_CORE_CONFIGURATION)
@@ -716,6 +717,7 @@ endif()
 target_link_libraries(${TARGET_NAME}
   PRIVATE
     ecaludp::ecaludp
+    atomic
 )
 
 target_include_directories(${TARGET_NAME}

--- a/ecal/core/CMakeLists.txt
+++ b/ecal/core/CMakeLists.txt
@@ -717,7 +717,6 @@ endif()
 target_link_libraries(${TARGET_NAME}
   PRIVATE
     ecaludp::ecaludp
-    atomic
 )
 
 target_include_directories(${TARGET_NAME}

--- a/ecal/core/src/ecal_global_accessors.cpp
+++ b/ecal/core/src/ecal_global_accessors.cpp
@@ -28,27 +28,26 @@
 #include "ecal_globals.h"
 #include "ecal_utils/filesystem.h"
 
-#include <atomic>
 #include <string>
 
 namespace eCAL
 {
-  std::unique_ptr<CGlobals>     g_globals_ctx(nullptr);
+  std::unique_ptr<CGlobals>          g_globals_ctx(nullptr);
 
-  std::string                   g_default_ini_file(ECAL_DEFAULT_CFG);
-  Configuration                 g_ecal_configuration{};
+  std::string                        g_default_ini_file(ECAL_DEFAULT_CFG);
+  Configuration                      g_ecal_configuration{};
 
-  std::string                   g_host_name;
-  std::string                   g_unit_name;
+  std::string                        g_host_name;
+  std::string                        g_unit_name;
   
-  std::string                   g_process_name;
-  std::string                   g_process_par;
-  int                           g_process_id(0);
-  std::string                   g_process_id_s;
-  std::string                   g_process_info;
+  std::string                        g_process_name;
+  std::string                        g_process_par;
+  int                                g_process_id(0);
+  std::string                        g_process_id_s;
+  Types::Atomic::StringSPtr          g_process_info;
 
-  eCAL::Process::eSeverity        g_process_severity(eCAL::Process::eSeverity::unknown);
-  eCAL::Process::eSeverityLevel  g_process_severity_level(eCAL::Process::eSeverityLevel::level1);
+  std::atomic<eCAL::Process::eSeverity>        g_process_severity(eCAL::Process::eSeverity::unknown);
+  std::atomic<eCAL::Process::eSeverityLevel>   g_process_severity_level(eCAL::Process::eSeverityLevel::level1);
 
   void SetGlobalUnitName(const char *unit_name_)
   {

--- a/ecal/core/src/ecal_global_accessors.h
+++ b/ecal/core/src/ecal_global_accessors.h
@@ -28,6 +28,7 @@
 #include <memory>
 
 #include <ecal/process_severity.h>
+#include <types/atomics.h>
 
 // Forward declaration of global accessible classes
 namespace eCAL
@@ -69,6 +70,9 @@ namespace eCAL
 
   void SetGlobalUnitName(const char *unit_name_);
 
+  void InitializeGlobals();
+  void FinalizeGlobals();
+
   // Declaration of getter functions for globally accessible variable instances
   CGlobals*               g_globals();
   Logging::CLogReceiver*  g_log_udp_receiver();
@@ -101,20 +105,20 @@ namespace eCAL
 #endif
 
   // declaration of globally accessible variables
-  extern std::unique_ptr<CGlobals>     g_globals_ctx;
+  extern std::unique_ptr<CGlobals>                   g_globals_ctx;
 
-  extern std::string                   g_default_ini_file;
-  extern Configuration                 g_ecal_configuration;
+  extern std::string                                 g_default_ini_file;
+  extern Configuration                               g_ecal_configuration;
 
-  extern std::string                   g_host_name;
-  extern std::string                   g_unit_name;
+  extern std::string                                 g_host_name;
+  extern std::string                                 g_unit_name;
 
-  extern std::string                   g_process_name;
-  extern std::string                   g_process_par;
-  extern int                           g_process_id;
-  extern std::string                   g_process_id_s;
-  extern std::string                   g_process_info;
+  extern std::string                                 g_process_name;
+  extern std::string                                 g_process_par;
+  extern int                                         g_process_id;
+  extern std::string                                 g_process_id_s;
+  extern Types::Atomic::StringSPtr                   g_process_info;
 
-  extern eCAL::Process::eSeverity        g_process_severity;
-  extern eCAL::Process::eSeverityLevel  g_process_severity_level;
+  extern std::atomic<eCAL::Process::eSeverity>       g_process_severity;
+  extern std::atomic<eCAL::Process::eSeverityLevel>  g_process_severity_level;
 }

--- a/ecal/core/src/ecal_process.cpp
+++ b/ecal/core/src/ecal_process.cpp
@@ -281,9 +281,9 @@ namespace eCAL
 
     void SetState(eCAL::Process::eSeverity severity_, eCAL::Process::eSeverityLevel level_, const std::string& info_)
     {
-      g_process_severity = severity_;
-      g_process_severity_level = level_;
-      g_process_info = info_;
+      g_process_severity.store(severity_, std::memory_order_release);
+      g_process_severity_level.store(level_, std::memory_order_release);
+      Types::Atomic::Update(g_process_info, info_);
     }
   }
 }

--- a/ecal/core/src/ecal_process.cpp
+++ b/ecal/core/src/ecal_process.cpp
@@ -283,7 +283,7 @@ namespace eCAL
     {
       g_process_severity.store(severity_, std::memory_order_release);
       g_process_severity_level.store(level_, std::memory_order_release);
-      Types::Atomic::Update(g_process_info, info_);
+      Types::Atomic::Store(g_process_info, info_);
     }
   }
 }

--- a/ecal/core/src/registration/ecal_process_registration.cpp
+++ b/ecal/core/src/registration/ecal_process_registration.cpp
@@ -46,10 +46,10 @@ eCAL::Registration::Sample eCAL::Registration::GetProcessRegisterSample()
   process_sample_process.shm_transport_domain = eCAL::Process::GetShmTransportDomain();
   process_sample_process.process_name         = eCAL::Process::GetProcessName();
   process_sample_process.unit_name            = eCAL::Process::GetUnitName();
-  process_sample_process.process_parameter               = eCAL::Process::GetProcessParameter();
-  process_sample_process.state.severity       = static_cast<Registration::eProcessSeverity>(g_process_severity);
-  process_sample_process.state.severity_level = static_cast<Registration::eProcessSeverityLevel>(g_process_severity_level);
-  process_sample_process.state.info           = g_process_info;
+  process_sample_process.process_parameter    = eCAL::Process::GetProcessParameter();
+  process_sample_process.state.severity       = static_cast<Registration::eProcessSeverity>(g_process_severity.load(std::memory_order_acquire));
+  process_sample_process.state.severity_level = static_cast<Registration::eProcessSeverityLevel>(g_process_severity_level.load(std::memory_order_acquire));
+  process_sample_process.state.info           = Types::Atomic::Read(g_process_info);
 #if ECAL_CORE_TIMEPLUGIN
   if (g_timegate() == nullptr)
   {

--- a/ecal/core/src/registration/ecal_process_registration.cpp
+++ b/ecal/core/src/registration/ecal_process_registration.cpp
@@ -49,7 +49,7 @@ eCAL::Registration::Sample eCAL::Registration::GetProcessRegisterSample()
   process_sample_process.process_parameter    = eCAL::Process::GetProcessParameter();
   process_sample_process.state.severity       = static_cast<Registration::eProcessSeverity>(g_process_severity.load(std::memory_order_acquire));
   process_sample_process.state.severity_level = static_cast<Registration::eProcessSeverityLevel>(g_process_severity_level.load(std::memory_order_acquire));
-  process_sample_process.state.info           = Types::Atomic::Read(g_process_info);
+  process_sample_process.state.info           = Types::Atomic::Load(g_process_info);
 #if ECAL_CORE_TIMEPLUGIN
   if (g_timegate() == nullptr)
   {

--- a/ecal/core/src/types/atomics.cpp
+++ b/ecal/core/src/types/atomics.cpp
@@ -1,0 +1,40 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2025 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+#include "atomics.h"
+
+namespace eCAL
+{
+  namespace Types
+  {
+    namespace Atomic
+    {    
+      void Update(StringSPtr& atomic_string_, const std::string& new_value_)
+      {
+        std::atomic_store(&atomic_string_, std::make_shared<std::string>(new_value_));
+      }
+
+      std::string Read(const StringSPtr& atomic_string_)
+      {
+        auto ptr = std::atomic_load(&atomic_string_);
+        return ptr ? *ptr : std::string{};
+      }
+    } // Atomic
+  } // Types
+} // eCAL

--- a/ecal/core/src/types/atomics.cpp
+++ b/ecal/core/src/types/atomics.cpp
@@ -25,12 +25,12 @@ namespace eCAL
   {
     namespace Atomic
     {    
-      void Update(StringSPtr& atomic_string_, const std::string& new_value_)
+      void Store(StringSPtr& atomic_string_, const std::string& new_value_)
       {
         std::atomic_store(&atomic_string_, std::make_shared<std::string>(new_value_));
       }
 
-      std::string Read(const StringSPtr& atomic_string_)
+      std::string Load(const StringSPtr& atomic_string_)
       {
         auto ptr = std::atomic_load(&atomic_string_);
         return ptr ? *ptr : std::string{};

--- a/ecal/core/src/types/atomics.cpp
+++ b/ecal/core/src/types/atomics.cpp
@@ -25,14 +25,14 @@ namespace eCAL
   {
     namespace Atomic
     {    
-      void Store(StringSPtr& atomic_string_, const std::string& new_value_)
+      void Store(StringSPtr& string_sptr_, const std::string& new_value_)
       {
-        std::atomic_store(&atomic_string_, std::make_shared<std::string>(new_value_));
+        std::atomic_store(&string_sptr_, std::make_shared<std::string>(new_value_));
       }
 
-      std::string Load(const StringSPtr& atomic_string_)
+      std::string Load(const StringSPtr& string_sptr_)
       {
-        auto ptr = std::atomic_load(&atomic_string_);
+        auto ptr = std::atomic_load(&string_sptr_);
         return ptr ? *ptr : std::string{};
       }
     } // Atomic

--- a/ecal/core/src/types/atomics.h
+++ b/ecal/core/src/types/atomics.h
@@ -18,7 +18,7 @@
 */
 
 /**
- * @brief  Definition of custom data types.
+ * @brief  Definition of types and functions to be used when working with atomic variables.
 **/
 
 #pragma once
@@ -34,9 +34,9 @@ namespace eCAL
     {
       using StringSPtr = std::shared_ptr<std::string>;
 
-      void Update(Atomic::StringSPtr& atomic_string_, const std::string& new_value_);
+      void Store(StringSPtr& atomic_string_, const std::string& new_value_);
 
-      std::string Read(const Atomic::StringSPtr& atomic_string_);
+      std::string Load(const StringSPtr& atomic_string_);
     } // Atomic
   } // Types
 } // eCAL

--- a/ecal/core/src/types/atomics.h
+++ b/ecal/core/src/types/atomics.h
@@ -1,0 +1,42 @@
+/* ========================= eCAL LICENSE =================================
+ *
+ * Copyright (C) 2016 - 2025 Continental Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * ========================= eCAL LICENSE =================================
+*/
+
+/**
+ * @brief  Definition of custom data types.
+**/
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+namespace eCAL
+{
+  namespace Types
+  {
+    namespace Atomic
+    {
+      using StringSPtr = std::shared_ptr<std::string>;
+
+      void Update(Atomic::StringSPtr& atomic_string_, const std::string& new_value_);
+
+      std::string Read(const Atomic::StringSPtr& atomic_string_);
+    } // Atomic
+  } // Types
+} // eCAL

--- a/ecal/core/src/types/atomics.h
+++ b/ecal/core/src/types/atomics.h
@@ -34,9 +34,23 @@ namespace eCAL
     {
       using StringSPtr = std::shared_ptr<std::string>;
 
-      void Store(StringSPtr& atomic_string_, const std::string& new_value_);
+      /**
+       * @brief This functions stores atomically a new value
+       *        by creating a new shared pointer for the variable.
+       * 
+       * @param string_sptr_ String shared pointer
+       * @param new_value_   Value to be set into the shared pointer
+       */
+      void Store(StringSPtr& string_sptr_, const std::string& new_value_);
 
-      std::string Load(const StringSPtr& atomic_string_);
+      /**
+       * @brief This functions loads atomically values out of a shared pointer.
+       * 
+       * @param string_sptr_ String shared pointer
+       * 
+       * @returns Copy of the value of the shared pointer as std::string.
+       */
+      std::string Load(const StringSPtr& string_sptr_);
     } // Atomic
   } // Types
 } // eCAL


### PR DESCRIPTION
### Description
- making enums atomic (g_process_severity, g_process_severity_level)
- introducing handling for strings to be handled atomic in a separate header (g_process_info)
    - Pro: no lock for reading
    - Con: Setting always generates a new string
    - Open for discussion (different approach: mutexes)

### Related issues
- Fixes #2262
