### PR TITLE
Move v5 callback maps to v5 implementation

### DIFF
--- a/ecal/core/include/ecal/v5/ecal_publisher.h
+++ b/ecal/core/include/ecal/v5/ecal_publisher.h
@@ -45,6 +45,8 @@ namespace eCAL
 
   ECAL_CORE_NAMESPACE_V5
   {
+    class CEventCallbackAdapater;
+
     /**
      * @brief eCAL publisher class.
      *
@@ -319,6 +321,7 @@ namespace eCAL
     private:
       // class members
       std::shared_ptr<CPublisherImpl> m_publisher_impl;
+      std::shared_ptr<CEventCallbackAdapater> m_callback_adapter;
       long long                       m_filter_id;
     };
   }

--- a/ecal/core/include/ecal/v5/ecal_publisher.h
+++ b/ecal/core/include/ecal/v5/ecal_publisher.h
@@ -45,7 +45,7 @@ namespace eCAL
 
   ECAL_CORE_NAMESPACE_V5
   {
-    class CEventCallbackAdapater;
+    class CPublisherEventCallbackAdapater;
 
     /**
      * @brief eCAL publisher class.
@@ -321,7 +321,7 @@ namespace eCAL
     private:
       // class members
       std::shared_ptr<CPublisherImpl> m_publisher_impl;
-      std::shared_ptr<CEventCallbackAdapater> m_callback_adapter;
+      std::shared_ptr<CPublisherEventCallbackAdapater> m_callback_adapter;
       long long                       m_filter_id;
     };
   }

--- a/ecal/core/include/ecal/v5/ecal_subscriber.h
+++ b/ecal/core/include/ecal/v5/ecal_subscriber.h
@@ -43,6 +43,8 @@ namespace eCAL
 
   ECAL_CORE_NAMESPACE_V5
   {
+    class CSubscriberEventCallbackAdapater;
+
     /**
      * @brief eCAL subscriber class.
     **/
@@ -287,6 +289,7 @@ namespace eCAL
     private:
       // class members
       std::shared_ptr<CSubscriberImpl> m_subscriber_impl;
+      std::shared_ptr<CSubscriberEventCallbackAdapater> m_callback_adapter;
     };
   }
 }

--- a/ecal/core/src/pubsub/ecal_publisher_impl.cpp
+++ b/ecal/core/src/pubsub/ecal_publisher_impl.cpp
@@ -366,7 +366,7 @@ namespace eCAL
     return(false);
   }
 
-  bool CPublisherImpl::SetEventCallback(const PubEventCallbackT callback_)
+  bool CPublisherImpl::SetEventCallback(const PubEventCallbackT& callback_)
   {
     if (!m_created) return false;
 

--- a/ecal/core/src/pubsub/ecal_publisher_impl.h
+++ b/ecal/core/src/pubsub/ecal_publisher_impl.h
@@ -81,11 +81,6 @@ namespace eCAL
 
     bool SetDataTypeInformation(const SDataTypeInformation& topic_info_);
 
-    // deprecated event callback interface
-    bool SetEventCallback(ePublisherEvent type_, const v5::PubEventCallbackT callback_);
-    bool RemoveEventCallback(ePublisherEvent type_);
-
-    // future event callback interface
     bool SetEventCallback(const PubEventCallbackT callback_);
     bool RemoveEventCallback();
 
@@ -153,12 +148,8 @@ namespace eCAL
     SSubscriptionMapT                      m_connection_map;
     std::atomic<size_t>                    m_connection_count{ 0 };
 
-    using EventCallbackMapT = std::map<ePublisherEvent, v5::PubEventCallbackT>;
-    std::mutex                             m_event_callback_map_mutex;
-    EventCallbackMapT                      m_event_callback_map;
-
     std::mutex                             m_event_id_callback_mutex;
-    PubEventCallbackT                  m_event_id_callback;
+    PubEventCallbackT                      m_event_id_callback;
 
     long long                              m_id = 0;
     long long                              m_clock = 0;

--- a/ecal/core/src/pubsub/ecal_publisher_impl.h
+++ b/ecal/core/src/pubsub/ecal_publisher_impl.h
@@ -81,7 +81,7 @@ namespace eCAL
 
     bool SetDataTypeInformation(const SDataTypeInformation& topic_info_);
 
-    bool SetEventCallback(const PubEventCallbackT callback_);
+    bool SetEventCallback(const PubEventCallbackT& callback_);
     bool RemoveEventCallback();
 
     bool SetAttribute(const std::string& attr_name_, const std::string& attr_value_);

--- a/ecal/core/src/pubsub/ecal_subscriber.cpp
+++ b/ecal/core/src/pubsub/ecal_subscriber.cpp
@@ -47,7 +47,7 @@ namespace eCAL
     CSubscriber(topic_name_, data_type_info_, config_)
   {
     // add event callback for all current event types
-    m_subscriber_impl->SetEventIDCallback(event_callback_);
+    m_subscriber_impl->SetEventCallback(event_callback_);
   }
 
   CSubscriber::~CSubscriber()

--- a/ecal/core/src/pubsub/ecal_subscriber_impl.cpp
+++ b/ecal/core/src/pubsub/ecal_subscriber_impl.cpp
@@ -166,7 +166,7 @@ namespace eCAL
     return(false);
   }
 
-  bool CSubscriberImpl::SetReceiveCallback(ReceiveCallbackT callback_)
+  bool CSubscriberImpl::SetReceiveCallback(const ReceiveCallbackT& callback_)
   {
     if (!m_created) return(false);
 
@@ -177,7 +177,7 @@ namespace eCAL
     // set receive callback
     {
       const std::lock_guard<std::mutex> lock(m_receive_callback_mutex);
-      m_receive_callback = std::move(callback_);
+      m_receive_callback = callback_;
     }
 
     return(true);
@@ -200,7 +200,7 @@ namespace eCAL
     return(true);
   }
 
-  bool CSubscriberImpl::SetEventCallback(const SubEventCallbackT callback_)
+  bool CSubscriberImpl::SetEventCallback(const SubEventCallbackT& callback_)
   {
     if (!m_created) return false;
 

--- a/ecal/core/src/pubsub/ecal_subscriber_impl.cpp
+++ b/ecal/core/src/pubsub/ecal_subscriber_impl.cpp
@@ -118,12 +118,6 @@ namespace eCAL
       m_receive_callback = nullptr;
     }
 
-    // reset event callback map
-    {
-      const std::lock_guard<std::mutex> lock(m_event_callback_map_mutex);
-      m_event_callback_map.clear();
-    }
-
     // mark as no more created
     m_created = false;
 
@@ -206,41 +200,7 @@ namespace eCAL
     return(true);
   }
 
-  bool CSubscriberImpl::SetEventCallback(eSubscriberEvent type_, v5::SubEventCallbackT callback_)
-  {
-    if (!m_created) return(false);
-
-#ifndef NDEBUG
-    Logging::Log(Logging::log_level_debug2, m_attributes.topic_name + "::CSubscriberImpl::SetEventCallback");
-#endif
-
-    // set event callback
-    {
-      const std::lock_guard<std::mutex> lock(m_event_callback_map_mutex);
-      m_event_callback_map[type_] = std::move(callback_);
-    }
-
-    return(true);
-  }
-
-  bool CSubscriberImpl::RemoveEventCallback(eSubscriberEvent type_)
-  {
-    if (!m_created) return(false);
-
-#ifndef NDEBUG
-    Logging::Log(Logging::log_level_debug2, m_attributes.topic_name + "::CSubscriberImpl::RemoveEventCallback");
-#endif
-
-    // remove event callback
-    {
-      const std::lock_guard<std::mutex> lock(m_event_callback_map_mutex);
-      m_event_callback_map[type_] = nullptr;
-    }
-
-    return(true);
-  }
-
-  bool CSubscriberImpl::SetEventIDCallback(const SubEventCallbackT callback_)
+  bool CSubscriberImpl::SetEventCallback(const SubEventCallbackT callback_)
   {
     if (!m_created) return false;
 
@@ -756,24 +716,6 @@ namespace eCAL
 
       // call event callback
       m_event_id_callback(topic_id, data);
-    }
-
-    // deprecated event handling with topic name
-    {
-      const std::lock_guard<std::mutex> lock(m_event_callback_map_mutex);
-      auto iter = m_event_callback_map.find(type_);
-      if (iter != m_event_callback_map.end() && iter->second)
-      {
-        v5::SSubEventCallbackData data;
-        data.type      = type_;
-        data.time      = eCAL::Time::GetMicroSeconds();
-        data.clock     = 0;
-        data.tid       = std::to_string(publication_info_.entity_id);
-        data.tdatatype = data_type_info_;
-
-        // call event callback
-        (iter->second)(m_attributes.topic_name.c_str(), &data);
-      }
     }
   }
 

--- a/ecal/core/src/pubsub/ecal_subscriber_impl.h
+++ b/ecal/core/src/pubsub/ecal_subscriber_impl.h
@@ -82,12 +82,7 @@ namespace eCAL
     bool SetReceiveCallback(ReceiveCallbackT callback_);
     bool RemoveReceiveCallback();
 
-    // deprecated event callback interface
-    bool SetEventCallback(eSubscriberEvent type_, v5::SubEventCallbackT callback_);
-    bool RemoveEventCallback(eSubscriberEvent type_);
-
-    // future event callback interface
-    bool SetEventIDCallback(const SubEventCallbackT callback_);
+    bool SetEventCallback(const SubEventCallbackT callback_);
     bool RemoveEventCallback();
 
     bool SetAttribute(const std::string& attr_name_, const std::string& attr_value_);
@@ -170,10 +165,6 @@ namespace eCAL
     std::atomic<int>                          m_receive_time;
 
     std::deque<size_t>                        m_sample_hash_queue;
-
-    using EventCallbackMapT = std::map<eSubscriberEvent, v5::SubEventCallbackT>;
-    std::mutex                                m_event_callback_map_mutex;
-    EventCallbackMapT                         m_event_callback_map;
 
     std::mutex                                m_event_id_callback_mutex;
     SubEventCallbackT                         m_event_id_callback;

--- a/ecal/core/src/pubsub/ecal_subscriber_impl.h
+++ b/ecal/core/src/pubsub/ecal_subscriber_impl.h
@@ -79,10 +79,10 @@ namespace eCAL
 
     bool Read(std::string& buf_, long long* time_ = nullptr, int rcv_timeout_ms_ = 0);
 
-    bool SetReceiveCallback(ReceiveCallbackT callback_);
+    bool SetReceiveCallback(const ReceiveCallbackT& callback_);
     bool RemoveReceiveCallback();
 
-    bool SetEventCallback(const SubEventCallbackT callback_);
+    bool SetEventCallback(const SubEventCallbackT& callback_);
     bool RemoveEventCallback();
 
     bool SetAttribute(const std::string& attr_name_, const std::string& attr_value_);

--- a/ecal/core/src/v5/pubsub/ecal_publisher.cpp
+++ b/ecal/core/src/v5/pubsub/ecal_publisher.cpp
@@ -38,6 +38,20 @@
 #include <utility>
 
 
+namespace {
+  eCAL::v5::SPubEventCallbackData v6tov5CallbackData(const eCAL::STopicId& topic_id_, const eCAL::SPubEventCallbackData& v6_callback_data_)
+  {
+    eCAL::v5::SPubEventCallbackData v5_callback_data;
+    v5_callback_data.type = v6_callback_data_.event_type;
+    v5_callback_data.time = v6_callback_data_.event_time;
+    v5_callback_data.clock = 0;
+    v5_callback_data.tid = std::to_string(topic_id_.topic_id.entity_id);
+    v5_callback_data.tdatatype = v6_callback_data_.subscriber_datatype;
+    return v5_callback_data;
+  }
+}
+
+
 namespace eCAL
 {
   ECAL_CORE_NAMESPACE_V5
@@ -46,9 +60,8 @@ namespace eCAL
     class CPublisherEventCallbackAdapater
     {
     public:
-      CPublisherEventCallbackAdapater(std::shared_ptr<CPublisherImpl> publisher_impl_)
+      CPublisherEventCallbackAdapater(const std::shared_ptr<CPublisherImpl>& publisher_impl_)
         : m_publisher_impl(publisher_impl_)
-        , m_is_registered(false)
       {
       }
 
@@ -96,22 +109,11 @@ namespace eCAL
         return publisher->SetEventCallback(internal_callback);
       }
 
-      v5::SPubEventCallbackData v6tov5CallbackData(const STopicId& topic_id_, const eCAL::SPubEventCallbackData& v6_callback_data_)
-      {
-        SPubEventCallbackData v5_callback_data;
-        v5_callback_data.type = v6_callback_data_.event_type;
-        v5_callback_data.time = v6_callback_data_.event_time;
-        v5_callback_data.clock = 0;
-        v5_callback_data.tid = std::to_string(topic_id_.topic_id.entity_id);
-        v5_callback_data.tdatatype = v6_callback_data_.subscriber_datatype;
-        return v5_callback_data;
-      }
-
       using EventCallbackMapT = std::map<ePublisherEvent, v5::PubEventCallbackT>;
       std::mutex                             m_event_callback_map_mutex;
       EventCallbackMapT                      m_event_callback_map;
       std::weak_ptr<CPublisherImpl>          m_publisher_impl;
-      bool                                   m_is_registered;
+      bool                                   m_is_registered{ false };
     };
 
     CPublisher::CPublisher() :

--- a/ecal/core/src/v5/pubsub/ecal_publisher.cpp
+++ b/ecal/core/src/v5/pubsub/ecal_publisher.cpp
@@ -37,10 +37,83 @@
 #include <string>
 #include <utility>
 
+
 namespace eCAL
 {
   ECAL_CORE_NAMESPACE_V5
   {
+    // Class to bridge legacy callbacks to v6 Callbacks
+    class CEventCallbackAdapater
+    {
+    public:
+      CEventCallbackAdapater(std::shared_ptr<CPublisherImpl> publisher_impl_)
+        : m_publisher_impl(publisher_impl_)
+        , m_is_registered(false)
+      {
+      }
+
+      bool AddEventCallback(ePublisherEvent type_, const PubEventCallbackT& callback_)
+      {
+        const std::lock_guard<std::mutex> guard(m_event_callback_map_mutex);
+        m_event_callback_map[type_] = callback_;
+      
+        if (!m_is_registered)
+        {
+          m_is_registered = true;
+          return RegisterCallbackWithPublisher();
+        }
+      
+        return true;
+      }
+      
+      bool RemoveEventCallback(ePublisherEvent type_)
+      {
+        const std::lock_guard<std::mutex> guard(m_event_callback_map_mutex);
+        m_event_callback_map[type_] = nullptr;
+      
+        return true;
+      }
+
+    private:
+      bool RegisterCallbackWithPublisher()
+      {
+        auto publisher = m_publisher_impl.lock();
+        if (publisher == nullptr)
+          return false;
+      
+        auto internal_callback = [this](const STopicId& topic_id_, const eCAL::SPubEventCallbackData& callback_data_)
+          {
+            const std::lock_guard<std::mutex> guard(m_event_callback_map_mutex);
+
+            const auto& v5_callback = m_event_callback_map.find(callback_data_.event_type);
+            if (v5_callback != m_event_callback_map.end() && v5_callback->second != nullptr)
+            {
+              auto v5_callback_data = v6tov5CallbackData(topic_id_, callback_data_);
+              v5_callback->second(topic_id_.topic_name.c_str(), &v5_callback_data);
+            }
+          };
+      
+        return publisher->SetEventCallback(internal_callback);
+      }
+
+      v5::SPubEventCallbackData v6tov5CallbackData(const STopicId& topic_id_, const eCAL::SPubEventCallbackData& v6_callback_data_)
+      {
+        SPubEventCallbackData v5_callback_data;
+        v5_callback_data.type = v6_callback_data_.event_type;
+        v5_callback_data.time = v6_callback_data_.event_time;
+        v5_callback_data.clock = 0;
+        v5_callback_data.tid = std::to_string(topic_id_.topic_id.entity_id);
+        v5_callback_data.tdatatype = v6_callback_data_.subscriber_datatype;
+        return v5_callback_data;
+      }
+
+      using EventCallbackMapT = std::map<ePublisherEvent, v5::PubEventCallbackT>;
+      std::mutex                             m_event_callback_map_mutex;
+      EventCallbackMapT                      m_event_callback_map;
+      std::weak_ptr<CPublisherImpl>          m_publisher_impl;
+      bool                                   m_is_registered;
+    };
+
     CPublisher::CPublisher() :
       m_publisher_impl(nullptr),
       m_filter_id(0)
@@ -67,9 +140,11 @@ namespace eCAL
     **/
     CPublisher::CPublisher(CPublisher&& rhs) noexcept :
                   m_publisher_impl(std::move(rhs.m_publisher_impl)),
+                  m_callback_adapter(std::move(rhs.m_callback_adapter)),
                   m_filter_id(rhs.m_filter_id)
     {
       rhs.m_publisher_impl = nullptr;
+      rhs.m_callback_adapter = nullptr;
     }
 
     /**
@@ -81,6 +156,7 @@ namespace eCAL
       Destroy();
 
       m_publisher_impl = std::move(rhs.m_publisher_impl);
+      m_callback_adapter = std::move(rhs.m_callback_adapter);
       m_filter_id  = rhs.m_filter_id;
       
       rhs.m_publisher_impl = nullptr;
@@ -98,6 +174,7 @@ namespace eCAL
 
       // create publisher
       m_publisher_impl = std::make_shared<CPublisherImpl>(data_type_info_, BuildWriterAttributes(topic_name_, config));
+      m_callback_adapter = std::make_shared<CEventCallbackAdapater>(m_publisher_impl);
 
       // register publisher
       g_pubgate()->Register(topic_name_, m_publisher_impl);
@@ -191,13 +268,14 @@ namespace eCAL
     {
       if (m_publisher_impl == nullptr) return(false);
       RemEventCallback(type_);
-      return(m_publisher_impl->SetEventCallback(type_, std::move(callback_)));
+
+      return(m_callback_adapter->AddEventCallback(type_, callback_));
     }
 
     bool CPublisher::RemEventCallback(ePublisherEvent type_)
     {
       if (m_publisher_impl == nullptr) return(false);
-      return(m_publisher_impl->RemoveEventCallback(type_));
+      return(m_callback_adapter->RemoveEventCallback(type_));
     }
 
     bool CPublisher::IsSubscribed() const

--- a/ecal/core/src/v5/pubsub/ecal_publisher.cpp
+++ b/ecal/core/src/v5/pubsub/ecal_publisher.cpp
@@ -43,10 +43,10 @@ namespace eCAL
   ECAL_CORE_NAMESPACE_V5
   {
     // Class to bridge legacy callbacks to v6 Callbacks
-    class CEventCallbackAdapater
+    class CPublisherEventCallbackAdapater
     {
     public:
-      CEventCallbackAdapater(std::shared_ptr<CPublisherImpl> publisher_impl_)
+      CPublisherEventCallbackAdapater(std::shared_ptr<CPublisherImpl> publisher_impl_)
         : m_publisher_impl(publisher_impl_)
         , m_is_registered(false)
       {
@@ -174,7 +174,7 @@ namespace eCAL
 
       // create publisher
       m_publisher_impl = std::make_shared<CPublisherImpl>(data_type_info_, BuildWriterAttributes(topic_name_, config));
-      m_callback_adapter = std::make_shared<CEventCallbackAdapater>(m_publisher_impl);
+      m_callback_adapter = std::make_shared<CPublisherEventCallbackAdapater>(m_publisher_impl);
 
       // register publisher
       g_pubgate()->Register(topic_name_, m_publisher_impl);

--- a/ecal/core/src/v5/pubsub/ecal_subscriber.cpp
+++ b/ecal/core/src/v5/pubsub/ecal_subscriber.cpp
@@ -38,6 +38,21 @@
 #include <string>
 #include <utility>
 
+namespace
+{
+  eCAL::v5::SSubEventCallbackData v6tov5CallbackData(const eCAL::STopicId& topic_id_, const eCAL::SSubEventCallbackData& v6_callback_data_)
+  {
+    eCAL::v5::SSubEventCallbackData v5_callback_data;
+    v5_callback_data.type = v6_callback_data_.event_type;
+    v5_callback_data.time = v6_callback_data_.event_time;
+    v5_callback_data.clock = 0;
+    v5_callback_data.tid = std::to_string(topic_id_.topic_id.entity_id);
+    v5_callback_data.tdatatype = v6_callback_data_.publisher_datatype;
+    return v5_callback_data;
+  }
+}
+
+
 namespace eCAL
 {
   ECAL_CORE_NAMESPACE_V5
@@ -46,9 +61,8 @@ namespace eCAL
     class CSubscriberEventCallbackAdapater
     {
     public:
-      CSubscriberEventCallbackAdapater(std::shared_ptr<CSubscriberImpl> subscriber_impl_)
+      CSubscriberEventCallbackAdapater(const std::shared_ptr<CSubscriberImpl>& subscriber_impl_)
         : m_subscriber_impl(subscriber_impl_)
-        , m_is_registered(false)
       {
       }
     
@@ -96,22 +110,11 @@ namespace eCAL
         return subscriber->SetEventCallback(internal_callback);
       }
     
-      v5::SSubEventCallbackData v6tov5CallbackData(const STopicId& topic_id_, const eCAL::SSubEventCallbackData& v6_callback_data_)
-      {
-        SSubEventCallbackData v5_callback_data;
-        v5_callback_data.type = v6_callback_data_.event_type;
-        v5_callback_data.time = v6_callback_data_.event_time;
-        v5_callback_data.clock = 0;
-        v5_callback_data.tid = std::to_string(topic_id_.topic_id.entity_id);
-        v5_callback_data.tdatatype = v6_callback_data_.publisher_datatype;
-        return v5_callback_data;
-      }
-    
       using EventCallbackMapT = std::map<eSubscriberEvent, v5::SubEventCallbackT>;
       std::mutex                             m_event_callback_map_mutex;
       EventCallbackMapT                      m_event_callback_map;
       std::weak_ptr<CSubscriberImpl>         m_subscriber_impl;
-      bool                                   m_is_registered;
+      bool                                   m_is_registered{ false };
     };
 
 

--- a/ecal/core/src/v5/pubsub/ecal_subscriber.cpp
+++ b/ecal/core/src/v5/pubsub/ecal_subscriber.cpp
@@ -167,6 +167,7 @@ namespace eCAL
 
       // create datareader
       m_subscriber_impl = std::make_shared<CSubscriberImpl>(data_type_info_, BuildReaderAttributes(topic_name_, config));
+      m_callback_adapter = std::make_shared<CSubscriberEventCallbackAdapater>(m_subscriber_impl);
 
       // register datareader
       g_subgate()->Register(topic_name_, m_subscriber_impl);

--- a/ecal/core/src/v5/pubsub/ecal_subscriber.cpp
+++ b/ecal/core/src/v5/pubsub/ecal_subscriber.cpp
@@ -42,6 +42,79 @@ namespace eCAL
 {
   ECAL_CORE_NAMESPACE_V5
   {
+    // Class to bridge legacy callbacks to v6 Callbacks
+    class CSubscriberEventCallbackAdapater
+    {
+    public:
+      CSubscriberEventCallbackAdapater(std::shared_ptr<CSubscriberImpl> subscriber_impl_)
+        : m_subscriber_impl(subscriber_impl_)
+        , m_is_registered(false)
+      {
+      }
+    
+      bool AddEventCallback(eSubscriberEvent type_, const SubEventCallbackT& callback_)
+      {
+        const std::lock_guard<std::mutex> guard(m_event_callback_map_mutex);
+        m_event_callback_map[type_] = callback_;
+    
+        if (!m_is_registered)
+        {
+          m_is_registered = true;
+          return RegisterCallbackWithSubscriber();
+        }
+    
+        return true;
+      }
+    
+      bool RemoveEventCallback(eSubscriberEvent type_)
+      {
+        const std::lock_guard<std::mutex> guard(m_event_callback_map_mutex);
+        m_event_callback_map[type_] = nullptr;
+    
+        return true;
+      }
+    
+    private:
+      bool RegisterCallbackWithSubscriber()
+      {
+        auto subscriber = m_subscriber_impl.lock();
+        if (subscriber == nullptr)
+          return false;
+    
+        auto internal_callback = [this](const STopicId& topic_id_, const eCAL::SSubEventCallbackData& callback_data_)
+          {
+            const std::lock_guard<std::mutex> guard(m_event_callback_map_mutex);
+    
+            const auto& v5_callback = m_event_callback_map.find(callback_data_.event_type);
+            if (v5_callback != m_event_callback_map.end() && v5_callback->second != nullptr)
+            {
+              auto v5_callback_data = v6tov5CallbackData(topic_id_, callback_data_);
+              v5_callback->second(topic_id_.topic_name.c_str(), &v5_callback_data);
+            }
+          };
+    
+        return subscriber->SetEventCallback(internal_callback);
+      }
+    
+      v5::SSubEventCallbackData v6tov5CallbackData(const STopicId& topic_id_, const eCAL::SSubEventCallbackData& v6_callback_data_)
+      {
+        SSubEventCallbackData v5_callback_data;
+        v5_callback_data.type = v6_callback_data_.event_type;
+        v5_callback_data.time = v6_callback_data_.event_time;
+        v5_callback_data.clock = 0;
+        v5_callback_data.tid = std::to_string(topic_id_.topic_id.entity_id);
+        v5_callback_data.tdatatype = v6_callback_data_.publisher_datatype;
+        return v5_callback_data;
+      }
+    
+      using EventCallbackMapT = std::map<eSubscriberEvent, v5::SubEventCallbackT>;
+      std::mutex                             m_event_callback_map_mutex;
+      EventCallbackMapT                      m_event_callback_map;
+      std::weak_ptr<CSubscriberImpl>         m_subscriber_impl;
+      bool                                   m_is_registered;
+    };
+
+
     CSubscriber::CSubscriber() :
       m_subscriber_impl(nullptr)
     {
@@ -184,13 +257,13 @@ namespace eCAL
     {
       if (m_subscriber_impl == nullptr) return(false);
       RemEventCallback(type_);
-      return(m_subscriber_impl->SetEventCallback(type_, callback_));
+      return(m_callback_adapter->AddEventCallback(type_, callback_));
     }
 
     bool CSubscriber::RemEventCallback(eSubscriberEvent type_)
     {
       if (m_subscriber_impl == nullptr) return(false);
-      return(m_subscriber_impl->RemoveEventCallback(type_));
+      return(m_callback_adapter->RemoveEventCallback(type_));
     }
 
     bool CSubscriber::IsPublished() const


### PR DESCRIPTION
The Publisher Implementation and Subscriber Implementation contained callback maps for both v6 and v5 style callbacks.
This PR removes the v5 style callback maps and moves them into the actual v5 implementations, thus cleaning up the core.

This implementation is used ONLY for the legacy Python bindings, so we should think about when we can remove those safely.