### PR TITLE
[Samples] Fixed compatibility with Qt 5.15

### DIFF
--- a/samples/cpp/services/rec_client_service_gui/src/EcalrecGuiClient.cpp
+++ b/samples/cpp/services/rec_client_service_gui/src/EcalrecGuiClient.cpp
@@ -51,7 +51,7 @@ EcalrecGuiClient::EcalrecGuiClient(QWidget *parent)
             //}
             this->updateClientListTreeWidget();
           });
-  recorder_service_poll_timer_->start(std::chrono::milliseconds(500));
+  recorder_service_poll_timer_->start(500);
 }
 
 EcalrecGuiClient::~EcalrecGuiClient()


### PR DESCRIPTION
Replaced QTimer::Start(chrono::milliseconds) with QTimer::Start(int) call in RecClientServiceGUI
