### PR TITLE
[Tests] Only build Rec RPC tests when ECAL_BUILD_APPS is on

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -558,7 +558,7 @@ if(ECAL_BUILD_TESTS)
   # ------------------------------------------------------
   # test apps
   # ------------------------------------------------------
-  if (ECAL_USE_HDF5 AND ECAL_USE_QT)
+  if (ECAL_BUILD_APPS AND ECAL_USE_HDF5 AND ECAL_USE_QT)
     add_subdirectory(app/rec/rec_tests/rec_rpc_tests)
   endif()
 endif()


### PR DESCRIPTION
This is important, as the tests depend on the eCAL Rec Apps, so we can only build and execute those tests when eCAL rec is being built as well