### PR TITLE
[test] Improved TopicIdsMatchSubscribers test especially for ARM

### DIFF
--- a/ecal/tests/cpp/pubsub_test/src/pubsub_event_callback_test.cpp
+++ b/ecal/tests/cpp/pubsub_test/src/pubsub_event_callback_test.cpp
@@ -60,7 +60,7 @@ protected:
 
   void wait_disc() const
   {
-    std::this_thread::sleep_for(200ms);
+    std::this_thread::sleep_for(300ms);
   }
 };
 
@@ -87,7 +87,7 @@ TEST_F(core_cpp_pubsub_event, PublisherCallback_TopicIdsMatchSubscribers)
       wait_disc();
       CSubscriber sub3("MyTopic");  expected_ids.insert(sub3.GetTopicId());
       wait_disc();
-      //wait_disc();
+      wait_disc();
     }
     wait_disc();
   } // destroy also Publisher


### PR DESCRIPTION
### Description
Sometimes the ARM GH runner did fail on one specific thest: PublisherCallback_TopicIdsMatchSubscribers. I was able to reproduces the error on my RaspberryPi 3. The failure was like this:

`conn_ids
    Which is: 
{ STopicId(topic_id: SEntityId(entity_id: 3253456991265, process_id: 11278, host_name: raspberrypi), topic_name: MyTopic),
 STopicId(topic_id: SEntityId(entity_id: 3253456887411, process_id: 11278, host_name: raspberrypi), topic_name: MyTopic) }
  
expected_ids
    Which is: 

{ STopicId(topic_id: SEntityId(entity_id: 3253660246210, process_id: 11278, host_name: raspberrypi), topic_name: MyTopic),
STopicId(topic_id: SEntityId(entity_id: 3253456991265, process_id: 11278, host_name: raspberrypi), topic_name: MyTopic),
STopicId(topic_id: SEntityId(entity_id: 3253456887411, process_id: 11278, host_name: raspberrypi), topic_name: MyTopic) }`

In 260 out of 1000 runs this error occured. 

After some tests with different and additional timings, which reduced the appearance of the failure, the best outcome was by uncommenting the additional wait_disc() line in the code which was obviously there before.

Now after another 1000 tests the failure did not appear anymore.
