### PR TITLE
[core] minor deserialization performance improvement.

### DIFF
--- a/ecal/core/src/serialization/ecal_serialize_monitoring.cpp
+++ b/ecal/core/src/serialization/ecal_serialize_monitoring.cpp
@@ -965,7 +965,7 @@ namespace{
         target_sample_.state_severity_level = reader.get_int32();
         break;
       case +eCAL::pb::ProcessState::optional_string_info:
-        target_sample_.state_info = reader.get_string();
+        AssignString(reader, target_sample_.state_info);
         break;
       }
     }
@@ -1005,22 +1005,22 @@ namespace{
         target_sample_.registration_clock = reader.get_int32();
         break;
       case +eCAL::pb::Process::optional_string_host_name:
-        target_sample_.host_name = reader.get_string();
+        AssignString(reader, target_sample_.host_name);
         break;
       case +eCAL::pb::Process::optional_string_shm_transport_domain:
-        target_sample_.shm_transport_domain = reader.get_string();
+        AssignString(reader, target_sample_.shm_transport_domain);
         break;
       case +eCAL::pb::Process::optional_int32_process_id:
         target_sample_.process_id = reader.get_int32();
         break;
       case +eCAL::pb::Process::optional_string_process_name:
-        target_sample_.process_name = reader.get_string();
+        AssignString(reader, target_sample_.process_name);
         break;
       case +eCAL::pb::Process::optional_string_unit_name:
-        target_sample_.unit_name = reader.get_string();
+        AssignString(reader, target_sample_.unit_name);
         break;
       case +eCAL::pb::Process::optional_string_process_parameter:
-        target_sample_.process_parameter = reader.get_string();
+        AssignString(reader, target_sample_.process_parameter);
         break;
       case +eCAL::pb::Process::optional_message_state:
       {
@@ -1031,19 +1031,19 @@ namespace{
         target_sample_.time_sync_state = reader.get_enum();
         break;
       case +eCAL::pb::Process::optional_string_time_sync_module_name:
-        target_sample_.time_sync_module_name = reader.get_string();
+        AssignString(reader, target_sample_.time_sync_module_name);
         break;
       case +eCAL::pb::Process::optional_int32_component_init_state:
         target_sample_.component_init_state = reader.get_int32();
         break;
       case +eCAL::pb::Process::optional_string_component_init_info:
-        target_sample_.component_init_info = reader.get_string();
+        AssignString(reader, target_sample_.component_init_info);
         break;
       case +eCAL::pb::Process::optional_string_ecal_runtime_version:
-        target_sample_.ecal_runtime_version = reader.get_string();
+        AssignString(reader, target_sample_.ecal_runtime_version);
         break;
       case +eCAL::pb::Process::optional_string_config_file_path:
-        target_sample_.config_file_path = reader.get_string();
+        AssignString(reader, target_sample_.config_file_path);
         break;
       default:
         reader.skip();

--- a/ecal/core/src/serialization/ecal_serialize_sample_payload.cpp
+++ b/ecal/core/src/serialization/ecal_serialize_sample_payload.cpp
@@ -283,16 +283,20 @@ namespace
       switch (reader.tag())
       {
       case +eCAL::pb::Topic::optional_string_topic_name:
-        topic_info.topic_name = reader.get_string();
+        AssignString(reader, topic_info.topic_name);
         break;
       case +eCAL::pb::Topic::optional_string_topic_id:
-        topic_info.topic_id = std::stoull(reader.get_string());
+        {
+          static thread_local std::string topic_id_string;
+          AssignString(reader, topic_id_string);
+          topic_info.topic_id = std::stoull(topic_id_string);
+        }
         break;
       case +eCAL::pb::Topic::optional_int32_process_id:
         topic_info.process_id = reader.get_int32();
         break;
       case +eCAL::pb::Topic::optional_string_host_name:
-        topic_info.host_name = reader.get_string();
+        AssignString(reader, topic_info.host_name);
         break;
       default:
         reader.skip();

--- a/ecal/core/src/serialization/ecal_serialize_sample_registration.cpp
+++ b/ecal/core/src/serialization/ecal_serialize_sample_registration.cpp
@@ -722,7 +722,10 @@ namespace
       switch (reader.tag())
       {
       case +eCAL::pb::LayerParShm::repeated_string_memory_file_list:
-        layer.memory_file_list.push_back(reader.get_string());
+        {
+          auto& memory_file_string = layer.memory_file_list.push_back();
+          AssignString(reader, memory_file_string);
+        }
         break;
       default:
         reader.skip();
@@ -883,7 +886,7 @@ namespace
       switch (reader.tag())
       {
       case +eCAL::pb::Topic::optional_string_host_name:
-        sample.identifier.host_name = reader.get_string();
+        AssignString(reader, sample.identifier.host_name);
         break;
       case +eCAL::pb::Topic::optional_int32_process_id:
         sample.identifier.process_id = reader.get_int32();
@@ -892,8 +895,12 @@ namespace
         AssignString(reader, sample.topic.process_name);
         break;
       case +eCAL::pb::Topic::optional_string_topic_id:
-        // this could possibly be faster if we do not need to construct a string here
-        sample.identifier.entity_id = std::stoull(reader.get_string());
+        {
+          static thread_local std::string entity_id_string;
+          AssignString(reader, entity_id_string);
+          // TODO: use std::from_chars after migration to C++17
+          sample.identifier.entity_id = std::stoull(entity_id_string);
+        }
         break;
       case +eCAL::pb::Topic::optional_string_topic_name:
         AssignString(reader, sample.topic.topic_name);
@@ -1159,7 +1166,11 @@ namespace
       switch (reader.tag())
       {
       case +eCAL::pb::Service::optional_string_service_id:
-        sample.identifier.entity_id = std::stoull(reader.get_string());
+        {
+          static thread_local std::string entity_id_string;
+          AssignString(reader, entity_id_string);
+          sample.identifier.entity_id = std::stoull(entity_id_string);
+        }
         break;
       case +eCAL::pb::Service::optional_int32_process_id:
         sample.identifier.process_id = reader.get_int32();
@@ -1235,7 +1246,11 @@ namespace
       switch (reader.tag())
       {
       case +eCAL::pb::Client::optional_string_service_id:
-        sample.identifier.entity_id = std::stoull(reader.get_string());
+        {
+          static thread_local std::string entity_id_string;
+          AssignString(reader, entity_id_string);
+          sample.identifier.entity_id = std::stoull(entity_id_string);
+        }
         break;
       case +eCAL::pb::Client::optional_int32_process_id:
         sample.identifier.process_id = reader.get_int32();


### PR DESCRIPTION
- Use AssignString instead of getString() (saves one string allocation)
- Thread local string variable for entity_id.