### PR TITLE
[Python] Update cibuildwheel action to version 3.3

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -25,7 +25,7 @@ jobs:
           git submodule update --init
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22
+        uses: pypa/cibuildwheel@v3.3
         env:
           CIBW_ARCHS: auto64
           CIBW_BUILD: cp3*-*


### PR DESCRIPTION
Wheel builds seem to be broken for Windows. Try by upgrading cibuildwheel.