### PR TITLE
[Tests] increased timeouts in ClientServer TimeBehavior tests

### DIFF
--- a/ecal/tests/cpp/clientserver_test/src/clientserver_test.cpp
+++ b/ecal/tests/cpp/clientserver_test/src/clientserver_test.cpp
@@ -513,7 +513,7 @@ TEST(core_cpp_clientserver, ClientServerBaseCallbackTimeout)
 // Test time-behavior of CallWithResponse with multiple servers when one server is slow
 TEST(core_cpp_clientserver, ClientServerCallWithResponseTimeBehavior)
 {
-  const std::chrono::milliseconds server_2_calculation_time(200);
+  const std::chrono::milliseconds server_2_calculation_time(1000);
 
   // initialize eCAL API
   eCAL::Initialize("clientserver base callback timeout time behavior test");
@@ -666,7 +666,7 @@ TEST(core_cpp_clientserver, ClientServerCallWithResponseTimeBehavior)
 // Also tests that the function only returns AFTER the user-callback has been called for all responses, even if that goes beyond the timeout.
 TEST(core_cpp_clientserver, ClientServerCallWithCallbackTimeBehavior)
 {
-  const std::chrono::milliseconds server_2_calculation_time(200);
+  const std::chrono::milliseconds server_2_calculation_time(1000);
     
   // initialize eCAL API
   eCAL::Initialize("clientserver call with callback time behavior test");


### PR DESCRIPTION
This should make the test more robust to CPU load jitter

Fixes #2437 