### PR TITLE
[core] Use integer for process id in ecal_memfile_sync (because using…

### DIFF
--- a/ecal/core/src/io/shm/ecal_memfile_sync.cpp
+++ b/ecal/core/src/io/shm/ecal_memfile_sync.cpp
@@ -48,7 +48,7 @@ namespace eCAL
     Destroy();
   }
 
-  bool CSyncMemoryFile::Connect(const std::string& process_id_)
+  bool CSyncMemoryFile::Connect(const int32_t process_id_)
   {
     if (!m_created) return false;
 
@@ -57,8 +57,9 @@ namespace eCAL
     //   we have ONE memory file per publisher and 1 or 2 events per memory file
 
     // the event names
-    const std::string event_snd_name = m_memfile_name + "_" + process_id_;
-    const std::string event_ack_name = m_memfile_name + "_" + process_id_ + "_ack";
+    const std::string process_id_string = std::to_string(process_id_);
+    const std::string event_snd_name = m_memfile_name + "_" + process_id_string;
+    const std::string event_ack_name = m_memfile_name + "_" + process_id_string + "_ack";
 
     // check for existing process
     const std::lock_guard<std::mutex> lock(m_event_handle_map_sync);
@@ -70,7 +71,7 @@ namespace eCAL
       SEventHandlePair event_pair;
       gOpenNamedEvent(&event_pair.event_snd, event_snd_name, true);
       gOpenNamedEvent(&event_pair.event_ack, event_ack_name, true);
-      m_event_handle_map.insert(std::pair<std::string, SEventHandlePair>(process_id_, event_pair));
+      m_event_handle_map.insert(std::pair<int32_t, SEventHandlePair>(process_id_, event_pair));
       return true;
     }
     else
@@ -103,7 +104,7 @@ namespace eCAL
   * Also, the disconnect does not prevent the `event_snd` not to be set when the publisher writes data. 
   * We should theoretically distinguish between not acknowledging, and not signaling send data.
   */
-  bool CSyncMemoryFile::Disconnect(const std::string& process_id_)
+  bool CSyncMemoryFile::Disconnect(const int32_t process_id_)
   {
     if (!m_created) return false;
 
@@ -315,7 +316,7 @@ namespace eCAL
   bool CSyncMemoryFile::Recreate(size_t size_)
   {
     // collect id's of the currently connected processes
-    std::vector<std::string> process_id_list;
+    std::vector<int32_t> process_id_list;
     {
       const std::lock_guard<std::mutex> lock(m_event_handle_map_sync);
       for (const auto& event_handle : m_event_handle_map)

--- a/ecal/core/src/io/shm/ecal_memfile_sync.h
+++ b/ecal/core/src/io/shm/ecal_memfile_sync.h
@@ -51,8 +51,8 @@ namespace eCAL
     CSyncMemoryFile(const std::string& base_name_, size_t size_, SSyncMemoryFileAttr attr_);
     ~CSyncMemoryFile();
 
-    bool Connect(const std::string& process_id_);
-    bool Disconnect(const std::string& process_id_);
+    bool Connect(int32_t process_id_);
+    bool Disconnect(int32_t process_id_);
 
     bool CheckSize(size_t size_);
     bool Write(CPayloadWriter& payload_, const SWriterAttr& data_, bool force_full_write_ = false);
@@ -81,7 +81,7 @@ namespace eCAL
       EventHandleT event_ack;
       bool         event_ack_is_invalid = false;    //!< The ack event has timeouted. Thus, we don't wait for it anymore, until the subscriber notifies us via registration layer that it is still alive.
     };
-    using EventHandleMapT = std::unordered_map<std::string, SEventHandlePair>;
+    using EventHandleMapT = std::unordered_map<int32_t, SEventHandlePair>;
     std::mutex       m_event_handle_map_sync;
     EventHandleMapT  m_event_handle_map;
   };

--- a/ecal/core/src/readwrite/shm/ecal_writer_shm.cpp
+++ b/ecal/core/src/readwrite/shm/ecal_writer_shm.cpp
@@ -97,7 +97,7 @@ namespace eCAL
 
     for (auto& memory_file : m_memory_file_vec)
     {
-      memory_file->Connect(std::to_string(process_id_));
+      memory_file->Connect(process_id_);
 #ifndef NDEBUG
       Logging::Log(Logging::log_level_debug1, std::string("CDataWriterSHM::ApplySubscription - Memory FileName: ") + memory_file->GetName() + " to ProcessId " + std::to_string(process_id_));
 #endif
@@ -142,7 +142,7 @@ namespace eCAL
     // If the removed subscription was the last one, we need to temporarily disconnect the process
     for (auto& memory_file : m_memory_file_vec)
     {
-      memory_file->Disconnect(std::to_string(process_id_));
+      memory_file->Disconnect(process_id_);
 #ifndef NDEBUG
       Logging::Log(Logging::log_level_debug1, std::string("CDataWriterSHM::RemoveSubscription - Memory FileName: ") + memory_file->GetName() + " to ProcessId " + std::to_string(process_id_));
 #endif


### PR DESCRIPTION
… a string here doesn't actually make any sense).

### Description
Changes the underlying type for handling the connected processes in ecal_memfile_sync.
They are ints everywhere else, there is no reason that they are strings in that class.

Feel free to merge!