### PR TITLE
[core] CDataWriterBase as template class

### DIFF
--- a/ecal/core/src/pubsub/ecal_publisher_impl.cpp
+++ b/ecal/core/src/pubsub/ecal_publisher_impl.cpp
@@ -598,7 +598,7 @@ namespace eCAL
       udp_tlayer.version = ecal_transport_layer_version;
       udp_tlayer.enabled = m_layers.udp.write_enabled;
       udp_tlayer.active = m_layers.udp.active;
-      udp_tlayer.par_layer.layer_par_udpmc = m_writer_udp->GetConnectionParameter().layer_par_udpmc;
+      udp_tlayer.par_layer.layer_par_udpmc = m_writer_udp->GetConnectionParameter();
       ecal_reg_sample_topic.transport_layer.push_back(udp_tlayer);
     }
 #endif
@@ -612,7 +612,7 @@ namespace eCAL
       shm_tlayer.version = ecal_transport_layer_version;
       shm_tlayer.enabled = m_layers.shm.write_enabled;
       shm_tlayer.active = m_layers.shm.active;
-      shm_tlayer.par_layer.layer_par_shm = m_writer_shm->GetConnectionParameter().layer_par_shm;
+      shm_tlayer.par_layer.layer_par_shm = m_writer_shm->GetConnectionParameter();
       ecal_reg_sample_topic.transport_layer.push_back(shm_tlayer);
     }
 #endif
@@ -626,7 +626,7 @@ namespace eCAL
       tcp_tlayer.version = ecal_transport_layer_version;
       tcp_tlayer.enabled = m_layers.tcp.write_enabled;
       tcp_tlayer.active = m_layers.tcp.active;
-      tcp_tlayer.par_layer.layer_par_tcp = m_writer_tcp->GetConnectionParameter().layer_par_tcp;
+      tcp_tlayer.par_layer.layer_par_tcp = m_writer_tcp->GetConnectionParameter();
       ecal_reg_sample_topic.transport_layer.push_back(tcp_tlayer);
     }
 #endif

--- a/ecal/core/src/readwrite/ecal_writer_base.h
+++ b/ecal/core/src/readwrite/ecal_writer_base.h
@@ -35,6 +35,7 @@
 
 namespace eCAL
 {
+  template <typename ConnectionParameter>
   class CDataWriterBase
   {
   public:
@@ -45,7 +46,7 @@ namespace eCAL
     virtual void ApplySubscription(const std::string& /*host_name_*/, const int32_t /*process_id_*/, const EntityIdT& /*topic_id_*/, const std::string& /*conn_par_*/) {};
     virtual void RemoveSubscription(const std::string& /*host_name_*/, const int32_t /*process_id_*/, const EntityIdT& /*topic_id_*/) {};
 
-    virtual Registration::ConnectionPar GetConnectionParameter() { return {}; };
+    virtual ConnectionParameter GetConnectionParameter() { return {}; };
 
     virtual bool PrepareWrite(const SWriterAttr& /*attr_*/) { return false; };
     virtual bool Write(CPayloadWriter& /*payload_*/, const SWriterAttr& /*attr_*/) { return false; };

--- a/ecal/core/src/readwrite/shm/ecal_writer_shm.cpp
+++ b/ecal/core/src/readwrite/shm/ecal_writer_shm.cpp
@@ -149,14 +149,14 @@ namespace eCAL
     }
   }
 
-  Registration::ConnectionPar CDataWriterSHM::GetConnectionParameter()
+  Registration::LayerParShm CDataWriterSHM::GetConnectionParameter()
   {
-    Registration::ConnectionPar connection_par;
+    Registration::LayerParShm layer_par_shm;
     for (auto& memory_file : m_memory_file_vec)
     {
-      connection_par.layer_par_shm.memory_file_list.push_back(memory_file->GetName());
+      layer_par_shm.memory_file_list.push_back(memory_file->GetName());
     }
-    return connection_par;
+    return layer_par_shm;
   }
 
   bool CDataWriterSHM::SetBufferCount(size_t buffer_count_)

--- a/ecal/core/src/readwrite/shm/ecal_writer_shm.h
+++ b/ecal/core/src/readwrite/shm/ecal_writer_shm.h
@@ -38,7 +38,7 @@
 
 namespace eCAL
 {
-  class CDataWriterSHM : public CDataWriterBase
+  class CDataWriterSHM : public CDataWriterBase<Registration::LayerParShm>
   {
   public:
     CDataWriterSHM(const eCALWriter::SHM::SAttributes& attr_);
@@ -52,7 +52,7 @@ namespace eCAL
     void ApplySubscription(const std::string& host_name_, int32_t process_id_, const EntityIdT& topic_id_, const std::string& conn_par_) override;
     void RemoveSubscription(const std::string& host_name_, int32_t process_id_, const EntityIdT& topic_id_) override;
 
-    Registration::ConnectionPar GetConnectionParameter() override;
+    Registration::LayerParShm GetConnectionParameter() override;
 
   protected:
     bool SetBufferCount(size_t buffer_count_);

--- a/ecal/core/src/readwrite/tcp/ecal_writer_tcp.cpp
+++ b/ecal/core/src/readwrite/tcp/ecal_writer_tcp.cpp
@@ -147,10 +147,10 @@ namespace eCAL
     return success;
   }
 
-  Registration::ConnectionPar CDataWriterTCP::GetConnectionParameter()
+  Registration::LayerParTcp CDataWriterTCP::GetConnectionParameter()
   {
-    Registration::ConnectionPar connection_par;
-    connection_par.layer_par_tcp.port = m_port;
+    Registration::LayerParTcp connection_par;
+    connection_par.port = m_port;
     return connection_par;
   }
 }

--- a/ecal/core/src/readwrite/tcp/ecal_writer_tcp.h
+++ b/ecal/core/src/readwrite/tcp/ecal_writer_tcp.h
@@ -37,7 +37,7 @@
 namespace eCAL
 {
   // ecal tcp writer
-  class CDataWriterTCP : public CDataWriterBase
+  class CDataWriterTCP : public CDataWriterBase<Registration::LayerParTcp>
   {
   public:
     CDataWriterTCP(const eCAL::eCALWriter::TCP::SAttributes& attr_);
@@ -46,7 +46,7 @@ namespace eCAL
 
     bool Write(const void* buf_, const SWriterAttr& attr_) override;
 
-    Registration::ConnectionPar GetConnectionParameter() override;
+    Registration::LayerParTcp GetConnectionParameter() override;
 
   private:
     eCAL::eCALWriter::TCP::SAttributes           m_attributes;

--- a/ecal/core/src/readwrite/udp/ecal_writer_udp.h
+++ b/ecal/core/src/readwrite/udp/ecal_writer_udp.h
@@ -33,7 +33,7 @@
 
 namespace eCAL
 {
-  class CDataWriterUdpMC : public CDataWriterBase
+  class CDataWriterUdpMC : public CDataWriterBase<Registration::LayerParUdpMC>
   {
   public:
     CDataWriterUdpMC(const eCALWriter::UDP::SAttributes& attr_);


### PR DESCRIPTION
## Use layer-specific connection parameters in data writers

### Summary

This PR refactors `CDataWriterBase` to be templated on the connection parameter type, allowing each transport writer to return its layer-specific registration data directly.

### Changes

* `CDataWriterBase` is now a template with an explicit connection parameter type.
* UDP, TCP, and SHM writers return their respective layer parameter structures instead of `Registration::ConnectionPar`.
* Publisher registration logic was simplified to consume layer parameters directly.

### Benefits

* Improved type safety and clearer writer interfaces
* Reduced indirection and structural overhead
* Cleaner, more maintainable registration code

### Compatibility

* Internal refactor only; no external API changes.

---
