### PR TITLE
[Core / Config] Expose Destructor / Copy / Move

### DIFF
--- a/ecal/core/include/ecal/config/configuration.h
+++ b/ecal/core/include/ecal/config/configuration.h
@@ -65,6 +65,13 @@ namespace eCAL
 
     ECAL_API Configuration();
 
+    ECAL_API ~Configuration();
+
+    ECAL_API Configuration(const Configuration&);
+    ECAL_API Configuration(Configuration&&) noexcept;
+    ECAL_API Configuration& operator=(const Configuration&);
+    ECAL_API Configuration& operator=(Configuration&&) noexcept;
+
     ECAL_API void InitFromConfig();
     ECAL_API void InitFromFile(const std::string& yaml_path_);
 

--- a/ecal/core/src/config/configuration.cpp
+++ b/ecal/core/src/config/configuration.cpp
@@ -74,7 +74,13 @@ namespace eCAL
       InitFromFile(g_default_ini_file);
     }
 
-    Configuration::Configuration() = default;
+    Configuration::Configuration()  = default;
+    Configuration::~Configuration() = default;
+    
+    Configuration::Configuration(const Configuration&) = default;
+    Configuration::Configuration(Configuration&&) noexcept = default;
+    Configuration& Configuration::operator=(const Configuration&) = default;
+    Configuration& Configuration::operator=(Configuration&&) noexcept = default;
 
     const std::string& Configuration::GetConfigurationFilePath() const
     {


### PR DESCRIPTION
Explicitly declared and exported Destructor / Copy / Move  in the header file and moved the default implementation to the cpp file

It is usually advised to explicitly implement Destructor / Copy / Move for library APIs, as re-generating those functions implicitly by the consuming compiler can lead to ABI issues.