### PR TITLE
[protozero] Fix missing header for Ubuntu 20 compilation.

### DIFF
--- a/ecal/protoc_gen_pbftags/main.cpp
+++ b/ecal/protoc_gen_pbftags/main.cpp
@@ -20,6 +20,7 @@
 #include <google/protobuf/compiler/code_generator.h>
 #include <google/protobuf/compiler/plugin.h>
 #include <google/protobuf/io/printer.h>
+#include <google/protobuf/io/zero_copy_stream.h>
 #include <google/protobuf/stubs/common.h>
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/descriptor.pb.h>


### PR DESCRIPTION
### Description
Added missing header in the pbftags in order to be able to build on ubuntu 20.
