### PR TITLE
Fix build failure when ECAL_USE_HDF5 is OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -415,9 +415,8 @@ endif()
 if(ECAL_USE_HDF5)
   add_subdirectory(contrib/measurement/hdf5)
   add_subdirectory(contrib/ecalhdf5)
+  add_subdirectory(contrib/measurement/base)
 endif()
-add_subdirectory(contrib/measurement/base)
-
 
 # --------------------------------------------------------
 # ecal core python binding

--- a/serialization/capnproto/CMakeLists.txt
+++ b/serialization/capnproto/CMakeLists.txt
@@ -35,7 +35,9 @@ if(ECAL_CAPNPROTO_BUILD_SAMPLES)
   add_subdirectory(samples/pubsub/addressbook_receive)
   add_subdirectory(samples/pubsub/addressbook_receive_dynamic)
   add_subdirectory(samples/pubsub/addressbook_send)
-  add_subdirectory(samples/measurement)
+  if(ECAL_USE_HDF5)
+    add_subdirectory(samples/measurement)
+  endif()
 endif()
 
 # --------------------------------------------------------

--- a/serialization/capnproto/capnproto/CMakeLists.txt
+++ b/serialization/capnproto/capnproto/CMakeLists.txt
@@ -85,31 +85,33 @@ install(
 ##########################
 # Capnproto measurement extension
 ##########################
-add_library(capnproto_measurement INTERFACE)
-add_library(eCAL::capnproto_measurement ALIAS capnproto_measurement)
+if(ECAL_USE_HDF5)
+  add_library(capnproto_measurement INTERFACE)
+  add_library(eCAL::capnproto_measurement ALIAS capnproto_measurement)
 
-target_link_libraries(capnproto_measurement 
-  INTERFACE 
-    eCAL::capnproto_base
-    eCAL::message_measurement
-)
+  target_link_libraries(capnproto_measurement 
+    INTERFACE 
+      eCAL::capnproto_base
+      eCAL::message_measurement
+  )
 
-target_sources(capnproto_measurement
-  INTERFACE
-    FILE_SET capnproto_measurement_headers
-    TYPE HEADERS
-    BASE_DIRS include
-    FILES
-      include/ecal/msg/capnproto/imeasurement.h
-      include/ecal/msg/capnproto/omeasurement.h
-)
+  target_sources(capnproto_measurement
+    INTERFACE
+      FILE_SET capnproto_measurement_headers
+      TYPE HEADERS
+      BASE_DIRS include
+      FILES
+        include/ecal/msg/capnproto/imeasurement.h
+        include/ecal/msg/capnproto/omeasurement.h
+  )
 
-target_compile_features(capnproto_measurement INTERFACE cxx_std_14)
+  target_compile_features(capnproto_measurement INTERFACE cxx_std_14)
 
-install(
-  TARGETS capnproto_measurement
-  EXPORT eCALCoreTargets  
-  ARCHIVE       DESTINATION "${eCAL_install_archive_dir}" COMPONENT sdk
-  LIBRARY       DESTINATION "${eCAL_install_lib_dir}"     COMPONENT sdk
-  FILE_SET capnproto_measurement_headers COMPONENT sdk
-)
+  install(
+    TARGETS capnproto_measurement
+    EXPORT eCALCoreTargets  
+    ARCHIVE       DESTINATION "${eCAL_install_archive_dir}" COMPONENT sdk
+    LIBRARY       DESTINATION "${eCAL_install_lib_dir}"     COMPONENT sdk
+    FILE_SET capnproto_measurement_headers COMPONENT sdk
+  )
+endif()

--- a/serialization/common/common/CMakeLists.txt
+++ b/serialization/common/common/CMakeLists.txt
@@ -71,31 +71,32 @@ install(
 #######################################
 # eCAL measurement message extensions #
 #######################################
-add_library(message_measurement INTERFACE)
-add_library(eCAL::message_measurement ALIAS message_measurement)
+if(ECAL_USE_HDF5)
+  add_library(message_measurement INTERFACE)
+  add_library(eCAL::message_measurement ALIAS message_measurement)
 
-target_link_libraries(message_measurement 
-  INTERFACE 
-    eCAL::measurement
-)
+  target_link_libraries(message_measurement 
+    INTERFACE 
+      eCAL::measurement
+  )
 
-target_sources(message_measurement
-  INTERFACE
-    FILE_SET message_measurement_headers
-    TYPE HEADERS
-    BASE_DIRS include
-    FILES
-      include/ecal/msg/imeasurement.h
-      include/ecal/msg/omeasurement.h
-)
+  target_sources(message_measurement
+    INTERFACE
+      FILE_SET message_measurement_headers
+      TYPE HEADERS
+      BASE_DIRS include
+      FILES
+        include/ecal/msg/imeasurement.h
+        include/ecal/msg/omeasurement.h
+  )
 
-target_compile_features(message_measurement INTERFACE cxx_std_14)
+  target_compile_features(message_measurement INTERFACE cxx_std_14)
 
-install(
-  TARGETS message_measurement
-  EXPORT eCALCoreTargets  
-  ARCHIVE       DESTINATION "${eCAL_install_archive_dir}" COMPONENT sdk
-  LIBRARY       DESTINATION "${eCAL_install_lib_dir}"     COMPONENT sdk
-  FILE_SET message_measurement_headers COMPONENT sdk
-)
-
+  install(
+    TARGETS message_measurement
+    EXPORT eCALCoreTargets  
+    ARCHIVE       DESTINATION "${eCAL_install_archive_dir}" COMPONENT sdk
+    LIBRARY       DESTINATION "${eCAL_install_lib_dir}"     COMPONENT sdk
+    FILE_SET message_measurement_headers COMPONENT sdk
+  )
+endif()

--- a/serialization/flatbuffers/CMakeLists.txt
+++ b/serialization/flatbuffers/CMakeLists.txt
@@ -34,7 +34,9 @@ add_subdirectory(flatbuffers)
 if(ECAL_FLATBUFFERS_BUILD_SAMPLES)
   add_subdirectory(samples/pubsub/monster_receive)
   add_subdirectory(samples/pubsub/monster_send)
-  add_subdirectory(samples/measurement)
+  if(ECAL_USE_HDF5)
+    add_subdirectory(samples/measurement)
+  endif()
 endif()
 
 # --------------------------------------------------------

--- a/serialization/flatbuffers/flatbuffers/CMakeLists.txt
+++ b/serialization/flatbuffers/flatbuffers/CMakeLists.txt
@@ -83,31 +83,33 @@ install(
 ##########################
 # flatbuffers measurement extension
 ##########################
-add_library(flatbuffers_measurement INTERFACE)
-add_library(eCAL::flatbuffers_measurement ALIAS flatbuffers_measurement)
+if(ECAL_USE_HDF5)
+  add_library(flatbuffers_measurement INTERFACE)
+  add_library(eCAL::flatbuffers_measurement ALIAS flatbuffers_measurement)
 
-target_link_libraries(flatbuffers_measurement 
-  INTERFACE 
-    eCAL::flatbuffers_base
-    eCAL::message_measurement
-)
+  target_link_libraries(flatbuffers_measurement 
+    INTERFACE 
+      eCAL::flatbuffers_base
+      eCAL::message_measurement
+  )
 
-target_sources(flatbuffers_measurement
-  INTERFACE
-    FILE_SET flatbuffers_measurement_headers
-    TYPE HEADERS
-    BASE_DIRS include
-    FILES
-      include/ecal/msg/flatbuffers/imeasurement.h
-      include/ecal/msg/flatbuffers/omeasurement.h
-)
+  target_sources(flatbuffers_measurement
+    INTERFACE
+      FILE_SET flatbuffers_measurement_headers
+      TYPE HEADERS
+      BASE_DIRS include
+      FILES
+        include/ecal/msg/flatbuffers/imeasurement.h
+        include/ecal/msg/flatbuffers/omeasurement.h
+  )
 
-target_compile_features(flatbuffers_measurement INTERFACE cxx_std_14)
+  target_compile_features(flatbuffers_measurement INTERFACE cxx_std_14)
 
-install(
-  TARGETS flatbuffers_measurement
-  EXPORT eCALCoreTargets  
-  ARCHIVE       DESTINATION "${eCAL_install_archive_dir}" COMPONENT sdk
-  LIBRARY       DESTINATION "${eCAL_install_lib_dir}"     COMPONENT sdk
-  FILE_SET flatbuffers_measurement_headers COMPONENT sdk
-)
+  install(
+    TARGETS flatbuffers_measurement
+    EXPORT eCALCoreTargets  
+    ARCHIVE       DESTINATION "${eCAL_install_archive_dir}" COMPONENT sdk
+    LIBRARY       DESTINATION "${eCAL_install_lib_dir}"     COMPONENT sdk
+    FILE_SET flatbuffers_measurement_headers COMPONENT sdk
+  )
+endif()

--- a/serialization/protobuf/CMakeLists.txt
+++ b/serialization/protobuf/CMakeLists.txt
@@ -44,7 +44,9 @@ if(ECAL_PROTOBUF_BUILD_SAMPLES)
   add_subdirectory(samples/services/ping_client)
   add_subdirectory(samples/services/ping_client_dyn)
   add_subdirectory(samples/services/ping_server)
-  add_subdirectory(samples/measurement)
+  if(ECAL_USE_HDF5)
+    add_subdirectory(samples/measurement)
+  endif()
 endif()
 
 # --------------------------------------------------------

--- a/serialization/protobuf/protobuf/CMakeLists.txt
+++ b/serialization/protobuf/protobuf/CMakeLists.txt
@@ -111,31 +111,33 @@ install(
 ##########################
 # Protobuf measurement extension
 ##########################
-add_library(protobuf_measurement INTERFACE)
-add_library(eCAL::protobuf_measurement ALIAS protobuf_measurement)
+if(ECAL_USE_HDF5)
+  add_library(protobuf_measurement INTERFACE)
+  add_library(eCAL::protobuf_measurement ALIAS protobuf_measurement)
 
-target_link_libraries(protobuf_measurement 
-  INTERFACE 
-    eCAL::protobuf_base
-    eCAL::message_measurement
-)
+  target_link_libraries(protobuf_measurement 
+    INTERFACE 
+      eCAL::protobuf_base
+      eCAL::message_measurement
+  )
 
-target_sources(protobuf_measurement
-  INTERFACE
-    FILE_SET proto_measurement_headers
-    TYPE HEADERS
-    BASE_DIRS include
-    FILES
-      include/ecal/msg/protobuf/imeasurement.h
-      include/ecal/msg/protobuf/omeasurement.h
-)
+  target_sources(protobuf_measurement
+    INTERFACE
+      FILE_SET proto_measurement_headers
+      TYPE HEADERS
+      BASE_DIRS include
+      FILES
+        include/ecal/msg/protobuf/imeasurement.h
+        include/ecal/msg/protobuf/omeasurement.h
+  )
 
-target_compile_features(protobuf_measurement INTERFACE cxx_std_14)
+  target_compile_features(protobuf_measurement INTERFACE cxx_std_14)
 
-install(
-  TARGETS protobuf_measurement
-  EXPORT eCALCoreTargets  
-  ARCHIVE       DESTINATION "${eCAL_install_archive_dir}" COMPONENT sdk
-  LIBRARY       DESTINATION "${eCAL_install_lib_dir}"     COMPONENT sdk
-  FILE_SET proto_measurement_headers COMPONENT sdk
-)
+  install(
+    TARGETS protobuf_measurement
+    EXPORT eCALCoreTargets  
+    ARCHIVE       DESTINATION "${eCAL_install_archive_dir}" COMPONENT sdk
+    LIBRARY       DESTINATION "${eCAL_install_lib_dir}"     COMPONENT sdk
+    FILE_SET proto_measurement_headers COMPONENT sdk
+  )
+endif()

--- a/serialization/string/CMakeLists.txt
+++ b/serialization/string/CMakeLists.txt
@@ -34,7 +34,9 @@ add_subdirectory(string)
 if(ECAL_STRING_BUILD_SAMPLES)
   add_subdirectory(samples/pubsub/hello_receive)
   add_subdirectory(samples/pubsub/hello_send)
-  add_subdirectory(samples/measurement)
+  if(ECAL_USE_HDF5)
+    add_subdirectory(samples/measurement)
+  endif()
 endif()
 
 # --------------------------------------------------------

--- a/serialization/string/string/CMakeLists.txt
+++ b/serialization/string/string/CMakeLists.txt
@@ -77,31 +77,33 @@ install(
 ##########################
 # std::string measurement extension
 ##########################
-add_library(string_measurement INTERFACE)
-add_library(eCAL::string_measurement ALIAS string_measurement)
+if(ECAL_USE_HDF5)
+  add_library(string_measurement INTERFACE)
+  add_library(eCAL::string_measurement ALIAS string_measurement)
 
-target_link_libraries(string_measurement 
-  INTERFACE 
-    eCAL::string_base
-    eCAL::message_measurement
-)
+  target_link_libraries(string_measurement 
+    INTERFACE 
+      eCAL::string_base
+      eCAL::message_measurement
+  )
 
-target_sources(string_measurement
-  INTERFACE
-    FILE_SET string_measurement_headers
-    TYPE HEADERS
-    BASE_DIRS include
-    FILES
-      include/ecal/msg/string/imeasurement.h
-      include/ecal/msg/string/omeasurement.h
-)
+  target_sources(string_measurement
+    INTERFACE
+      FILE_SET string_measurement_headers
+      TYPE HEADERS
+      BASE_DIRS include
+      FILES
+        include/ecal/msg/string/imeasurement.h
+        include/ecal/msg/string/omeasurement.h
+  )
 
-target_compile_features(string_measurement INTERFACE cxx_std_14)
+  target_compile_features(string_measurement INTERFACE cxx_std_14)
 
-install(
-  TARGETS string_measurement
-  EXPORT eCALCoreTargets  
-  ARCHIVE       DESTINATION "${eCAL_install_archive_dir}" COMPONENT sdk
-  LIBRARY       DESTINATION "${eCAL_install_lib_dir}"     COMPONENT sdk
-  FILE_SET string_measurement_headers COMPONENT sdk
-)
+  install(
+    TARGETS string_measurement
+    EXPORT eCALCoreTargets  
+    ARCHIVE       DESTINATION "${eCAL_install_archive_dir}" COMPONENT sdk
+    LIBRARY       DESTINATION "${eCAL_install_lib_dir}"     COMPONENT sdk
+    FILE_SET string_measurement_headers COMPONENT sdk
+  )
+endif()


### PR DESCRIPTION
### Description
Currently, the build fails when `ECAL_USE_HDF5` is set to OFF because the measurement target is strictly coupled with hdf5.

This commit modifies the CMake configuration to:
- Move 'contrib/measurement/base' inclusion inside the `ECAL_USE_HDF5` guard.
- Guard `message_measurement` target definition with `ECAL_USE_HDF5`.
- Guard measurement extensions of serializers with `ECAL_USE_HDF5`.

### Related issues
Fixes #2443
