### PR TITLE
Add configurable SHM registration receive poll intervall

### DIFF
--- a/ecal/core/include/ecal/config/registration.h
+++ b/ecal/core/include/ecal/config/registration.h
@@ -44,8 +44,9 @@ namespace eCAL
       {
         struct Configuration
         {
-          std::string domain     { "ecal_mon" };          //!< Domain name for shared memory based registration (Default: ecal_mon)
-          size_t      queue_size { 1024 };                //!< Queue size of registration events (Default: 1024)
+          std::string  domain           { "ecal_mon" };          //!< Domain name for shared memory based registration (Default: ecal_mon)
+          size_t       queue_size       { 1024 };                //!< Queue size of registration events (Default: 1024)
+          unsigned int receive_poll_ms  { 15U };                 //!< Polling period in ms for receiving shared memory registration events (Default: 15)
         };
       }
 

--- a/ecal/core/src/config/builder/registration_attribute_builder.cpp
+++ b/ecal/core/src/config/builder/registration_attribute_builder.cpp
@@ -41,6 +41,7 @@ namespace eCAL
 
     attr.shm.domain        = reg_config.local.shm.domain;
     attr.shm.queue_size    = reg_config.local.shm.queue_size;
+    attr.shm.receive_poll_ms = reg_config.local.shm.receive_poll_ms;
      
     switch (config_.communication_mode)
     {

--- a/ecal/core/src/config/configuration_to_yaml.cpp
+++ b/ecal/core/src/config/configuration_to_yaml.cpp
@@ -122,8 +122,9 @@ namespace YAML
   Node convert<eCAL::Registration::Local::SHM::Configuration>::encode(const eCAL::Registration::Local::SHM::Configuration& config_)
   {
     Node node;
-    node["domain"]     = config_.domain;
-    node["queue_size"] = config_.queue_size;
+    node["domain"]          = config_.domain;
+    node["queue_size"]      = config_.queue_size;
+    node["receive_poll_ms"] = config_.receive_poll_ms;
     return node;
   }
 
@@ -131,6 +132,7 @@ namespace YAML
   {
     AssignValue<std::string>(config_.domain, node_, "domain");
     AssignValue<size_t>(config_.queue_size, node_, "queue_size");
+    AssignValue<unsigned int>(config_.receive_poll_ms, node_, "receive_poll_ms");
     return true;
   }
   

--- a/ecal/core/src/config/default_configuration.cpp
+++ b/ecal/core/src/config/default_configuration.cpp
@@ -191,6 +191,8 @@ namespace eCAL
       ss << R"(      domain:  )"                                     << quoteString(config_.registration.local.shm.domain)          << "\n";
       ss << R"(      # Queue size of registration events)"                                                                          << "\n";
       ss << R"(      queue_size: )"                                  << config_.registration.local.shm.queue_size                   << "\n";
+      ss << R"(      # Polling period in milliseconds for SHM registration receive loop)"                                          << "\n";
+      ss << R"(      receive_poll_ms: )"                             << config_.registration.local.shm.receive_poll_ms              << "\n";
       ss << R"(    udp:)"                                                                                                           << "\n";
       ss << R"(      # Specify port for local registration traffic)"                                                                << "\n";
       ss << R"(      port: )"                                        << config_.registration.local.udp.port                         << "\n";

--- a/ecal/core/src/registration/config/attributes/registration_attributes.h
+++ b/ecal/core/src/registration/config/attributes/registration_attributes.h
@@ -48,6 +48,7 @@ namespace eCAL
     {
       std::string    domain;
       size_t         queue_size;
+      unsigned int   receive_poll_ms;
     };
 
     struct SAttributes

--- a/ecal/core/src/registration/config/builder/udp_shm_attribute_builder.cpp
+++ b/ecal/core/src/registration/config/builder/udp_shm_attribute_builder.cpp
@@ -57,6 +57,7 @@ namespace eCAL
 
       sender_attr.domain     = provider_attr_.shm.domain;
       sender_attr.queue_size = provider_attr_.shm.queue_size;
+      sender_attr.receive_poll_ms = provider_attr_.shm.receive_poll_ms;
 
       return sender_attr;
     }

--- a/ecal/core/src/registration/shm/config/attributes/registration_shm_attributes.h
+++ b/ecal/core/src/registration/shm/config/attributes/registration_shm_attributes.h
@@ -29,8 +29,9 @@ namespace eCAL
     {
       struct SAttributes
       {
-        std::string  domain;
-        size_t       queue_size;
+        std::string   domain;
+        size_t        queue_size;
+        unsigned int  receive_poll_ms;
       };
     }
   }

--- a/ecal/core/src/registration/shm/ecal_registration_receiver_shm.cpp
+++ b/ecal/core/src/registration/shm/ecal_registration_receiver_shm.cpp
@@ -53,7 +53,7 @@ namespace eCAL
     m_memfile_broadcast_reader->Bind(m_memfile_broadcast.get());
 
     m_memfile_broadcast_reader_thread = std::make_unique<CCallbackThread>(std::bind(&CRegistrationReceiverSHM::Receive, this));
-    m_memfile_broadcast_reader_thread->start(std::chrono::milliseconds(Config::GetRegistrationRefreshMs() / 2));
+    m_memfile_broadcast_reader_thread->start(std::chrono::milliseconds(attr_.receive_poll_ms));
   }
 
   CRegistrationReceiverSHM::~CRegistrationReceiverSHM()

--- a/ecal/tests/cpp/config_test/src/yaml_processing_test.cpp
+++ b/ecal/tests/cpp/config_test/src/yaml_processing_test.cpp
@@ -48,6 +48,7 @@ TEST(core_cpp_config_yaml /*unused*/, yaml_processing_comparison /*unused*/)
     config.registration.local.transport_type = eCAL::Registration::Local::eTransportType::shm;
     config.registration.local.shm.domain = "ecal_don";
     config.registration.local.shm.queue_size = 2048;
+    config.registration.local.shm.receive_poll_ms = 12;
     config.registration.local.udp.port = 15000;
     // There is unfortunately only one transport type
     config.registration.network.transport_type = eCAL::Registration::Network::eTransportType::udp;
@@ -113,6 +114,7 @@ TEST(core_cpp_config_yaml /*unused*/, yaml_processing_comparison /*unused*/)
     EXPECT_EQ(config.registration.local.transport_type, config_from_yaml.registration.local.transport_type);
     EXPECT_EQ(config.registration.local.shm.domain, config_from_yaml.registration.local.shm.domain);
     EXPECT_EQ(config.registration.local.shm.queue_size, config_from_yaml.registration.local.shm.queue_size);
+    EXPECT_EQ(config.registration.local.shm.receive_poll_ms, config_from_yaml.registration.local.shm.receive_poll_ms);
     EXPECT_EQ(config.registration.local.udp.port, config_from_yaml.registration.local.udp.port);
     EXPECT_EQ(config.registration.network.transport_type, config_from_yaml.registration.network.transport_type);
     EXPECT_EQ(config.registration.network.udp.port, config_from_yaml.registration.network.udp.port);

--- a/lang/c/core/include/ecal_c/config/registration.h
+++ b/lang/c/core/include/ecal_c/config/registration.h
@@ -37,6 +37,7 @@ struct eCAL_Registration_Local_SHM_Configuration
 {
   const char* domain; //!< Domain name for shared memory based registration (Default: ecal_mon)
   size_t queue_size; //!< Queue size of registration events (Default: 1024)
+  unsigned int receive_poll_ms; //!< Polling period in ms for receiving shared memory registration events (Default: 15)
 };
 
 struct eCAL_Registration_Local_UDP_Configuration

--- a/lang/c/core/src/configuration.cpp
+++ b/lang/c/core/src/configuration.cpp
@@ -184,6 +184,7 @@ void Assign_Registration_Configuration(struct eCAL_Registration_Configuration* c
 
   configuration_c_->local.shm.domain = configuration_.local.shm.domain.c_str();
   configuration_c_->local.shm.queue_size = configuration_.local.shm.queue_size;
+  configuration_c_->local.shm.receive_poll_ms = configuration_.local.shm.receive_poll_ms;
 
   configuration_c_->local.udp.port = configuration_.local.udp.port;
 
@@ -409,6 +410,7 @@ void Assign_Registration_Configuration(eCAL::Registration::Configuration& config
   configuration_.local.transport_type = Convert_Registration_Local_eTransportType(configuration_c_->local.transport_type);
   configuration_.local.shm.domain = configuration_c_->local.shm.domain != NULL ? configuration_c_->local.shm.domain : "";
   configuration_.local.shm.queue_size = configuration_c_->local.shm.queue_size;
+  configuration_.local.shm.receive_poll_ms = configuration_c_->local.shm.receive_poll_ms;
   configuration_.local.udp.port = configuration_c_->local.udp.port;
 
   // Assign Network::Configuration

--- a/lang/c/tests/config_test/src/config_test.cpp
+++ b/lang/c/tests/config_test/src/config_test.cpp
@@ -63,6 +63,7 @@ TEST_F(config_test_c, Registration)
     EXPECT_STREQ(configuration0->registration.shm_transport_domain, eCAL_GetConfiguration()->registration.shm_transport_domain);
     EXPECT_EQ(configuration0->registration.local.shm.queue_size, eCAL_Config_GetShmMonitoringQueueSize());
     EXPECT_EQ(configuration0->registration.local.shm.queue_size, eCAL_GetConfiguration()->registration.local.shm.queue_size);
+    EXPECT_EQ(configuration0->registration.local.shm.receive_poll_ms, eCAL_GetConfiguration()->registration.local.shm.receive_poll_ms);
     EXPECT_STREQ(configuration0->registration.local.shm.domain, eCAL_Config_GetShmMonitoringDomain());
     EXPECT_STREQ(configuration0->registration.local.shm.domain, eCAL_GetConfiguration()->registration.local.shm.domain);
 

--- a/lang/csharp/Eclipse.eCAL.Core.Test/ConfigTest.cs
+++ b/lang/csharp/Eclipse.eCAL.Core.Test/ConfigTest.cs
@@ -53,6 +53,7 @@ public class ConfigTest
     config.Registration.Local.TransportType = 0; // eCAL::Registration::Local::eTransportType::shm
     config.Registration.Local.SHM.Domain = "ecal_don";
     config.Registration.Local.SHM.QueueSize = 2048;
+    config.Registration.Local.SHM.ReceivePollMs = 12;
     config.Registration.Local.UDP.Port = 15000;
     config.Registration.Network.TransportType = 0; // eCAL::Registration::Network::eTransportType::udp
     config.Registration.Network.UDP.Port = 16000;
@@ -128,6 +129,7 @@ public class ConfigTest
     Assert.AreEqual(config.Registration.Local.TransportType, ecalConfig.Registration.Local.TransportType, "Local.TransportType mismatch");
     Assert.AreEqual(config.Registration.Local.SHM.Domain, ecalConfig.Registration.Local.SHM.Domain, "Local.SHM.Domain mismatch");
     Assert.AreEqual(config.Registration.Local.SHM.QueueSize, ecalConfig.Registration.Local.SHM.QueueSize, "Local.SHM.QueueSize mismatch");
+    Assert.AreEqual(config.Registration.Local.SHM.ReceivePollMs, ecalConfig.Registration.Local.SHM.ReceivePollMs, "Local.SHM.ReceivePollMs mismatch");
     Assert.AreEqual(config.Registration.Local.UDP.Port, ecalConfig.Registration.Local.UDP.Port, "Local.UDP.Port mismatch");
     Assert.AreEqual(config.Registration.Network.TransportType, ecalConfig.Registration.Network.TransportType, "Network.TransportType mismatch");
     Assert.AreEqual(config.Registration.Network.UDP.Port, ecalConfig.Registration.Network.UDP.Port, "Network.UDP.Port mismatch");

--- a/lang/csharp/Eclipse.eCAL.Core/include/config/clr_registration.h
+++ b/lang/csharp/Eclipse.eCAL.Core/include/config/clr_registration.h
@@ -87,23 +87,27 @@ namespace Eclipse {
         public:
           property System::String^ Domain;
           property size_t QueueSize;
+          property unsigned int ReceivePollMs;
 
           RegistrationLocalSHMConfiguration() {
             ::eCAL::Registration::Local::SHM::Configuration native_config;
             Domain = Internal::StlStringToString(native_config.domain);
             QueueSize = native_config.queue_size;
+            ReceivePollMs = native_config.receive_poll_ms;
           }
 
           // Native struct constructor
           RegistrationLocalSHMConfiguration(const ::eCAL::Registration::Local::SHM::Configuration& native_config) {
             Domain = Internal::StlStringToString(native_config.domain);
             QueueSize = native_config.queue_size;
+            ReceivePollMs = native_config.receive_poll_ms;
           }
 
           ::eCAL::Registration::Local::SHM::Configuration ToNative() {
             ::eCAL::Registration::Local::SHM::Configuration native_config;
             native_config.domain = Internal::StringToStlString(Domain);
             native_config.queue_size = QueueSize;
+            native_config.receive_poll_ms = ReceivePollMs;
             return native_config;
           }
         };

--- a/lang/python/src/nanobind_core/src/core/config/py_registration.cpp
+++ b/lang/python/src/nanobind_core/src/core/config/py_registration.cpp
@@ -40,7 +40,8 @@ void AddConfigRegistration(nanobind::module_& module)
   nb::class_<eCAL::Registration::Local::SHM::Configuration>(module, "LocalSHMConfig")
     .def(nb::init<>())
     .def_rw("domain", &eCAL::Registration::Local::SHM::Configuration::domain)
-    .def_rw("queue_size", &eCAL::Registration::Local::SHM::Configuration::queue_size);
+    .def_rw("queue_size", &eCAL::Registration::Local::SHM::Configuration::queue_size)
+    .def_rw("receive_poll_ms", &eCAL::Registration::Local::SHM::Configuration::receive_poll_ms);
 
   // Local::UDP::Configuration
   nb::class_<eCAL::Registration::Local::UDP::Configuration>(module, "LocalUDPConfig")


### PR DESCRIPTION
Allow to configure SHM registration poll intervall (previously half of registration refresh), to allow faster connection creation.

~~We should discuss if we want to bring this to support/v6.1 although it's strictly speaking not a bugfix.~~
We can't really, since it extens public API through the configuration API.
