### PR TITLE
Feature/fix dl linking error

### DIFF
--- a/ecal/core/CMakeLists.txt
+++ b/ecal/core/CMakeLists.txt
@@ -717,7 +717,7 @@ target_link_libraries(ecal_core_private
     $<$<BOOL:${ECAL_CORE_TRANSPORT_TCP}>:tcp_pubsub::tcp_pubsub>
     $<$<BOOL:${ECAL_CORE_TIMEPLUGIN}>:ecaltime>
     ecaludp::ecaludp
-    $<$<AND:$<BOOL:${UNIX}>,$<NOT:$<BOOL:${QNXNTO}>>>:dl>
+    ${CMAKE_DL_LIBS}
     $<$<AND:$<BOOL:${UNIX}>,$<NOT:$<BOOL:${APPLE}>>,$<NOT:$<BOOL:${QNXNTO}>>>:rt>
     $<$<AND:$<BOOL:${UNIX}>,$<NOT:$<BOOL:${APPLE}>>,$<NOT:$<BOOL:${QNXNTO}>>>:atomic>
     $<$<STREQUAL:${CMAKE_SYSTEM_NAME},FreeBSD>:util>

--- a/ecal/core/cfg/CMakeLists.txt
+++ b/ecal/core/cfg/CMakeLists.txt
@@ -56,7 +56,6 @@ add_dependencies(run_${PROJECT_NAME} ${PROJECT_NAME})
 
 target_link_libraries(${PROJECT_NAME} 
   PRIVATE
-    $<$<AND:$<BOOL:${UNIX}>,$<NOT:$<BOOL:${QNXNTO}>>>:dl>
     ecal_core_private
 )
 

--- a/ecal/tests/cpp/config_test/CMakeLists.txt
+++ b/ecal/tests/cpp/config_test/CMakeLists.txt
@@ -42,7 +42,6 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 
 target_link_libraries(${PROJECT_NAME}
   PRIVATE 
-    $<$<AND:$<BOOL:${UNIX}>,$<NOT:$<BOOL:${QNXNTO}>>>:dl>
     ecal_core_private
     eCAL::ecal-utils
     Threads::Threads

--- a/ecal/tests/cpp/event_test/CMakeLists.txt
+++ b/ecal/tests/cpp/event_test/CMakeLists.txt
@@ -29,7 +29,6 @@ ecal_add_gtest(${PROJECT_NAME} ${event_test_src})
 
 target_link_libraries(${PROJECT_NAME}
   PRIVATE
-    $<$<BOOL:${UNIX}>:dl>
     $<$<AND:$<BOOL:${UNIX}>,$<NOT:$<BOOL:${APPLE}>>>:rt>
     Threads::Threads
     ecal_core_private

--- a/ecal/tests/cpp/io_memfile_test/CMakeLists.txt
+++ b/ecal/tests/cpp/io_memfile_test/CMakeLists.txt
@@ -53,7 +53,6 @@ target_include_directories(${PROJECT_NAME} PRIVATE $<TARGET_PROPERTY:eCAL::core,
 
 target_link_libraries(${PROJECT_NAME} 
   PRIVATE
-    $<$<BOOL:${UNIX}>:dl>
     $<$<AND:$<BOOL:${UNIX}>,$<NOT:$<BOOL:${APPLE}>>>:rt>
     Threads::Threads
     eCAL::ecal-utils

--- a/ecal/tests/cpp/registration_test/CMakeLists.txt
+++ b/ecal/tests/cpp/registration_test/CMakeLists.txt
@@ -29,7 +29,6 @@ ecal_add_gtest(${PROJECT_NAME} ${registration_test_src})
 
 target_link_libraries(${PROJECT_NAME} 
   PRIVATE
-    $<$<BOOL:${UNIX}>:dl>
     $<$<AND:$<BOOL:${UNIX}>,$<NOT:$<BOOL:${APPLE}>>>:rt>
     Threads::Threads
     ecal_core_private

--- a/lib/ecal_utils/CMakeLists.txt
+++ b/lib/ecal_utils/CMakeLists.txt
@@ -55,7 +55,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 )
 
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
-target_link_librarries(${PROJECT_NAME} 
+target_link_libraries(${PROJECT_NAME} 
   PRIVATE  
     ${CMAKE_DL_LIBS}
 )

--- a/lib/ecal_utils/CMakeLists.txt
+++ b/lib/ecal_utils/CMakeLists.txt
@@ -55,6 +55,10 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 )
 
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
+target_link_librarries(${PROJECT_NAME} 
+  PRIVATE  
+    ${CMAKE_DL_LIBS}
+)
 
 # filesystem.cpp uses fts on Linux, some distibutions (i.e: Alpine) have fts as a
 # separate library


### PR DESCRIPTION
Directly let utils link to dl, and use ${CMAKE_DL_LIBS} variable for that usecase.
