### PR TITLE
docs: link ecal-mcp (MCP server exposing eCAL to LLM clients)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ eCAL comes with a set of read-to-use tools that will help you with developing, t
 * [ecal-toolbox](https://github.com/mathworks/ecal-toolbox) - Mathworks simulink toolbox for eCAL
 * [ecal-mongraph](https://github.com/ecal-io/ecal-mongraph) - Simple graph visualization for eCAL
 * [ecal-gpsd-client](https://github.com/eclipse-ecal/ecal-gpsd-client) - eCAL gpsd client
+* [ecal-mcp](https://github.com/zpg6/ecal-mcp) - MCP server for eCAL
 
 ## eCAL & Foxglove
 * [ecal-foxglove-bridge](https://github.com/eclipse-ecal/ecal-foxglove-bridge) - Visualize eCAL messages with Foxglove Studio


### PR DESCRIPTION
`ecal-mcp` is a local MCP server that exposes eCAL to LLM clients (Cursor, Claude Desktop, etc.). It's a single native Rust binary built on [`rustecal`](https://github.com/eclipse-ecal/rustecal) and the official [`rmcp`](https://github.com/modelcontextprotocol/rust-sdk) SDK — **it joins the eCAL network on the host like any other participant. No daemons, no sidecars.**

It exposes the eCAL monitoring/pub-sub/service surface as MCP tools so an LLM agent can:
- diagnose why a topic isn't behaving (`ecal_diagnose_topic` — combines a monitoring snapshot with a live measurement window and emits structured `findings`: missing publisher/subscriber, type-signature mismatch, no shared transport, cross-host SHM-domain split, ongoing drops, unhealthy producer process)
- measure actual on-the-wire rate / payload size / inter-arrival jitter (`ecal_topic_stats`)
- list publishers / subscribers / services / service clients / processes with substring filtering
- drain eCAL log messages with level / time / process filters
- one-shot publish + windowed subscribe + call services on every discovered replica (or a specific one by `server_entity_id`)

Prebuilt Linux x86_64 / aarch64 + Windows x86_64 binaries are released on GitHub with `.sha256` files and one-line install scripts.

Test coverage spans two Docker-based e2e testing "tiers": 30 single-host SHM cases, plus 15 cross-container cases on a 4-host topology in network mode + TCP (cross-host transport negotiation, real protobuf `FileDescriptorSet` round-tripping, multi-publisher / multi-subscriber listing, mixed-role host attribution).

## Ask

I'd love feedback from the eCAL maintainers — both on the link itself and (more importantly) on the tool. If anyone is willing to point it at a real deployment and tell me what's missing or wrong, I'd really appreciate it. Issues / discussion welcome at https://github.com/zpg6/ecal-mcp.

... until then I'll leave this here as a draft :)