### PR TITLE
[rec][bugfix] hdf5 writer threads waits on inverted condition.

### DIFF
--- a/app/rec/rec_client_core/src/job/hdf5_writer_thread.cpp
+++ b/app/rec/rec_client_core/src/job/hdf5_writer_thread.cpp
@@ -164,7 +164,7 @@ namespace eCAL
           std::unique_lock<decltype(input_mutex_)> input_lock(input_mutex_);
 
           // Wait until something is set to an input variable (frame_buffer_, topic info)
-          input_cv_.wait(input_lock, [this]() { return IsInterrupted() || IsFlushing() || !frame_buffer_.empty() || !new_topic_info_map_available_; });
+          input_cv_.wait(input_lock, [this]() { return IsInterrupted() || IsFlushing() || !frame_buffer_.empty() || new_topic_info_map_available_; });
 
           if (IsInterrupted())
             break;


### PR DESCRIPTION
One of the conditions that the hdf5 writer thread waits on for writing data was inverted, so the thread was performing more work than neccessary.
