### PR TITLE
[CMake eCALConfig] only find protobuf if eCAL was configured with protobuf

### DIFF
--- a/cmake/eCALConfig.cmake.in
+++ b/cmake/eCALConfig.cmake.in
@@ -30,12 +30,14 @@ set(eCAL_VERSION_STRING @eCAL_VERSION_STRING@)
 set(CMAKE_MAP_IMPORTED_CONFIG_MINSIZEREL Release "")
 set(CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO Release "")
 
-# Try and find protobuf in Config mode first
-# (Primarily for Windows where we provide protobuf as part of eCAL)
-find_package(Protobuf CONFIG)
-if(NOT Protobuf_FOUND)
-  # Search for Protobuf using Module mode (with no Config mode fallback)
-  find_package(Protobuf MODULE REQUIRED)
+if(@ECAL_USE_PROTOBUF@)
+  # Try and find protobuf in Config mode first
+  # (Primarily for Windows where we provide protobuf as part of eCAL)
+  find_package(Protobuf CONFIG)
+  if(NOT Protobuf_FOUND)
+    # Search for Protobuf using Module mode (with no Config mode fallback)
+    find_package(Protobuf MODULE REQUIRED)
+  endif()
 endif()
 
 include("@PACKAGE_eCAL_install_cmake_dir@/helper_functions/ecal_add_functions.cmake")


### PR DESCRIPTION
Fixes #2636