### PR TITLE
[core] Gate publisher sends by active connection layer

### DIFF
--- a/ecal/core/src/pubsub/ecal_publisher_impl.cpp
+++ b/ecal/core/src/pubsub/ecal_publisher_impl.cpp
@@ -104,6 +104,64 @@ namespace
 
 namespace eCAL
 {
+  void CPublisherImpl::SSendLayerConnectionCounters::Increment(TransportLayer::eType layer_)
+  {
+    switch (layer_)
+    {
+    case TransportLayer::eType::udp_mc:
+      udp.fetch_add(1, std::memory_order_relaxed);
+      break;
+    case TransportLayer::eType::shm:
+      shm.fetch_add(1, std::memory_order_relaxed);
+      break;
+    case TransportLayer::eType::tcp:
+      tcp.fetch_add(1, std::memory_order_relaxed);
+      break;
+    default:
+      break;
+    }
+  }
+
+  void CPublisherImpl::SSendLayerConnectionCounters::Decrement(TransportLayer::eType layer_)
+  {
+    switch (layer_)
+    {
+    case TransportLayer::eType::udp_mc:
+      udp.fetch_sub(1, std::memory_order_relaxed);
+      break;
+    case TransportLayer::eType::shm:
+      shm.fetch_sub(1, std::memory_order_relaxed);
+      break;
+    case TransportLayer::eType::tcp:
+      tcp.fetch_sub(1, std::memory_order_relaxed);
+      break;
+    default:
+      break;
+    }
+  }
+
+  void CPublisherImpl::SSendLayerConnectionCounters::Reset()
+  {
+    udp.store(0, std::memory_order_relaxed);
+    shm.store(0, std::memory_order_relaxed);
+    tcp.store(0, std::memory_order_relaxed);
+  }
+
+  bool CPublisherImpl::SSendLayerConnectionCounters::UdpEnabled() const
+  {
+    return (udp.load(std::memory_order_relaxed) > 0);
+  }
+
+  bool CPublisherImpl::SSendLayerConnectionCounters::ShmEnabled() const
+  {
+    return (shm.load(std::memory_order_relaxed) > 0);
+  }
+
+  bool CPublisherImpl::SSendLayerConnectionCounters::TcpEnabled() const
+  {
+    return (tcp.load(std::memory_order_relaxed) > 0);
+  }
+
   CPublisherImpl::CPublisherImpl(const SDataTypeInformation& topic_info_, const eCAL::eCALWriter::SAttributes& attr_, SPublisherGlobalContext global_context_)
     : m_publisher_id(eCAL::Util::GenerateUniqueEntityId())
     , m_topic_info(topic_info_)
@@ -141,6 +199,7 @@ namespace eCAL
     {
       const std::lock_guard<std::mutex> lock(m_connection_map_mutex);
       m_connection_map.clear();
+      m_connection_count.store(0, std::memory_order_relaxed);
     }
 
     // mark as no more created
@@ -155,9 +214,9 @@ namespace eCAL
     // get payload buffer size (one time, to avoid multiple computations)
     const size_t payload_buf_size(payload_.GetSize());
 
-    const bool udp_send_enabled = m_udp_send_enabled.load(std::memory_order_relaxed);
-    const bool shm_send_enabled = m_shm_send_enabled.load(std::memory_order_relaxed);
-    const bool tcp_send_enabled = m_tcp_send_enabled.load(std::memory_order_relaxed);
+    const bool udp_send_enabled = m_send_layer_connection_counters.UdpEnabled();
+    const bool shm_send_enabled = m_send_layer_connection_counters.ShmEnabled();
+    const bool tcp_send_enabled = m_send_layer_connection_counters.TcpEnabled();
 
     // are we allowed to perform zero copy writing?
     bool allow_zero_copy(false);
@@ -456,21 +515,34 @@ namespace eCAL
       {
         // existing connection, we got the second update now
         auto& connection = subscription_info_iter->second;
+        const bool was_active = connection.state;
 
         // if this connection was inactive before
         // activate it now and flag a new connection finally
-        if (!connection.state)
+        if (!was_active)
         {
           is_new_connection = true;
+          m_connection_count.fetch_add(1, std::memory_order_relaxed);
+          // first active update: selected layer becomes effective for sending
+          connection = SConnection{ data_type_info_, sub_layer_states_, transport_layer_for_subscription, true };
+          m_send_layer_connection_counters.Increment(connection.selected_layer);
         }
+        else
+        {
+          // selected_layer is expected to stay stable for active eCAL connections
+#ifndef NDEBUG
+          if (connection.selected_layer != transport_layer_for_subscription)
+          {
+            eCAL::Logging::Log(Logging::log_level_warning, m_attributes.topic_name + "::CPublisherImpl::ApplySubscriberRegistration - selected transport layer changed unexpectedly for active connection");
+          }
+#endif
 
-        // update the data type, the layer states and set the state active
-        connection = SConnection{ data_type_info_, sub_layer_states_, transport_layer_for_subscription, true };
+          // keep selected_layer unchanged and refresh metadata/state
+          connection.data_type_info = data_type_info_;
+          connection.layer_states = sub_layer_states_;
+          connection.state = true;
+        }
       }
-
-      // update connection count
-      m_connection_count = GetConnectionCount();
-      UpdateSendEnabledLayers();
     }
 
 
@@ -502,12 +574,18 @@ namespace eCAL
     {
       const std::lock_guard<std::mutex> lock(m_connection_map_mutex);
 
-      // remove key from connection map
-      m_connection_map.erase(subscription_info_);
+      auto subscription_info_iter = m_connection_map.find(subscription_info_);
+      if (subscription_info_iter != m_connection_map.end())
+      {
+        if (subscription_info_iter->second.state)
+        {
+          m_connection_count.fetch_sub(1, std::memory_order_relaxed);
+          m_send_layer_connection_counters.Decrement(subscription_info_iter->second.selected_layer);
+        }
 
-      // update connection count
-      m_connection_count = GetConnectionCount();
-      UpdateSendEnabledLayers();
+        // remove key from connection map
+        m_connection_map.erase(subscription_info_iter);
+      }
     }
 
     // fire disconnect event
@@ -708,55 +786,6 @@ namespace eCAL
     FireEvent(ePublisherEvent::disconnected, subscription_info_, data_type_info_);
   }
 
-  size_t CPublisherImpl::GetConnectionCount()
-  {
-    // no need to lock map here for now, map locked by caller
-    size_t count(0);
-    for (const auto& sub : m_connection_map)
-    {
-      if (sub.second.state)
-      {
-        count++;
-      }
-    }
-    return count;
-  }
-
-  void CPublisherImpl::UpdateSendEnabledLayers()
-  {
-    // no need to lock map here for now, map locked by caller
-    bool udp_send_enabled(false);
-    bool shm_send_enabled(false);
-    bool tcp_send_enabled(false);
-
-    for (const auto& sub : m_connection_map)
-    {
-      if (!sub.second.state)
-      {
-        continue;
-      }
-
-      switch (sub.second.selected_layer)
-      {
-      case TransportLayer::eType::udp_mc:
-        udp_send_enabled = true;
-        break;
-      case TransportLayer::eType::shm:
-        shm_send_enabled = true;
-        break;
-      case TransportLayer::eType::tcp:
-        tcp_send_enabled = true;
-        break;
-      default:
-        break;
-      }
-    }
-
-    m_udp_send_enabled.store(udp_send_enabled, std::memory_order_relaxed);
-    m_shm_send_enabled.store(shm_send_enabled, std::memory_order_relaxed);
-    m_tcp_send_enabled.store(tcp_send_enabled, std::memory_order_relaxed);
-  }
-
   bool CPublisherImpl::StartUdpLayer()
   {
 #if ECAL_CORE_TRANSPORT_UDP
@@ -840,7 +869,6 @@ namespace eCAL
 #if ECAL_CORE_TRANSPORT_UDP
     // flag disabled
     m_layers.udp.write_enabled = false;
-    m_udp_send_enabled.store(false, std::memory_order_relaxed);
 
     // destroy writer
     m_writer_udp.reset();
@@ -849,7 +877,6 @@ namespace eCAL
 #if ECAL_CORE_TRANSPORT_SHM
     // flag disabled
     m_layers.shm.write_enabled = false;
-    m_shm_send_enabled.store(false, std::memory_order_relaxed);
 
     // destroy writer
     m_writer_shm.reset();
@@ -858,11 +885,12 @@ namespace eCAL
 #if ECAL_CORE_TRANSPORT_TCP
     // flag disabled
     m_layers.tcp.write_enabled = false;
-    m_tcp_send_enabled.store(false, std::memory_order_relaxed);
 
     // destroy writer
     m_writer_tcp.reset();
 #endif
+
+  m_send_layer_connection_counters.Reset();
   }
 
   size_t CPublisherImpl::PrepareWrite(long long id_, size_t len_)

--- a/ecal/core/src/pubsub/ecal_publisher_impl.cpp
+++ b/ecal/core/src/pubsub/ecal_publisher_impl.cpp
@@ -508,40 +508,29 @@ namespace eCAL
 
       if (subscription_info_iter == m_connection_map.end())
       {
-        // add subscriber to connection map, connection state false
-        m_connection_map[subscription_info_] = SConnection{ data_type_info_, sub_layer_states_, transport_layer_for_subscription, false };
+        m_connection_map[subscription_info_] = SConnection{ data_type_info_, sub_layer_states_, transport_layer_for_subscription, eConnectionState::pending };
+        m_send_layer_connection_counters.Increment(transport_layer_for_subscription);
       }
       else
       {
-        // existing connection, we got the second update now
         auto& connection = subscription_info_iter->second;
-        const bool was_active = connection.state;
 
-        // if this connection was inactive before
-        // activate it now and flag a new connection finally
-        if (!was_active)
+#ifndef NDEBUG
+        if (connection.selected_layer != transport_layer_for_subscription)
+        {
+          eCAL::Logging::Log(Logging::log_level_warning, m_attributes.topic_name + "::CPublisherImpl::ApplySubscriberRegistration - selected transport layer changed unexpectedly for connection");
+        }
+#endif
+
+        if (connection.state == eConnectionState::pending)
         {
           is_new_connection = true;
           m_connection_count.fetch_add(1, std::memory_order_relaxed);
-          // first active update: selected layer becomes effective for sending
-          connection = SConnection{ data_type_info_, sub_layer_states_, transport_layer_for_subscription, true };
-          m_send_layer_connection_counters.Increment(connection.selected_layer);
+          connection.state = eConnectionState::established;
         }
-        else
-        {
-          // selected_layer is expected to stay stable for active eCAL connections
-#ifndef NDEBUG
-          if (connection.selected_layer != transport_layer_for_subscription)
-          {
-            eCAL::Logging::Log(Logging::log_level_warning, m_attributes.topic_name + "::CPublisherImpl::ApplySubscriberRegistration - selected transport layer changed unexpectedly for active connection");
-          }
-#endif
 
-          // keep selected_layer unchanged and refresh metadata/state
-          connection.data_type_info = data_type_info_;
-          connection.layer_states = sub_layer_states_;
-          connection.state = true;
-        }
+        connection.data_type_info = data_type_info_;
+        connection.layer_states = sub_layer_states_;
       }
     }
 
@@ -577,10 +566,16 @@ namespace eCAL
       auto subscription_info_iter = m_connection_map.find(subscription_info_);
       if (subscription_info_iter != m_connection_map.end())
       {
-        if (subscription_info_iter->second.state)
+        auto& connection = subscription_info_iter->second;
+        if (connection.state == eConnectionState::established)
         {
           m_connection_count.fetch_sub(1, std::memory_order_relaxed);
-          m_send_layer_connection_counters.Decrement(subscription_info_iter->second.selected_layer);
+        }
+
+        if (connection.state != eConnectionState::closed)
+        {
+          m_send_layer_connection_counters.Decrement(connection.selected_layer);
+          connection.state = eConnectionState::closed;
         }
 
         // remove key from connection map
@@ -890,7 +885,7 @@ namespace eCAL
     m_writer_tcp.reset();
 #endif
 
-  m_send_layer_connection_counters.Reset();
+    m_send_layer_connection_counters.Reset();
   }
 
   size_t CPublisherImpl::PrepareWrite(long long id_, size_t len_)

--- a/ecal/core/src/pubsub/ecal_publisher_impl.cpp
+++ b/ecal/core/src/pubsub/ecal_publisher_impl.cpp
@@ -213,10 +213,15 @@ namespace eCAL
   {
     // get payload buffer size (one time, to avoid multiple computations)
     const size_t payload_buf_size(payload_.GetSize());
-
-    const bool udp_send_enabled = m_send_layer_connection_counters.UdpEnabled();
-    const bool shm_send_enabled = m_send_layer_connection_counters.ShmEnabled();
-    const bool tcp_send_enabled = m_send_layer_connection_counters.TcpEnabled();
+#if ECAL_CORE_TRANSPORT_SHM
+    const bool shm_send_enabled = m_writer_shm && m_send_layer_connection_counters.ShmEnabled();
+#endif
+#if ECAL_CORE_TRANSPORT_UDP    
+    const bool udp_send_enabled = m_writer_udp && m_send_layer_connection_counters.UdpEnabled();
+#endif
+#if ECAL_CORE_TRANSPORT_TCP
+    const bool tcp_send_enabled = m_writer_tcp && m_send_layer_connection_counters.TcpEnabled();
+#endif
 
     // are we allowed to perform zero copy writing?
     bool allow_zero_copy(false);
@@ -225,11 +230,11 @@ namespace eCAL
 #endif
 #if ECAL_CORE_TRANSPORT_UDP
     // udp is active -> no zero copy
-    allow_zero_copy &= !(m_writer_udp && udp_send_enabled);
+    allow_zero_copy &= !udp_send_enabled;
 #endif
 #if ECAL_CORE_TRANSPORT_TCP
     // tcp is active -> no zero copy
-    allow_zero_copy &= !(m_writer_tcp && tcp_send_enabled);
+    allow_zero_copy &= !tcp_send_enabled;
 #endif
 
     // create a payload copy for all layer
@@ -249,7 +254,7 @@ namespace eCAL
     // SHM
     ////////////////////////////////////////////////////////////////////////////
 #if ECAL_CORE_TRANSPORT_SHM
-    if (m_writer_shm && shm_send_enabled)
+    if (shm_send_enabled)
     {
 #ifndef NDEBUG
       eCAL::Logging::Log(Logging::log_level_debug3, m_attributes.topic_name + "::CPublisherImpl::Write::SHM");
@@ -312,7 +317,7 @@ namespace eCAL
     // UDP (MC)
     ////////////////////////////////////////////////////////////////////////////
 #if ECAL_CORE_TRANSPORT_UDP
-    if (m_writer_udp && udp_send_enabled)
+    if (udp_send_enabled)
     {
 #ifndef NDEBUG
       eCAL::Logging::Log(Logging::log_level_debug3, m_attributes.topic_name + "::CPublisherImpl::Write::udp");
@@ -361,7 +366,7 @@ namespace eCAL
     // TCP
     ////////////////////////////////////////////////////////////////////////////
 #if ECAL_CORE_TRANSPORT_TCP
-    if (m_writer_tcp && tcp_send_enabled)
+    if (tcp_send_enabled)
     {
 #ifndef NDEBUG
       eCAL::Logging::Log(Logging::log_level_debug3, m_attributes.topic_name + "::CPublisherImpl::Send::TCP");

--- a/ecal/core/src/pubsub/ecal_publisher_impl.cpp
+++ b/ecal/core/src/pubsub/ecal_publisher_impl.cpp
@@ -155,6 +155,10 @@ namespace eCAL
     // get payload buffer size (one time, to avoid multiple computations)
     const size_t payload_buf_size(payload_.GetSize());
 
+    const bool udp_send_enabled = m_udp_send_enabled.load(std::memory_order_relaxed);
+    const bool shm_send_enabled = m_shm_send_enabled.load(std::memory_order_relaxed);
+    const bool tcp_send_enabled = m_tcp_send_enabled.load(std::memory_order_relaxed);
+
     // are we allowed to perform zero copy writing?
     bool allow_zero_copy(false);
 #if ECAL_CORE_TRANSPORT_SHM
@@ -162,11 +166,11 @@ namespace eCAL
 #endif
 #if ECAL_CORE_TRANSPORT_UDP
     // udp is active -> no zero copy
-    allow_zero_copy &= !m_writer_udp;
+    allow_zero_copy &= !(m_writer_udp && udp_send_enabled);
 #endif
 #if ECAL_CORE_TRANSPORT_TCP
     // tcp is active -> no zero copy
-    allow_zero_copy &= !m_writer_tcp;
+    allow_zero_copy &= !(m_writer_tcp && tcp_send_enabled);
 #endif
 
     // create a payload copy for all layer
@@ -186,7 +190,7 @@ namespace eCAL
     // SHM
     ////////////////////////////////////////////////////////////////////////////
 #if ECAL_CORE_TRANSPORT_SHM
-    if (m_writer_shm)
+    if (m_writer_shm && shm_send_enabled)
     {
 #ifndef NDEBUG
       eCAL::Logging::Log(Logging::log_level_debug3, m_attributes.topic_name + "::CPublisherImpl::Write::SHM");
@@ -249,7 +253,7 @@ namespace eCAL
     // UDP (MC)
     ////////////////////////////////////////////////////////////////////////////
 #if ECAL_CORE_TRANSPORT_UDP
-    if (m_writer_udp)
+    if (m_writer_udp && udp_send_enabled)
     {
 #ifndef NDEBUG
       eCAL::Logging::Log(Logging::log_level_debug3, m_attributes.topic_name + "::CPublisherImpl::Write::udp");
@@ -298,7 +302,7 @@ namespace eCAL
     // TCP
     ////////////////////////////////////////////////////////////////////////////
 #if ECAL_CORE_TRANSPORT_TCP
-    if (m_writer_tcp)
+    if (m_writer_tcp && tcp_send_enabled)
     {
 #ifndef NDEBUG
       eCAL::Logging::Log(Logging::log_level_debug3, m_attributes.topic_name + "::CPublisherImpl::Send::TCP");
@@ -406,8 +410,8 @@ namespace eCAL
 #endif
 
     // determine if we need to start a transport layer
-    const TransportLayer::eType layer2activate = DetermineTransportLayer2Start(pub_layers, sub_layers, m_attributes.host_name == subscription_info_.host_name);
-    switch (layer2activate)
+    const TransportLayer::eType transport_layer_for_subscription = DetermineTransportLayer(pub_layers, sub_layers, m_attributes.host_name == subscription_info_.host_name);
+    switch (transport_layer_for_subscription)
     {
     case TransportLayer::eType::udp_mc:
       StartUdpLayer();
@@ -446,7 +450,7 @@ namespace eCAL
       if (subscription_info_iter == m_connection_map.end())
       {
         // add subscriber to connection map, connection state false
-        m_connection_map[subscription_info_] = SConnection{ data_type_info_, sub_layer_states_, false };
+        m_connection_map[subscription_info_] = SConnection{ data_type_info_, sub_layer_states_, transport_layer_for_subscription, false };
       }
       else
       {
@@ -461,11 +465,12 @@ namespace eCAL
         }
 
         // update the data type, the layer states and set the state active
-        connection = SConnection{ data_type_info_, sub_layer_states_, true };
+        connection = SConnection{ data_type_info_, sub_layer_states_, transport_layer_for_subscription, true };
       }
 
       // update connection count
       m_connection_count = GetConnectionCount();
+      UpdateSendEnabledLayers();
     }
 
 
@@ -502,6 +507,7 @@ namespace eCAL
 
       // update connection count
       m_connection_count = GetConnectionCount();
+      UpdateSendEnabledLayers();
     }
 
     // fire disconnect event
@@ -716,6 +722,41 @@ namespace eCAL
     return count;
   }
 
+  void CPublisherImpl::UpdateSendEnabledLayers()
+  {
+    // no need to lock map here for now, map locked by caller
+    bool udp_send_enabled(false);
+    bool shm_send_enabled(false);
+    bool tcp_send_enabled(false);
+
+    for (const auto& sub : m_connection_map)
+    {
+      if (!sub.second.state)
+      {
+        continue;
+      }
+
+      switch (sub.second.selected_layer)
+      {
+      case TransportLayer::eType::udp_mc:
+        udp_send_enabled = true;
+        break;
+      case TransportLayer::eType::shm:
+        shm_send_enabled = true;
+        break;
+      case TransportLayer::eType::tcp:
+        tcp_send_enabled = true;
+        break;
+      default:
+        break;
+      }
+    }
+
+    m_udp_send_enabled.store(udp_send_enabled, std::memory_order_relaxed);
+    m_shm_send_enabled.store(shm_send_enabled, std::memory_order_relaxed);
+    m_tcp_send_enabled.store(tcp_send_enabled, std::memory_order_relaxed);
+  }
+
   bool CPublisherImpl::StartUdpLayer()
   {
 #if ECAL_CORE_TRANSPORT_UDP
@@ -799,6 +840,7 @@ namespace eCAL
 #if ECAL_CORE_TRANSPORT_UDP
     // flag disabled
     m_layers.udp.write_enabled = false;
+    m_udp_send_enabled.store(false, std::memory_order_relaxed);
 
     // destroy writer
     m_writer_udp.reset();
@@ -807,6 +849,7 @@ namespace eCAL
 #if ECAL_CORE_TRANSPORT_SHM
     // flag disabled
     m_layers.shm.write_enabled = false;
+    m_shm_send_enabled.store(false, std::memory_order_relaxed);
 
     // destroy writer
     m_writer_shm.reset();
@@ -815,6 +858,7 @@ namespace eCAL
 #if ECAL_CORE_TRANSPORT_TCP
     // flag disabled
     m_layers.tcp.write_enabled = false;
+    m_tcp_send_enabled.store(false, std::memory_order_relaxed);
 
     // destroy writer
     m_writer_tcp.reset();
@@ -840,7 +884,7 @@ namespace eCAL
     return snd_hash;
   }
 
-  TransportLayer::eType CPublisherImpl::DetermineTransportLayer2Start(const std::vector<eTLayerType>& enabled_pub_layer_, const std::vector<eTLayerType>& enabled_sub_layer_, bool same_host_)
+  TransportLayer::eType CPublisherImpl::DetermineTransportLayer(const std::vector<eTLayerType>& enabled_pub_layer_, const std::vector<eTLayerType>& enabled_sub_layer_, bool same_host_)
   {
     // determine the priority list to use
     const Publisher::Configuration::LayerPriorityVector& layer_priority_vector = same_host_ ? m_attributes.layer_priority_local : m_attributes.layer_priority_remote;

--- a/ecal/core/src/pubsub/ecal_publisher_impl.h
+++ b/ecal/core/src/pubsub/ecal_publisher_impl.h
@@ -131,10 +131,11 @@ namespace eCAL
     void FireDisconnectEvent(const SSubscriptionInfo& subscription_info_, const SDataTypeInformation& data_type_info_);
 
     size_t GetConnectionCount();
+    void UpdateSendEnabledLayers();
 
     size_t PrepareWrite(long long id_, size_t len_);
 
-    TransportLayer::eType DetermineTransportLayer2Start(const std::vector<eTLayerType>& enabled_pub_layer_, const std::vector<eTLayerType>& enabled_sub_layer_, bool same_host_);
+    TransportLayer::eType DetermineTransportLayer(const std::vector<eTLayerType>& enabled_pub_layer_, const std::vector<eTLayerType>& enabled_sub_layer_, bool same_host_);
     
     int32_t GetFrequency();
 
@@ -150,12 +151,16 @@ namespace eCAL
     {
       SDataTypeInformation data_type_info;
       SLayerStates         layer_states;
+      TransportLayer::eType selected_layer = TransportLayer::eType::none;
       bool                 state = false;
     };
     using SSubscriptionMapT = std::map<SSubscriptionInfo, SConnection>;
     mutable std::mutex                     m_connection_map_mutex;
     SSubscriptionMapT                      m_connection_map;
     std::atomic<size_t>                    m_connection_count{ 0 };
+    std::atomic<bool>                      m_udp_send_enabled{ false };
+    std::atomic<bool>                      m_shm_send_enabled{ false };
+    std::atomic<bool>                      m_tcp_send_enabled{ false };
 
     std::mutex                             m_event_id_callback_mutex;
     PubEventCallbackT                      m_event_id_callback;

--- a/ecal/core/src/pubsub/ecal_publisher_impl.h
+++ b/ecal/core/src/pubsub/ecal_publisher_impl.h
@@ -144,12 +144,19 @@ namespace eCAL
 
     std::vector<char>                      m_payload_buffer;
 
+    enum class eConnectionState
+    {
+      pending,
+      established,
+      closed
+    };
+
     struct SConnection
     {
       SDataTypeInformation data_type_info;
       SLayerStates         layer_states;
       TransportLayer::eType selected_layer = TransportLayer::eType::none;
-      bool                 state = false;
+      eConnectionState     state = eConnectionState::closed;
     };
     using SSubscriptionMapT = std::map<SSubscriptionInfo, SConnection>;
 

--- a/ecal/core/src/pubsub/ecal_publisher_impl.h
+++ b/ecal/core/src/pubsub/ecal_publisher_impl.h
@@ -130,9 +130,6 @@ namespace eCAL
     void FireConnectEvent   (const SSubscriptionInfo& subscription_info_, const SDataTypeInformation& data_type_info_);
     void FireDisconnectEvent(const SSubscriptionInfo& subscription_info_, const SDataTypeInformation& data_type_info_);
 
-    size_t GetConnectionCount();
-    void UpdateSendEnabledLayers();
-
     size_t PrepareWrite(long long id_, size_t len_);
 
     TransportLayer::eType DetermineTransportLayer(const std::vector<eTLayerType>& enabled_pub_layer_, const std::vector<eTLayerType>& enabled_sub_layer_, bool same_host_);
@@ -155,12 +152,26 @@ namespace eCAL
       bool                 state = false;
     };
     using SSubscriptionMapT = std::map<SSubscriptionInfo, SConnection>;
+
+    struct SSendLayerConnectionCounters
+    {
+      void Increment(TransportLayer::eType layer_);
+      void Decrement(TransportLayer::eType layer_);
+      void Reset();
+
+      bool UdpEnabled() const;
+      bool ShmEnabled() const;
+      bool TcpEnabled() const;
+
+      std::atomic<size_t> udp{ 0 };
+      std::atomic<size_t> shm{ 0 };
+      std::atomic<size_t> tcp{ 0 };
+    };
+
     mutable std::mutex                     m_connection_map_mutex;
     SSubscriptionMapT                      m_connection_map;
     std::atomic<size_t>                    m_connection_count{ 0 };
-    std::atomic<bool>                      m_udp_send_enabled{ false };
-    std::atomic<bool>                      m_shm_send_enabled{ false };
-    std::atomic<bool>                      m_tcp_send_enabled{ false };
+    SSendLayerConnectionCounters           m_send_layer_connection_counters;
 
     std::mutex                             m_event_id_callback_mutex;
     PubEventCallbackT                      m_event_id_callback;


### PR DESCRIPTION
This change tracks publisher connections and selected transport layers using atomic counters and explicit connection states. Writes now skip transport layers without active subscribers, reducing unnecessary data copies and network traffic while preserving zero-copy SHM where possible. Connection counts are updated incrementally instead of recalculated from the connection map. Transport counters are reset when writers are destroyed.