### PR TITLE
Make lambda captures explicit for C++20

### DIFF
--- a/app/mma/include/interruptable_timer.h
+++ b/app/mma/include/interruptable_timer.h
@@ -105,7 +105,7 @@ private:
       auto sleep_duration = period_ - (end - start);
 
       std::unique_lock<std::mutex> stopLock(stopMutex);
-      stopCv.wait_for(stopLock, sleep_duration, [=] {return stopping; });
+      stopCv.wait_for(stopLock, sleep_duration, [this] {return stopping; });
     }
   }
   

--- a/app/mon/mon_gui/src/widgets/models/group_tree_model.cpp
+++ b/app/mon/mon_gui/src/widgets/models/group_tree_model.cpp
@@ -179,7 +179,7 @@ void GroupTreeModel::insertItemIntoGroups(QAbstractTreeItem* item)
       current_group_identifier  = item->data(remaining_sub_groups.front(), (Qt::ItemDataRole)ItemDataRoles::GroupRole); //-V1016
 
       auto subgroup_list = group_item->findChildren(
-            [=](QAbstractTreeItem* child)
+            [current_group_identifier](QAbstractTreeItem* child)
             {
               if (child->type() == (int)TreeItemType::Group)
               {

--- a/app/sys/sys_core/include/threading/blocking_queue.h
+++ b/app/sys/sys_core/include/threading/blocking_queue.h
@@ -53,7 +53,7 @@ public:
    */
   T pop() {
     std::unique_lock<std::mutex> lock(this->m_mutex);
-    this->m_condition.wait(lock, [=] { return !this->m_queue.empty(); });
+    this->m_condition.wait(lock, [this] { return !this->m_queue.empty(); });
     T rc(std::move(this->m_queue.back()));
     this->m_queue.pop_back();
     return rc;

--- a/app/sys/sys_core/include/threading/interruptible_thread.h
+++ b/app/sys/sys_core/include/threading/interruptible_thread.h
@@ -131,7 +131,7 @@ protected:
    */
   void SleepFor(std::chrono::nanoseconds sleep_duration){
     std::unique_lock<std::mutex> interruptLock(m_interruptMutex);
-    m_interruptCv.wait_for(interruptLock, sleep_duration, [=] {return bool(m_isInterrupted); });
+    m_interruptCv.wait_for(interruptLock, sleep_duration, [this] {return bool(m_isInterrupted); });
   }
 
   std::mutex              m_startup_mutex;      /**< A Mutex for thread safe starting of this thread */

--- a/app/sys/sys_gui/src/ecalsys_gui.cpp
+++ b/app/sys/sys_gui/src/ecalsys_gui.cpp
@@ -121,55 +121,55 @@ EcalsysGui::EcalsysGui(QWidget *parent)
         this->setTheme(Theme::Dark);
     });
 
-  connect(ui_.action_task_add,                   &QAction::triggered, [=]() {ui_.tasks_dockwidget->raise(); task_widget_->addTask(); });
-  connect(ui_.action_task_edit,                  &QAction::triggered, [=]() {ui_.tasks_dockwidget->raise(); task_widget_->setEditControlsVisibility(); });
-  connect(ui_.action_task_duplicate,             &QAction::triggered, [=]() {ui_.tasks_dockwidget->raise(); task_widget_->duplicateSelectedTasks(); });
-  connect(ui_.action_task_remove,                &QAction::triggered, [=]() {ui_.tasks_dockwidget->raise(); task_widget_->removeSelectedTasks(); });
-  connect(ui_.action_task_start,                 &QAction::triggered, [=]() {task_widget_->startAllTasks(); });
-  connect(ui_.action_task_stop,                  &QAction::triggered, [=]() {task_widget_->stopAllTasks(); });
-  connect(ui_.action_task_restart,               &QAction::triggered, [=]() {task_widget_->restartAllTasks(); });
-  connect(ui_.action_task_start_selected,        &QAction::triggered, [=]() {ui_.tasks_dockwidget->raise(); task_widget_->startSelectedTasks(); });
-  connect(ui_.action_task_stop_selected,         &QAction::triggered, [=]() {ui_.tasks_dockwidget->raise(); task_widget_->stopSelectedTasks(); });
-  connect(ui_.action_task_restart_selected,      &QAction::triggered, [=]() {ui_.tasks_dockwidget->raise(); task_widget_->restartSelectedTasks(); });
+  connect(ui_.action_task_add,                   &QAction::triggered, [this]() {ui_.tasks_dockwidget->raise(); task_widget_->addTask(); });
+  connect(ui_.action_task_edit,                  &QAction::triggered, [this]() {ui_.tasks_dockwidget->raise(); task_widget_->setEditControlsVisibility(); });
+  connect(ui_.action_task_duplicate,             &QAction::triggered, [this]() {ui_.tasks_dockwidget->raise(); task_widget_->duplicateSelectedTasks(); });
+  connect(ui_.action_task_remove,                &QAction::triggered, [this]() {ui_.tasks_dockwidget->raise(); task_widget_->removeSelectedTasks(); });
+  connect(ui_.action_task_start,                 &QAction::triggered, [this]() {task_widget_->startAllTasks(); });
+  connect(ui_.action_task_stop,                  &QAction::triggered, [this]() {task_widget_->stopAllTasks(); });
+  connect(ui_.action_task_restart,               &QAction::triggered, [this]() {task_widget_->restartAllTasks(); });
+  connect(ui_.action_task_start_selected,        &QAction::triggered, [this]() {ui_.tasks_dockwidget->raise(); task_widget_->startSelectedTasks(); });
+  connect(ui_.action_task_stop_selected,         &QAction::triggered, [this]() {ui_.tasks_dockwidget->raise(); task_widget_->stopSelectedTasks(); });
+  connect(ui_.action_task_restart_selected,      &QAction::triggered, [this]() {ui_.tasks_dockwidget->raise(); task_widget_->restartSelectedTasks(); });
 
-  connect(ui_.action_task_fast_kill,             &QAction::triggered, [=]() {task_widget_->stopAllTasks(false, true); });
-  connect(ui_.action_task_fast_restart,          &QAction::triggered, [=]() {task_widget_->restartAllTasks(false, true); });
-  connect(ui_.action_task_fast_kill_selected,    &QAction::triggered, [=]() {ui_.tasks_dockwidget->raise(); task_widget_->stopSelectedTasks(false, true); });
-  connect(ui_.action_task_fast_restart_selected, &QAction::triggered, [=]() {ui_.tasks_dockwidget->raise(); task_widget_->restartSelectedTasks(false, true); });
+  connect(ui_.action_task_fast_kill,             &QAction::triggered, [this]() {task_widget_->stopAllTasks(false, true); });
+  connect(ui_.action_task_fast_restart,          &QAction::triggered, [this]() {task_widget_->restartAllTasks(false, true); });
+  connect(ui_.action_task_fast_kill_selected,    &QAction::triggered, [this]() {ui_.tasks_dockwidget->raise(); task_widget_->stopSelectedTasks(false, true); });
+  connect(ui_.action_task_fast_restart_selected, &QAction::triggered, [this]() {ui_.tasks_dockwidget->raise(); task_widget_->restartSelectedTasks(false, true); });
   for (auto action : ui_.menu_task_target_override->actions())
   {
     if (action->menu())
     {
-      connect(action->menu(), &QMenu::aboutToShow, [=]() {this->updateHostActions(action->menu()); });
+      connect(action->menu(), &QMenu::aboutToShow, [this, action]() {this->updateHostActions(action->menu()); });
     }
   }
-  connect(ui_.menu_task_start_all_on_host,        &QMenu::triggered,   [=](QAction* action) {this->task_widget_->startAllTasks(action->text().toStdString()); });
-  connect(ui_.menu_task_restart_all_on_host,      &QMenu::triggered,   [=](QAction* action) {this->task_widget_->restartAllTasks(true, true, action->text().toStdString()); });
-  connect(ui_.menu_task_start_selected_on_host,   &QMenu::triggered,   [=](QAction* action) {ui_.tasks_dockwidget->raise(); this->task_widget_->startSelectedTasks(action->text().toStdString()); });
-  connect(ui_.menu_task_restart_selected_on_host, &QMenu::triggered,   [=](QAction* action) {ui_.tasks_dockwidget->raise(); this->task_widget_->restartSelectedTasks(true, true, action->text().toStdString()); });
-  connect(ui_.action_task_import_from_cloud,      &QAction::triggered, [=]() {this->showImportFromCloudWindow(); });
-  connect(ui_.action_task_update_from_cloud,      &QAction::triggered, [=]() {task_widget_->updateFromCloud(); });
+  connect(ui_.menu_task_start_all_on_host,        &QMenu::triggered,   [this](QAction* action) {this->task_widget_->startAllTasks(action->text().toStdString()); });
+  connect(ui_.menu_task_restart_all_on_host,      &QMenu::triggered,   [this](QAction* action) {this->task_widget_->restartAllTasks(true, true, action->text().toStdString()); });
+  connect(ui_.menu_task_start_selected_on_host,   &QMenu::triggered,   [this](QAction* action) {ui_.tasks_dockwidget->raise(); this->task_widget_->startSelectedTasks(action->text().toStdString()); });
+  connect(ui_.menu_task_restart_selected_on_host, &QMenu::triggered,   [this](QAction* action) {ui_.tasks_dockwidget->raise(); this->task_widget_->restartSelectedTasks(true, true, action->text().toStdString()); });
+  connect(ui_.action_task_import_from_cloud,      &QAction::triggered, [this]() {this->showImportFromCloudWindow(); });
+  connect(ui_.action_task_update_from_cloud,      &QAction::triggered, [this]() {task_widget_->updateFromCloud(); });
 
-  connect(ui_.action_group_add,                   &QAction::triggered, [=]() {ui_.groups_dockwidget->raise(); group_widget_->addGroup(); });
-  connect(ui_.action_group_edit,                  &QAction::triggered, [=]() {ui_.groups_dockwidget->raise(); group_widget_->showEditControls(); });
-  connect(ui_.action_group_duplicate,             &QAction::triggered, [=]() {ui_.groups_dockwidget->raise(); group_widget_->duplicateSelectedGroups(); });
-  connect(ui_.action_group_remove,                &QAction::triggered, [=]() {ui_.groups_dockwidget->raise(); group_widget_->removeSelectedGroups(); });
-  connect(ui_.action_group_start_selected,        &QAction::triggered, [=]() {ui_.groups_dockwidget->raise(); group_widget_->startSelectedTasks(); });
-  connect(ui_.action_group_stop_selected,         &QAction::triggered, [=]() {ui_.groups_dockwidget->raise(); group_widget_->stopSelectedTasks(); });
-  connect(ui_.action_group_restart_selected,      &QAction::triggered, [=]() {ui_.groups_dockwidget->raise(); group_widget_->restartSelectedTasks(); });
-  connect(ui_.action_group_fast_kill_selected,    &QAction::triggered, [=]() {ui_.groups_dockwidget->raise(); group_widget_->stopSelectedTasks(false, true); });
-  connect(ui_.action_group_fast_restart_selected, &QAction::triggered, [=]() {ui_.groups_dockwidget->raise(); group_widget_->restartSelectedTasks(false, true); });
+  connect(ui_.action_group_add,                   &QAction::triggered, [this]() {ui_.groups_dockwidget->raise(); group_widget_->addGroup(); });
+  connect(ui_.action_group_edit,                  &QAction::triggered, [this]() {ui_.groups_dockwidget->raise(); group_widget_->showEditControls(); });
+  connect(ui_.action_group_duplicate,             &QAction::triggered, [this]() {ui_.groups_dockwidget->raise(); group_widget_->duplicateSelectedGroups(); });
+  connect(ui_.action_group_remove,                &QAction::triggered, [this]() {ui_.groups_dockwidget->raise(); group_widget_->removeSelectedGroups(); });
+  connect(ui_.action_group_start_selected,        &QAction::triggered, [this]() {ui_.groups_dockwidget->raise(); group_widget_->startSelectedTasks(); });
+  connect(ui_.action_group_stop_selected,         &QAction::triggered, [this]() {ui_.groups_dockwidget->raise(); group_widget_->stopSelectedTasks(); });
+  connect(ui_.action_group_restart_selected,      &QAction::triggered, [this]() {ui_.groups_dockwidget->raise(); group_widget_->restartSelectedTasks(); });
+  connect(ui_.action_group_fast_kill_selected,    &QAction::triggered, [this]() {ui_.groups_dockwidget->raise(); group_widget_->stopSelectedTasks(false, true); });
+  connect(ui_.action_group_fast_restart_selected, &QAction::triggered, [this]() {ui_.groups_dockwidget->raise(); group_widget_->restartSelectedTasks(false, true); });
   for (auto action : ui_.menu_group_target_override->actions())
   {
     if (action->menu())
     {
-      connect(action->menu(), &QMenu::aboutToShow, [=]() {this->updateHostActions(action->menu()); });
+      connect(action->menu(), &QMenu::aboutToShow, [this, action]() {this->updateHostActions(action->menu()); });
     }
   }
-  connect(ui_.menu_group_start_selected_on_host,   &QMenu::triggered,   [=](QAction* action) {ui_.groups_dockwidget->raise(); group_widget_->startSelectedTasks(action->text().toStdString()); });
-  connect(ui_.menu_group_restart_selected_on_host, &QMenu::triggered,   [=](QAction* action) {ui_.groups_dockwidget->raise(); group_widget_->restartSelectedTasks(true, true, action->text().toStdString()); });
-  connect(ui_.action_group_expand,                 &QAction::triggered, [=]() {ui_.groups_dockwidget->raise(); group_widget_->expandGroups(); });
-  connect(ui_.action_group_collapse,               &QAction::triggered, [=]() {ui_.groups_dockwidget->raise(); group_widget_->collapseGroups(); });
+  connect(ui_.menu_group_start_selected_on_host,   &QMenu::triggered,   [this](QAction* action) {ui_.groups_dockwidget->raise(); group_widget_->startSelectedTasks(action->text().toStdString()); });
+  connect(ui_.menu_group_restart_selected_on_host, &QMenu::triggered,   [this](QAction* action) {ui_.groups_dockwidget->raise(); group_widget_->restartSelectedTasks(true, true, action->text().toStdString()); });
+  connect(ui_.action_group_expand,                 &QAction::triggered, [this]() {ui_.groups_dockwidget->raise(); group_widget_->expandGroups(); });
+  connect(ui_.action_group_collapse,               &QAction::triggered, [this]() {ui_.groups_dockwidget->raise(); group_widget_->collapseGroups(); });
 
   // Special show-console button for Windows
 #ifdef _WIN32

--- a/app/sys/sys_gui/src/widgets/group_edit_widget/group_edit_widget.cpp
+++ b/app/sys/sys_gui/src/widgets/group_edit_widget/group_edit_widget.cpp
@@ -119,7 +119,7 @@ GroupEditWidget::GroupEditWidget(QWidget *parent)
 
   // Agressivly move the current index back to the name column in order to get proper keyboard search behaviour
   connect(ui_.state_available_tasks_tree->selectionModel(), &QItemSelectionModel::currentChanged,
-    [=](const QModelIndex & current, const QModelIndex & /*previous*/)
+    [this](const QModelIndex & current, const QModelIndex & /*previous*/)
     {
       if ((TaskTreeModel::Columns)(current.column()) != TaskTreeModel::Columns::TASK_NAME)
       {
@@ -129,7 +129,7 @@ GroupEditWidget::GroupEditWidget(QWidget *parent)
     }
   );
   connect(ui_.state_active_tasks_tree->selectionModel(), &QItemSelectionModel::currentChanged,
-    [=](const QModelIndex & current, const QModelIndex & /*previous*/)
+    [this](const QModelIndex & current, const QModelIndex & /*previous*/)
     {
       if (((GroupStateMinTaskStateTreeModel::Columns)(current.column()) != GroupStateMinTaskStateTreeModel::Columns::TASK_NAME)
         && ((GroupStateMinTaskStateTreeModel::Columns)(current.column()) != GroupStateMinTaskStateTreeModel::Columns::SEVERITY)

--- a/app/sys/sys_gui/src/widgets/groupwidget/group_widget.cpp
+++ b/app/sys/sys_gui/src/widgets/groupwidget/group_widget.cpp
@@ -114,7 +114,7 @@ GroupWidget::GroupWidget(GroupEditWidget* group_edit_widget, QWidget *parent)
 
   // Agressivly move the current index back to the name column in order to get proper keyboard search behaviour
   connect(ui_.group_tree->selectionModel(), &QItemSelectionModel::currentChanged,
-    [=](const QModelIndex & current, const QModelIndex & /*previous*/)
+    [this](const QModelIndex & current, const QModelIndex & /*previous*/)
     {
       if ((GroupTreeModel::Columns)(current.column()) != GroupTreeModel::Columns::NAME)
       {

--- a/app/sys/sys_gui/src/widgets/taskwidget/task_widget.cpp
+++ b/app/sys/sys_gui/src/widgets/taskwidget/task_widget.cpp
@@ -66,7 +66,7 @@ TaskWidget::TaskWidget(QWidget *parent)
 
   updateTargetCompleter();
   connect(target_completer_, static_cast<void(QCompleter::*)(const QString &)>(&QCompleter::activated),
-    [=]() {targetEditingFinished(); });
+    [this]() {targetEditingFinished(); });
   ui_.target_lineedit->setCompleter(target_completer_);
 
   // Model For the task-tree

--- a/lib/ThreadingUtils/include/ThreadingUtils/InterruptibleThread.h
+++ b/lib/ThreadingUtils/include/ThreadingUtils/InterruptibleThread.h
@@ -139,7 +139,7 @@ protected:
    */
   void SleepFor(std::chrono::nanoseconds sleep_duration){
     std::unique_lock<std::mutex> interruptLock(m_interruptMutex);
-    m_interruptCv.wait_for(interruptLock, sleep_duration, [=] {return bool(m_isInterrupted); });
+    m_interruptCv.wait_for(interruptLock, sleep_duration, [this] {return bool(m_isInterrupted); });
   }
 
   std::mutex              m_startup_mutex;      /**< A Mutex for thread safe starting of this thread */


### PR DESCRIPTION
C++20 deprecates implicit capture of this via [=], which triggers
warnings in lambdas that access members through the default by-value
capture. Replace those lambdas with explicit captures, primarily [this],
and capture additional local values only where needed.

This keeps the code compatible with C++20 while preserving the existing
runtime behavior.
