### PR TITLE
[GH Action] change toolchain action vendor

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -66,7 +66,7 @@ jobs:
       # Using ccache on Windows requires the Ninja generator
       # This action calls vcvarsall for us to setup the desired toolchain
     - name: Setup MSVC toolchain
-      uses: Chatterino/msvc-dev-cmd@v2
+      uses: Chatterino/msvc-dev-cmd@v2.0.5
       with:
         arch: x64
         toolset: 14.29 # v142 / vs2019

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -66,7 +66,7 @@ jobs:
       # Using ccache on Windows requires the Ninja generator
       # This action calls vcvarsall for us to setup the desired toolchain
     - name: Setup MSVC toolchain
-      uses: Chatterino/msvc-dev-cmd@v2.0.5
+      uses: step-security/msvc-dev-cmd@v1
       with:
         arch: x64
         toolset: 14.29 # v142 / vs2019


### PR DESCRIPTION
The currently latest v2.0.6 action has an issue that ./index.ps1 is not found.