### PR TITLE
Fix: compiler warnings

### DIFF
--- a/contrib/ecalhdf5/src/eh5_meas_file_v2.cpp
+++ b/contrib/ecalhdf5/src/eh5_meas_file_v2.cpp
@@ -275,14 +275,10 @@ bool eCAL::eh5::HDF5MeasFileV2::GetEntryData(long long entry_id, void* data) con
 
   if (dataset_id < 0) return false;
 
-  auto size = H5Dget_storage_size(dataset_id);
-
   herr_t read_status = -1;
-  if (size >= 0)
-  {
-    read_status = H5Dread(dataset_id, H5T_NATIVE_UCHAR, H5S_ALL, H5S_ALL, H5P_DEFAULT, data);
-  }
 
+  read_status = H5Dread(dataset_id, H5T_NATIVE_UCHAR, H5S_ALL, H5S_ALL, H5P_DEFAULT, data);
+  
   H5Dclose(dataset_id);
 
   return (read_status >= 0);

--- a/contrib/ecalhdf5/src/hdf5_helper.cpp
+++ b/contrib/ecalhdf5/src/hdf5_helper.cpp
@@ -72,13 +72,12 @@ bool ReadStringEntryAsString(hid_t root, const std::string& url, std::string& da
   const auto size = H5Dget_storage_size(dataset_id);
 
   herr_t read_status = -1;
-  if (size >= 0)
-  {
-    data.resize(size);
-    const auto string_data_type = H5Tcopy(H5T_C_S1);
-    H5Tset_size(string_data_type, size);
-    read_status = H5Dread(dataset_id, string_data_type, H5S_ALL, H5S_ALL, H5P_DEFAULT, static_cast<void*>(const_cast<char*>(data.data())));
-  }
+  
+  data.resize(size);
+  const auto string_data_type = H5Tcopy(H5T_C_S1);
+  H5Tset_size(string_data_type, size);
+  read_status = H5Dread(dataset_id, string_data_type, H5S_ALL, H5S_ALL, H5P_DEFAULT, static_cast<void*>(const_cast<char*>(data.data())));
+
 
   H5Dclose(dataset_id);
   return (read_status >= 0);
@@ -129,11 +128,9 @@ bool ReadBinaryEntryAsString(hid_t root, const std::string& url, std::string& da
   data.resize(size);
 
   herr_t read_status = -1;
-  if (size >= 0)
-  {
-    read_status = H5Dread(dataset_id, H5T_NATIVE_UCHAR, H5S_ALL, H5S_ALL, H5P_DEFAULT, static_cast<void*>(const_cast<char*>(data.data())));
-  }
 
+  read_status = H5Dread(dataset_id, H5T_NATIVE_UCHAR, H5S_ALL, H5S_ALL, H5P_DEFAULT, static_cast<void*>(const_cast<char*>(data.data())));
+  
   H5Dclose(dataset_id);
   return (read_status >= 0);
 }

--- a/serialization/common/common/include/ecal/msg/imeasurement.h
+++ b/serialization/common/common/include/ecal/msg/imeasurement.h
@@ -44,8 +44,8 @@ namespace eCAL
       using MessageT = T;
 
       IMessageChannel(IChannel&& binary_channel_)
-        : m_serializer{std::make_shared<Serializer>()}
-        , binary_channel(std::move(binary_channel_))
+        : binary_channel(std::move(binary_channel_))
+        , m_serializer{std::make_shared<Serializer>()}
       {
         // We are trying to create a "strong" type, based on only a channel name
         // There is a good chance, that the created channel does not match the data

--- a/serialization/common/common/include/ecal/msg/omeasurement.h
+++ b/serialization/common/common/include/ecal/msg/omeasurement.h
@@ -55,11 +55,7 @@ namespace eCAL
         // The way we handle Publishers requires us to do a two pass serialization;
         size_t message_size = m_serializer->MessageSize(entry_.message);
         buffer.resize(message_size);
-        if (message_size == 0)
-        {
-          m_serializer->Serialize(entry_.message, nullptr, 0);
-        }
-        else
+        if (message_size > 0)
         {
           m_serializer->Serialize(entry_.message, static_cast<void*>(&buffer[0]), buffer.size());
         }

--- a/serialization/common/common/include/ecal/msg/omeasurement.h
+++ b/serialization/common/common/include/ecal/msg/omeasurement.h
@@ -28,8 +28,6 @@ namespace eCAL
     template <typename T, typename Serializer>
     class OMessageChannel
     {
-      friend OMessageChannel CreateChannel(OMeasurement& meas_, const std::string& channel_name_);
-
     public:
       // Should those be private?
       using SerializerT = Serializer;


### PR DESCRIPTION
### Description
I used eCAL in a project via CMake FetchContent.  -Werror is enabled globally in my project, and I encountered several CMake warnings. This PR addresses those gcc warnings.


### Related issues

