### PR TITLE
Remove eTimeSyncMode

### DIFF
--- a/ecal/core/src/registration/ecal_process_registration.cpp
+++ b/ecal/core/src/registration/ecal_process_registration.cpp
@@ -70,18 +70,7 @@ eCAL::Registration::Sample eCAL::Registration::GetProcessRegisterSample()
     }
     else
     {
-      switch (timegate->GetSyncMode())
-      {
-      case CTimeGate::eTimeSyncMode::realtime:
-        process_sample_process.time_sync_state = Registration::eTimeSyncState::tsync_realtime;
-        break;
-      case CTimeGate::eTimeSyncMode::replay:
-        process_sample_process.time_sync_state = Registration::eTimeSyncState::tsync_replay;
-        break;
-      default:
-        process_sample_process.time_sync_state = Registration::eTimeSyncState::tsync_none;
-        break;
-      }
+      process_sample_process.time_sync_state = Registration::eTimeSyncState::tsync_realtime;
     }
     process_sample_process.time_sync_module_name = timegate->GetName();
   }

--- a/ecal/core/src/time/ecal_timegate.h
+++ b/ecal/core/src/time/ecal_timegate.h
@@ -37,9 +37,6 @@ namespace eCAL
   public:
     static std::shared_ptr<CTimeGate> CreateTimegate();
 
-    // TODO: these need to be removed
-    enum eTimeSyncMode { none, realtime, replay };
-
   private:
     CTimeGate(CTimePlugin&& time_plugin, std::string plugin_name);
 
@@ -65,8 +62,6 @@ namespace eCAL
     void SleepForNanoseconds(long long duration_nsecs_);
 
     void GetStatus(int& error_, std::string* status_message_);
-
-    eTimeSyncMode GetSyncMode() { return(eTimeSyncMode::realtime); };
 
     CTimePlugin m_time_plugin;
     std::string m_plugin_name;


### PR DESCRIPTION
Removed the unused `eSyncTimeMode` enum and its associated references across the codebase as requested in issue #2524 

## Changes
Removed eSyncTimeMode definition and dependent usage.
Cleaned up related methods.

## Testing
[X] Build succeeds without warnings across target platforms.